### PR TITLE
coverage: add missing tests for `Checks`

### DIFF
--- a/Source/Mockolate/Events/MockRaises.cs
+++ b/Source/Mockolate/Events/MockRaises.cs
@@ -27,7 +27,7 @@ public class MockRaises<T>(IMockSetup setup, MockInteractions interactions) : IM
 			throw new MockException("The method of an event subscription may not be null.");
 		}
 
-		interactions.RegisterInteraction(new EventSubscription(interactions.GetNextIndex(), name, target, method));
+		((IMockInteractions)interactions).RegisterInteraction(new EventSubscription(interactions.GetNextIndex(), name, target, method));
 		setup.AddEvent(name, target, method);
 	}
 
@@ -39,7 +39,7 @@ public class MockRaises<T>(IMockSetup setup, MockInteractions interactions) : IM
 			throw new MockException("The method of an event unsubscription may not be null.");
 		}
 
-		interactions.RegisterInteraction(new EventUnsubscription(interactions.GetNextIndex(), name, target, method));
+		((IMockInteractions)interactions).RegisterInteraction(new EventUnsubscription(interactions.GetNextIndex(), name, target, method));
 		setup.RemoveEvent(name, target, method);
 	}
 

--- a/Source/Mockolate/Interactions/IMockInteractions.cs
+++ b/Source/Mockolate/Interactions/IMockInteractions.cs
@@ -1,0 +1,12 @@
+namespace Mockolate.Interactions;
+
+/// <summary>
+///     Keeps track of the interactions on the <see cref="Mock{T}" /> and its verifications.
+/// </summary>
+public interface IMockInteractions
+{
+	/// <summary>
+	///     Registers an <paramref name="interaction"/>.
+	/// </summary>
+	IInteraction RegisterInteraction(IInteraction interaction);
+}

--- a/Source/Mockolate/Interactions/MockInteractions.cs
+++ b/Source/Mockolate/Interactions/MockInteractions.cs
@@ -10,7 +10,7 @@ namespace Mockolate.Interactions;
 ///     Keeps track of the interactions on the <see cref="Mock{T}" /> and its verifications.
 /// </summary>
 [DebuggerDisplay("{_interactions}")]
