### PR TITLE
refactor: avoid reflection

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -13,7 +13,11 @@ internal record MockClass : Class
 		if (!IsInterface && types[0] is INamedTypeSymbol namedTypeSymbol)
 		{
 			Constructors =
-				new EquatableArray<Method>(namedTypeSymbol.Constructors.Select(x => new Method(x)).ToArray());
+				new EquatableArray<Method>(namedTypeSymbol.Constructors
+				.Where(x => x.DeclaredAccessibility == Accessibility.Protected ||
+				            x.DeclaredAccessibility == Accessibility.ProtectedOrInternal ||
+				            x.DeclaredAccessibility == Accessibility.Public)
+				.Select(x => new Method(x)).ToArray());
 		}
 	}
 

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Mockolate.SourceGenerators.Entities;
 using Type = Mockolate.SourceGenerators.Entities.Type;
@@ -16,6 +17,7 @@ internal static partial class SourceGeneration
 			..mockClass.GetAllNamespaces(),
 			"Mockolate.Checks",
 			"Mockolate.Events",
+			"Mockolate.Exceptions",
 			"Mockolate.Protected",
 			"Mockolate.Setup",
 		];
@@ -36,7 +38,7 @@ internal static partial class SourceGeneration
 		sb.Append("internal static class For").Append(name).AppendLine();
 		sb.AppendLine("{");
 
-		AppendMock(sb, mockClass);
+		AppendMock(sb, mockClass, namespaces);
 		sb.AppendLine();
 
 		AppendMockObject(sb, mockClass, namespaces);
@@ -45,7 +47,7 @@ internal static partial class SourceGeneration
 		return sb.ToString();
 	}
 
-	private static void AppendMock(StringBuilder sb, MockClass mockClass)
+	private static void AppendMock(StringBuilder sb, MockClass mockClass, string[] namespaces)
 	{
 		sb.Append("\t/// <summary>").AppendLine();
 		sb.Append("\t///     The mock class for <see cref=\"").Append(mockClass.ClassName).Append("\" />");
@@ -69,7 +71,50 @@ internal static partial class SourceGeneration
 				"\t\tpublic Mock(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior) : base(mockBehavior)")
 			.AppendLine();
 		sb.AppendLine("\t\t{");
-		sb.Append("\t\t\tObject = Create<MockObject>(constructorParameters);").AppendLine();
+		if (mockClass.IsInterface || mockClass.Constructors?.All(m => m.Parameters.Count == 0) != false)
+		{
+			sb.Append("\t\t\tObject = new MockObject(this);").AppendLine();
+		}
+		else if (mockClass.Constructors?.Count > 0)
+		{
+			sb.Append("\t\t\tif (constructorParameters is null || constructorParameters.Parameters.Length == 0)").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			if (mockClass.Constructors.Value.Any(mockClass => mockClass.Parameters.Count == 0))
+			{
+				sb.Append("\t\t\t\tObject = new MockObject(this);").AppendLine();
+			}
+			else
+			{
+				sb.Append("\t\t\t\tthrow new MockException(\"No parameterless constructor found for '").Append(mockClass.ClassName).Append("'. Please provide constructor parameters.\");").AppendLine();
+			}
+			sb.Append("\t\t\t}").AppendLine();
+			foreach (Method constructor in mockClass.Constructors)
+			{
+				sb.Append("\t\t\telse if (constructorParameters.Parameters.Length == ").Append(constructor.Parameters.Count);
+				int index = 0;
+				foreach (MethodParameter parameter in constructor.Parameters)
+				{
+					sb.AppendLine().Append("\t\t\t    && TryCast(constructorParameters.Parameters[").Append(index++).Append("], out ").Append(parameter.Type.GetMinimizedString(namespaces)).Append(" p").Append(index).Append(")");
+				}
+				sb.Append(")").AppendLine();
+				sb.Append("\t\t\t{").AppendLine();
+				sb.Append("\t\t\t\tObject = new MockObject(this");
+				for (int i=1;i<=constructor.Parameters.Count;i++)
+				{
+					sb.Append(", p").Append(i);
+				}
+				sb.Append(");").AppendLine();
+				sb.Append("\t\t\t}").AppendLine();
+			}
+			sb.Append("\t\t\telse").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\tthrow new MockException($\"Could not find any constructor that matches the {constructorParameters.Parameters.Length} given parameters ({string.Join(\", \", constructorParameters.Parameters)}).\");").AppendLine();
+			sb.Append("\t\t\t}").AppendLine();
+		}
+		else
+		{
+			sb.Append("\t\t\tthrow new MockException(\"Could not find any constructor for the base type '").Append(mockClass.ClassName).Append("'.\");").AppendLine();
+		}
 		sb.AppendLine("\t\t}");
 		sb.AppendLine();
 		sb.Append("\t\t/// <inheritdoc cref=\"Mock{").Append(mockClass.ClassName)

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
@@ -104,7 +104,7 @@ internal static partial class SourceGeneration
 				sb.Append(")").AppendLine();
 				sb.Append("\t\t\t{").AppendLine();
 				sb.Append("\t\t\t\tObject = new MockObject(this");
