### PR TITLE
feat: add Expectation to `CheckResult`

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/HappyCaseBenchmarks.Simple.cs
+++ b/Benchmarks/Mockolate.Benchmarks/HappyCaseBenchmarks.Simple.cs
@@ -2,6 +2,7 @@ using aweXpect;
 using BenchmarkDotNet.Attributes;
 using FakeItEasy;
 using NSubstitute;
+using Mockolate.Checks;
 
 namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static

--- a/Source/Mockolate/Checks/CheckResult.cs
+++ b/Source/Mockolate/Checks/CheckResult.cs
@@ -14,12 +14,18 @@ public class CheckResult<TMock>
 	private readonly IInteraction[] _interactions;
 	private readonly TMock _mock;
 
+	/// <summary>
+	///     The expectation of this check result.
+	/// </summary>
+	public string Expectation { get; }
+
 	/// <inheritdoc cref="CheckResult{TMock}" />
-	public CheckResult(TMock mock, Checks checks, IInteraction[] interactions)
+	public CheckResult(TMock mock, Checks checks, IInteraction[] interactions, string expectation)
 	{
 		_mock = mock;
 		_checks = checks;
 		_interactions = interactions;
+		Expectation = expectation;
 	}
 
 	/// <summary>
@@ -43,70 +49,16 @@ public class CheckResult<TMock>
 		}
 
 		_checks.Verified(verified);
-		return result.AtLeastOnce();
+		return result._interactions.Length >= 1;
 	}
 
 	/// <summary>
-	///     …at least the expected number of <paramref name="times" />.
+	/// Verifies that the specified <paramref name="predicate"/> holds true for the current set of interactions.
 	/// </summary>
-	public bool AtLeast(int times)
+	public bool Verify(Func<IInteraction[], bool> predicate)
 	{
 		_checks.Verified(_interactions);
-		return _interactions.Length >= times;
-	}
-
-	/// <summary>
-	///     …at least once.
-	/// </summary>
-	public bool AtLeastOnce()
-	{
-		_checks.Verified(_interactions);
-		return _interactions.Length >= 1;
-	}
-
-	/// <summary>
-	///     …at most the expected number of <paramref name="times" />.
-	/// </summary>
-	public bool AtMost(int times)
-	{
-		_checks.Verified(_interactions);
-		return _interactions.Length <= times;
-	}
-
-	/// <summary>
-	///     …at most once.
-	/// </summary>
-	public bool AtMostOnce()
-	{
-		_checks.Verified(_interactions);
-		return _interactions.Length <= 1;
-	}
-
-	/// <summary>
-	///     …exactly the expected number of <paramref name="times" />.
-	/// </summary>
-	public bool Exactly(int times)
-	{
-		_checks.Verified(_interactions);
-		return _interactions.Length == times;
-	}
-
-	/// <summary>
-	///     …never.
-	/// </summary>
-	public bool Never()
-	{
-		_checks.Verified(_interactions);
-		return _interactions.Length == 0;
-	}
-
-	/// <summary>
-	///     …exactly once.
-	/// </summary>
-	public bool Once()
-	{
-		_checks.Verified(_interactions);
-		return _interactions.Length == 1;
+		return predicate(_interactions);
 	}
 }
 

--- a/Source/Mockolate/Checks/CheckResultExtensions.cs
+++ b/Source/Mockolate/Checks/CheckResultExtensions.cs
@@ -1,0 +1,49 @@
+namespace Mockolate.Checks;
+
+/// <summary>
+///     The expectation contains the matching interactions for verification.
+/// </summary>
+public static class CheckResultExtensions
+{
+	/// <summary>
+	///     …at least the expected number of <paramref name="times" />.
+	/// </summary>
+	public static bool AtLeast<TMock>(this CheckResult<TMock> checkResult, int times)
+		=> checkResult.Verify(interactions => interactions.Length >= times);
+
+	/// <summary>
+	///     …at least once.
+	/// </summary>
+	public static bool AtLeastOnce<TMock>(this CheckResult<TMock> checkResult)
+		=> checkResult.Verify(interactions => interactions.Length >= 1);
+
+	/// <summary>
+	///     …at most the expected number of <paramref name="times" />.
+	/// </summary>
+	public static bool AtMost<TMock>(this CheckResult<TMock> checkResult, int times)
+		=> checkResult.Verify(interactions => interactions.Length <= times);
+
+	/// <summary>
+	///     …at most once.
+	/// </summary>
+	public static bool AtMostOnce<TMock>(this CheckResult<TMock> checkResult)
+		=> checkResult.Verify(interactions => interactions.Length <= 1);
+
+	/// <summary>
+	///     …exactly the expected number of <paramref name="times" />.
+	/// </summary>
+	public static bool Exactly<TMock>(this CheckResult<TMock> checkResult, int times)
+		=> checkResult.Verify(interactions => interactions.Length == times);
+
+	/// <summary>
+	///     …never.
+	/// </summary>
+	public static bool Never<TMock>(this CheckResult<TMock> checkResult)
+		=> checkResult.Verify(interactions => interactions.Length == 0);
+
+	/// <summary>
+	///     …exactly once.
+	/// </summary>
+	public static bool Once<TMock>(this CheckResult<TMock> checkResult)
+		=> checkResult.Verify(interactions => interactions.Length == 1);
+}

