### PR TITLE
fix: nullability issue with events

### DIFF
--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ExtensionsClass.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ExtensionsClass.cs
@@ -11,7 +11,7 @@ internal static partial class SourceGeneration
 	public static string GetExtensionClass(string name, Class @class)
 	{
 		string[] namespaces =
-			[.. @class.GetClassNamespaces(), "Mockolate.Checks", "Mockolate.Events", "Mockolate.Setup",];
+			[.. @class.GetClassNamespaces(), "Mockolate.Checks", "Mockolate.Events", "Mockolate.Protected", "Mockolate.Setup",];
 		StringBuilder sb = new();
 		sb.AppendLine(Header);
 		foreach (string @namespace in namespaces.Distinct().OrderBy(n => n))

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MockClass.cs
@@ -247,7 +247,7 @@ internal static partial class SourceGeneration
 					sb.Append("override ");
 				}
 
-				sb.Append("event ").Append(@event.Type.GetMinimizedString(namespaces))
+				sb.Append("event ").Append(@event.Type.GetMinimizedString(namespaces).TrimEnd('?'))
 					.Append("? ").Append(@event.Name).AppendLine();
 			}
 

--- a/Source/Mockolate/Mockolate.csproj
+++ b/Source/Mockolate/Mockolate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<None Include="$(MSBuildProjectDirectory)\..\Mockolate.SourceGenerators\bin\$(Configuration)\netstandard2.0\Mockolate.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+		<None Include="$(MSBuildProjectDirectory)\..\Mockolate.SourceGenerators\bin\$(Configuration)\netstandard2.0\Mockolate.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Mockolate/Protected/ProtectedMock.cs
+++ b/Source/Mockolate/Protected/ProtectedMock.cs
@@ -2,7 +2,7 @@ using Mockolate.Checks;
 using Mockolate.Events;
 using Mockolate.Setup;
 
-namespace Mockolate;
+namespace Mockolate.Protected;
 
 /// <summary>
 ///     Provides protected access to mock setup, invocation, and event tracking features for the specified type parameter.

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -78,15 +78,6 @@ namespace Mockolate
     {
         protected Mock(Mockolate.MockBehavior behavior) { }
     }
-    public class ProtectedMock<T> : Mockolate.IMock
-    {
-        public ProtectedMock(Mockolate.Mock<T> mock) { }
-        public Mockolate.Checks.MockAccessed<T>.Protected Accessed { get; }
-        public Mockolate.Checks.MockEvent<T>.Protected Event { get; }
-        public Mockolate.Checks.MockInvoked<T>.Protected Invoked { get; }
-        public Mockolate.Events.MockRaises<T>.Protected Raise { get; }
-        public Mockolate.Setup.MockSetups<T>.Protected Setup { get; }
-    }
     public static class ReturnsAsyncExtensions
     {
         public static Mockolate.Setup.ReturnMethodSetup<System.Threading.Tasks.Task<TReturn>> ReturnsAsync<TReturn>(this Mockolate.Setup.ReturnMethodSetup<System.Threading.Tasks.Task<TReturn>> setup, System.Func<TReturn> callback) { }
@@ -336,6 +327,18 @@ namespace Mockolate.Monitor
         public Mockolate.Checks.MockAccessed<T> Accessed { get; }
         public Mockolate.Checks.MockEvent<T> Event { get; }
         public Mockolate.Checks.MockInvoked<T> Invoked { get; }
+    }
+}
+namespace Mockolate.Protected
+{
+    public class ProtectedMock<T> : Mockolate.IMock
+    {
+        public ProtectedMock(Mockolate.Mock<T> mock) { }
+        public Mockolate.Checks.MockAccessed<T>.Protected Accessed { get; }
+        public Mockolate.Checks.MockEvent<T>.Protected Event { get; }
+        public Mockolate.Checks.MockInvoked<T>.Protected Invoked { get; }
+        public Mockolate.Events.MockRaises<T>.Protected Raise { get; }
+        public Mockolate.Setup.MockSetups<T>.Protected Setup { get; }
     }
 }
 namespace Mockolate.Setup

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -78,15 +78,6 @@ namespace Mockolate
     {
         protected Mock(Mockolate.MockBehavior behavior) { }
     }
