### PR TITLE
fix: support deeply nested types

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -12,11 +12,14 @@ internal record Class
 		ClassName = GetTypeName(type, additionalNamespaces);
 
 		var containingType = type.ContainingType;
-		while (containingType is not null)
+		if (containingType is not null)
 		{
 			ContainingType = new Type(containingType);
-			ClassName = containingType.Name + "." + ClassName;
-			containingType = containingType.ContainingType;
+			while (containingType is not null)
+			{
+				ClassName = containingType.Name + "." + ClassName;
+				containingType = containingType.ContainingType;
+			}
 		}
 
 		IsInterface = type.TypeKind == TypeKind.Interface;

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -11,10 +11,12 @@ internal record Class
 		Namespace = type.ContainingNamespace.ToString();
 		ClassName = GetTypeName(type, additionalNamespaces);
 
-		if (type.ContainingType is not null)
+		var containingType = type.ContainingType;
+		while (containingType is not null)
 		{
-			ContainingType = new Type(type.ContainingType);
-			ClassName = type.ContainingType.Name + "." + ClassName;
+			ContainingType = new Type(containingType);
+			ClassName = containingType.Name + "." + ClassName;
+			containingType = containingType.ContainingType;
 		}
 
 		IsInterface = type.TypeKind == TypeKind.Interface;

--- a/Tests/Mockolate.Tests/BaseClassTests.cs
+++ b/Tests/Mockolate.Tests/BaseClassTests.cs
@@ -1,7 +1,3 @@
-using Mockolate.Checks;
-using Mockolate.Setup;
-using Mockolate.Tests.TestHelpers;
-
 namespace Mockolate.Tests;
 
 public sealed class BaseClassTests

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -7,6 +7,17 @@ namespace Mockolate.Tests;
 public sealed partial class MockTests
 {
 	[Fact]
+	public async Task DoubleNestedInterfaces_ShouldStillWork()
+	{
+		var mock = Mock.Create<Nested.Nested2.IMyDoubleNestedService>();
+		mock.Setup.IsValid.InitializeWith(true);
+
+		var result = mock.Object.IsValid;
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
 	public async Task Behavior_ShouldBeSet()
 	{
 		MyMock<string> sut = new("", MockBehavior.Default with
@@ -126,4 +137,15 @@ public sealed partial class MockTests
 
 		public int Number { get; }
 	}
+	public sealed class Nested
+	{
+		public sealed class Nested2
+		{
+			public interface IMyDoubleNestedService
+			{
+				bool IsValid { get; }
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
This PR fixes the handling of deeply nested types in the Mockolate source generator by modifying the type resolution logic to properly traverse and construct names for types that are nested multiple levels deep (e.g., `Outer.Middle.Inner` classes).

### Key changes:
- Modified the type name construction logic to handle deeply nested types using a while loop
- Added test coverage for double-nested interfaces to verify the fix works correctly

---

- *Fixes #43*