--- a/Source/Mockolate/Checks/MockAccessed.cs
+++ b/Source/Mockolate/Checks/MockAccessed.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Mockolate.Checks.Interactions;
+using Mockolate.Internals;
 
 namespace Mockolate.Checks;
 
@@ -15,7 +16,8 @@ public class MockAccessed<T, TMock>(Checks checks, TMock mock) : IMockAccessed<T
 				.OfType<PropertyGetterAccess>()
 				.Where(property => property.Name.Equals(propertyName))
 				.Cast<IInteraction>()
-				.ToArray());
+				.ToArray(),
+        $"accessed getter of property {propertyName.SubstringAfterLast('.')}");
 
 	/// <inheritdoc cref="IMockAccessed{TMock}.PropertySetter(string, With.Parameter)" />
 	CheckResult<TMock> IMockAccessed<TMock>.PropertySetter(string propertyName, With.Parameter value)
@@ -24,7 +26,8 @@ public class MockAccessed<T, TMock>(Checks checks, TMock mock) : IMockAccessed<T
 				.OfType<PropertySetterAccess>()
 				.Where(property => property.Name.Equals(propertyName) && value.Matches(property.Value))
 				.Cast<IInteraction>()
-				.ToArray());
+				.ToArray(),
+        $"accessed setter of property {propertyName.SubstringAfterLast('.')} with value {value}");
 
 	/// <summary>
 	///     A proxy implementation of <see cref="IMockAccessed{TMock}" /> that forwards all calls to the provided

--- a/Source/Mockolate/Checks/MockEvent.cs
+++ b/Source/Mockolate/Checks/MockEvent.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Mockolate.Checks.Interactions;
+using Mockolate.Internals;
 
 namespace Mockolate.Checks;
 
@@ -15,7 +16,8 @@ public class MockEvent<T, TMock>(Checks checks, TMock mock) : IMockEvent<TMock>
 				.OfType<EventSubscription>()
 				.Where(@event => @event.Name.Equals(eventName))
 				.Cast<IInteraction>()
-				.ToArray());
+				.ToArray(),
+        $"subscribed to event {eventName.SubstringAfterLast('.')}");
 
 	/// <inheritdoc cref="IMockEvent{TMock}.Unsubscribed(string)" />
 	CheckResult<TMock> IMockEvent<TMock>.Unsubscribed(string eventName)
@@ -24,7 +26,8 @@ public class MockEvent<T, TMock>(Checks checks, TMock mock) : IMockEvent<TMock>
 				.OfType<EventUnsubscription>()
 				.Where(@event => @event.Name.Equals(eventName))
 				.Cast<IInteraction>()
-				.ToArray());
+				.ToArray(),
+        $"unsubscribed from event {eventName.SubstringAfterLast('.')}");
 
 	/// <summary>
 	///     A proxy implementation of <see cref="IMockEvent{TMock}" /> that forwards all calls to the provided

--- a/Source/Mockolate/Checks/MockInvoked.cs
+++ b/Source/Mockolate/Checks/MockInvoked.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Mockolate.Checks.Interactions;
+using Mockolate.Internals;
 
 namespace Mockolate.Checks;
 
@@ -18,7 +19,8 @@ public class MockInvoked<T, TMock>(Checks checks, TMock mock) : IMockInvoked<TMo
 					method.Parameters.Length == parameters.Length &&
 					!parameters.Where((parameter, i) => !parameter.Matches(method.Parameters[i])).Any())
 				.Cast<IInteraction>()
-				.ToArray());
+				.ToArray(),
+        $"invoked method {methodName.SubstringAfterLast('.')}({string.Join(", ", parameters.Select(x => x.ToString()))})");
 
 	/// <summary>
 	///     A proxy implementation of <see cref="IMockInvoked{TMock}" /> that forwards all calls to the provided

--- a/Source/Mockolate/Internals/StringExtensions.cs
+++ b/Source/Mockolate/Internals/StringExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Mockolate.Internals;
+
+internal static class StringExtensions
+{
+	internal static string SubstringUntilFirst(this string name, char c)
+	{
+		int index = name.IndexOf(c);
+		if (index >= 0)
+		{
+			return name.Substring(0, index);
+		}
+
+		return name;
+	}
+
+	internal static string SubstringAfterLast(this string name, char c)
+	{
+		int index = name.LastIndexOf(c);
+		if (index >= 0)
+		{
+			return name.Substring(index + 1);
+		}
+
+		return name;
+	}
+}

