### PR TITLE
coverage: add missing tests for `Mock<T>`

### DIFF
--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MockClass.cs
@@ -69,7 +69,7 @@ internal static partial class SourceGeneration
 				"\t\tpublic Mock(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior) : base(mockBehavior)")
 			.AppendLine();
 		sb.AppendLine("\t\t{");
-		sb.Append("\t\t\tObject = TryCreate<MockObject>(constructorParameters);").AppendLine();
+		sb.Append("\t\t\tObject = Create<MockObject>(constructorParameters);").AppendLine();
 		sb.AppendLine("\t\t}");
 		sb.AppendLine();
 		sb.Append("\t\t/// <inheritdoc cref=\"Mock{").Append(mockClass.ClassName)

--- a/Source/Mockolate/Mock.cs
+++ b/Source/Mockolate/Mock.cs
@@ -71,29 +71,29 @@ public abstract class Mock<T> : IMock
 	/// <summary>
 	///     Attempts to create an instance of the specified type using the provided constructor parameters.
 	/// </summary>
-	protected TObject TryCreate<TObject>(ConstructorParameters? constructorParameters)
+	protected TObject Create<TObject>(ConstructorParameters? constructorParameters)
 	{
-		if (constructorParameters is null)
+		if (constructorParameters?.Parameters.Length > 0)
 		{
 			try
 			{
-				return (TObject)Activator.CreateInstance(typeof(TObject), this)!;
+				return (TObject)Activator.CreateInstance(typeof(TObject), [this, .. constructorParameters.Parameters,])!;
 			}
 			catch
 			{
 				throw new MockException(
-					$"Could not create an instance of '{typeof(TObject)}' without constructor parameters.");
+					$"Could not create an instance of '{typeof(TObject)}' with {constructorParameters.Parameters.Length} parameters ({string.Join(", ", constructorParameters.Parameters)}).");
 			}
 		}
 
 		try
 		{
-			return (TObject)Activator.CreateInstance(typeof(TObject), [this, .. constructorParameters.Parameters,])!;
+			return (TObject)Activator.CreateInstance(typeof(TObject), this)!;
 		}
 		catch
 		{
 			throw new MockException(
-				$"Could not create an instance of '{typeof(TObject)}' with {constructorParameters.Parameters.Length} parameters ({string.Join(", ", constructorParameters.Parameters)}).");
+				$"Could not create an instance of '{typeof(TObject)}' without constructor parameters.");
 		}
 	}
 
@@ -132,7 +132,7 @@ public abstract class Mock<T> : IMock
 			if (_behavior.ThrowWhenNotSetup)
 			{
 				throw new MockNotSetupException(
-					$"The method '{methodName}({string.Join(",", parameters.Select(x => x?.GetType()))})' was invoked without prior setup.");
+					$"The method '{methodName}({string.Join(", ", parameters.Select(x => x?.GetType()))})' was invoked without prior setup.");
 			}
 
 			return new MethodSetupResult<TResult>(matchingSetup, _behavior,
@@ -154,7 +154,7 @@ public abstract class Mock<T> : IMock
 		if (matchingSetup is null && _behavior.ThrowWhenNotSetup)
 		{
 			throw new MockNotSetupException(
-				$"The method '{methodName}({string.Join(",", parameters.Select(x => x?.GetType()))})' was invoked without prior setup.");
+				$"The method '{methodName}({string.Join(", ", parameters.Select(x => x?.GetType()))})' was invoked without prior setup.");
 		}
 
 		matchingSetup?.Invoke(invocation, _behavior);

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -43,7 +43,7 @@ namespace Mockolate
         public abstract T Object { get; }
         public Mockolate.Events.MockRaises<T> Raise { get; }
         public Mockolate.Setup.MockSetups<T> Setup { get; }
-        protected TObject TryCreate<TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
+        protected TObject Create<TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
         public static T op_Implicit(Mockolate.Mock<T> mock) { }
     }
     public abstract class Mock<T1, T2> : Mockolate.Mock<T1>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -43,7 +43,7 @@ namespace Mockolate
         public abstract T Object { get; }
         public Mockolate.Events.MockRaises<T> Raise { get; }
         public Mockolate.Setup.MockSetups<T> Setup { get; }
