### PR TITLE
refactor: restructure the build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ publish-test-results, benchmarks, static-code-analysis, pack, mutation-tests ]
+        needs: [ publish-test-results, build-pages, benchmarks, static-code-analysis, pack, mutation-tests ]
         permissions:
             contents: write
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,6 @@ jobs:
     pack:
         name: "Pack"
         runs-on: ubuntu-latest
-        needs: [ publish-test-results, benchmarks, static-code-analysis ]
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -172,7 +171,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack, mutation-tests ]
+        needs: [ publish-test-results, benchmarks, static-code-analysis, pack, mutation-tests ]
         permissions:
             contents: write
         steps:


### PR DESCRIPTION
This PR refactors the build workflow dependencies to adjust job execution order by moving the dependencies from the `pack` job to the `push` job.