--- a/Source/Mockolate/Internals/TypeFormatter.cs
+++ b/Source/Mockolate/Internals/TypeFormatter.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Mockolate.Internals;
+
+internal static class TypeFormatter
+{
+	private static readonly Dictionary<Type, string> Aliases = new()
+	{
+		{
+			typeof(byte), "byte"
+		},
+		{
+			typeof(sbyte), "sbyte"
+		},
+		{
+			typeof(short), "short"
+		},
+		{
+			typeof(ushort), "ushort"
+		},
+		{
+			typeof(int), "int"
+		},
+		{
+			typeof(uint), "uint"
+		},
+		{
+			typeof(long), "long"
+		},
+		{
+			typeof(ulong), "ulong"
+		},
+		{
+			typeof(float), "float"
+		},
+		{
+			typeof(double), "double"
+		},
+		{
+			typeof(decimal), "decimal"
+		},
+		{
+			typeof(object), "object"
+		},
+		{
+			typeof(bool), "bool"
+		},
+		{
+			typeof(char), "char"
+		},
+		{
+			typeof(string), "string"
+		},
+		{
+			typeof(void), "void"
+		},
+		{
+			typeof(nint), "nint"
+		},
+		{
+			typeof(nuint), "nuint"
+		},
+	};
+
+	internal static string FormatType(this Type value)
+	{
+		var stringBuilder = new StringBuilder();
+		FormatType(value, stringBuilder);
+		return stringBuilder.ToString();
+	}
+
+	private static void FormatType(
+		Type value,
+		StringBuilder stringBuilder)
+	{
+		if (value.IsArray)
+		{
+			FormatType(value.GetElementType()!, stringBuilder);
+			stringBuilder.Append("[]");
+		}
+		else if (TryFindPrimitiveAlias(value, out string? alias))
+		{
+			stringBuilder.Append(alias);
+		}
+		else if (value.IsGenericType)
+		{
+			Type genericTypeDefinition = value.GetGenericTypeDefinition();
+			stringBuilder.Append(genericTypeDefinition.Name.SubstringUntilFirst('`'));
+			stringBuilder.Append('<');
+			bool isFirstArgument = true;
+			foreach (Type argument in value.GetGenericArguments())
+			{
+				if (!isFirstArgument)
+				{
+					stringBuilder.Append(", ");
+				}
+
+				isFirstArgument = false;
+				FormatType(argument, stringBuilder);
+			}
+
+			stringBuilder.Append('>');
+		}
+		else
+		{
+			stringBuilder.Append(value.Name);
+		}
+	}
+
+	private static bool TryFindPrimitiveAlias(Type value, [NotNullWhen(true)] out string? alias)
+	{
+		if (Aliases.TryGetValue(value, out string? typeAlias))
+		{
+			alias = typeAlias;
+			return true;
+		}
+
+		Type? underlyingType = Nullable.GetUnderlyingType(value);
+
+		if (underlyingType != null &&
+			Aliases.TryGetValue(underlyingType, out string? underlyingAlias))
+		{
+			alias = $"{underlyingAlias}?";
+			return true;
+		}
+
+		alias = null;
+		return false;
+	}
+}

--- a/Source/Mockolate/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/Mockolate/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,33 @@
+﻿#if !NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+	/// <summary>
+	///     Indicates that a parameter captures the expression passed for another parameter as a string.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	[ExcludeFromCodeCoverage]
+	internal sealed class CallerArgumentExpressionAttribute : Attribute
+	{
+		/// <summary>
+		///     Initializes a new instance of the <see cref="CallerArgumentExpressionAttribute" /> class.
+		/// </summary>
+		/// <param name="parameterName">The name of the parameter whose expression should be captured as a string.</param>
+		public CallerArgumentExpressionAttribute(string parameterName)
+		{
+			ParameterName = parameterName;
+		}
+
+		/// <summary>
+		///     Gets the name of the parameter whose expression should be captured as a string.
+		/// </summary>
+		public string ParameterName { get; }
+	}
+}
+
+#endif

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -148,21 +148,23 @@ namespace Mockolate
     public static class With
     {
         public static Mockolate.With.Parameter<T> Any<T>() { }
-        public static Mockolate.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
+        public static Mockolate.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.With.InvokedOutParameter<T> Out<T>() { }
-        public static Mockolate.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
+        public static Mockolate.With.OutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
         public static Mockolate.With.InvokedRefParameter<T> Ref<T>() { }
-        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, T> setter) { }
-        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
+        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue2 = "") { }
         public class InvokedOutParameter<T> : Mockolate.With.Parameter
         {
             public InvokedOutParameter() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public class InvokedRefParameter<T> : Mockolate.With.Parameter
         {
             public InvokedRefParameter() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public class NamedParameter : System.IEquatable<Mockolate.With.NamedParameter>
         {
@@ -172,9 +174,10 @@ namespace Mockolate
         }
         public class OutParameter<T> : Mockolate.With.Parameter
         {
-            public OutParameter(System.Func<T> setter) { }
+            public OutParameter(System.Func<T> setter, string setterExpression) { }
             public T GetValue() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public abstract class Parameter
         {
@@ -190,9 +193,10 @@ namespace Mockolate
         }
         public class RefParameter<T> : Mockolate.With.Parameter
         {
-            public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+            public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter, string? predicateExpression, string setterExpression) { }
             public T GetValue(T value) { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
     }
 }
@@ -215,7 +219,8 @@ namespace Mockolate.Checks
     }
     public class CheckResult<TMock>
     {
-        public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions) { }
+        public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions, string expectation) { }
+        public string Expectation { get; }
         public bool AtLeast(int times) { }
         public bool AtLeastOnce() { }
         public bool AtMost(int times) { }
