### PR TITLE
feat: support multiple callbacks

### DIFF
--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MethodSetups.cs
@@ -59,8 +59,8 @@ internal static partial class SourceGeneration
 
 		sb.Append(") : MethodSetup").AppendLine();
 		sb.Append("{").AppendLine();
-		sb.Append("\tprivate Action<").Append(typeParams).Append(">? _callback;").AppendLine();
-		sb.Append("\tprivate List<Action<").Append(typeParams).Append(">> _returnCallbacks = [];").AppendLine();
+		sb.Append("\tprivate readonly List<Action<").Append(typeParams).Append(">> _callbacks = [];").AppendLine();
+		sb.Append("\tprivate readonly List<Action<").Append(typeParams).Append(">> _returnCallbacks = [];").AppendLine();
 		sb.Append("\tint _currentReturnCallbackIndex = -1;").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t/// <summary>").AppendLine();
@@ -69,9 +69,9 @@ internal static partial class SourceGeneration
 		sb.Append("\t/// </summary>").AppendLine();
 		sb.Append("\tpublic VoidMethodSetup<").Append(typeParams).Append("> Callback(Action callback)").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t_callback = (")
+		sb.Append("\t\t_callbacks.Add((")
 			.Append(string.Join(", ", Enumerable.Range(0, numberOfParameters).Select(_ => "_")))
-			.Append(") => callback();").AppendLine();
+			.Append(") => callback());").AppendLine();
 		sb.Append("\t\treturn this;").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
@@ -82,7 +82,7 @@ internal static partial class SourceGeneration
 		sb.Append("\tpublic VoidMethodSetup<").Append(typeParams).Append("> Callback(Action<").Append(typeParams)
 			.Append("> callback)").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t_callback = callback;").AppendLine();
+		sb.Append("\t\t_callbacks.Add(callback);").AppendLine();
 		sb.Append("\t\treturn this;").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
@@ -156,8 +156,8 @@ internal static partial class SourceGeneration
 			.Append(numberOfParameters - 1).Append("], out var p").Append(numberOfParameters).Append(", behavior))")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_callback?.Invoke(")
-			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}"))).Append(");")
+		sb.Append("\t\t\t_callbacks.ForEach(callback => callback.Invoke(")
+			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}"))).Append("));")
 			.AppendLine();
 		sb.Append("\t\t\tif (_returnCallbacks.Count > 0)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
@@ -237,8 +237,8 @@ internal static partial class SourceGeneration
 
 		sb.Append(") : MethodSetup").AppendLine();
 		sb.Append("{").AppendLine();
-		sb.Append("\tprivate Action<").Append(typeParams).Append(">? _callback;").AppendLine();
-		sb.Append("\tprivate List<Func<").Append(typeParams).Append(", TReturn>> _returnCallbacks = [];").AppendLine();
+		sb.Append("\tprivate readonly List<Action<").Append(typeParams).Append(">> _callbacks = [];").AppendLine();
+		sb.Append("\tprivate readonly List<Func<").Append(typeParams).Append(", TReturn>> _returnCallbacks = [];").AppendLine();
 		sb.Append("\tint _currentReturnCallbackIndex = -1;").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t/// <summary>").AppendLine();
@@ -248,9 +248,9 @@ internal static partial class SourceGeneration
 		sb.Append("\tpublic ReturnMethodSetup<TReturn, ").Append(typeParams).Append("> Callback(Action callback)")
 			.AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t_callback = (")
+		sb.Append("\t\t_callbacks.Add((")
 			.Append(string.Join(", ", Enumerable.Range(0, numberOfParameters).Select(_ => "_")))
-			.Append(") => callback();").AppendLine();
+			.Append(") => callback());").AppendLine();
 		sb.Append("\t\treturn this;").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
@@ -261,7 +261,7 @@ internal static partial class SourceGeneration
 		sb.Append("\tpublic ReturnMethodSetup<TReturn, ").Append(typeParams).Append("> Callback(Action<")
 			.Append(typeParams).Append("> callback)").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t_callback = callback;").AppendLine();
+		sb.Append("\t\t_callbacks.Add(callback);").AppendLine();
 		sb.Append("\t\treturn this;").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
@@ -359,8 +359,8 @@ internal static partial class SourceGeneration
 			.Append(numberOfParameters - 1).Append("], out var p").Append(numberOfParameters).Append(", behavior))")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_callback?.Invoke(")
-			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}"))).Append(");")
+		sb.Append("\t\t\t_callbacks.ForEach(callback => callback.Invoke(")
+			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}"))).Append("));")
 			.AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.Append("\t}").AppendLine();
@@ -395,9 +395,6 @@ internal static partial class SourceGeneration
 			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}")))
 			.Append(") is TResult result)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_callback?.Invoke(")