-				for (int i=1;i<=constructor.Parameters.Count;i++)
+				for (int i = 1; i <= constructor.Parameters.Count; i++)
 				{
 					sb.Append(", p").Append(i);
 				}

--- a/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/SourceGeneration.ForMock.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Mockolate.SourceGenerators.Entities;
 using Type = Mockolate.SourceGenerators.Entities.Type;

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -154,12 +154,13 @@ public abstract class MethodSetup : IMethodSetup
 	}
 
 	/// <summary>
-	///     Attempts to cast the specified value to the type parameter T, returning a value that
-	///     indicates whether the cast was successful.
+	///     Attempts to cast the specified value to the type parameter <typeparamref name="T"/>,
+	///     returning a value that indicates whether the cast was successful.
 	/// </summary>
 	/// <remarks>
-	///     If value is not of type T and is not null, result is set to the default value for type T as
-	///     provided by the behavior's <see cref="MockBehavior.DefaultValueGenerator" />.
+	///     If value is not of type <typeparamref name="T" /> and is not <see langword="null" />,
+	///     result is set to the default value for type <typeparamref name="T" /> as provided
+	///     by the <paramref name="behavior" />.
 	/// </remarks>
 	protected static bool TryCast<T>(object? value, out T result, MockBehavior behavior)
 	{

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -32,7 +32,7 @@ namespace Mockolate
         public abstract T Object { get; }
         public Mockolate.Events.MockRaises<T> Raise { get; }
         public Mockolate.Setup.MockSetups<T> Setup { get; }
-        protected TObject Create<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
+        protected bool TryCast<TValue>(object? value, out TValue result) { }
         public static T op_Implicit(Mockolate.MockBase<T> mock) { }
     }
     public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -31,7 +31,7 @@ namespace Mockolate
         public abstract T Object { get; }
         public Mockolate.Events.MockRaises<T> Raise { get; }
         public Mockolate.Setup.MockSetups<T> Setup { get; }
-        protected TObject Create<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]  TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
+        protected bool TryCast<TValue>(object? value, out TValue result) { }
         public static T op_Implicit(Mockolate.MockBase<T> mock) { }
     }
     public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -30,7 +30,7 @@ namespace Mockolate
         public abstract T Object { get; }
         public Mockolate.Events.MockRaises<T> Raise { get; }
         public Mockolate.Setup.MockSetups<T> Setup { get; }
-        protected TObject Create<TObject>(Mockolate.BaseClass.ConstructorParameters? constructorParameters) { }
+        protected bool TryCast<TValue>(object? value, out TValue result) { }
         public static T op_Implicit(Mockolate.MockBase<T> mock) { }
     }
     public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -47,7 +47,18 @@ public sealed partial class MockTests
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(
-				"Could not find any constructor that matches the 3 given parameters (foo, 1, 2).");
+				"Could not find any constructor for 'MockTests.MyBaseClassWithConstructor' that matches the 3 given parameters (foo, 1, 2).");
+	}
+
+	[Fact]
+	public async Task Create_BaseClassWithoutConstructor_ShouldThrowMockException()
+	{
+		void Act()
+			=> _ = Mock.Create<MyBaseClassWithoutConstructor>();
+
+		await That(Act).Throws<MockException>()
+			.WithMessage(
+				"Could not find any constructor at all for the base type 'MockTests.MyBaseClassWithoutConstructor'. Therefore mocking is not supported!");
 	}
 
 	[Fact]