@@ -224,6 +229,7 @@ namespace Mockolate.Checks
         public bool Never() { }
         public bool Once() { }
         public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
+        public bool Verify(System.Func<Mockolate.Checks.Interactions.IInteraction[], bool> predicate) { }
     }
     public class Checks
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -217,17 +217,20 @@ namespace Mockolate.Checks
             public Mockolate.Checks.CheckResult<TMock> Setter(Mockolate.With.Parameter<TProperty> value) { }
         }
     }
+    public static class CheckResultExtensions
+    {
+        public static bool AtLeast<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool AtLeastOnce<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool AtMost<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool AtMostOnce<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Exactly<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool Never<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Once<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+    }
     public class CheckResult<TMock>
     {
         public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions, string expectation) { }
         public string Expectation { get; }
-        public bool AtLeast(int times) { }
-        public bool AtLeastOnce() { }
-        public bool AtMost(int times) { }
-        public bool AtMostOnce() { }
-        public bool Exactly(int times) { }
-        public bool Never() { }
-        public bool Once() { }
         public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
         public bool Verify(System.Func<Mockolate.Checks.Interactions.IInteraction[], bool> predicate) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -148,21 +148,23 @@ namespace Mockolate
     public static class With
     {
         public static Mockolate.With.Parameter<T> Any<T>() { }
-        public static Mockolate.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
+        public static Mockolate.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.With.InvokedOutParameter<T> Out<T>() { }
-        public static Mockolate.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
+        public static Mockolate.With.OutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
         public static Mockolate.With.InvokedRefParameter<T> Ref<T>() { }
-        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, T> setter) { }
-        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
+        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue2 = "") { }
         public class InvokedOutParameter<T> : Mockolate.With.Parameter
         {
             public InvokedOutParameter() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public class InvokedRefParameter<T> : Mockolate.With.Parameter
         {
             public InvokedRefParameter() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public class NamedParameter : System.IEquatable<Mockolate.With.NamedParameter>
         {
@@ -172,9 +174,10 @@ namespace Mockolate
         }
         public class OutParameter<T> : Mockolate.With.Parameter
         {
-            public OutParameter(System.Func<T> setter) { }
+            public OutParameter(System.Func<T> setter, string setterExpression) { }
             public T GetValue() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public abstract class Parameter
         {
@@ -190,9 +193,10 @@ namespace Mockolate
         }
         public class RefParameter<T> : Mockolate.With.Parameter
         {
-            public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+            public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter, string? predicateExpression, string setterExpression) { }
             public T GetValue(T value) { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
     }
 }
@@ -215,7 +219,8 @@ namespace Mockolate.Checks
     }
     public class CheckResult<TMock>
     {
-        public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions) { }
+        public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions, string expectation) { }
+        public string Expectation { get; }
         public bool AtLeast(int times) { }
         public bool AtLeastOnce() { }
         public bool AtMost(int times) { }
@@ -224,6 +229,7 @@ namespace Mockolate.Checks
         public bool Never() { }
         public bool Once() { }
         public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
+        public bool Verify(System.Func<Mockolate.Checks.Interactions.IInteraction[], bool> predicate) { }
     }
     public class Checks
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -217,17 +217,20 @@ namespace Mockolate.Checks
             public Mockolate.Checks.CheckResult<TMock> Setter(Mockolate.With.Parameter<TProperty> value) { }
         }
     }
+    public static class CheckResultExtensions
+    {
+        public static bool AtLeast<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool AtLeastOnce<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool AtMost<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool AtMostOnce<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Exactly<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool Never<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Once<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+    }
     public class CheckResult<TMock>
     {
         public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions, string expectation) { }
         public string Expectation { get; }