-			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}"))).Append(");")
-			.AppendLine();
 		sb.Append("\t\t\treturn result;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Mockolate.Checks;
 using Mockolate.Exceptions;
@@ -12,7 +13,7 @@ namespace Mockolate.Setup;
 public class ReturnMethodSetup<TReturn>(string name) : MethodSetup
 {
 	private readonly List<Func<TReturn>> _returnCallbacks = [];
-	private Action? _callback;
+	private readonly List<Action> _callbacks = [];
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -20,7 +21,7 @@ public class ReturnMethodSetup<TReturn>(string name) : MethodSetup
 	/// </summary>
 	public ReturnMethodSetup<TReturn> Callback(Action callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -62,7 +63,7 @@ public class ReturnMethodSetup<TReturn>(string name) : MethodSetup
 
 	/// <inheritdoc cref="MethodSetup.ExecuteCallback(MethodInvocation, MockBehavior)" />
 	protected override void ExecuteCallback(MethodInvocation invocation, MockBehavior behavior)
-		=> _callback?.Invoke();
+		=> _callbacks.ForEach(callback => callback.Invoke());
 
 	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(MethodInvocation, MockBehavior)" />
 	protected override TResult GetReturnValue<TResult>(MethodInvocation invocation, MockBehavior behavior)
@@ -104,7 +105,7 @@ public class ReturnMethodSetup<TReturn, T1>(string name, With.NamedParameter mat
 	: MethodSetup
 {
 	private readonly List<Func<T1, TReturn>> _returnCallbacks = [];
-	private Action<T1>? _callback;
+	private readonly List<Action<T1>> _callbacks = [];
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -112,7 +113,7 @@ public class ReturnMethodSetup<TReturn, T1>(string name, With.NamedParameter mat
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1> Callback(Action callback)
 	{
-		_callback = _ => callback();
+		_callbacks.Add(_ => callback());
 		return this;
 	}
 
@@ -121,7 +122,7 @@ public class ReturnMethodSetup<TReturn, T1>(string name, With.NamedParameter mat
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1> Callback(Action<T1> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -184,7 +185,7 @@ public class ReturnMethodSetup<TReturn, T1>(string name, With.NamedParameter mat
 	{
 		if (TryCast<T1>(invocation.Parameters[0], out T1? p1, behavior))
 		{
-			_callback?.Invoke(p1);
+			_callbacks.ForEach(callback => callback.Invoke(p1));
 		}
 	}
 
@@ -211,7 +212,6 @@ public class ReturnMethodSetup<TReturn, T1>(string name, With.NamedParameter mat
 				$"The return callback only supports '{typeof(TReturn)}' and not '{typeof(TResult)}'.");
 		}
 
-		_callback?.Invoke(p1);
 		return result;
 	}
 
@@ -250,7 +250,7 @@ public class ReturnMethodSetup<TReturn, T1, T2>(string name, With.NamedParameter
 	: MethodSetup
 {
 	private readonly List<Func<T1, T2, TReturn>> _returnCallbacks = [];
-	private Action<T1, T2>? _callback;
+	private readonly List<Action<T1, T2>> _callbacks = [];
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -258,7 +258,7 @@ public class ReturnMethodSetup<TReturn, T1, T2>(string name, With.NamedParameter
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1, T2> Callback(Action callback)
 	{
-		_callback = (_, _) => callback();
+		_callbacks.Add((_, _) => callback());
 		return this;
 	}
 
@@ -267,7 +267,7 @@ public class ReturnMethodSetup<TReturn, T1, T2>(string name, With.NamedParameter
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1, T2> Callback(Action<T1, T2> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -331,7 +331,7 @@ public class ReturnMethodSetup<TReturn, T1, T2>(string name, With.NamedParameter
 		if (TryCast<T1>(invocation.Parameters[0], out T1? p1, behavior) &&
 		    TryCast<T2>(invocation.Parameters[1], out T2? p2, behavior))
 		{
-			_callback?.Invoke(p1, p2);
+			_callbacks.ForEach(callback => callback.Invoke(p1, p2));
 		}
 	}
 
@@ -364,7 +364,6 @@ public class ReturnMethodSetup<TReturn, T1, T2>(string name, With.NamedParameter
 				$"The return callback only supports '{typeof(TReturn)}' and not '{typeof(TResult)}'.");
 		}
 
-		_callback?.Invoke(p1, p2);
 		return result;
 	}
 
@@ -407,7 +406,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3>(
 	: MethodSetup
 {
 	private readonly List<Func<T1, T2, T3, TReturn>> _returnCallbacks = [];
-	private Action<T1, T2, T3>? _callback;
+	private readonly List<Action<T1, T2, T3>> _callbacks = [];
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -415,7 +414,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3>(
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1, T2, T3> Callback(Action callback)
 	{
-		_callback = (_, _, _) => callback();
+		_callbacks.Add((_, _, _) => callback());
 		return this;
 	}
 
@@ -424,7 +423,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3>(
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1, T2, T3> Callback(Action<T1, T2, T3> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -489,7 +488,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3>(
 		    TryCast<T2>(invocation.Parameters[1], out T2? p2, behavior) &&
 		    TryCast<T3>(invocation.Parameters[2], out T3? p3, behavior))
 		{
-			_callback?.Invoke(p1, p2, p3);
+			_callbacks.ForEach(callback => callback.Invoke(p1, p2, p3));
 		}
 	}
 
@@ -524,7 +523,6 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3>(
 		Func<T1, T2, T3, TReturn>? returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
 		if (returnCallback(p1, p2, p3) is TResult result)
 		{
-			_callback?.Invoke(p1, p2, p3);
 			return result;
 		}
 
@@ -572,7 +570,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4>(
 	: MethodSetup
 {
 	private readonly List<Func<T1, T2, T3, T4, TReturn>> _returnCallbacks = [];
-	private Action<T1, T2, T3, T4>? _callback;
+	private readonly List<Action<T1, T2, T3, T4>> _callbacks = [];
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -580,7 +578,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4>(
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1, T2, T3, T4> Callback(Action callback)
 	{
-		_callback = (_, _, _, _) => callback();
+		_callbacks.Add((_, _, _, _) => callback());
 		return this;
 	}
 
@@ -589,7 +587,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4>(
 	/// </summary>
 	public ReturnMethodSetup<TReturn, T1, T2, T3, T4> Callback(Action<T1, T2, T3, T4> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -655,7 +653,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4>(
 		    TryCast<T3>(invocation.Parameters[2], out T3? p3, behavior) &&
 		    TryCast<T4>(invocation.Parameters[3], out T4? p4, behavior))
 		{
-			_callback?.Invoke(p1, p2, p3, p4);
+			_callbacks.ForEach(callback => callback.Invoke(p1, p2, p3, p4));
 		}
 	}
 
@@ -696,7 +694,6 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4>(
 		Func<T1, T2, T3, T4, TReturn>? returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
 		if (returnCallback(p1, p2, p3, p4) is TResult result)
 		{
-			_callback?.Invoke(p1, p2, p3, p4);
 			return result;
 		}
 

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -11,8 +11,8 @@ namespace Mockolate.Setup;
 /// </summary>
 public class VoidMethodSetup(string name) : MethodSetup
 {
+	private readonly List<Action> _callbacks = [];
 	private readonly List<Action> _returnCallbacks = [];
-	private Action? _callback;
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -20,7 +20,7 @@ public class VoidMethodSetup(string name) : MethodSetup
 	/// </summary>
 	public VoidMethodSetup Callback(Action callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -54,7 +54,7 @@ public class VoidMethodSetup(string name) : MethodSetup
 	/// <inheritdoc cref="MethodSetup.ExecuteCallback(MethodInvocation, MockBehavior)" />
 	protected override void ExecuteCallback(MethodInvocation invocation, MockBehavior behavior)
 	{
-		_callback?.Invoke();
+		_callbacks.ForEach(callback => callback.Invoke());
 		if (_returnCallbacks.Count > 0)
 		{
 			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
@@ -86,8 +86,8 @@ public class VoidMethodSetup(string name) : MethodSetup
 /// </summary>
 public class VoidMethodSetup<T1>(string name, With.NamedParameter match1) : MethodSetup
 {
+	private readonly List<Action<T1>> _callbacks = [];
 	private readonly List<Action<T1>> _returnCallbacks = [];
-	private Action<T1>? _callback;
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -95,7 +95,7 @@ public class VoidMethodSetup<T1>(string name, With.NamedParameter match1) : Meth
 	/// </summary>
 	public VoidMethodSetup<T1> Callback(Action callback)
 	{
-		_callback = _ => callback();
+		_callbacks.Add(_ => callback());
 		return this;
 	}
 
@@ -104,7 +104,7 @@ public class VoidMethodSetup<T1>(string name, With.NamedParameter match1) : Meth
 	/// </summary>
 	public VoidMethodSetup<T1> Callback(Action<T1> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -149,7 +149,7 @@ public class VoidMethodSetup<T1>(string name, With.NamedParameter match1) : Meth
 	{
 		if (TryCast<T1>(invocation.Parameters[0], out T1? p1, behavior))
 		{
-			_callback?.Invoke(p1);
+			_callbacks.ForEach(callback => callback.Invoke(p1));
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
@@ -197,8 +197,8 @@ public class VoidMethodSetup<T1>(string name, With.NamedParameter match1) : Meth
 /// </summary>
 public class VoidMethodSetup<T1, T2>(string name, With.NamedParameter match1, With.NamedParameter match2) : MethodSetup
 {
+	private readonly List<Action<T1, T2>> _callbacks = [];
 	private readonly List<Action<T1, T2>> _returnCallbacks = [];
-	private Action<T1, T2>? _callback;
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -206,7 +206,7 @@ public class VoidMethodSetup<T1, T2>(string name, With.NamedParameter match1, Wi
 	/// </summary>
 	public VoidMethodSetup<T1, T2> Callback(Action callback)
 	{
-		_callback = (_, _) => callback();
+		_callbacks.Add((_, _) => callback());
 		return this;
 	}
 
@@ -215,7 +215,7 @@ public class VoidMethodSetup<T1, T2>(string name, With.NamedParameter match1, Wi
 	/// </summary>
 	public VoidMethodSetup<T1, T2> Callback(Action<T1, T2> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -261,7 +261,7 @@ public class VoidMethodSetup<T1, T2>(string name, With.NamedParameter match1, Wi
 		if (TryCast<T1>(invocation.Parameters[0], out T1? p1, behavior) &&
 		    TryCast<T2>(invocation.Parameters[1], out T2? p2, behavior))
 		{
-			_callback?.Invoke(p1, p2);
+			_callbacks.ForEach(callback => callback.Invoke(p1, p2));
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
@@ -313,8 +313,8 @@ public class VoidMethodSetup<T1, T2, T3>(
 	With.NamedParameter match2,
 	With.NamedParameter match3) : MethodSetup
 {
+	private readonly List<Action<T1, T2, T3>> _callbacks = [];
 	private readonly List<Action<T1, T2, T3>> _returnCallbacks = [];
-	private Action<T1, T2, T3>? _callback;
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -322,7 +322,7 @@ public class VoidMethodSetup<T1, T2, T3>(
 	/// </summary>
 	public VoidMethodSetup<T1, T2, T3> Callback(Action callback)
 	{
-		_callback = (_, _, _) => callback();
+		_callbacks.Add((_, _, _) => callback());
 		return this;
 	}
 
@@ -331,7 +331,7 @@ public class VoidMethodSetup<T1, T2, T3>(
 	/// </summary>
 	public VoidMethodSetup<T1, T2, T3> Callback(Action<T1, T2, T3> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -378,7 +378,7 @@ public class VoidMethodSetup<T1, T2, T3>(
 		    TryCast<T2>(invocation.Parameters[1], out T2? p2, behavior) &&
 		    TryCast<T3>(invocation.Parameters[2], out T3? p3, behavior))
 		{
-			_callback?.Invoke(p1, p2, p3);
+			_callbacks.ForEach(callback => callback.Invoke(p1, p2, p3));
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
@@ -431,8 +431,8 @@ public class VoidMethodSetup<T1, T2, T3, T4>(
 	With.NamedParameter match3,
 	With.NamedParameter match4) : MethodSetup
 {
+	private readonly List<Action<T1, T2, T3, T4>> _callbacks = [];
 	private readonly List<Action<T1, T2, T3, T4>> _returnCallbacks = [];
-	private Action<T1, T2, T3, T4>? _callback;
 	private int _currentReturnCallbackIndex = -1;
 
 	/// <summary>
@@ -440,7 +440,7 @@ public class VoidMethodSetup<T1, T2, T3, T4>(
 	/// </summary>
 	public VoidMethodSetup<T1, T2, T3, T4> Callback(Action callback)
 	{
-		_callback = (_, _, _, _) => callback();
+		_callbacks.Add((_, _, _, _) => callback());
 		return this;
 	}
 
@@ -449,7 +449,7 @@ public class VoidMethodSetup<T1, T2, T3, T4>(
 	/// </summary>
 	public VoidMethodSetup<T1, T2, T3, T4> Callback(Action<T1, T2, T3, T4> callback)
 	{
-		_callback = callback;
+		_callbacks.Add(callback);
 		return this;
 	}
 
@@ -497,7 +497,7 @@ public class VoidMethodSetup<T1, T2, T3, T4>(
 		    TryCast<T3>(invocation.Parameters[2], out T3? p3, behavior) &&
 		    TryCast<T4>(invocation.Parameters[3], out T4? p4, behavior))
 		{
-			_callback?.Invoke(p1, p2, p3, p4);
+			_callbacks.ForEach(callback => callback.Invoke(p1, p2, p3, p4));
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);

--- a/Tests/Mockolate.Tests/Setup/ReturnMethodSetupTests.cs
+++ b/Tests/Mockolate.Tests/Setup/ReturnMethodSetupTests.cs
@@ -11,36 +11,38 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
-			sut.Setup.Method0().Callback(() => { isCalled = true; });
+			sut.Setup.Method0()
+				.Callback(() => { callCount++; })
+				.Returns(1);
 
 			sut.Object.Method0();
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
-			sut.Setup.Method0().Callback(() => { isCalled = true; });
+			sut.Setup.Method0().Callback(() => { callCount++; });
 
 			sut.Object.Method1(1);
 			sut.Object.Method0(false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task GetReturnValue_InvalidType_ShouldThrowMockException()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			MyReturnMethodSetup setup = new("foo");
-			setup.Callback(() => { isCalled = true; }).Returns(3);
+			setup.Callback(() => { callCount++; }).Returns(3);
 			MethodInvocation invocation = new("foo", Array.Empty<object?>());
 
 			void Act()
@@ -50,7 +52,7 @@ public class ReturnMethodSetupTests
 				.WithMessage("""
 				             The return callback only supports 'System.Int32' and not 'System.String'.
 				             """);
-			await That(isCalled).IsFalse().Because("The callback should only be executed on success!");
+			await That(callCount).IsEqualTo(0).Because("The callback should only be executed on success!");
 		}
 
 		[Fact]
@@ -70,6 +72,25 @@ public class ReturnMethodSetupTests
 			await That(result1).IsEqualTo(4);
 			await That(result2).HasMessage("foo");
 			await That(result3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
+
+			sut.Setup.Method0()
+				.Callback(() => { callCount1++; })
+				.Callback(() => { callCount2++; })
+				.Returns(1);
+
+			sut.Object.Method0();
+			sut.Object.Method0();
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(2);
 		}
 
 		[Fact]
@@ -189,93 +210,94 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; })
+				.Returns(1);
 
 			sut.Object.Method1(3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method0();
 			sut.Object.Method1(2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenParameterDoesNotMatch()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1(With.Matching<int>(v => v != 1))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method1(1);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
 				.Callback(v =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue = v;
 				});
 
 			sut.Object.Method1(3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue).IsEqualTo(3);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
-				.Callback(v => { isCalled = true; });
+				.Callback(v => { callCount++; });
 
 			sut.Object.Method0();
 			sut.Object.Method1(2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenParameterDoesNotMatch()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1(With.Matching<int>(v => v != 1))
-				.Callback(v => { isCalled = true; });
+				.Callback(v => { callCount++; });
 
 			sut.Object.Method1(1);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -297,9 +319,9 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task GetReturnValue_InvalidType_ShouldThrowMockException()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			MyReturnMethodSetup<int> setup = new("foo");
-			setup.Callback(() => { isCalled = true; }).Returns(x => 3 * x);
+			setup.Callback(() => { callCount++; }).Returns(x => 3 * x);
 			MethodInvocation invocation = new("foo", [2,]);
 
 			void Act()
@@ -309,7 +331,7 @@ public class ReturnMethodSetupTests
 				.WithMessage("""
 				             The return callback only supports 'System.Int32' and not 'System.String'.
 				             """);
-			await That(isCalled).IsFalse().Because("The callback should only be executed on success!");
+			await That(callCount).IsEqualTo(0).Because("The callback should only be executed on success!");
 		}
 
 		[Fact]
@@ -329,6 +351,25 @@ public class ReturnMethodSetupTests
 			await That(result1).IsEqualTo(4);
 			await That(result2).HasMessage("foo");
 			await That(result3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
+
+			sut.Setup.Method1(With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback(v => { callCount2 += v; })
+				.Returns(1);
+
+			sut.Object.Method1(1);
+			sut.Object.Method1(2);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(3);
 		}
 
 		[Fact]
@@ -354,19 +395,19 @@ public class ReturnMethodSetupTests
 		public async Task OutParameter_ShouldSet()
 		{
 			int receivedValue = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1WithOutParameter(With.Out(() => 3))
 				.Callback(v =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue = v;
 				});
 
 			sut.Object.Method1WithOutParameter(out int value);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value).IsEqualTo(3);
 			await That(receivedValue).IsEqualTo(0);
 		}
@@ -375,20 +416,20 @@ public class ReturnMethodSetupTests
 		public async Task RefParameter_ShouldSet()
 		{
 			int receivedValue = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method1WithRefParameter(With.Ref<int>(v => 3))
 				.Callback(v =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue = v;
 				});
 
 			int value = 2;
 			sut.Object.Method1WithRefParameter(ref value);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value).IsEqualTo(3);
 			await That(receivedValue).IsEqualTo(2);
 		}
@@ -520,15 +561,16 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; })
+				.Returns(1);
 
 			sut.Object.Method2(1, 2);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -537,36 +579,36 @@ public class ReturnMethodSetupTests
 		[InlineData(false, true)]
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method2(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method1(1);
 			sut.Object.Method2(1, 2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
@@ -574,14 +616,14 @@ public class ReturnMethodSetupTests
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 				});
 
 			sut.Object.Method2(2, 4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 		}
@@ -592,30 +634,30 @@ public class ReturnMethodSetupTests
 		[InlineData(false, true)]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method2(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2))
-				.Callback((v1, v2) => { isCalled = true; });
+				.Callback((v1, v2) => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2) => { isCalled = true; });
+				.Callback((v1, v2) => { callCount++; });
 
 			sut.Object.Method1(1);
 			sut.Object.Method2(1, 2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -653,9 +695,9 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task GetReturnValue_InvalidType_ShouldThrowMockException()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			MyReturnMethodSetup<int, int> setup = new("foo");
-			setup.Callback(() => { isCalled = true; }).Returns(3);
+			setup.Callback(() => { callCount++; }).Returns(3);
 			MethodInvocation invocation = new("foo", [2, 3,]);
 
 			void Act()
@@ -665,7 +707,7 @@ public class ReturnMethodSetupTests
 				.WithMessage("""
 				             The return callback only supports 'System.Int32' and not 'System.String'.
 				             """);
-			await That(isCalled).IsFalse().Because("The callback should only be executed on success!");
+			await That(callCount).IsEqualTo(0).Because("The callback should only be executed on success!");
 		}
 
 		[Fact]
@@ -685,6 +727,25 @@ public class ReturnMethodSetupTests
 			await That(result1).IsEqualTo(4);
 			await That(result2).HasMessage("foo");
 			await That(result3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
+
+			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2) => { callCount2 += v1 * v2; })
+				.Returns(1);
+
+			sut.Object.Method2(1, 2);
+			sut.Object.Method2(2, 2);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(6);
 		}
 
 		[Fact]
@@ -711,20 +772,20 @@ public class ReturnMethodSetupTests
 		{
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method2WithOutParameter(With.Out(() => 2), With.Out(() => 4))
 				.Callback((v1, v2) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 				});
 
 			sut.Object.Method2WithOutParameter(out int value1, out int value2);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -736,13 +797,13 @@ public class ReturnMethodSetupTests
 		{
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method2WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10))
 				.Callback((v1, v2) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 				});
@@ -751,7 +812,7 @@ public class ReturnMethodSetupTests
 			int value2 = 4;
 			sut.Object.Method2WithRefParameter(ref value1, ref value2);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);
@@ -887,15 +948,16 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; })
+				.Returns(1);
 
 			sut.Object.Method3(1, 2, 3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -906,37 +968,37 @@ public class ReturnMethodSetupTests
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method3(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 			sut.Object.Method3(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
@@ -945,7 +1007,7 @@ public class ReturnMethodSetupTests
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2, v3) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -953,7 +1015,7 @@ public class ReturnMethodSetupTests
 
 			sut.Object.Method3(2, 4, 6);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 			await That(receivedValue3).IsEqualTo(6);
@@ -967,31 +1029,31 @@ public class ReturnMethodSetupTests
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method3(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3))
-				.Callback((v1, v2, v3) => { isCalled = true; });
+				.Callback((v1, v2, v3) => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2, v3) => { isCalled = true; });
+				.Callback((v1, v2, v3) => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 			sut.Object.Method3(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -1045,9 +1107,9 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task GetReturnValue_InvalidType_ShouldThrowMockException()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			MyReturnMethodSetup<int, int, int> setup = new("foo");
-			setup.Callback(() => { isCalled = true; }).Returns(3);
+			setup.Callback(() => { callCount++; }).Returns(3);
 			MethodInvocation invocation = new("foo", [1, 2, 3,]);
 
 			void Act()
@@ -1057,7 +1119,7 @@ public class ReturnMethodSetupTests
 				.WithMessage("""
 				             The return callback only supports 'System.Int32' and not 'System.String'.
 				             """);
-			await That(isCalled).IsFalse().Because("The callback should only be executed on success!");
+			await That(callCount).IsEqualTo(0).Because("The callback should only be executed on success!");
 		}
 
 		[Fact]
@@ -1077,6 +1139,25 @@ public class ReturnMethodSetupTests
 			await That(result1).IsEqualTo(4);
 			await That(result2).HasMessage("foo");
 			await That(result3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
+
+			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2, v3) => { callCount2 += v1 * v2 * v3; })
+				.Returns(1);
+
+			sut.Object.Method3(1, 2, 3);
+			sut.Object.Method3(2, 2, 3);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(18);
 		}
 
 		[Fact]
@@ -1104,13 +1185,13 @@ public class ReturnMethodSetupTests
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method3WithOutParameter(With.Out(() => 2), With.Out(() => 4), With.Out(() => 6))
 				.Callback((v1, v2, v3) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1118,7 +1199,7 @@ public class ReturnMethodSetupTests
 
 			sut.Object.Method3WithOutParameter(out int value1, out int value2, out int value3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -1133,14 +1214,14 @@ public class ReturnMethodSetupTests
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method3WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10),
 					With.Ref<int>(v => v * 10))
 				.Callback((v1, v2, v3) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1151,7 +1232,7 @@ public class ReturnMethodSetupTests
 			int value3 = 6;
 			sut.Object.Method3WithRefParameter(ref value1, ref value2, ref value3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);
@@ -1293,15 +1374,16 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; })
+				.Returns(1);
 
 			sut.Object.Method4(1, 2, 3, 4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -1313,37 +1395,37 @@ public class ReturnMethodSetupTests
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method4(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 			sut.Object.Method4(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
@@ -1353,7 +1435,7 @@ public class ReturnMethodSetupTests
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2, v3, v4) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1362,7 +1444,7 @@ public class ReturnMethodSetupTests
 
 			sut.Object.Method4(2, 4, 6, 8);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 			await That(receivedValue3).IsEqualTo(6);
@@ -1378,31 +1460,31 @@ public class ReturnMethodSetupTests
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method4(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4))
-				.Callback((v1, v2, v3, v4) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4) => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2, v3, v4) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4) => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 			sut.Object.Method4(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -1472,9 +1554,9 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task GetReturnValue_InvalidType_ShouldThrowMockException()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			MyReturnMethodSetup<int, int, int, int> setup = new("foo");
-			setup.Callback(() => { isCalled = true; }).Returns(3);
+			setup.Callback(() => { callCount++; }).Returns(3);
 			MethodInvocation invocation = new("foo", [1, 2, 3, 4,]);
 
 			void Act()
@@ -1484,7 +1566,7 @@ public class ReturnMethodSetupTests
 				.WithMessage("""
 				             The return callback only supports 'System.Int32' and not 'System.String'.
 				             """);
-			await That(isCalled).IsFalse().Because("The callback should only be executed on success!");
+			await That(callCount).IsEqualTo(0).Because("The callback should only be executed on success!");
 		}
 
 		[Fact]
@@ -1504,6 +1586,25 @@ public class ReturnMethodSetupTests
 			await That(result1).IsEqualTo(4);
 			await That(result2).HasMessage("foo");
 			await That(result3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
+
+			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2, v3, v4) => { callCount2 += v1 * v2 * v3 * v4; })
+				.Returns(1);
+
+			sut.Object.Method4(1, 2, 3, 4);
+			sut.Object.Method4(2, 2, 3, 4);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(72);
 		}
 
 		[Fact]
@@ -1532,14 +1633,14 @@ public class ReturnMethodSetupTests
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method4WithOutParameter(With.Out(() => 2), With.Out(() => 4), With.Out(() => 6),
 					With.Out(() => 8))
 				.Callback((v1, v2, v3, v4) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1548,7 +1649,7 @@ public class ReturnMethodSetupTests
 
 			sut.Object.Method4WithOutParameter(out int value1, out int value2, out int value3, out int value4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -1566,14 +1667,14 @@ public class ReturnMethodSetupTests
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method4WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10),
 					With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10))
 				.Callback((v1, v2, v3, v4) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1586,7 +1687,7 @@ public class ReturnMethodSetupTests
 			int value4 = 8;
 			sut.Object.Method4WithRefParameter(ref value1, ref value2, ref value3, ref value4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);
@@ -1731,15 +1832,16 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; })
+				.Returns(1);
 
 			sut.Object.Method5(1, 2, 3, 4, 5);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -1752,38 +1854,38 @@ public class ReturnMethodSetupTests
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4, bool isMatch5)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method5(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4),
 					With.Matching<int>(v => isMatch5))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method5(1, 2, 3, 4, 5);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 			sut.Object.Method5(1, 2, 3, 4, 5, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
@@ -1794,7 +1896,7 @@ public class ReturnMethodSetupTests
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2, v3, v4, v5) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1804,7 +1906,7 @@ public class ReturnMethodSetupTests
 
 			sut.Object.Method5(2, 4, 6, 8, 10);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 			await That(receivedValue3).IsEqualTo(6);
@@ -1822,32 +1924,32 @@ public class ReturnMethodSetupTests
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4, bool isMatch5)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method5(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4),
 					With.Matching<int>(v => isMatch5))
-				.Callback((v1, v2, v3, v4, v5) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4, v5) => { callCount++; });
 
 			sut.Object.Method5(1, 2, 3, 4, 5);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2, v3, v4, v5) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4, v5) => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 			sut.Object.Method5(1, 2, 3, 4, 5, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -1933,9 +2035,9 @@ public class ReturnMethodSetupTests
 		[Fact]
 		public async Task GetReturnValue_InvalidType_ShouldThrowMockException()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			MyReturnMethodSetup<int, int, int, int, int> setup = new("foo");
-			setup.Callback(() => { isCalled = true; }).Returns(3);
+			setup.Callback(() => { callCount++; }).Returns(3);
 			MethodInvocation invocation = new("foo", [1, 2, 3, 4, 5,]);
 
 			void Act()
@@ -1945,7 +2047,7 @@ public class ReturnMethodSetupTests
 				.WithMessage("""
 				             The return callback only supports 'System.Int32' and not 'System.String'.
 				             """);
-			await That(isCalled).IsFalse().Because("The callback should only be executed on success!");
+			await That(callCount).IsEqualTo(0).Because("The callback should only be executed on success!");
 		}
 
 		[Fact]
@@ -1965,6 +2067,25 @@ public class ReturnMethodSetupTests
 			await That(result1).IsEqualTo(4);
 			await That(result2).HasMessage("foo");
 			await That(result3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
+
+			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2, v3, v4, v5) => { callCount2 += v1 * v2 * v3 * v4 * v5; })
+				.Returns(1);
+
+			sut.Object.Method5(1, 2, 3, 4, 5);
+			sut.Object.Method5(2, 2, 3, 4, 5);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(360);
 		}
 
 		[Fact]
@@ -1994,14 +2115,14 @@ public class ReturnMethodSetupTests
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
 			int receivedValue5 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method5WithOutParameter(With.Out(() => 2), With.Out(() => 4), With.Out(() => 6),
 					With.Out(() => 8), With.Out(() => 10))
 				.Callback((v1, v2, v3, v4, v5) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -2012,7 +2133,7 @@ public class ReturnMethodSetupTests
 			sut.Object.Method5WithOutParameter(out int value1, out int value2, out int value3, out int value4,
 				out int value5);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -2033,14 +2154,14 @@ public class ReturnMethodSetupTests
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
 			int receivedValue5 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IReturnMethodSetupTest> sut = Mock.For<IReturnMethodSetupTest>();
 
 			sut.Setup.Method5WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10),
 					With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10))
 				.Callback((v1, v2, v3, v4, v5) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -2055,7 +2176,7 @@ public class ReturnMethodSetupTests
 			int value5 = 10;
 			sut.Object.Method5WithRefParameter(ref value1, ref value2, ref value3, ref value4, ref value5);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);

--- a/Tests/Mockolate.Tests/Setup/VoidMethodSetupTests.cs
+++ b/Tests/Mockolate.Tests/Setup/VoidMethodSetupTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Mockolate.Exceptions;
 using Mockolate.Setup;
+using static Mockolate.Tests.Setup.ReturnMethodSetupTests;
 
 namespace Mockolate.Tests.Setup;
 
@@ -38,28 +39,28 @@ public class VoidMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
-			sut.Setup.Method0().Callback(() => { isCalled = true; });
+			sut.Setup.Method0().Callback(() => { callCount++; });
 
 			sut.Object.Method0();
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
-			sut.Setup.Method0().Callback(() => { isCalled = true; });
+			sut.Setup.Method0().Callback(() => { callCount++; });
 
 			sut.Object.Method1(1);
 			sut.Object.Method0(false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -81,6 +82,24 @@ public class VoidMethodSetupTests
 
 			await That(result1).HasMessage("foo");
 			await That(result2).HasMessage("foo");
+		}
+
+		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
+
+			sut.Setup.Method0()
+				.Callback(() => { callCount1++; })
+				.Callback(() => { callCount2++; });
+
+			sut.Object.Method0();
+			sut.Object.Method0();
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(2);
 		}
 
 		[Fact]
@@ -144,93 +163,93 @@ public class VoidMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method1(3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method0();
 			sut.Object.Method1(2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenParameterDoesNotMatch()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1(With.Matching<int>(v => v != 1))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method1(1);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
 				.Callback(v =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue = v;
 				});
 
 			sut.Object.Method1(3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue).IsEqualTo(3);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1(With.Any<int>())
-				.Callback(v => { isCalled = true; });
+				.Callback(v => { callCount++; });
 
 			sut.Object.Method0();
 			sut.Object.Method1(2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenParameterDoesNotMatch()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1(With.Matching<int>(v => v != 1))
-				.Callback(v => { isCalled = true; });
+				.Callback(v => { callCount++; });
 
 			sut.Object.Method1(1);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -255,22 +274,40 @@ public class VoidMethodSetupTests
 		}
 
 		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
+
+			sut.Setup.Method1(With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback(v => { callCount2 += v; });
+
+			sut.Object.Method1(1);
+			sut.Object.Method1(2);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(3);
+		}
+
+		[Fact]
 		public async Task OutParameter_ShouldSet()
 		{
 			int receivedValue = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1WithOutParameter(With.Out(() => 3))
 				.Callback(v =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue = v;
 				});
 
 			sut.Object.Method1WithOutParameter(out int value);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value).IsEqualTo(3);
 			await That(receivedValue).IsEqualTo(0);
 		}
@@ -279,20 +316,20 @@ public class VoidMethodSetupTests
 		public async Task RefParameter_ShouldSet()
 		{
 			int receivedValue = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method1WithRefParameter(With.Ref<int>(v => 3))
 				.Callback(v =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue = v;
 				});
 
 			int value = 2;
 			sut.Object.Method1WithRefParameter(ref value);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value).IsEqualTo(3);
 			await That(receivedValue).IsEqualTo(2);
 		}
@@ -372,15 +409,15 @@ public class VoidMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -389,36 +426,36 @@ public class VoidMethodSetupTests
 		[InlineData(false, true)]
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method2(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method1(1);
 			sut.Object.Method2(1, 2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
@@ -426,14 +463,14 @@ public class VoidMethodSetupTests
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 				});
 
 			sut.Object.Method2(2, 4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 		}
@@ -444,30 +481,30 @@ public class VoidMethodSetupTests
 		[InlineData(false, true)]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method2(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2))
-				.Callback((v1, v2) => { isCalled = true; });
+				.Callback((v1, v2) => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2) => { isCalled = true; });
+				.Callback((v1, v2) => { callCount++; });
 
 			sut.Object.Method1(1);
 			sut.Object.Method2(1, 2, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -492,24 +529,42 @@ public class VoidMethodSetupTests
 		}
 
 		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
+
+			sut.Setup.Method2(With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2) => { callCount2 += v1 * v2; });
+
+			sut.Object.Method2(1, 2);
+			sut.Object.Method2(2, 2);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(6);
+		}
+
+		[Fact]
 		public async Task OutParameter_ShouldSet()
 		{
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method2WithOutParameter(With.Out(() => 2), With.Out(() => 4))
 				.Callback((v1, v2) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 				});
 
 			sut.Object.Method2WithOutParameter(out int value1, out int value2);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -521,13 +576,13 @@ public class VoidMethodSetupTests
 		{
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method2WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10))
 				.Callback((v1, v2) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 				});