-        protected TObject TryCreate<TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
+        protected TObject Create<TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
         public static T op_Implicit(Mockolate.Mock<T> mock) { }
     }
     public abstract class Mock<T1, T2> : Mockolate.Mock<T1>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -43,7 +43,7 @@ namespace Mockolate
         public abstract T Object { get; }
         public Mockolate.Events.MockRaises<T> Raise { get; }
         public Mockolate.Setup.MockSetups<T> Setup { get; }
-        protected TObject TryCreate<TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
+        protected TObject Create<TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
         public static T op_Implicit(Mockolate.Mock<T> mock) { }
     }
     public abstract class Mock<T1, T2> : Mockolate.Mock<T1>

--- a/Tests/Mockolate.Tests/MockTests.Methods.cs
+++ b/Tests/Mockolate.Tests/MockTests.Methods.cs
@@ -10,14 +10,14 @@ public sealed partial class MockTests
 	public async Task Execute_MethodWithReturnValue_ShouldBeRegistered(int numberOfInvocations)
 	{
 		Mock<IMyService> sut = Mock.For<IMyService>();
-		sut.Setup.Double(With.Any<int>()).Returns(1);
+		sut.Setup.Multiply(With.Any<int>(), With.Any<int>()).Returns(1);
 
 		for (int i = 0; i < numberOfInvocations; i++)
 		{
-			sut.Object.Double(i);
+			sut.Object.Multiply(i, 4);
 		}
 
-		await That(sut.Invoked.Double(With.Any<int>()).Exactly(numberOfInvocations));
+		await That(sut.Invoked.Multiply(With.Any<int>(), With.Any<int>()).Exactly(numberOfInvocations));
 	}
 
 	[Theory]
@@ -26,14 +26,14 @@ public sealed partial class MockTests
 	public async Task Execute_VoidMethod_ShouldBeRegistered(int numberOfInvocations)
 	{
 		Mock<IMyService> sut = Mock.For<IMyService>();
-		sut.Setup.SetIsValid(With.Any<bool>());
+		sut.Setup.SetIsValid(With.Any<bool>(), With.Any<Func<bool>>());
 
 		for (int i = 0; i < numberOfInvocations; i++)
 		{
-			sut.Object.SetIsValid(i % 2 == 0);
+			sut.Object.SetIsValid(i % 2 == 0, () => true);
 		}
 
-		await That(sut.Invoked.SetIsValid(With.Any<bool>()).Exactly(numberOfInvocations));
+		await That(sut.Invoked.SetIsValid(With.Any<bool>(), With.Any<Func<bool>>()).Exactly(numberOfInvocations));
 	}
 
 	[Theory]
@@ -48,11 +48,11 @@ public sealed partial class MockTests
 		});
 
 		void Act()
-			=> sut.Object.SetIsValid(true);
+			=> sut.Object.SetIsValid(true, () => true);
 
 		await That(Act).Throws<MockNotSetupException>().OnlyIf(throwWhenNotSetup)
 			.WithMessage("""
-			             The method 'Mockolate.Tests.MockTests.IMyService.SetIsValid(System.Boolean)' was invoked without prior setup.
+			             The method 'Mockolate.Tests.MockTests.IMyService.SetIsValid(System.Boolean, System.Func`1[System.Boolean])' was invoked without prior setup.
 			             """);
 	}
 
@@ -65,11 +65,11 @@ public sealed partial class MockTests
 		});
 
 		void Act()
-			=> sut.Object.Double(3);
+			=> sut.Object.Multiply(3, 4);
 
 		await That(Act).Throws<MockNotSetupException>()
 			.WithMessage("""
-			             The method 'Mockolate.Tests.MockTests.IMyService.Double(System.Int32)' was invoked without prior setup.
+			             The method 'Mockolate.Tests.MockTests.IMyService.Multiply(System.Int32, System.Int32)' was invoked without prior setup.
 			             """);
 	}
 