-    public class ProtectedMock<T> : Mockolate.IMock
-    {
-        public ProtectedMock(Mockolate.Mock<T> mock) { }
-        public Mockolate.Checks.MockAccessed<T>.Protected Accessed { get; }
-        public Mockolate.Checks.MockEvent<T>.Protected Event { get; }
-        public Mockolate.Checks.MockInvoked<T>.Protected Invoked { get; }
-        public Mockolate.Events.MockRaises<T>.Protected Raise { get; }
-        public Mockolate.Setup.MockSetups<T>.Protected Setup { get; }
-    }
     public static class ReturnsAsyncExtensions
     {
         public static Mockolate.Setup.ReturnMethodSetup<System.Threading.Tasks.Task<TReturn>> ReturnsAsync<TReturn>(this Mockolate.Setup.ReturnMethodSetup<System.Threading.Tasks.Task<TReturn>> setup, System.Func<TReturn> callback) { }
@@ -336,6 +327,18 @@ namespace Mockolate.Monitor
         public Mockolate.Checks.MockAccessed<T> Accessed { get; }
         public Mockolate.Checks.MockEvent<T> Event { get; }
         public Mockolate.Checks.MockInvoked<T> Invoked { get; }
+    }
+}
+namespace Mockolate.Protected
+{
+    public class ProtectedMock<T> : Mockolate.IMock
+    {
+        public ProtectedMock(Mockolate.Mock<T> mock) { }
+        public Mockolate.Checks.MockAccessed<T>.Protected Accessed { get; }
+        public Mockolate.Checks.MockEvent<T>.Protected Event { get; }
+        public Mockolate.Checks.MockInvoked<T>.Protected Invoked { get; }
+        public Mockolate.Events.MockRaises<T>.Protected Raise { get; }
+        public Mockolate.Setup.MockSetups<T>.Protected Setup { get; }
     }
 }
 namespace Mockolate.Setup

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -78,15 +78,6 @@ namespace Mockolate
     {
         protected Mock(Mockolate.MockBehavior behavior) { }
     }
-    public class ProtectedMock<T> : Mockolate.IMock
-    {
-        public ProtectedMock(Mockolate.Mock<T> mock) { }
-        public Mockolate.Checks.MockAccessed<T>.Protected Accessed { get; }
-        public Mockolate.Checks.MockEvent<T>.Protected Event { get; }
-        public Mockolate.Checks.MockInvoked<T>.Protected Invoked { get; }
-        public Mockolate.Events.MockRaises<T>.Protected Raise { get; }
-        public Mockolate.Setup.MockSetups<T>.Protected Setup { get; }
-    }
     public static class ReturnsAsyncExtensions
     {
         public static Mockolate.Setup.ReturnMethodSetup<System.Threading.Tasks.Task<TReturn>> ReturnsAsync<TReturn>(this Mockolate.Setup.ReturnMethodSetup<System.Threading.Tasks.Task<TReturn>> setup, System.Func<TReturn> callback) { }
@@ -322,6 +313,18 @@ namespace Mockolate.Monitor
         public Mockolate.Checks.MockAccessed<T> Accessed { get; }
         public Mockolate.Checks.MockEvent<T> Event { get; }
         public Mockolate.Checks.MockInvoked<T> Invoked { get; }
+    }
+}
+namespace Mockolate.Protected
+{
+    public class ProtectedMock<T> : Mockolate.IMock
+    {
+        public ProtectedMock(Mockolate.Mock<T> mock) { }
+        public Mockolate.Checks.MockAccessed<T>.Protected Accessed { get; }
+        public Mockolate.Checks.MockEvent<T>.Protected Event { get; }
+        public Mockolate.Checks.MockInvoked<T>.Protected Invoked { get; }
+        public Mockolate.Events.MockRaises<T>.Protected Raise { get; }
+        public Mockolate.Setup.MockSetups<T>.Protected Setup { get; }
     }
 }
 namespace Mockolate.Setup