@@ -536,7 +591,7 @@ public class VoidMethodSetupTests
 			int value2 = 4;
 			sut.Object.Method2WithRefParameter(ref value1, ref value2);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);
@@ -623,15 +678,15 @@ public class VoidMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -642,37 +697,37 @@ public class VoidMethodSetupTests
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method3(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 			sut.Object.Method3(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
@@ -681,7 +736,7 @@ public class VoidMethodSetupTests
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2, v3) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -689,7 +744,7 @@ public class VoidMethodSetupTests
 
 			sut.Object.Method3(2, 4, 6);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 			await That(receivedValue3).IsEqualTo(6);
@@ -703,31 +758,31 @@ public class VoidMethodSetupTests
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method3(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3))
-				.Callback((v1, v2, v3) => { isCalled = true; });
+				.Callback((v1, v2, v3) => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2, v3) => { isCalled = true; });
+				.Callback((v1, v2, v3) => { callCount++; });
 
 			sut.Object.Method2(1, 2);
 			sut.Object.Method3(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -752,18 +807,36 @@ public class VoidMethodSetupTests
 		}
 
 		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
+
+			sut.Setup.Method3(With.Any<int>(), With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2, v3) => { callCount2 += v1 * v2 * v3; });
+
+			sut.Object.Method3(1, 2, 3);
+			sut.Object.Method3(2, 2, 3);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(18);
+		}
+
+		[Fact]
 		public async Task OutParameter_ShouldSet()
 		{
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method3WithOutParameter(With.Out(() => 2), With.Out(() => 4), With.Out(() => 6))
 				.Callback((v1, v2, v3) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -771,7 +844,7 @@ public class VoidMethodSetupTests
 
 			sut.Object.Method3WithOutParameter(out int value1, out int value2, out int value3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -786,14 +859,14 @@ public class VoidMethodSetupTests
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method3WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10),
 					With.Ref<int>(v => v * 10))
 				.Callback((v1, v2, v3) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -804,7 +877,7 @@ public class VoidMethodSetupTests
 			int value3 = 6;
 			sut.Object.Method3WithRefParameter(ref value1, ref value2, ref value3);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);
@@ -894,15 +967,15 @@ public class VoidMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -914,37 +987,37 @@ public class VoidMethodSetupTests
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method4(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 			sut.Object.Method4(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
@@ -954,7 +1027,7 @@ public class VoidMethodSetupTests
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2, v3, v4) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -963,7 +1036,7 @@ public class VoidMethodSetupTests
 
 			sut.Object.Method4(2, 4, 6, 8);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 			await That(receivedValue3).IsEqualTo(6);
@@ -979,31 +1052,31 @@ public class VoidMethodSetupTests
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method4(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4))
-				.Callback((v1, v2, v3, v4) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4) => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2, v3, v4) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4) => { callCount++; });
 
 			sut.Object.Method3(1, 2, 3);
 			sut.Object.Method4(1, 2, 3, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -1028,20 +1101,38 @@ public class VoidMethodSetupTests
 		}
 
 		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