@@ -78,7 +78,7 @@ public sealed partial class MockTests
 	{
 		Mock<IMyService> sut = Mock.For<IMyService>();
 
-		int result = sut.Object.Double(3);
+		int result = sut.Object.Multiply(3, 4);
 
 		await That(result).IsEqualTo(default(int));
 	}

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -1,5 +1,6 @@
 using Mockolate.Exceptions;
 using Mockolate.Tests.TestHelpers;
+using static Mockolate.BaseClass;
 
 namespace Mockolate.Tests;
 
@@ -14,6 +15,42 @@ public sealed partial class MockTests
 		});
 
 		await That(sut.Hidden.Behavior.ThrowWhenNotSetup).IsTrue();
+	}
+
+	[Fact]
+	public async Task Create_WithRequiredParameters_WithEmptyParameters_ShouldThrowMockException()
+	{
+		var mock = new MyMock<MyBaseClass>(new MyBaseClass());
+
+		void Act()
+			=> _ = mock.HiddenCreate<MyBaseClass>(BaseClass.WithConstructorParameters());
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("Could not create an instance of 'Mockolate.Tests.MockTests+MyBaseClass' without constructor parameters.");
+	}
+
+	[Fact]
+	public async Task Create_WithRequiredParameters_WithoutParameters_ShouldThrowMockException()
+	{
+		var mock = new MyMock<MyBaseClass>(new MyBaseClass());
+
+		void Act()
+			=> _ = mock.HiddenCreate<MyBaseClass>();
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("Could not create an instance of 'Mockolate.Tests.MockTests+MyBaseClass' without constructor parameters.");
+	}
+
+	[Fact]
+	public async Task Create_WithTooManyParameters_ShouldThrowMockException()
+	{
+		var mock = new MyMock<MyBaseClass>(new MyBaseClass());
+
+		void Act()
+			=> _ = mock.HiddenCreate<MyBaseClass>(BaseClass.WithConstructorParameters(1, 2, "foo"));
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("Could not create an instance of 'Mockolate.Tests.MockTests+MyBaseClass' with 3 parameters (1, 2, foo).");
 	}
 
 	[Fact]
@@ -43,13 +80,24 @@ public sealed partial class MockTests
 		public bool? IsValid { get; set; }
 		public int Counter { get; set; }
 
-		public int Double(int value);
+		public int Multiply(int value, int multiplier);
 
-		public void SetIsValid(bool isValid);
+		public void SetIsValid(bool isValid, Func<bool> predicate);
 	}
 
 	public class MyBaseClass
 	{
 		public virtual string VirtualMethod() => "Base";
+	}
+
+	public class MyBaseClassWithConstructor
+	{
+		public MyBaseClassWithConstructor(string text)
+		{
+			Text = text;
+		}
+		public int Number { get; }
+		public string Text { get; }
+		public virtual string VirtualMethod() => Text;
 	}
 }

--- a/Tests/Mockolate.Tests/TestHelpers/MyMock.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/MyMock.cs
@@ -1,6 +1,7 @@
 using Mockolate.Checks;
 using Mockolate.Events;
 using Mockolate.Setup;
+using static Mockolate.BaseClass;
 
 namespace Mockolate.Tests.TestHelpers;
 
@@ -22,6 +23,9 @@ public class MyMock<T>(T @object, MockBehavior? behavior = null) : Mock<T>(behav
 		=> this;
 
 	public override T Object => @object;
+
+	public TObject HiddenCreate<TObject>(ConstructorParameters? constructorParameters = null)
+		=> Create<TObject>(constructorParameters);
 }
 
 public class MyMock<T, T2>(T @object = default!, MockBehavior? behavior = null)


### PR DESCRIPTION
This PR adds missing test coverage for the `Mock<T>` class by adding tests that verify error handling when creating mock instances with invalid constructor parameters. The changes include renaming a protected method and updating corresponding test methods.