### PR TITLE
fix: ignore warning in generated code

### DIFF
--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.cs
@@ -247,7 +247,9 @@ internal static partial class SourceGeneration
 
 		sb.Append("\tprivate partial class MockGenerator").AppendLine();
 		sb.Append("\t{").AppendLine();
+		sb.Append("\t\t#pragma warning disable CS0649 // Field 'field' is never assigned to, and will always have its default value 'value' ").AppendLine();
 		sb.Append("\t\tprivate object? _value;").AppendLine();
+		sb.Append("\t\t#pragma warning restore CS0649").AppendLine();
 		sb.Append(
 				"\t\tpartial void Generate(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior, params Type[] types);")
 			.AppendLine();


### PR DESCRIPTION
This PR fixes a compiler warning in generated code by adding pragma directives to suppress warning [CS0649](https://learn.microsoft.com/en-us/dotnet/csharp/misc/CS0649) for an unused field.