+
+			sut.Setup.Method4(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2, v3, v4) => { callCount2 += v1 * v2 * v3 * v4; });
+
+			sut.Object.Method4(1, 2, 3, 4);
+			sut.Object.Method4(2, 2, 3, 4);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(72);
+		}
+
+		[Fact]
 		public async Task OutParameter_ShouldSet()
 		{
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method4WithOutParameter(With.Out(() => 2), With.Out(() => 4), With.Out(() => 6),
 					With.Out(() => 8))
 				.Callback((v1, v2, v3, v4) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1050,7 +1141,7 @@ public class VoidMethodSetupTests
 
 			sut.Object.Method4WithOutParameter(out int value1, out int value2, out int value3, out int value4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -1068,14 +1159,14 @@ public class VoidMethodSetupTests
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method4WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10),
 					With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10))
 				.Callback((v1, v2, v3, v4) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1088,7 +1179,7 @@ public class VoidMethodSetupTests
 			int value4 = 8;
 			sut.Object.Method4WithRefParameter(ref value1, ref value2, ref value3, ref value4);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);
@@ -1181,15 +1272,15 @@ public class VoidMethodSetupTests
 		[Fact]
 		public async Task Callback_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method5(1, 2, 3, 4, 5);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 		}
 
 		[Theory]