@@ -106,5 +117,13 @@ public sealed partial class MockTests
 		public int Number { get; }
 		public string Text { get; }
 		public virtual string VirtualMethod() => Text;
+	}
+
+	public class MyBaseClassWithoutConstructor
+	{
+		private MyBaseClassWithoutConstructor()
+		{ }
+
+		public int Number { get; }
 	}
 }

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -20,40 +20,43 @@ public sealed partial class MockTests
 	[Fact]
 	public async Task Create_WithRequiredParameters_WithEmptyParameters_ShouldThrowMockException()
 	{
-		MyMock<MyBaseClass> mock = new(new MyBaseClass());
-
 		void Act()
-			=> _ = mock.HiddenCreate<MyBaseClass>(WithConstructorParameters());
+			=> _ = Mock.Create<MyBaseClassWithConstructor>(WithConstructorParameters());
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(
-				"Could not create an instance of 'Mockolate.Tests.MockTests+MyBaseClass' without constructor parameters.");
+				"No parameterless constructor found for 'MockTests.MyBaseClassWithConstructor'. Please provide constructor parameters.");
 	}
 
 	[Fact]
 	public async Task Create_WithRequiredParameters_WithoutParameters_ShouldThrowMockException()
 	{
-		MyMock<MyBaseClass> mock = new(new MyBaseClass());
-
 		void Act()
-			=> _ = mock.HiddenCreate<MyBaseClass>();
+			=> _ = Mock.Create<MyBaseClassWithConstructor>();
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(
-				"Could not create an instance of 'Mockolate.Tests.MockTests+MyBaseClass' without constructor parameters.");
+				"No parameterless constructor found for 'MockTests.MyBaseClassWithConstructor'. Please provide constructor parameters.");
 	}
 
 	[Fact]
 	public async Task Create_WithTooManyParameters_ShouldThrowMockException()
 	{
-		MyMock<MyBaseClass> mock = new(new MyBaseClass());
-
 		void Act()
-			=> _ = mock.HiddenCreate<MyBaseClass>(WithConstructorParameters(1, 2, "foo"));
+			=> _ = Mock.Create<MyBaseClassWithConstructor>(WithConstructorParameters("foo", 1, 2));
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(
-				"Could not create an instance of 'Mockolate.Tests.MockTests+MyBaseClass' with 3 parameters (1, 2, foo).");
+				"Could not find any constructor that matches the 3 given parameters (foo, 1, 2).");
+	}
+
+	[Fact]
+	public async Task Create_WithMatchingParameters_ShouldCreateMock()
+	{
+		Mock<MyBaseClassWithConstructor> Act()
+			=> _ = Mock.Create<MyBaseClassWithConstructor>(WithConstructorParameters("foo"));
+
+		await That(Act).DoesNotThrow().AndWhoseResult.IsNotNull();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/TestHelpers/MyMock.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/MyMock.cs
@@ -23,9 +23,6 @@ public class MyMock<T>(T @object, MockBehavior? behavior = null) : Mock<T>(behav
 		=> this;
 
 	public override T Object => @object;
-
-	public TObject HiddenCreate<TObject>(ConstructorParameters? constructorParameters = null)
-		=> Create<TObject>(constructorParameters);
 }
 
 public class MyMock<T, T2>(T @object = default!, MockBehavior? behavior = null)


### PR DESCRIPTION
This PR refactors the Mockolate mocking framework to eliminate runtime reflection in favor of compile-time code generation for creating mock objects. This change improves performance and allows for better compile-time type checking.

### Key changes:
- Replaced reflection-based object creation with generated constructor matching logic
- Updated error messages to be more specific and helpful 
- Added type casting helper method to MockBase class

---

- *Fixes #41*