### PR TITLE
fix: support internal mock types

### DIFF
--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.Extensions.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.Extensions.cs
@@ -38,7 +38,7 @@ internal static partial class SourceGeneration
 		          #nullable enable
 
 		          """);
-		sb.Append("public static class ExtensionsFor").Append(name).AppendLine();
+		sb.Append("internal static class ExtensionsFor").Append(name).AppendLine();
 		sb.AppendLine("{");
 		if (mockClass.AdditionalImplementations.Any())
 		{

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.SetupExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.SetupExtensions.cs
@@ -33,7 +33,7 @@ internal static partial class SourceGeneration
 
 		          """);
 		sb.AppendLine();
-		sb.Append("public static class SetupExtensionsFor").Append(name).AppendLine();
+		sb.Append("internal static class SetupExtensionsFor").Append(name).AppendLine();
 		sb.AppendLine("{");
 
 		AppendRaisesExtensions(sb, @class, namespaces);

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
@@ -32,7 +32,7 @@ internal static partial class SourceGeneration
 		          #nullable enable
 
 		          """);
-		sb.Append("public static class For").Append(name).AppendLine();
+		sb.Append("internal static class For").Append(name).AppendLine();
 		sb.AppendLine("{");
 
 		AppendMock(sb, mockClass);

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MethodSetups.cs
@@ -51,7 +51,7 @@ internal static partial class SourceGeneration
 		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
 			.Append(numberOfParameters).Append("\" /> returning <see langword=\"void\" />.").AppendLine();
 		sb.Append("/// </summary>").AppendLine();
-		sb.Append("public class VoidMethodSetup<").Append(typeParams).Append(">(string name");
+		sb.Append("internal class VoidMethodSetup<").Append(typeParams).Append(">(string name");
 		for (int i = 1; i <= numberOfParameters; i++)
 		{
 			sb.Append(", With.NamedParameter match").Append(i);
@@ -238,7 +238,7 @@ internal static partial class SourceGeneration
 		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
 			.Append(numberOfParameters).Append("\" /> returning <typeparamref name=\"TReturn\" />.").AppendLine();
 		sb.Append("/// </summary>").AppendLine();
-		sb.Append("public class ReturnMethodSetup<TReturn, ").Append(typeParams).Append(">(string name");
+		sb.Append("internal class ReturnMethodSetup<TReturn, ").Append(typeParams).Append(">(string name");
 		for (int i = 1; i <= numberOfParameters; i++)
 		{
 			sb.Append(", With.NamedParameter match").Append(i);

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MockRegistration.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.MockRegistration.cs
@@ -21,7 +21,7 @@ internal static partial class SourceGeneration
 		sb.AppendLine("namespace Mockolate;");
 		sb.AppendLine();
 		sb.AppendLine("#nullable enable");
-		sb.AppendLine("public static partial class Mock");
+		sb.AppendLine("internal static partial class Mock");
 		sb.AppendLine("{");
 		sb.AppendLine("\tprivate partial class MockGenerator");
 		sb.AppendLine("\t{");

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ReturnsAsyncExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ReturnsAsyncExtensions.cs
@@ -21,7 +21,7 @@ internal static partial class SourceGeneration
 		sb.Append("/// <summary>").AppendLine();
 		sb.Append("///     Extensions for setting up asynchronous return values.").AppendLine();
 		sb.Append("/// </summary>").AppendLine();
-		sb.Append("public static class ReturnsAsyncExtensions2").AppendLine();
+		sb.Append("internal static class ReturnsAsyncExtensions2").AppendLine();
 		sb.Append("{").AppendLine();
 		foreach (int number in numberOfParameters)
 		{

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.cs
@@ -32,7 +32,7 @@ internal static partial class SourceGeneration
 		sb.AppendLine("/// <summary>");
 		sb.AppendLine("///     Create new mocks by calling <see cref=\"Mock.Create{T}\" />.");
 		sb.AppendLine("/// </summary>");
-		sb.AppendLine("public static partial class Mock");
+		sb.AppendLine("internal static partial class Mock");
 		sb.AppendLine("{");
 		sb.AppendLine("\t/// <summary>");
 		sb.AppendLine(

--- a/Tests/Mockolate.Tests/TestHelpers/IMyService.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/IMyService.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Mockolate.Tests.TestHelpers;
 
-namespace Mockolate.Tests.TestHelpers;
-
-public interface IMyService
+internal interface IMyService
 {
 	void DoSomething(int value, bool flag);
 }

--- a/Tests/Mockolate.Tests/TestHelpers/MyServiceBase.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/MyServiceBase.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Mockolate.Tests.TestHelpers;
 
-namespace Mockolate.Tests.TestHelpers;
-
-public class MyServiceBase
+internal class MyServiceBase
 {
 	public virtual void DoSomething(int value, bool flag)
 	{


### PR DESCRIPTION
This PR changes the visibility of generated mock classes and test helper types from public to internal to support internal mock types in the Mockolate testing framework.

---

- *Fixes #30*