### PR TITLE
feat: move `Then` to extensions

### DIFF
--- a/Source/Mockolate/Checks/CheckResult.cs
+++ b/Source/Mockolate/Checks/CheckResult.cs
@@ -12,45 +12,24 @@ public class CheckResult<TMock>
 {
 	private readonly MockInteractions _interactions;
 	private readonly IInteraction[] _matchingInteractions;
-	private readonly TMock _mock;
 
 	/// <summary>
 	///     The expectation of this check result.
 	/// </summary>
 	public string Expectation { get; }
 
+	/// <summary>
+	///     The mock object for which this expectation applies.
+	/// </summary>
+	public TMock Mock { get; }
+
 	/// <inheritdoc cref="CheckResult{TMock}" />
 	public CheckResult(TMock mock, MockInteractions interactions, IInteraction[] matchingInteractions, string expectation)
 	{
-		_mock = mock;
+		Mock = mock;
 		_interactions = interactions;
 		_matchingInteractions = matchingInteractions;
 		Expectation = expectation;
-	}
-
-	/// <summary>
-	///     Supports fluent chaining of verifications in a given order.
-	/// </summary>
-	public bool Then(params Func<TMock, CheckResult<TMock>>[] orderedChecks)
-	{
-		CheckResult<TMock> result = this;
-		List<IInteraction> verified = [];
-		int after = -1;
-		foreach (Func<TMock, CheckResult<TMock>>? check in orderedChecks)
-		{
-			if (!result._matchingInteractions.Any(x => x.Index > after))
-			{
-				_interactions.Verified(verified);
-				return false;
-			}
-
-			verified.AddRange(result._matchingInteractions.Where(x => x.Index > after));
-			after = result._matchingInteractions.Min(x => x.Index);
-			result = check(_mock);
-		}
-
-		_interactions.Verified(verified);
-		return result._matchingInteractions.Any(x => x.Index > after);
 	}
 
 	/// <summary>

--- a/Source/Mockolate/Checks/CheckResultExtensions.cs
+++ b/Source/Mockolate/Checks/CheckResultExtensions.cs
@@ -58,7 +58,6 @@ public static class CheckResultExtensions
 	public static bool Then<TMock>(this CheckResult<TMock> checkResult, params Func<TMock, CheckResult<TMock>>[] orderedChecks)
 	{
 		CheckResult<TMock> result = checkResult;
-		List<IInteraction> verified = [];
 		int after = -1;
 		foreach (Func<TMock, CheckResult<TMock>>? check in orderedChecks)
 		{

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -220,12 +220,13 @@ namespace Mockolate.Checks
         public static bool Exactly<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
         public static bool Never<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
         public static bool Once<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Then<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
     }
     public class CheckResult<TMock>
     {
         public CheckResult(TMock mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
+        public TMock Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
     public interface IMockAccessed<TMock>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -220,12 +220,13 @@ namespace Mockolate.Checks
         public static bool Exactly<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
         public static bool Never<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
         public static bool Once<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Then<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
     }
     public class CheckResult<TMock>
     {
         public CheckResult(TMock mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
+        public TMock Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
     public interface IMockAccessed<TMock>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -206,12 +206,13 @@ namespace Mockolate.Checks
         public static bool Exactly<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, int times) { }
         public static bool Never<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
         public static bool Once<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult) { }
+        public static bool Then<TMock>(this Mockolate.Checks.CheckResult<TMock> checkResult, params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
     }
     public class CheckResult<TMock>
     {
         public CheckResult(TMock mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public bool Then(params System.Func<TMock, Mockolate.Checks.CheckResult<TMock>>[] orderedChecks) { }
+        public TMock Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
     public interface IMockAccessed<TMock>


### PR DESCRIPTION
This PR moves the `Then` method from the `CheckResult<TMock>` class to the `CheckResultExtensions` class to make it an extension method, improving the API design by separating core functionality from fluent chaining capabilities.

### Key changes:
- Moved `Then` method from instance method to extension method
- Added `Mock` property to `CheckResult<TMock>` class for public access