-        public bool AtLeast(int times) { }
-        public bool AtLeastOnce() { }
-        public bool AtMost(int times) { }
-        public bool AtMostOnce() { }
-        public bool Exactly(int times) { }
-        public bool Never() { }
-        public bool Once() { }
         public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
         public bool Verify(System.Func<Mockolate.Checks.Interactions.IInteraction[], bool> predicate) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -134,21 +134,23 @@ namespace Mockolate
     public static class With
     {
         public static Mockolate.With.Parameter<T> Any<T>() { }
-        public static Mockolate.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
+        public static Mockolate.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.With.InvokedOutParameter<T> Out<T>() { }
-        public static Mockolate.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
+        public static Mockolate.With.OutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
         public static Mockolate.With.InvokedRefParameter<T> Ref<T>() { }
-        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, T> setter) { }
-        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
+        public static Mockolate.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue2 = "") { }
         public class InvokedOutParameter<T> : Mockolate.With.Parameter
         {
             public InvokedOutParameter() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public class InvokedRefParameter<T> : Mockolate.With.Parameter
         {
             public InvokedRefParameter() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public class NamedParameter : System.IEquatable<Mockolate.With.NamedParameter>
         {
@@ -158,9 +160,10 @@ namespace Mockolate
         }
         public class OutParameter<T> : Mockolate.With.Parameter
         {
-            public OutParameter(System.Func<T> setter) { }
+            public OutParameter(System.Func<T> setter, string setterExpression) { }
             public T GetValue() { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
         public abstract class Parameter
         {
@@ -176,9 +179,10 @@ namespace Mockolate
         }
         public class RefParameter<T> : Mockolate.With.Parameter
         {
-            public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+            public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter, string? predicateExpression, string setterExpression) { }
             public T GetValue(T value) { }
             public override bool Matches(object? value) { }
+            public override string ToString() { }
         }
     }
 }
@@ -201,7 +205,8 @@ namespace Mockolate.Checks
     }
     public class CheckResult<TMock>
     {
-        public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions) { }
+        public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions, string expectation) { }
+        public string Expectation { get; }
         public bool AtLeast(int times) { }
         public bool AtLeastOnce() { }
         public bool AtMost(int times) { }
@@ -210,6 +215,7 @@ namespace Mockolate.Checks
         public bool Never() { }
         public bool Once() { }
         public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
+        public bool Verify(System.Func<Mockolate.Checks.Interactions.IInteraction[], bool> predicate) { }
     }
     public class Checks
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -203,17 +203,20 @@ namespace Mockolate.Checks
             public Mockolate.Checks.CheckResult<TMock> Setter(Mockolate.With.Parameter<TProperty> value) { }
         }
     }
+    public static class CheckResultExtensions
+    {
+        public static bool AtLeast<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool AtLeastOnce<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool AtMost<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool AtMostOnce<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Exactly<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
+        public static bool Never<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Once<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+    }
     public class CheckResult<TMock>
     {
         public CheckResult(TMock mock, Mockolate.Checks.Checks checks, Mockolate.Checks.Interactions.IInteraction[] interactions, string expectation) { }
         public string Expectation { get; }
-        public bool AtLeast(int times) { }
-        public bool AtLeastOnce() { }
-        public bool AtMost(int times) { }
-        public bool AtMostOnce() { }
-        public bool Exactly(int times) { }
-        public bool Never() { }
-        public bool Once() { }
         public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
         public bool Verify(System.Func<Mockolate.Checks.Interactions.IInteraction[], bool> predicate) { }
     }

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -18,7 +18,7 @@ public class ExampleTests
 
 		int result = mock.Object.MyMethod(3);
 
-		var check = mock.Invoked.MyMethod(With.Any<int>());
+		CheckResult<Mock<MyClass>> check = mock.Invoked.MyMethod(With.Any<int>());
 		await That(result).IsEqualTo(5);
 		await That(check.Once());
 	}

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using Mockolate.Checks;
 using Mockolate.Tests.Dummy;
 
 namespace Mockolate.ExampleTests;
@@ -17,8 +18,9 @@ public class ExampleTests
 
 		int result = mock.Object.MyMethod(3);
 
+		var check = mock.Invoked.MyMethod(With.Any<int>());
 		await That(result).IsEqualTo(5);
-		await That(mock.Invoked.MyMethod(With.Any<int>()).Once());
+		await That(check.Once());
 	}
 
 #if NET8_0_OR_GREATER