-public class MockInteractions
+public class MockInteractions : IMockInteractions
 {
 	private readonly ConcurrentDictionary<int, IInteraction> _interactions = [];
 	private int _index = -1;
@@ -38,7 +38,8 @@ public class MockInteractions
 	/// </summary>
 	public int GetNextIndex() => Interlocked.Increment(ref _index);
 
-	internal IInteraction RegisterInteraction(IInteraction interaction)
+	/// <inheritdoc cref="IMockInteractions.RegisterInteraction(IInteraction)" />
+	IInteraction IMockInteractions.RegisterInteraction(IInteraction interaction)
 	{
 		_interactions.TryAdd(interaction.Index, interaction);
 		return interaction;

--- a/Source/Mockolate/Mock.cs
+++ b/Source/Mockolate/Mock.cs
@@ -84,7 +84,7 @@ public abstract class MockBase<T> : IMock
 		MockInteractions interactions = ((IMock)this).Interactions;
 		parameters ??= [null,];
 		IInteraction invocation =
-			interactions.RegisterInteraction(new MethodInvocation(interactions.GetNextIndex(), methodName, parameters));
+			((IMockInteractions)interactions).RegisterInteraction(new MethodInvocation(interactions.GetNextIndex(), methodName, parameters));
 
 		MethodSetup? matchingSetup = Setup.GetMethodSetup(invocation);
 		if (matchingSetup is null)
@@ -109,7 +109,7 @@ public abstract class MockBase<T> : IMock
 		MockInteractions interactions = ((IMock)this).Interactions;
 		parameters ??= [null,];
 		IInteraction invocation =
-			interactions.RegisterInteraction(new MethodInvocation(interactions.GetNextIndex(), methodName, parameters));
+			((IMockInteractions)interactions).RegisterInteraction(new MethodInvocation(interactions.GetNextIndex(), methodName, parameters));
 
 		MethodSetup? matchingSetup = Setup.GetMethodSetup(invocation);
 		if (matchingSetup is null && _behavior.ThrowWhenNotSetup)
@@ -127,7 +127,7 @@ public abstract class MockBase<T> : IMock
 	{
 		MockInteractions interactions = ((IMock)this).Interactions;
 		IInteraction invocation =
-			interactions.RegisterInteraction(new PropertySetterAccess(interactions.GetNextIndex(), propertyName, value));
+			((IMockInteractions)interactions).RegisterInteraction(new PropertySetterAccess(interactions.GetNextIndex(), propertyName, value));
 		PropertySetup matchingSetup = Setup.GetPropertySetup(propertyName);
 		matchingSetup.InvokeSetter(invocation, value);
 	}
@@ -135,9 +135,9 @@ public abstract class MockBase<T> : IMock
 	/// <inheritdoc cref="IMock.Get{TResult}(string)" />
 	TResult IMock.Get<TResult>(string propertyName)
 	{
-		MockInteractions? checks = ((IMock)this).Interactions;
+		MockInteractions? interactions = ((IMock)this).Interactions;
 		IInteraction invocation =
-			checks.RegisterInteraction(new PropertyGetterAccess(checks.GetNextIndex(), propertyName));
+			((IMockInteractions)interactions).RegisterInteraction(new PropertyGetterAccess(interactions.GetNextIndex(), propertyName));
 		PropertySetup matchingSetup = Setup.GetPropertySetup(propertyName);
 		return matchingSetup.InvokeGetter<TResult>(invocation);
 	}

--- a/Source/Mockolate/Monitor/MockMonitor.cs
+++ b/Source/Mockolate/Monitor/MockMonitor.cs
@@ -58,7 +58,7 @@ public abstract class MockMonitor
 		{
 			foreach (IInteraction? invocation in _monitoredInvocations.Interactions.Skip(_monitoringStart))
 			{
-				Interactions.RegisterInteraction(invocation);
+				((IMockInteractions)Interactions).RegisterInteraction(invocation);
 			}
 		}
 

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -344,6 +344,10 @@ namespace Mockolate.Interactions
     {
         int Index { get; }
     }
+    public interface IMockInteractions
+    {
+        Mockolate.Interactions.IInteraction RegisterInteraction(Mockolate.Interactions.IInteraction interaction);
+    }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MethodInvocation : Mockolate.Interactions.IInteraction
     {
@@ -354,7 +358,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{_interactions}")]
-    public class MockInteractions
+    public class MockInteractions : Mockolate.Interactions.IMockInteractions
     {
         public MockInteractions() { }
         public int Count { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -343,6 +343,10 @@ namespace Mockolate.Interactions
     {
         int Index { get; }
     }
+    public interface IMockInteractions
+    {
+        Mockolate.Interactions.IInteraction RegisterInteraction(Mockolate.Interactions.IInteraction interaction);
+    }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MethodInvocation : Mockolate.Interactions.IInteraction
     {
@@ -353,7 +357,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{_interactions}")]
-    public class MockInteractions
+    public class MockInteractions : Mockolate.Interactions.IMockInteractions
     {
         public MockInteractions() { }
         public int Count { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -328,6 +328,10 @@ namespace Mockolate.Interactions
     {
         int Index { get; }
     }
+    public interface IMockInteractions
+    {
+        Mockolate.Interactions.IInteraction RegisterInteraction(Mockolate.Interactions.IInteraction interaction);
+    }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MethodInvocation : Mockolate.Interactions.IInteraction
     {
@@ -338,7 +342,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{_interactions}")]
-    public class MockInteractions
+    public class MockInteractions : Mockolate.Interactions.IMockInteractions
     {
         public MockInteractions() { }
         public int Count { get; }

--- a/Tests/Mockolate.Tests/Checks/MockAccessedTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockAccessedTests.ProtectedTests.cs
@@ -1,0 +1,47 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockAccessedTests
+{
+	public sealed class ProtectedTests
+	{
+		[Fact]
+		public async Task PropertyGetter_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, mock);
+			IMockAccessed<Mock<int>> @protected = new MockAccessed<int, Mock<int>>.Protected(accessed, mockInteractions, mock);
+			interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
+			interactions.RegisterInteraction(new PropertyGetterAccess(1, "foo.bar"));
+
+			var result1 = accessed.PropertyGetter("foo.bar");
+			var result2 = @protected.PropertyGetter("foo.bar");
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+
+		[Fact]
+		public async Task PropertySetter_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, mock);
+			IMockAccessed<Mock<int>> @protected = new MockAccessed<int, Mock<int>>.Protected(accessed, mockInteractions, mock);
+			interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 1));
+			interactions.RegisterInteraction(new PropertySetterAccess(1, "foo.bar", 2));
+
+			var result1 = accessed.PropertySetter("foo.bar", With.Any<int>());
+			var result2 = @protected.PropertySetter("foo.bar", With.Any<int>());
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockAccessedTests.ProxyTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockAccessedTests.ProxyTests.cs
@@ -1,0 +1,47 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockAccessedTests
+{
+	public sealed class ProxyTests
+	{
+		[Fact]
+		public async Task PropertyGetter_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, mock);
+			IMockAccessed<Mock<int>> proxy = new MockAccessed<int, Mock<int>>.Proxy(accessed, mockInteractions, mock);
+			interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
+			interactions.RegisterInteraction(new PropertyGetterAccess(1, "foo.bar"));
+
+			var result1 = accessed.PropertyGetter("foo.bar");
+			var result2 = proxy.PropertyGetter("foo.bar");
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+
+		[Fact]
+		public async Task PropertySetter_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, mock);
+			IMockAccessed<Mock<int>> proxy = new MockAccessed<int, Mock<int>>.Proxy(accessed, mockInteractions, mock);
+			interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 1));
+			interactions.RegisterInteraction(new PropertySetterAccess(1, "foo.bar", 2));
+
+			var result1 = accessed.PropertySetter("foo.bar", With.Any<int>());
+			var result2 = proxy.PropertySetter("foo.bar", With.Any<int>());
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockAccessedTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockAccessedTests.cs
@@ -1,0 +1,97 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockAccessedTests
+{
+	[Fact]
+	public async Task PropertyGetter_WithoutInteractions_ShouldReturnNeverResult()
+	{
+		var interactions = new MockInteractions();
+		IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(interactions, new MyMock<int>(1));
+
+		var result = accessed.PropertyGetter("foo.bar");
+
+		await That(result).Never();
+		await That(result.Expectation).IsEqualTo("accessed getter of property bar");
+	}
+
+	[Fact]
+	public async Task PropertyGetter_WhenNameMatches_ShouldReturnOnce()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
+
+		var result = accessed.PropertyGetter("foo.bar");
+
+		await That(result).Once();
+	}
+
+	[Fact]
+	public async Task PropertyGetter_WhenNameDoesNotMatch_ShouldReturnNever()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
+
+		var result = accessed.PropertyGetter("baz.bar");
+
+		await That(result).Never();
+	}
+
+	[Fact]
+	public async Task PropertySetter_WhenOnlyValueMatches_ShouldReturnNever()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
+
+		var result = accessed.PropertySetter("baz.bar", With.Any<int>());
+
+		await That(result).Never();
+	}
+
+	[Fact]
+	public async Task PropertySetter_WithoutInteractions_ShouldReturnNeverResult()
+	{
+		var interactions = new MockInteractions();
+		IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(interactions, new MyMock<int>(1));
+
+		var result = accessed.PropertySetter("foo.bar", With.Any<int>());
+
+		await That(result).Never();
+		await That(result.Expectation).IsEqualTo("accessed setter of property bar with value With.Any<int>()");
+	}
+
+	[Fact]
+	public async Task PropertySetter_WhenNameAndValueMatches_ShouldReturnOnce()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
+
+		var result = accessed.PropertySetter("foo.bar", With.Any<int>());
+
+		await That(result).Once();
+	}
+
+	[Fact]
+	public async Task PropertySetter_WhenOnlyNameMatches_ShouldReturnNever()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockAccessed<Mock<int>> accessed = new MockAccessed<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
+
+		var result = accessed.PropertySetter("foo.bar", With.Any<string>());
+
+		await That(result).Never();
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockEventTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockEventTests.ProtectedTests.cs
@@ -1,0 +1,48 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+using static Mockolate.Checks.CheckResult;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockEventTests
+{
+	public sealed class ProtectedTests
+	{
+		[Fact]
+		public async Task Subscribed_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, mock);
+			IMockEvent<Mock<int>> @protected = new MockEvent<int, Mock<int>>.Protected(@event, mockInteractions, mock);
+			interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, GetMethodInfo()));
+			interactions.RegisterInteraction(new EventSubscription(1, "foo.bar", mock, GetMethodInfo()));
+
+			var result1 = @event.Subscribed("foo.bar");
+			var result2 = @protected.Subscribed("foo.bar");
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+
+		[Fact]
+		public async Task Unsubscribed_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, mock);
+			IMockEvent<Mock<int>> @protected = new MockEvent<int, Mock<int>>.Protected(@event, mockInteractions, mock);
+			interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, GetMethodInfo()));
+			interactions.RegisterInteraction(new EventUnsubscription(1, "foo.bar", mock, GetMethodInfo()));
+
+			var result1 = @event.Unsubscribed("foo.bar");
+			var result2 = @protected.Unsubscribed("foo.bar");
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockEventTests.ProxyTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockEventTests.ProxyTests.cs
@@ -1,0 +1,48 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+using static Mockolate.Checks.CheckResult;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockEventTests
+{
+	public sealed class ProxyTests
+	{
+		[Fact]
+		public async Task Subscribed_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, mock);
+			IMockEvent<Mock<int>> proxy = new MockEvent<int, Mock<int>>.Proxy(@event, mockInteractions, mock);
+			interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, GetMethodInfo()));
+			interactions.RegisterInteraction(new EventSubscription(1, "foo.bar", mock, GetMethodInfo()));
+
+			var result1 = @event.Subscribed("foo.bar");
+			var result2 = proxy.Subscribed("foo.bar");
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+
+		[Fact]
+		public async Task Unsubscribed_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, mock);
+			IMockEvent<Mock<int>> proxy = new MockEvent<int, Mock<int>>.Proxy(@event, mockInteractions, mock);
+			interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, GetMethodInfo()));
+			interactions.RegisterInteraction(new EventUnsubscription(1, "foo.bar", mock, GetMethodInfo()));
+
+			var result1 = @event.Unsubscribed("foo.bar");
+			var result2 = proxy.Unsubscribed("foo.bar");
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockEventTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockEventTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Reflection;
+using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockEventTests
+{
+	[Fact]
+	public async Task Subscribed_WithoutInteractions_ShouldReturnNeverResult()
+	{
+		var interactions = new MockInteractions();
+		IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(interactions, new MyMock<int>(1));
+
+		var result = @event.Subscribed("foo.bar");
+
+		await That(result).Never();
+		await That(result.Expectation).IsEqualTo("subscribed to event bar");
+	}
+
+	[Fact]
+	public async Task Subscribed_WhenNameMatches_ShouldReturnOnce()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, GetMethodInfo()));
+
+		var result = @event.Subscribed("foo.bar");
+
+		await That(result).Once();
+	}
+
+	[Fact]
+	public async Task Subscribed_WhenNameDoesNotMatch_ShouldReturnNever()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, GetMethodInfo()));
+
+		var result = @event.Subscribed("baz.bar");
+
+		await That(result).Never();
+	}
+
+	[Fact]
+	public async Task Unsubscribed_WithoutInteractions_ShouldReturnNeverResult()
+	{
+		var interactions = new MockInteractions();
+		IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(interactions, new MyMock<int>(1));
+
+		var result = @event.Unsubscribed("foo.bar");
+
+		await That(result).Never();
+		await That(result.Expectation).IsEqualTo("unsubscribed from event bar");
+	}
+
+	[Fact]
+	public async Task Unsubscribed_WhenNameMatches_ShouldReturnOnce()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, GetMethodInfo()));
+
+		var result = @event.Unsubscribed("foo.bar");
+
+		await That(result).Once();
+	}
+
+	[Fact]
+	public async Task Unsubscribed_WhenNameDoesNotMatch_ShouldReturnNever()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockEvent<Mock<int>> @event = new MockEvent<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, GetMethodInfo()));
+
+		var result = @event.Unsubscribed("baz.bar");
+
+		await That(result).Never();
+	}
+
+	private static MethodInfo GetMethodInfo()
+	{
+		return typeof(MockEventTests).GetMethod(nameof(GetMethodInfo), BindingFlags.Static)!;
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockInvokedTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockInvokedTests.ProtectedTests.cs
@@ -1,0 +1,29 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockInvokedTests
+{
+	public sealed class ProtectedTests
+	{
+		[Fact]
+		public async Task PropertySetter_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(mockInteractions, mock);
+			IMockInvoked<Mock<int>> @protected = new MockInvoked<int, Mock<int>>.Protected(invoked, mockInteractions, mock);
+			interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [1]));
+			interactions.RegisterInteraction(new MethodInvocation(1, "foo.bar", [2]));
+
+			var result1 = invoked.Method("foo.bar", With.Any<int>());
+			var result2 = @protected.Method("foo.bar", With.Any<int>());
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockInvokedTests.ProxyTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockInvokedTests.ProxyTests.cs
@@ -1,0 +1,29 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockInvokedTests
+{
+	public sealed class ProxyTests
+	{
+		[Fact]
+		public async Task PropertySetter_ShouldForwardToInner()
+		{
+			var mockInteractions = new MockInteractions();
+			IMockInteractions interactions = mockInteractions;
+			var mock = new MyMock<int>(1);
+			IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(mockInteractions, mock);
+			IMockInvoked<Mock<int>> proxy = new MockInvoked<int, Mock<int>>.Proxy(invoked, mockInteractions, mock);
+			interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [1]));
+			interactions.RegisterInteraction(new MethodInvocation(1, "foo.bar", [2]));
+
+			var result1 = invoked.Method("foo.bar", With.Any<int>());
+			var result2 = proxy.Method("foo.bar", With.Any<int>());
+
+			await That(result1).Twice();
+			await That(result2).Twice();
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/Checks/MockInvokedTests.cs
+++ b/Tests/Mockolate.Tests/Checks/MockInvokedTests.cs
@@ -1,0 +1,59 @@
+﻿using Mockolate.Checks;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Checks;
+
+public sealed partial class MockInvokedTests
+{
+	[Fact]
+	public async Task Method_WhenOnlyValueMatches_ShouldReturnNever()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4]));
+
+		var result = invoked.Method("baz.bar", With.Any<int>());
+
+		await That(result).Never();
+	}
+
+	[Fact]
+	public async Task Method_WithoutInteractions_ShouldReturnNeverResult()
+	{
+		var interactions = new MockInteractions();
+		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(interactions, new MyMock<int>(1));
+
+		var result = invoked.Method("foo.bar", With.Any<int>());
+
+		await That(result).Never();
+		await That(result.Expectation).IsEqualTo("invoked method bar(With.Any<int>())");
+	}
+
+	[Fact]
+	public async Task Method_WhenNameAndValueMatches_ShouldReturnOnce()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4]));
+
+		var result = invoked.Method("foo.bar", With.Any<int>());
+
+		await That(result).Once();
+	}
+
+	[Fact]
+	public async Task Method_WhenOnlyNameMatches_ShouldReturnNever()
+	{
+		var mockInteractions = new MockInteractions();
+		IMockInteractions interactions = mockInteractions;
+		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(mockInteractions, new MyMock<int>(1));
+		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4]));
+
+		var result = invoked.Method("foo.bar", With.Any<string>());
+
+		await That(result).Never();
+	}
+}


### PR DESCRIPTION
This PR adds comprehensive test coverage for the `Checks` namespace by introducing new test files for `MockInvoked`, `MockEvent`, and `MockAccessed` classes, along with their associated proxy and protected variants. Additionally, it introduces an `IMockInteractions` interface to improve the API design.

### Key changes:
- Adds test coverage for mock invocation, event, and access verification functionality
- Introduces `IMockInteractions` interface to formalize mock interaction registration
- Updates public API surface to reflect the new interface implementation