### PR TITLE
fix: avoid source name conflicts in generated files

### DIFF
--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -105,7 +105,7 @@ public class MockGenerator : IIncrementalGenerator
 			{
 				int suffix = 1;
 				string actualName = mockToGenerate.GetClassNameWithoutDots();
-				while (result.Any(r => r.Name == actualName))
+				while (result.Any(r => r.Name.Equals(actualName, StringComparison.OrdinalIgnoreCase)))
 				{
 					actualName = $"{mockToGenerate.GetClassNameWithoutDots()}_{suffix++}";
 				}
@@ -119,7 +119,7 @@ public class MockGenerator : IIncrementalGenerator
 				{
 					int suffix = 1;
 					string actualName = item.GetClassNameWithoutDots();
-					while (result.Any(r => r.Name == actualName))
+					while (result.Any(r => r.Name.Equals(actualName, StringComparison.OrdinalIgnoreCase)))
 					{
 						actualName = $"{item.GetClassNameWithoutDots()}_{suffix++}";
 					}
@@ -147,7 +147,7 @@ public class MockGenerator : IIncrementalGenerator
 
 			int suffix = 1;
 			string actualName = name;
-			while (result.Any(r => r.Name == actualName))
+			while (result.Any(r => actualName.Equals(r.Name, StringComparison.OrdinalIgnoreCase)))
 			{
 				actualName = $"{name}_{suffix++}";
 			}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockFactoryTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockFactoryTests.cs
@@ -21,7 +21,7 @@ public class MockFactoryTests
 			     			var y = factory.Create<IMyInterface>();
 			             }
 			         }