--- a/Tests/Mockolate.Tests/Checks/CheckResultExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Checks/CheckResultExtensionsTests.cs
@@ -1,0 +1,140 @@
+using System.Linq;
+using Mockolate.Checks;
+using Mockolate.Checks.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public class CheckResultExtensionsTests
+{
+	[Theory]
+	[InlineData(0, 0, true)]
+	[InlineData(2, 3, false)]
+	[InlineData(2, 2, true)]
+	[InlineData(2, 1, true)]
+	public async Task AtLeast_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	{
+		MyMock<int> mock = new(0);
+		MyInteraction[] interactions = Enumerable.Range(0, count)
+			.Select(_ => new MyInteraction())
+			.ToArray();
+		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions, "foo");
+
+		bool result = sut.AtLeast(times);
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, false)]
+	[InlineData(1, true)]
+	[InlineData(2, true)]
+	[InlineData(3, true)]
+	public async Task AtLeastOnce_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		MyMock<int> mock = new(0);
+		MyInteraction[] interactions = Enumerable.Range(0, count)
+			.Select(_ => new MyInteraction())
+			.ToArray();
+		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions, "foo");
+
+		bool result = sut.AtLeastOnce();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, 0, true)]
+	[InlineData(2, 1, false)]
+	[InlineData(2, 2, true)]
+	[InlineData(2, 3, true)]
+	public async Task AtMost_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	{
+		MyMock<int> mock = new(0);
+		MyInteraction[] interactions = Enumerable.Range(0, count)
+			.Select(_ => new MyInteraction())
+			.ToArray();
+		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions, "foo");
+
+		bool result = sut.AtMost(times);
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, true)]
+	[InlineData(1, true)]
+	[InlineData(2, false)]
+	[InlineData(3, false)]
+	public async Task AtMostOnce_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		MyMock<int> mock = new(0);
+		MyInteraction[] interactions = Enumerable.Range(0, count)
+			.Select(_ => new MyInteraction())
+			.ToArray();
+		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions, "foo");
+
+		bool result = sut.AtMostOnce();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, 0, true)]
+	[InlineData(2, 3, false)]
+	[InlineData(2, 2, true)]
+	[InlineData(2, 1, false)]
+	public async Task Exactly_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	{
+		MyMock<int> mock = new(0);
+		MyInteraction[] interactions = Enumerable.Range(0, count)
+			.Select(_ => new MyInteraction())
+			.ToArray();
+		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions, "foo");
+
+		bool result = sut.Exactly(times);
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, true)]
+	[InlineData(1, false)]
+	[InlineData(2, false)]
+	[InlineData(3, false)]
+	public async Task Never_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		MyMock<int> mock = new(0);
+		MyInteraction[] interactions = Enumerable.Range(0, count)
+			.Select(_ => new MyInteraction())
+			.ToArray();
+		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions, "foo");
+
+		bool result = sut.Never();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, false)]
+	[InlineData(1, true)]
+	[InlineData(2, false)]
+	[InlineData(3, false)]
+	public async Task Once_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		MyMock<int> mock = new(0);
+		MyInteraction[] interactions = Enumerable.Range(0, count)
+			.Select(_ => new MyInteraction())
+			.ToArray();
+		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions, "foo");
+
+		bool result = sut.Once();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	private class MyInteraction : IInteraction
+	{
+		public int Index => 0;
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/CheckResultTests.cs
+++ b/Tests/Mockolate.Tests/Checks/CheckResultTests.cs
@@ -7,134 +7,60 @@ namespace Mockolate.Tests.Checks;
 
 public class CheckResultTests
 {
-	[Theory]
-	[InlineData(0, 0, true)]
-	[InlineData(2, 3, false)]
-	[InlineData(2, 2, true)]
-	[InlineData(2, 1, true)]
-	public async Task AtLeast_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	[Fact]
+	public async Task Expectation_PropertyGetter_ShouldHaveExpectedValue()
 	{
-		MyMock<int> mock = new(0);
-		MyInteraction[] interactions = Enumerable.Range(0, count)
-			.Select(_ => new MyInteraction())
-			.ToArray();
-		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions);
+		Mock<IMyService> sut = Mock.For<IMyService>();
 
-		bool result = sut.AtLeast(times);
+		CheckResult<Mock<IMyService>> check = sut.Accessed.MyProperty.Getter();
 
-		await That(result).IsEqualTo(expectedResult);
+		await That(check.Expectation).IsEqualTo("accessed getter of property MyProperty");
 	}
 
-	[Theory]
-	[InlineData(0, false)]
-	[InlineData(1, true)]
-	[InlineData(2, true)]
-	[InlineData(3, true)]
-	public async Task AtLeastOnce_ShouldReturnExpectedResult(int count, bool expectedResult)
+	[Fact]
+	public async Task Expectation_PropertySetter_ShouldHaveExpectedValue()
 	{
-		MyMock<int> mock = new(0);
-		MyInteraction[] interactions = Enumerable.Range(0, count)
-			.Select(_ => new MyInteraction())
-			.ToArray();
-		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions);
+		Mock<IMyService> sut = Mock.For<IMyService>();
 
-		bool result = sut.AtLeastOnce();
+		CheckResult<Mock<IMyService>> check = sut.Accessed.MyProperty.Setter(With.Any<int>());
 
-		await That(result).IsEqualTo(expectedResult);
+		await That(check.Expectation).IsEqualTo("accessed setter of property MyProperty with value With.Any<int>()");
 	}
 
