### PR TITLE
coverage: enable mutation tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
-                        9.0.x
+                        10.0.x
             -   name: Run mutation tests
                 run: ./build.sh MutationTests MutationTestDashboard
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,25 @@ jobs:
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks
     
+    mutation-tests:
+        name: "Mutation tests"
+        runs-on: ubuntu-latest
+        env:
+            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+            DOTNET_NOLOGO: true
+        steps:
+            -   uses: actions/checkout@v5
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v5
+                with:
+                    dotnet-version: |
+                        8.0.x
+                        9.0.x
+            -   name: Run mutation tests
+                run: ./build.sh MutationTests MutationTestDashboard
+    
     static-code-analysis:
         name: "Static code analysis"
         runs-on: ubuntu-latest
@@ -153,7 +172,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack ]
+        needs: [ pack, mutation-tests ]
         permissions:
             contents: write
         steps:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build](https://github.com/aweXpect/Mockolate/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/Mockolate/actions/workflows/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_Mockolate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_Mockolate)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_Mockolate&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_Mockolate)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FMockolate%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/Mockolate/main)
 
 **Mockolate** is a modern, strongly-typed mocking library for .NET, powered by source generators. It enables fast, compile-time validated mocks for interfaces and classes, supporting .NET Standard 2.0, .NET 8, .NET 10, and .NET Framework 4.8.
 


### PR DESCRIPTION
Adds mutation testing integration (Stryker) into the build pipeline and CI workflow, including publishing results and uploading reports to the Stryker dashboard.

### Key changes
- Pins the dotnet-stryker tool version and adds mutation test badge generation.
- Introduces a new target to upload mutation test reports to the Stryker dashboard.
- Adds a dedicated GitHub Actions job for mutation tests and makes release dependent on it.