-			     
+
 			         public interface IMyInterface
 			         {
 			             void MyMethod(int v1, bool v2, double v3, long v4, uint v5, string v6, DateTime v7);

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Threading;
+
+namespace Mockolate.SourceGenerators.Tests;
+
+public class MockGeneratorTests
+{
+	[Fact]
+	public async Task WhenNamesConflict_ShouldAppendAnIndex()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using System.Threading;
+			     using System.Threading.Tasks;
+			     using Mockolate;
+
+			     namespace MyCode
+			     {
+			         public class Program
+			         {
+			             public static void Main(string[] args)
+			             {
+			     			var m1 = Mock.Create<IMyInt>();
+			     			var m2 = Mock.Create<I.MyInt>();
+			     			var m3 = Mock.Create<IMy<int>>();
+			             }
+			         }
+			     
+			         public interface IMyInt { }
+			     
+			         public class I
+			         {
+			     		public interface MyInt { }
+			         }
+
+			         public interface IMy<T> { }
+			     }
+			     """);
+
+		await ThatAll(
+			That(result.Sources.Keys).Contains([
+				"ForIMyInt.g.cs",
+				"ForIMyInt_1.g.cs",
+				"ForIMyInt_2.g.cs",
+				"ForIMyInt.Extensions.g.cs",
+				"ForIMyInt_1.Extensions.g.cs",
+				"ForIMyInt_2.Extensions.g.cs",
+				"ForIMyInt.SetupExtensions.g.cs",
+				"ForIMyInt_1.SetupExtensions.g.cs",
+				"ForIMyInt_2.SetupExtensions.g.cs",
+				]).InAnyOrder().IgnoringCase(),
+			That(result.Diagnostics).IsEmpty()
+		);
+	}
+
+	[Fact]
+	public async Task WhenNamesConflictForAdditionalClasses_ShouldAppendAnIndex()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using System.Threading;
+			     using System.Threading.Tasks;
+			     using Mockolate;
+			     
+			     namespace MyCode
+			     {
+			         public class Program
+			         {
+			             public static void Main(string[] args)
+			             {
+			     			var m1 = Mock.Create<I, IMyInt, I.MyInt, IMy<int>>();
+			             }
+			         }
+			     
+			         public interface IMyInt { }
+			     
+			         public class I
+			         {
+			     		public interface MyInt { }
+			         }
+			     
+			         public interface IMy<T> { }
+			     }
+			     """);
+
+		await ThatAll(
+			That(result.Sources.Keys).Contains([
+				"ForI_IMyInt_IMyInt_IMyint.g.cs",
+				"ForI_IMyInt_IMyInt_IMyint.Extensions.g.cs",
+				"ForIMyInt.SetupExtensions.g.cs",
+				"ForIMyInt_1.SetupExtensions.g.cs",
+				"ForIMyInt_2.SetupExtensions.g.cs",
+				]).InAnyOrder().IgnoringCase(),
+			That(result.Diagnostics).IsEmpty()
+		);
+	}
+
+	[Fact]
+	public async Task WhenUsingMockCreateFromOtherNamespace_ShouldNotBeIncluded()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using System.Threading;
+			     using System.Threading.Tasks;
+
+			     namespace MyCode
+			     {
+			         public class Program
+			         {
+			             public static void Main(string[] args)
+			             {
+			     			var m1 = Mock.Create<IMyInterface>();
+			             }
+			         }
+			     
+			         public interface IMyInterface { }
+			     
+			         public class Mock
+			         {
+			     		public static Mock<T> Create<T>() => new Mock<T>();
+			         }
+
+			         public class Mock<T>{ }
+			     }
+			     """);
+
+		await ThatAll(
+			That(result.Sources.Keys).IsEqualTo([
+				"Mock.g.cs",
+				"MockRegistration.g.cs",
+				]).InAnyOrder().IgnoringCase(),
+			That(result.Diagnostics).IsEmpty()
+		);
+	}
+
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/Generator.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/Generator.cs
@@ -8,7 +8,8 @@ namespace Mockolate.SourceGenerators.Tests.TestHelpers;
 
 public static class Generator
 {
-	private static string[] NoWarn = [
+	private static readonly string[] NoWarn =
+	[
 		"CS8019" /* Unnecessary using directive. */,
 		"CS8321" /* The local function is declared but never used */,
 		// TODO: Remove the following errors when tests work with extension syntax
@@ -18,7 +19,12 @@ public static class Generator
 		"CS0710" /* Static classes cannot have instance constructors */,
 		"CS1503" /* cannot convert from ... */,
 		"CS1513" /* } expected */,
+		"CS1001" /* Identifier expected */,
 		"CS1002" /* ; expected */,
+		"CS1026" /* ) expected */,
+		"CS1519" /* Invalid token '(' in class, record, … */,
+		"CS0501" /*  */,
+		"CS8124" /* Tuple must contain at least two elem… */,
 		"CS1003" /* Syntax error, ',' expected */,
 		"CS0119" /* 'identifier' is a type, which is not valid in the given context */,
 		"CS0246" /* A namespace cannot directly contain members such as fields or methods */,
@@ -47,12 +53,13 @@ public static class Generator
 		driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation,
 			out ImmutableArray<Diagnostic> diagnostics);
 
-		var compilationDiagnostics = outputCompilation.GetDiagnostics();
+		ImmutableArray<Diagnostic> compilationDiagnostics = outputCompilation.GetDiagnostics();
 		GeneratorDriverRunResult runResult = driver.GetRunResult();
 		Dictionary<string, string> generatedSources = runResult.Results
 			.SelectMany(runResult => runResult.GeneratedSources)
 			.ToDictionary(source => source.HintName, source => source.SourceText.ToString());
-		string[] diagnosticMessages = [
+		string[] diagnosticMessages =
+		[
 			..compilationDiagnostics.Where(x => !NoWarn.Contains(x.Id)).Select(ToDiagnosticString),
 			..diagnostics.Where(x => !NoWarn.Contains(x.Id)).Select(ToDiagnosticString),
 		];
@@ -61,7 +68,7 @@ public static class Generator
 
 	private static string ToDiagnosticString(Diagnostic d)
 	{
-		var result = d.ToString();
+		string result = d.ToString();
 		if (result.StartsWith("Mockolate.SourceGenerators\\Mockolate.SourceGenerators.MockGenerator\\"))
 		{
 			result = result["Mockolate.SourceGenerators\\Mockolate.SourceGenerators.MockGenerator\\".Length..];

--- a/Tests/Mockolate.SourceGenerators.Tests/Tests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Tests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading;
 
 namespace Mockolate.SourceGenerators.Tests;
+
 public class Tests
 {
 	[Fact]
@@ -25,12 +26,12 @@ public class Tests
 			     			var z = Mock.Create<MyBaseClass>();
 			             }
 			         }
-			     
+
 			         public interface IMyInterface
 			         {
 			             void MyMethod(int v1, bool v2, double v3, long v4, uint v5, string v6, DateTime v7);
 			         }
-			     
+
 			         public class MyBaseClass
 			         {
 			             protected virtual Task<int> MyMethod(int v1, bool v2, double v3, long v4, uint v5, string v6, DateTime v7, TimeSpan v8, CancellationToken v9)
@@ -119,12 +120,12 @@ public class Tests
 			     			var x = Mockolate.Mock.Create<IMyInterface1, IMyInterface2>();
 			             }
 			         }
-			     
+
 			         public interface IMyInterface1
 			         {
 			             void MyMethod(int v1);
 			         }
-			     
+
 			         public interface IMyInterface2
 			         {
 			             void MyMethod(int v1);
@@ -156,12 +157,12 @@ public class Tests
 			     			var x = Mockolate.Mock.Create<IMyInterface1>();
 			             }
 			         }
-			     
+
 			         public interface IMyInterface1 : IMyInterface2
 			         {
 			             new void MyMethod(int v1);
 			         }
-			     
+
 			         public interface IMyInterface2
 			         {
 			             void MyMethod(int v1);


### PR DESCRIPTION
This PR fixes source name conflicts in generated files by implementing case-insensitive comparison for name collision detection. The changes ensure that generated mock files avoid naming conflicts regardless of case differences.

### Key changes:
- Replaced case-sensitive string equality checks with case-insensitive comparisons using `StringComparison.OrdinalIgnoreCase`
- Added comprehensive test coverage for various conflict scenarios including interface names and nested types
- Enhanced test infrastructure with additional compiler warning suppressions