-	[Theory]
-	[InlineData(0, 0, true)]
-	[InlineData(2, 1, false)]
-	[InlineData(2, 2, true)]
-	[InlineData(2, 3, true)]
-	public async Task AtMost_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	[Fact]
+	public async Task Expectation_Method_ShouldHaveExpectedValue()
 	{
-		MyMock<int> mock = new(0);
-		MyInteraction[] interactions = Enumerable.Range(0, count)
-			.Select(_ => new MyInteraction())
-			.ToArray();
-		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions);
+		Mock<IMyService> sut = Mock.For<IMyService>();
 
-		bool result = sut.AtMost(times);
+		CheckResult<Mock<IMyService>> check = sut.Invoked.DoSomething(With.Any<int?>(), "foo");
 
-		await That(result).IsEqualTo(expectedResult);
+		await That(check.Expectation).IsEqualTo("invoked method DoSomething(With.Any<int?>(), \"foo\")");
 	}
 
-	[Theory]
-	[InlineData(0, true)]
-	[InlineData(1, true)]
-	[InlineData(2, false)]
-	[InlineData(3, false)]
-	public async Task AtMostOnce_ShouldReturnExpectedResult(int count, bool expectedResult)
+	[Fact]
+	public async Task Expectation_EventSubscription_ShouldHaveExpectedValue()
 	{
-		MyMock<int> mock = new(0);
-		MyInteraction[] interactions = Enumerable.Range(0, count)
-			.Select(_ => new MyInteraction())
-			.ToArray();
-		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions);
+		Mock<IMyService> sut = Mock.For<IMyService>();
 
-		bool result = sut.AtMostOnce();
+		CheckResult<Mock<IMyService>> check = sut.Event.SomethingHappened.Subscribed();
 
-		await That(result).IsEqualTo(expectedResult);
+		await That(check.Expectation).IsEqualTo("subscribed to event SomethingHappened");
 	}
 
-	[Theory]
-	[InlineData(0, 0, true)]
-	[InlineData(2, 3, false)]
-	[InlineData(2, 2, true)]
-	[InlineData(2, 1, false)]
-	public async Task Exactly_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	[Fact]
+	public async Task Expectation_EventUnsubscription_ShouldHaveExpectedValue()
 	{
-		MyMock<int> mock = new(0);
-		MyInteraction[] interactions = Enumerable.Range(0, count)
-			.Select(_ => new MyInteraction())
-			.ToArray();
-		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions);
+		Mock<IMyService> sut = Mock.For<IMyService>();
 
-		bool result = sut.Exactly(times);
+		CheckResult<Mock<IMyService>> check = sut.Event.SomethingHappened.Unsubscribed();
 
-		await That(result).IsEqualTo(expectedResult);
+		await That(check.Expectation).IsEqualTo("unsubscribed from event SomethingHappened");
 	}
 
-	[Theory]
-	[InlineData(0, true)]
-	[InlineData(1, false)]
-	[InlineData(2, false)]
-	[InlineData(3, false)]
-	public async Task Never_ShouldReturnExpectedResult(int count, bool expectedResult)
+	public interface IMyService
 	{
-		MyMock<int> mock = new(0);
-		MyInteraction[] interactions = Enumerable.Range(0, count)
-			.Select(_ => new MyInteraction())
-			.ToArray();
-		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions);
-
-		bool result = sut.Never();
-
-		await That(result).IsEqualTo(expectedResult);
-	}
-
-	[Theory]
-	[InlineData(0, false)]
-	[InlineData(1, true)]
-	[InlineData(2, false)]
-	[InlineData(3, false)]
-	public async Task Once_ShouldReturnExpectedResult(int count, bool expectedResult)
-	{
-		MyMock<int> mock = new(0);
-		MyInteraction[] interactions = Enumerable.Range(0, count)
-			.Select(_ => new MyInteraction())
-			.ToArray();
-		CheckResult<Mock<int>> sut = new(mock, new Mockolate.Checks.Checks(), interactions);
-
-		bool result = sut.Once();
-
-		await That(result).IsEqualTo(expectedResult);
-	}
-
-	private class MyInteraction : IInteraction
-	{
-		public int Index => 0;
+		event EventHandler? SomethingHappened;
+		int MyProperty { get; set; }
+		void DoSomething(int? value, string otherValue);
 	}
 }