--- a/Tests/Mockolate.Tests/Mockolate.Tests.csproj
+++ b/Tests/Mockolate.Tests/Mockolate.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\Source\Mockolate.SourceGenerators\Mockolate.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
-		<ProjectReference Include="..\..\Source\Mockolate\Mockolate.csproj"/>
+		<ProjectReference Include="..\..\Source\Mockolate.SourceGenerators\Mockolate.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\..\Source\Mockolate\Mockolate.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
+++ b/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
@@ -49,6 +49,8 @@ public sealed class ProtectedMockTests
 		await That(mock.Protected.Event.MyEvent.Unsubscribed().Once());
 	}
 
+#pragma warning disable CS0067 // Event is never used
+#pragma warning disable CA1070 // Do not declare event fields as virtual
 	public abstract class MyProtectedClass
 	{
 		public delegate void MyEventHandler(object? sender, EventArgs e);
@@ -69,4 +71,6 @@ public sealed class ProtectedMockTests
 		public void UnregisterEvent(MyEventHandler callback)
 			=> MyEvent -= callback;
 	}
+#pragma warning restore CA1070 // Do not declare event fields as virtual
+#pragma warning restore CS0067 // Event is never used
 }

--- a/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
+++ b/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mockolate.Tests.Protected;
+
+public sealed class ProtectedMockTests
+{
+	[Fact]
+	public async Task CanAccessProtectedProperties()
+	{
+		var mock = Mock.For<MyProtectedClass>();
+
+		mock.Protected.Setup.MyProtectedProperty.InitializeWith(42);
+
+		var result = mock.Object.GetMyProtectedProperty();
+
+		await That(mock.Protected.Accessed.MyProtectedProperty.Getter().Once());
+		await That(result).IsEqualTo(42);
+	}
+
+	[Fact]
+	public async Task CanAccessProtectedMethods()
+	{
+		var mock = Mock.For<MyProtectedClass>();
+
+		mock.Protected.Setup.MyProtectedMethod(With.Any<string>())
+			.Returns(v => $"Hello, {v}!");
+
+		var result = mock.Object.InvokeMyProtectedMethod("foo");
+
+		await That(mock.Protected.Invoked.MyProtectedMethod("foo").Once());
+		await That(result).IsEqualTo("Hello, foo!");
+	}
+
+	[Fact]
+	public async Task CanAccessProtectedEvents()
+	{
+		int callCount = 0;
+		var mock = Mock.For<MyProtectedClass>();
+		MyProtectedClass.MyEventHandler handler = (s, e) => callCount++;
+
+		mock.Object.RegisterEvent(handler);
+		mock.Protected.Raise.MyEvent(this, EventArgs.Empty);
+
+		await That(mock.Protected.Event.MyEvent.Subscribed().Once());
+		await That(mock.Protected.Event.MyEvent.Unsubscribed().Never());
+		mock.Object.UnregisterEvent(handler);
+		await That(mock.Protected.Event.MyEvent.Unsubscribed().Once());
+	}
+
+	public abstract class MyProtectedClass
+	{
+		public delegate void MyEventHandler(object? sender, EventArgs e);
+
+		protected virtual event MyEventHandler? MyEvent;
+		protected virtual int MyProtectedProperty { get; set; }
+		protected abstract string MyProtectedMethod(string input);
+
+		public int GetMyProtectedProperty()
+			=> MyProtectedProperty;
+
+		public string InvokeMyProtectedMethod(string input)
+			=> MyProtectedMethod(input);
+
+		public void RegisterEvent(MyEventHandler callback)
+			=> MyEvent += callback;
+
+		public void UnregisterEvent(MyEventHandler callback)
+			=> MyEvent -= callback;
+	}
+}


### PR DESCRIPTION
This pull request fixes a nullability issue with events in the Mockolate framework. The changes address a problem where nullable event types were being double-marked with the `?` operator in generated code.

### Key changes:
- Fixed event type generation to avoid double nullable markers
- Moved the `ProtectedMock` class to its own namespace (`Mockolate.Protected`)
- Updated namespace imports to include the new protected namespace