@@ -1202,38 +1293,38 @@ public class VoidMethodSetupTests
 		public async Task Callback_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4, bool isMatch5)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method5(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4),
 					With.Matching<int>(v => isMatch5))
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method5(1, 2, 3, 4, 5);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task Callback_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback(() => { isCalled = true; });
+				.Callback(() => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 			sut.Object.Method5(1, 2, 3, 4, 5, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldExecuteWhenInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			int receivedValue1 = 0;
 			int receivedValue2 = 0;
 			int receivedValue3 = 0;
@@ -1244,7 +1335,7 @@ public class VoidMethodSetupTests
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
 				.Callback((v1, v2, v3, v4, v5) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1254,7 +1345,7 @@ public class VoidMethodSetupTests
 
 			sut.Object.Method5(2, 4, 6, 8, 10);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(receivedValue2).IsEqualTo(4);
 			await That(receivedValue3).IsEqualTo(6);
@@ -1272,32 +1363,32 @@ public class VoidMethodSetupTests
 		public async Task CallbackWithValue_ShouldNotExecuteWhenAnyParameterDoesNotMatch(bool isMatch1, bool isMatch2,
 			bool isMatch3, bool isMatch4, bool isMatch5)
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method5(With.Matching<int>(v => isMatch1), With.Matching<int>(v => isMatch2),
 					With.Matching<int>(v => isMatch3), With.Matching<int>(v => isMatch4),
 					With.Matching<int>(v => isMatch5))
-				.Callback((v1, v2, v3, v4, v5) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4, v5) => { callCount++; });
 
 			sut.Object.Method5(1, 2, 3, 4, 5);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
 		public async Task CallbackWithValue_ShouldNotExecuteWhenOtherMethodIsInvoked()
 		{
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
-				.Callback((v1, v2, v3, v4, v5) => { isCalled = true; });
+				.Callback((v1, v2, v3, v4, v5) => { callCount++; });
 
 			sut.Object.Method4(1, 2, 3, 4);
 			sut.Object.Method5(1, 2, 3, 4, 5, false);
 
-			await That(isCalled).IsFalse();
+			await That(callCount).IsEqualTo(0);
 		}
 
 		[Fact]
@@ -1322,6 +1413,24 @@ public class VoidMethodSetupTests
 		}
 
 		[Fact]
+		public async Task MultipleCallbacks_ShouldAllGetInvoked()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
+
+			sut.Setup.Method5(With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>(), With.Any<int>())
+				.Callback(() => { callCount1++; })
+				.Callback((v1, v2, v3, v4, v5) => { callCount2 += v1 * v2 * v3 * v4 * v5; });
+
+			sut.Object.Method5(1, 2, 3, 4, 5);
+			sut.Object.Method5(2, 2, 3, 4, 5);
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(360);
+		}
+
+		[Fact]
 		public async Task OutParameter_ShouldSet()
 		{
 			int receivedValue1 = 0;
@@ -1329,14 +1438,14 @@ public class VoidMethodSetupTests
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
 			int receivedValue5 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method5WithOutParameter(With.Out(() => 2), With.Out(() => 4), With.Out(() => 6),
 					With.Out(() => 8), With.Out(() => 10))
 				.Callback((v1, v2, v3, v4, v5) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1347,7 +1456,7 @@ public class VoidMethodSetupTests
 			sut.Object.Method5WithOutParameter(out int value1, out int value2, out int value3, out int value4,
 				out int value5);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(2);
 			await That(receivedValue1).IsEqualTo(0);
 			await That(value2).IsEqualTo(4);
@@ -1368,14 +1477,14 @@ public class VoidMethodSetupTests
 			int receivedValue3 = 0;
 			int receivedValue4 = 0;
 			int receivedValue5 = 0;
-			bool isCalled = false;
+			int callCount = 0;
 			Mock<IVoidMethodSetupTest> sut = Mock.For<IVoidMethodSetupTest>();
 
 			sut.Setup.Method5WithRefParameter(With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10),
 					With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10), With.Ref<int>(v => v * 10))
 				.Callback((v1, v2, v3, v4, v5) =>
 				{
-					isCalled = true;
+					callCount++;
 					receivedValue1 = v1;
 					receivedValue2 = v2;
 					receivedValue3 = v3;
@@ -1390,7 +1499,7 @@ public class VoidMethodSetupTests
 			int value5 = 10;
 			sut.Object.Method5WithRefParameter(ref value1, ref value2, ref value3, ref value4, ref value5);
 
-			await That(isCalled).IsTrue();
+			await That(callCount).IsEqualTo(1);
 			await That(value1).IsEqualTo(20);
 			await That(receivedValue1).IsEqualTo(2);
 			await That(value2).IsEqualTo(40);


### PR DESCRIPTION
This PR implements support for multiple callbacks in the Mockolate mocking framework, enabling users to register and execute multiple callback functions for a single method setup. The implementation ensures that each callback is invoked only once per method call.

### Key changes:
- Refactored callback storage from single nullable instances to Lists for accumulating multiple callbacks
- Updated both void and return method setups to support chaining multiple callbacks
- Added comprehensive test coverage verifying that multiple callbacks are executed correctly

---

- *Fixes #8*