--- a/Tests/Mockolate.Tests/Checks/MockCheckTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockCheckTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Mockolate.Tests.Checks;
+﻿using Mockolate.Checks;
+
+namespace Mockolate.Tests.Checks;
 
 public class MockCheckTests
 {

--- a/Tests/Mockolate.Tests/Events/MockRaisesTests.cs
+++ b/Tests/Mockolate.Tests/Events/MockRaisesTests.cs
@@ -1,4 +1,5 @@
-﻿using Mockolate.Events;
+﻿using Mockolate.Checks;
+using Mockolate.Events;
 using Mockolate.Exceptions;
 
 namespace Mockolate.Tests.Events;

--- a/Tests/Mockolate.Tests/MockTests.Methods.cs
+++ b/Tests/Mockolate.Tests/MockTests.Methods.cs
@@ -1,3 +1,4 @@
+using Mockolate.Checks;
 using Mockolate.Exceptions;
 
 namespace Mockolate.Tests;

--- a/Tests/Mockolate.Tests/MockTests.Properties.cs
+++ b/Tests/Mockolate.Tests/MockTests.Properties.cs
@@ -1,3 +1,4 @@
+using Mockolate.Checks;
 using Mockolate.Exceptions;
 
 namespace Mockolate.Tests;

--- a/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
@@ -1,3 +1,4 @@
+using Mockolate.Checks;
 using Mockolate.Monitor;
 
 namespace Mockolate.Tests.Monitor;

--- a/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
+++ b/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Mockolate.Tests.Protected;
+﻿using Mockolate.Checks;
+
+namespace Mockolate.Tests.Protected;
 
 public sealed class ProtectedMockTests
 {

--- a/Tests/Mockolate.Tests/WithTests.cs
+++ b/Tests/Mockolate.Tests/WithTests.cs
@@ -83,7 +83,7 @@ public sealed class WithTests
 	}
 
 	[Fact]
-	public async Task ToString_WithRef_ShouldReturExpectednValue()
+	public async Task ToString_WithRef_ShouldReturnExpectedValue()
 	{
 		With.RefParameter<int?> sut = With.Ref<int?>(v => v * 3);
 		string expectedValue = "With.Ref<int?>(v => v * 3)";

--- a/Tests/Mockolate.Tests/WithTests.cs
+++ b/Tests/Mockolate.Tests/WithTests.cs
@@ -16,6 +16,83 @@ public sealed class WithTests
 		await That(result).IsEqualTo(expectMatch);
 	}
 
+	[Fact]
+	public async Task ToString_Implicit_ShouldReturnExpectedValue()
+	{
+		With.Parameter<int?> sut = 6;
+		string expectedValue = "6";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedValue);
+	}
+
+	[Fact]
+	public async Task ToString_WithAny_ShouldReturnExpectedValue()
+	{
+		With.Parameter<string> sut = With.Any<string>();
+		string expectedValue = "With.Any<string>()";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedValue);
+	}
+
+	[Fact]
+	public async Task ToString_WithMatching_ShouldReturnExpectedValue()
+	{
+		With.Parameter<string> sut = With.Matching<string>(x => x.Length == 3);
+		string expectedValue = "With.Matching<string>(x => x.Length == 3)";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedValue);
+	}
+
+	[Fact]
+	public async Task ToString_WithOut_ShouldReturnExpectedValue()
+	{
+		With.OutParameter<int> sut = With.Out<int>(() => 3);
+		string expectedValue = "With.Out<int>(() => 3)";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedValue);
+	}
+
+	[Fact]
+	public async Task ToString_WithOut_Invoked_ShouldReturnExpectedValue()
+	{
+		With.InvokedOutParameter<int> sut = With.Out<int>();
+		string expectedValue = "With.Out<int>()";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedValue);
+	}
+
+	[Fact]
+	public async Task ToString_WithRef_Invoked_ShouldReturnExpectedValue()
+	{
+		With.InvokedRefParameter<int> sut = With.Ref<int>();
+		string expectedValue = "With.Ref<int>()";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedValue);
+	}
+
+	[Fact]
+	public async Task ToString_WithRef_ShouldReturExpectednValue()
+	{
+		With.RefParameter<int?> sut = With.Ref<int?>(v => v * 3);
+		string expectedValue = "With.Ref<int?>(v => v * 3)";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedValue);
+	}
+
 	[Theory]
 	[InlineData(null)]
 	[InlineData("")]


### PR DESCRIPTION
This PR adds an `Expectation` property to the `CheckResult` class to provide descriptive text about what interaction is being checked. The implementation extracts existing verification logic into extension methods and enhances parameter types with better string representation.

### Key changes:
- Added `Expectation` property to `CheckResult<TMock>` class with descriptive text
- Moved verification methods from `CheckResult` to `CheckResultExtensions` as extension methods
- Enhanced `With` parameter classes with `ToString()` implementations