### PR TITLE
refactor: change object of verification result

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
@@ -201,7 +201,7 @@ internal static partial class Sources
 				.Append(string.Join(", ", method.Parameters.Select(p => $"<paramref name=\"{p.Name}\"/>"))).Append(".")
 				.AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic VerificationResult<Mock<").Append(allClasses).Append(">> ").Append(method.Name).Append("(");
+			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>> ").Append(method.Name).Append("(");
 			int i = 0;
 			foreach (MethodParameter parameter in method.Parameters)
 			{
@@ -225,7 +225,7 @@ internal static partial class Sources
 			}
 
 			sb.Append(")").AppendLine();
-			sb.Append("\t\t\t=> ((IMockInvoked<Mock<").Append(allClasses).Append(">>)mock).Method(\"")
+			sb.Append("\t\t\t=> ((IMockInvoked<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Method(\"")
 				.Append(@class.GetFullName(method.Name))
 				.Append("\"");
 
@@ -289,8 +289,8 @@ internal static partial class Sources
 			sb.Append("\t\t///     Validates the invocations for the property <see cref=\"").Append(@class.ClassName.EscapeForXmlDoc())
 				.Append(".").Append(property.Name.EscapeForXmlDoc()).Append("\"/>.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic VerificationResult<Mock<").Append(allClasses).Append(">> ").Append(property.Name).Append("()").AppendLine();
-			sb.Append("\t\t\t=> ((IMockGot<Mock<").Append(allClasses).Append(">>)mock).Property(\"").Append(@class.GetFullName(property.Name)).Append("\");").AppendLine();
+			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>> ").Append(property.Name).Append("()").AppendLine();
+			sb.Append("\t\t\t=> ((IMockGot<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Property(\"").Append(@class.GetFullName(property.Name)).Append("\");").AppendLine();
 		}
 
 		sb.AppendLine("\t}");
@@ -330,11 +330,11 @@ internal static partial class Sources
 			sb.Append("\t\t/// <summary>").AppendLine();
 			sb.Append("\t\t///     Verifies the indexer read access for <see cref=\"").Append(@class.ClassName.EscapeForXmlDoc()).Append("\"/> on the mock.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic VerificationResult<Mock<").Append(allClasses).Append(">>")
+			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>")
 				.Append(isProtected ? ".Protected" : "").Append(" GotIndexer").Append("(").Append(string.Join(", ", indexerParameters.Value.Select((p, i) => $"With.Parameter<{p.Type.GetMinimizedString(namespaces)}>? parameter{i + 1}"))).Append(")").AppendLine();
 			sb.AppendLine("\t\t{");
 			sb.Append("\t\t\tMockGotIndexer<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">> indexer = new(verify);").AppendLine();
-			sb.Append("\t\t\treturn ((IMockGotIndexer<Mock<").Append(allClasses).Append(">>)indexer).Got(").Append(string.Join(", ", indexerParameters.Value.Select((p, i) => $"parameter{i + 1}"))).Append(");").AppendLine();
+			sb.Append("\t\t\treturn ((IMockGotIndexer<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>)indexer).Got(").Append(string.Join(", ", indexerParameters.Value.Select((p, i) => $"parameter{i + 1}"))).Append(");").AppendLine();
 			sb.AppendLine("\t\t}");
 		}
 
@@ -384,8 +384,8 @@ internal static partial class Sources
 			sb.Append("\t\t///     Validates the invocations for the property <see cref=\"").Append(@class.ClassName.EscapeForXmlDoc())
 				.Append(".").Append(property.Name.EscapeForXmlDoc()).Append("\"/>.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic VerificationResult<Mock<").Append(allClasses).Append(">> ").Append(property.Name).Append("(With.Parameter<").Append(property.Type.GetMinimizedString(namespaces)).Append("> value)").AppendLine();
-			sb.Append("\t\t\t=> ((IMockSet<Mock<").Append(allClasses).Append(">>)mock).Property(\"").Append(@class.GetFullName(property.Name)).Append("\", value);").AppendLine();
+			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>> ").Append(property.Name).Append("(With.Parameter<").Append(property.Type.GetMinimizedString(namespaces)).Append("> value)").AppendLine();
+			sb.Append("\t\t\t=> ((IMockSet<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Property(\"").Append(@class.GetFullName(property.Name)).Append("\", value);").AppendLine();
 		}
 
 		sb.AppendLine("\t}");
@@ -424,11 +424,11 @@ internal static partial class Sources
 			sb.Append("\t\t/// <summary>").AppendLine();
 			sb.Append("\t\t///     Verifies the indexer write access for <see cref=\"").Append(@class.ClassName.EscapeForXmlDoc()).Append("\"/> on the mock.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic VerificationResult<Mock<").Append(allClasses).Append(">>")
+			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>")
 				.Append(isProtected ? ".Protected" : "").Append(" SetIndexer").Append("(").Append(string.Join(", ", indexer.IndexerParameters.Value.Select((p, i) => $"With.Parameter<{p.Type.GetMinimizedString(namespaces)}>? parameter{i + 1}"))).Append(", With.Parameter<").Append(indexer.Type.GetMinimizedString(namespaces)).Append(">? value)").AppendLine();
 			sb.AppendLine("\t\t{");
 			sb.Append("\t\t\tMockSetIndexer<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">> indexer = new(verify);").AppendLine();
-			sb.Append("\t\t\treturn ((IMockSetIndexer<Mock<").Append(allClasses).Append(">>)indexer).Set(value, ").Append(string.Join(", ", indexer.IndexerParameters.Value.Select((p, i) => $"parameter{i + 1}"))).Append(");").AppendLine();
+			sb.Append("\t\t\treturn ((IMockSetIndexer<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>)indexer).Set(value, ").Append(string.Join(", ", indexer.IndexerParameters.Value.Select((p, i) => $"parameter{i + 1}"))).Append(");").AppendLine();
 			sb.AppendLine("\t\t}");
 		}
 
@@ -485,9 +485,9 @@ internal static partial class Sources
 			sb.Append("\t\t///     Validates the subscriptions for the event <see cref=\"")
 				.Append(@class.ClassName.EscapeForXmlDoc()).Append(".").Append(@event.Name.EscapeForXmlDoc()).Append("\"/>.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic VerificationResult<Mock<").Append(allClasses).Append(">> ")
+			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>> ")
 				.Append(@event.Name).Append("()").AppendLine();
-			sb.Append("\t\t\t=> ((IMockSubscribedTo<Mock<").Append(allClasses).Append(">>)mock).Event(\"").Append(@class.GetFullName(@event.Name)).Append("\");").AppendLine();
+			sb.Append("\t\t\t=> ((IMockSubscribedTo<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Event(\"").Append(@class.GetFullName(@event.Name)).Append("\");").AppendLine();
 		}
 
 		sb.AppendLine("\t}");
@@ -508,9 +508,9 @@ internal static partial class Sources
 			sb.Append("\t\t///     Validates the unsubscription for the event <see cref=\"")
 				.Append(@class.ClassName.EscapeForXmlDoc()).Append(".").Append(@event.Name.EscapeForXmlDoc()).Append("\"/>.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic VerificationResult<Mock<").Append(allClasses).Append(">> ")
+			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>> ")
 				.Append(@event.Name).Append("()").AppendLine();
-			sb.Append("\t\t\t=> ((IMockUnsubscribedFrom<Mock<").Append(allClasses).Append(">>)mock).Event(\"").Append(@class.GetFullName(@event.Name)).Append("\");").AppendLine();
+			sb.Append("\t\t\t=> ((IMockUnsubscribedFrom<MockVerify<").Append(@class.ClassName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Event(\"").Append(@class.GetFullName(@event.Name)).Append("\");").AppendLine();
 		}
 
 		sb.AppendLine("\t}");

--- a/Source/Mockolate/Verify/IVerificationResult.cs
+++ b/Source/Mockolate/Verify/IVerificationResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Mockolate.Interactions;
+
+namespace Mockolate.Verify;
+
+/// <summary>
+///     The result of a verification containing the matching interactions.
+/// </summary>
+public interface IVerificationResult<out TVerify>
+{
+	/// <summary>
+	///     The expectation of this check result.
+	/// </summary>
+	string Expectation { get; }
+
+	/// <summary>
+	///     The verify object for which this expectation applies.
+	/// </summary>
+	TVerify Object { get; }
+
+	/// <summary>
+	/// Verifies that the specified <paramref name="predicate"/> holds true for the current set of interactions.
+	/// </summary>
+	bool Verify(Func<IInteraction[], bool> predicate);
+}

--- a/Source/Mockolate/Verify/MockGot.cs
+++ b/Source/Mockolate/Verify/MockGot.cs
@@ -7,22 +7,25 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Check which properties got read on the mocked instance <typeparamref name="TMock" />.
 /// </summary>
-public class MockGot<T, TMock>(IMockVerify<TMock> verify) : IMockGot<TMock>
+public class MockGot<T, TMock>(MockVerify<T, TMock> verify) : IMockGot<MockVerify<T, TMock>>
 {
 	/// <inheritdoc cref="IMockGot{TMock}.Property(string)" />
-	VerificationResult<TMock> IMockGot<TMock>.Property(string propertyName)
-		=> new(verify.Mock, verify.Interactions,
-			verify.Interactions.Interactions
+	VerificationResult<MockVerify<T, TMock>> IMockGot<MockVerify<T, TMock>>.Property(string propertyName)
+	{
+		MockInteractions interactions = ((IMockVerify<TMock>)verify).Interactions;
+		return new(verify, interactions,
+			interactions.Interactions
 				.OfType<PropertyGetterAccess>()
 				.Where(property => property.Name.Equals(propertyName))
 				.Cast<IInteraction>()
 				.ToArray(),
-        $"got property {propertyName.SubstringAfterLast('.')}");
+		$"got property {propertyName.SubstringAfterLast('.')}");
+	}
 
 	/// <summary>
 	///     Check which protected properties got read on the mocked instance <typeparamref name="TMock" />.
 	/// </summary>
-	public class Protected(IMockVerify<TMock> verify) : MockGot<T, TMock>(verify)
+	public class Protected(MockVerify<T, TMock> verify) : MockGot<T, TMock>(verify)
 	{
 	}
 }

--- a/Source/Mockolate/Verify/MockGotIndexer.cs
+++ b/Source/Mockolate/Verify/MockGotIndexer.cs
@@ -6,12 +6,14 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Check which indexers got read on the mocked instance <typeparamref name="TMock" />.
 /// </summary>
-public class MockGotIndexer<T, TMock>(IMockVerify<TMock> verify) : IMockGotIndexer<TMock>
+public class MockGotIndexer<T, TMock>(MockVerify<T, TMock> verify) : IMockGotIndexer<MockVerify<T, TMock>>
 {
 	/// <inheritdoc cref="IMockGotIndexer{TMock}.Got(With.Parameter?[])" />
-	VerificationResult<TMock> IMockGotIndexer<TMock>.Got(params With.Parameter?[] parameters)
-		=> new(verify.Mock, verify.Interactions,
-			verify.Interactions.Interactions
+	VerificationResult<MockVerify<T, TMock>> IMockGotIndexer<MockVerify<T, TMock>>.Got(params With.Parameter?[] parameters)
+	{
+		MockInteractions interactions = ((IMockVerify<TMock>)verify).Interactions;
+		return new(verify, interactions,
+			interactions.Interactions
 				.OfType<IndexerGetterAccess>()
 				.Where(indexer => indexer.Parameters.Length == parameters.Length &&
 				!parameters.Where((parameter, i) => parameter is null
@@ -19,12 +21,13 @@ public class MockGotIndexer<T, TMock>(IMockVerify<TMock> verify) : IMockGotIndex
 					: !parameter.Matches(indexer.Parameters[i])).Any())
 				.Cast<IInteraction>()
 				.ToArray(),
-        $"got indexer {string.Join(", ", parameters.Select(x => x?.ToString() ?? "null"))}");
+		$"got indexer {string.Join(", ", parameters.Select(x => x?.ToString() ?? "null"))}");
+	}
 
 	/// <summary>
 	///     Check which protected indexers got read on the mocked instance <typeparamref name="TMock" />.
 	/// </summary>
-	public class Protected(IMockVerify<TMock> verify) : MockGotIndexer<T, TMock>(verify)
+	public class Protected(MockVerify<T, TMock> verify) : MockGotIndexer<T, TMock>(verify)
 	{
 	}
 }

--- a/Source/Mockolate/Verify/MockInvoked.cs
+++ b/Source/Mockolate/Verify/MockInvoked.cs
@@ -7,12 +7,14 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Check which methods got invoked on the mocked instance for <typeparamref name="TMock" />.
 /// </summary>
-public class MockInvoked<T, TMock>(IMockVerify<TMock> verify) : IMockInvoked<TMock>
+public class MockInvoked<T, TMock>(MockVerify<T, TMock> verify) : IMockInvoked<MockVerify<T, TMock>>
 {
 	/// <inheritdoc cref="IMockInvoked{TMock}.Method(string, With.Parameter[])" />
-	VerificationResult<TMock> IMockInvoked<TMock>.Method(string methodName, params With.Parameter[] parameters)
-		=> new(verify.Mock, verify.Interactions,
-			verify.Interactions.Interactions
+	VerificationResult<MockVerify<T, TMock>> IMockInvoked<MockVerify<T, TMock>>.Method(string methodName, params With.Parameter[] parameters)
+	{
+		MockInteractions interactions = ((IMockVerify<TMock>)verify).Interactions;
+		return new(verify, interactions,
+			interactions.Interactions
 				.OfType<MethodInvocation>()
 				.Where(method =>
 					method.Name.Equals(methodName) &&
@@ -20,12 +22,13 @@ public class MockInvoked<T, TMock>(IMockVerify<TMock> verify) : IMockInvoked<TMo
 					!parameters.Where((parameter, i) => !parameter.Matches(method.Parameters[i])).Any())
 				.Cast<IInteraction>()
 				.ToArray(),
-        $"invoked method {methodName.SubstringAfterLast('.')}({string.Join(", ", parameters.Select(x => x.ToString()))})");
+		$"invoked method {methodName.SubstringAfterLast('.')}({string.Join(", ", parameters.Select(x => x.ToString()))})");
+	}
 
 	/// <summary>
 	///     Check which protected methods got invoked on the mocked instance <typeparamref name="TMock" />.
 	/// </summary>
-	public class Protected(IMockVerify<TMock> verify) : MockInvoked<T, TMock>(verify)
+	public class Protected(MockVerify<T, TMock> verify) : MockInvoked<T, TMock>(verify)
 	{
 	}
 }

--- a/Source/Mockolate/Verify/MockSet.cs
+++ b/Source/Mockolate/Verify/MockSet.cs
@@ -7,22 +7,25 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Check which properties were set on the mocked instance <typeparamref name="TMock" />.
 /// </summary>
-public class MockSet<T, TMock>(IMockVerify<TMock> verify) : IMockSet<TMock>
+public class MockSet<T, TMock>(MockVerify<T, TMock> verify) : IMockSet<MockVerify<T, TMock>>
 {
 	/// <inheritdoc cref="IMockSet{TMock}.Property(string, With.Parameter)" />
-	VerificationResult<TMock> IMockSet<TMock>.Property(string propertyName, With.Parameter value)
-		=> new(verify.Mock, verify.Interactions,
-			verify.Interactions.Interactions
+	VerificationResult<MockVerify<T, TMock>> IMockSet<MockVerify<T, TMock>>.Property(string propertyName, With.Parameter value)
+	{
+		MockInteractions interactions = ((IMockVerify<TMock>)verify).Interactions;
+		return new(verify, interactions,
+			interactions.Interactions
 				.OfType<PropertySetterAccess>()
 				.Where(property => property.Name.Equals(propertyName) && value.Matches(property.Value))
 				.Cast<IInteraction>()
 				.ToArray(),
-        $"set property {propertyName.SubstringAfterLast('.')} to value {value}");
+		$"set property {propertyName.SubstringAfterLast('.')} to value {value}");
+	}
 
 	/// <summary>
 	///     Check which protected properties were set on the mocked instance <typeparamref name="TMock" />.
 	/// </summary>
-	public class Protected(IMockVerify<TMock> verify) : MockSet<T, TMock>(verify)
+	public class Protected(MockVerify<T, TMock> verify) : MockSet<T, TMock>(verify)
 	{
 	}
 }

--- a/Source/Mockolate/Verify/MockSetIndexer.cs
+++ b/Source/Mockolate/Verify/MockSetIndexer.cs
@@ -6,12 +6,14 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Check which indexers were set on the mocked instance <typeparamref name="TMock" />.
 /// </summary>
-public class MockSetIndexer<T, TMock>(IMockVerify<TMock> verify) : IMockSetIndexer<TMock>
+public class MockSetIndexer<T, TMock>(MockVerify<T, TMock> verify) : IMockSetIndexer<MockVerify<T, TMock>>
 {
 	/// <inheritdoc cref="IMockSetIndexer{TMock}.Set(With.Parameter?, With.Parameter?[])" />
-	VerificationResult<TMock> IMockSetIndexer<TMock>.Set(With.Parameter? value, params With.Parameter?[] parameters)
-		=> new(verify.Mock, verify.Interactions,
-			verify.Interactions.Interactions
+	VerificationResult<MockVerify<T, TMock>> IMockSetIndexer<MockVerify<T, TMock>>.Set(With.Parameter? value, params With.Parameter?[] parameters)
+	{
+		MockInteractions interactions = ((IMockVerify<TMock>)verify).Interactions;
+		return new(verify, interactions,
+			interactions.Interactions
 				.OfType<IndexerSetterAccess>()
 				.Where(indexer => indexer.Parameters.Length == parameters.Length &&
 				(value is null ? indexer.Value is null : value!.Matches(indexer.Value)) &&
@@ -20,12 +22,13 @@ public class MockSetIndexer<T, TMock>(IMockVerify<TMock> verify) : IMockSetIndex
 					: !parameter.Matches(indexer.Parameters[i])).Any())
 				.Cast<IInteraction>()
 				.ToArray(),
-        $"set indexer {string.Join(", ", parameters.Select(x => x?.ToString() ?? "null"))} to value {(value?.ToString() ?? "null")}");
+		$"set indexer {string.Join(", ", parameters.Select(x => x?.ToString() ?? "null"))} to value {(value?.ToString() ?? "null")}");
+	}
 
 	/// <summary>
 	///     Check which protected indexers were set on the mocked instance <typeparamref name="TMock" />.
 	/// </summary>
-	public class Protected(IMockVerify<TMock> verify) : MockSetIndexer<T, TMock>(verify)
+	public class Protected(MockVerify<T, TMock> verify) : MockSetIndexer<T, TMock>(verify)
 	{
 	}
 }

--- a/Source/Mockolate/Verify/MockSubscribedTo.cs
+++ b/Source/Mockolate/Verify/MockSubscribedTo.cs
@@ -7,22 +7,25 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Check which events were subscribed to on the mocked instance <typeparamref name="TMock" />.
 /// </summary>
-public class MockSubscribedTo<T, TMock>(IMockVerify<TMock> verify) : IMockSubscribedTo<TMock>
+public class MockSubscribedTo<T, TMock>(MockVerify<T, TMock> verify) : IMockSubscribedTo<MockVerify<T, TMock>>
 {
 	/// <inheritdoc cref="IMockSubscribedTo{TMock}.Event(string)" />
-	VerificationResult<TMock> IMockSubscribedTo<TMock>.Event(string eventName)
-		=> new(verify.Mock, verify.Interactions,
-			verify.Interactions.Interactions
+	VerificationResult<MockVerify<T, TMock>> IMockSubscribedTo<MockVerify<T, TMock>>.Event(string eventName)
+	{
+		MockInteractions interactions = ((IMockVerify<TMock>)verify).Interactions;
+		return new(verify, interactions,
+			interactions.Interactions
 				.OfType<EventSubscription>()
 				.Where(@event => @event.Name.Equals(eventName))
 				.Cast<IInteraction>()
 				.ToArray(),
-        $"subscribed to event {eventName.SubstringAfterLast('.')}");
+		$"subscribed to event {eventName.SubstringAfterLast('.')}");
+	}
 
 	/// <summary>
 	///     Check which protected events were subscribed to on the mocked instance <typeparamref name="TMock" />.
 	/// </summary>
-	public class Protected(IMockVerify<TMock> verify) : MockSubscribedTo<T, TMock>(verify)
+	public class Protected(MockVerify<T, TMock> verify) : MockSubscribedTo<T, TMock>(verify)
 	{
 	}
 }

--- a/Source/Mockolate/Verify/MockUnsubscribedFrom.cs
+++ b/Source/Mockolate/Verify/MockUnsubscribedFrom.cs
@@ -7,22 +7,25 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Check which events were unsubscribed from on the mocked instance <typeparamref name="TMock" />.
 /// </summary>
-public class MockUnsubscribedFrom<T, TMock>(IMockVerify<TMock> verify) : IMockUnsubscribedFrom<TMock>
+public class MockUnsubscribedFrom<T, TMock>(MockVerify<T, TMock> verify) : IMockUnsubscribedFrom<MockVerify<T, TMock>>
 {
 	/// <inheritdoc cref="IMockUnsubscribedFrom{TMock}.Event(string)" />
-	VerificationResult<TMock> IMockUnsubscribedFrom<TMock>.Event(string eventName)
-		=> new(verify.Mock, verify.Interactions,
-			verify.Interactions.Interactions
+	VerificationResult<MockVerify<T, TMock>> IMockUnsubscribedFrom<MockVerify<T, TMock>>.Event(string eventName)
+	{
+		MockInteractions interactions = ((IMockVerify<TMock>)verify).Interactions;
+		return new(verify, interactions,
+			interactions.Interactions
 				.OfType<EventUnsubscription>()
 				.Where(@event => @event.Name.Equals(eventName))
 				.Cast<IInteraction>()
 				.ToArray(),
-        $"unsubscribed from event {eventName.SubstringAfterLast('.')}");
+		$"unsubscribed from event {eventName.SubstringAfterLast('.')}");
+	}
 
 	/// <summary>
 	///     Check which protected events were unsubscribed from on the mocked instance <typeparamref name="TMock" />.
 	/// </summary>
-	public class Protected(IMockVerify<TMock> verify) : MockUnsubscribedFrom<T, TMock>(verify)
+	public class Protected(MockVerify<T, TMock> verify) : MockUnsubscribedFrom<T, TMock>(verify)
 	{
 	}
 }

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -4,25 +4,20 @@ using Mockolate.Interactions;
 namespace Mockolate.Verify;
 
 /// <summary>
-///     The expectation contains the matching interactions for verification.
+///     The result of a verification containing the matching interactions.
 /// </summary>
-public class VerificationResult<TMock>
+public class VerificationResult<TVerify> : IVerificationResult<TVerify>
 {
 	private readonly MockInteractions _interactions;
 	private readonly IInteraction[] _matchingInteractions;
 
 	/// <summary>
-	///     The expectation of this check result.
+	///     The verify object for which this expectation applies.
 	/// </summary>
-	public string Expectation { get; }
-
-	/// <summary>
-	///     The mock object for which this expectation applies.
-	/// </summary>
-	public TMock Mock { get; }
+	public TVerify Mock { get; }
 
 	/// <inheritdoc cref="VerificationResult{TMock}" />
-	public VerificationResult(TMock mock, MockInteractions interactions, IInteraction[] matchingInteractions, string expectation)
+	public VerificationResult(TVerify mock, MockInteractions interactions, IInteraction[] matchingInteractions, string expectation)
 	{
 		Mock = mock;
 		_interactions = interactions;
@@ -30,12 +25,20 @@ public class VerificationResult<TMock>
 		Expectation = expectation;
 	}
 
-	/// <summary>
-	/// Verifies that the specified <paramref name="predicate"/> holds true for the current set of interactions.
-	/// </summary>
+	#region IVerificationResult<TVerify>
+
+	/// <inheritdoc cref="IVerificationResult{TVerify}.Expectation" />
+	public string Expectation { get; }
+
+	/// <inheritdoc cref="IVerificationResult{TVerify}.Object" />
+	TVerify IVerificationResult<TVerify>.Object => Mock;
+
+	/// <inheritdoc cref="IVerificationResult{TVerify}.Verify(Func{IInteraction[], Boolean})" />
 	public bool Verify(Func<IInteraction[], bool> predicate)
 	{
 		_interactions.Verified(_matchingInteractions);
 		return predicate(_matchingInteractions);
 	}
+
+	#endregion
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -748,60 +748,66 @@ namespace Mockolate.Verify
         Mockolate.Interactions.MockInteractions Interactions { get; }
         TMock Mock { get; }
     }
-    public class MockGotIndexer<T, TMock> : Mockolate.Verify.IMockGotIndexer<TMock>
+    public interface IVerificationResult<out TVerify>
     {
-        public MockGotIndexer(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        string Expectation { get; }
+        TVerify Object { get; }
+        bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate);
+    }
+    public class MockGotIndexer<T, TMock> : Mockolate.Verify.IMockGotIndexer<Mockolate.Verify.MockVerify<T, TMock>>
+    {
+        public MockGotIndexer(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockGotIndexer<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockGot<T, TMock> : Mockolate.Verify.IMockGot<TMock>
+    public class MockGot<T, TMock> : Mockolate.Verify.IMockGot<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockGot(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockGot(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockGot<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockInvoked<T, TMock> : Mockolate.Verify.IMockInvoked<TMock>
+    public class MockInvoked<T, TMock> : Mockolate.Verify.IMockInvoked<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockInvoked(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockInvoked(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockInvoked<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSetIndexer<T, TMock> : Mockolate.Verify.IMockSetIndexer<TMock>
+    public class MockSetIndexer<T, TMock> : Mockolate.Verify.IMockSetIndexer<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSetIndexer(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSetIndexer(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSetIndexer<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSet<T, TMock> : Mockolate.Verify.IMockSet<TMock>
+    public class MockSet<T, TMock> : Mockolate.Verify.IMockSet<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSet(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSet(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSet<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSubscribedTo<T, TMock> : Mockolate.Verify.IMockSubscribedTo<TMock>
+    public class MockSubscribedTo<T, TMock> : Mockolate.Verify.IMockSubscribedTo<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSubscribedTo(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSubscribedTo(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSubscribedTo<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockUnsubscribedFrom<T, TMock> : Mockolate.Verify.IMockUnsubscribedFrom<TMock>
+    public class MockUnsubscribedFrom<T, TMock> : Mockolate.Verify.IMockUnsubscribedFrom<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockUnsubscribedFrom(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockUnsubscribedFrom(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockUnsubscribedFrom<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
     public class MockVerify<T, TMock> : Mockolate.Verify.IMockVerify<TMock>
@@ -827,11 +833,11 @@ namespace Mockolate.Verify
         public static void Then<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
         public static void Twice<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
     }
-    public class VerificationResult<TMock>
+    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult<TVerify>
     {
-        public VerificationResult(TMock mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
+        public VerificationResult(TVerify mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public TMock Mock { get; }
+        public TVerify Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -747,60 +747,66 @@ namespace Mockolate.Verify
         Mockolate.Interactions.MockInteractions Interactions { get; }
         TMock Mock { get; }
     }
-    public class MockGotIndexer<T, TMock> : Mockolate.Verify.IMockGotIndexer<TMock>
+    public interface IVerificationResult<out TVerify>
     {
-        public MockGotIndexer(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        string Expectation { get; }
+        TVerify Object { get; }
+        bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate);
+    }
+    public class MockGotIndexer<T, TMock> : Mockolate.Verify.IMockGotIndexer<Mockolate.Verify.MockVerify<T, TMock>>
+    {
+        public MockGotIndexer(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockGotIndexer<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockGot<T, TMock> : Mockolate.Verify.IMockGot<TMock>
+    public class MockGot<T, TMock> : Mockolate.Verify.IMockGot<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockGot(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockGot(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockGot<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockInvoked<T, TMock> : Mockolate.Verify.IMockInvoked<TMock>
+    public class MockInvoked<T, TMock> : Mockolate.Verify.IMockInvoked<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockInvoked(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockInvoked(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockInvoked<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSetIndexer<T, TMock> : Mockolate.Verify.IMockSetIndexer<TMock>
+    public class MockSetIndexer<T, TMock> : Mockolate.Verify.IMockSetIndexer<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSetIndexer(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSetIndexer(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSetIndexer<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSet<T, TMock> : Mockolate.Verify.IMockSet<TMock>
+    public class MockSet<T, TMock> : Mockolate.Verify.IMockSet<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSet(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSet(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSet<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSubscribedTo<T, TMock> : Mockolate.Verify.IMockSubscribedTo<TMock>
+    public class MockSubscribedTo<T, TMock> : Mockolate.Verify.IMockSubscribedTo<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSubscribedTo(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSubscribedTo(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSubscribedTo<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockUnsubscribedFrom<T, TMock> : Mockolate.Verify.IMockUnsubscribedFrom<TMock>
+    public class MockUnsubscribedFrom<T, TMock> : Mockolate.Verify.IMockUnsubscribedFrom<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockUnsubscribedFrom(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockUnsubscribedFrom(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockUnsubscribedFrom<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
     public class MockVerify<T, TMock> : Mockolate.Verify.IMockVerify<TMock>
@@ -826,11 +832,11 @@ namespace Mockolate.Verify
         public static void Then<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
         public static void Twice<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
     }
-    public class VerificationResult<TMock>
+    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult<TVerify>
     {
-        public VerificationResult(TMock mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
+        public VerificationResult(TVerify mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public TMock Mock { get; }
+        public TVerify Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -732,60 +732,66 @@ namespace Mockolate.Verify
         Mockolate.Interactions.MockInteractions Interactions { get; }
         TMock Mock { get; }
     }
-    public class MockGotIndexer<T, TMock> : Mockolate.Verify.IMockGotIndexer<TMock>
+    public interface IVerificationResult<out TVerify>
     {
-        public MockGotIndexer(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        string Expectation { get; }
+        TVerify Object { get; }
+        bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate);
+    }
+    public class MockGotIndexer<T, TMock> : Mockolate.Verify.IMockGotIndexer<Mockolate.Verify.MockVerify<T, TMock>>
+    {
+        public MockGotIndexer(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockGotIndexer<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockGot<T, TMock> : Mockolate.Verify.IMockGot<TMock>
+    public class MockGot<T, TMock> : Mockolate.Verify.IMockGot<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockGot(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockGot(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockGot<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockInvoked<T, TMock> : Mockolate.Verify.IMockInvoked<TMock>
+    public class MockInvoked<T, TMock> : Mockolate.Verify.IMockInvoked<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockInvoked(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockInvoked(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockInvoked<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSetIndexer<T, TMock> : Mockolate.Verify.IMockSetIndexer<TMock>
+    public class MockSetIndexer<T, TMock> : Mockolate.Verify.IMockSetIndexer<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSetIndexer(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSetIndexer(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSetIndexer<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSet<T, TMock> : Mockolate.Verify.IMockSet<TMock>
+    public class MockSet<T, TMock> : Mockolate.Verify.IMockSet<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSet(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSet(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSet<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockSubscribedTo<T, TMock> : Mockolate.Verify.IMockSubscribedTo<TMock>
+    public class MockSubscribedTo<T, TMock> : Mockolate.Verify.IMockSubscribedTo<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockSubscribedTo(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockSubscribedTo(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockSubscribedTo<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
-    public class MockUnsubscribedFrom<T, TMock> : Mockolate.Verify.IMockUnsubscribedFrom<TMock>
+    public class MockUnsubscribedFrom<T, TMock> : Mockolate.Verify.IMockUnsubscribedFrom<Mockolate.Verify.MockVerify<T, TMock>>
     {
-        public MockUnsubscribedFrom(Mockolate.Verify.IMockVerify<TMock> verify) { }
+        public MockUnsubscribedFrom(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         public class Protected : Mockolate.Verify.MockUnsubscribedFrom<T, TMock>
         {
-            public Protected(Mockolate.Verify.IMockVerify<TMock> verify) { }
+            public Protected(Mockolate.Verify.MockVerify<T, TMock> verify) { }
         }
     }
     public class MockVerify<T, TMock> : Mockolate.Verify.IMockVerify<TMock>
@@ -811,11 +817,11 @@ namespace Mockolate.Verify
         public static void Then<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
         public static void Twice<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
     }
-    public class VerificationResult<TMock>
+    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult<TVerify>
     {
-        public VerificationResult(TMock mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
+        public VerificationResult(TVerify mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public TMock Mock { get; }
+        public TVerify Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -22,7 +22,7 @@ public class ExampleTests
 
 		int result = mock.Subject.MyMethod(3);
 
-		VerificationResult<Mock<MyClass>> check = mock.Verify.Invoked.MyMethod(With.Any<int>());
+		var check = mock.Verify.Invoked.MyMethod(With.Any<int>());
 		await That(result).IsEqualTo(5);
 		check.Once();
 	}

--- a/Tests/Mockolate.Tests/Internals/StringExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Internals/StringExtensionsTests.cs
@@ -11,9 +11,9 @@ public sealed class StringExtensionsTests
 	{
 		MockInteractions interactions = new();
 		MockVerify<int, Mock<int>> verify = new(interactions, new MyMock<int>(1));
-		IMockGot<Mock<int>> mockGot = new MockGot<int, Mock<int>>(verify);
+		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 
-		VerificationResult<Mock<int>> result = mockGot.Property("SomeNameWithoutADot");
+		var result = mockGot.Property("SomeNameWithoutADot");
 
 		result.Never();
 		await That(result.Expectation).IsEqualTo("got property SomeNameWithoutADot");
@@ -24,9 +24,9 @@ public sealed class StringExtensionsTests
 	{
 		MockInteractions interactions = new();
 		MockVerify<int, Mock<int>> verify = new(interactions, new MyMock<int>(1));
-		IMockGot<Mock<int>> accessed = new MockGot<int, Mock<int>>(verify);
+		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 
-		VerificationResult<Mock<int>> result = accessed.Property(".bar");
+		var result = mockGot.Property(".bar");
 
 		result.Never();
 		await That(result.Expectation).IsEqualTo("got property bar");

--- a/Tests/Mockolate.Tests/Verify/MockGotIndexerTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockGotIndexerTests.ProtectedTests.cs
@@ -15,13 +15,13 @@ public sealed partial class MockGotIndexerTests
 			IMockInteractions interactions = mockInteractions;
 			MyMock<int> mock = new(1);
 			MockVerify<int, Mock<int>> verify = new(mockInteractions, mock);
-			IMockGotIndexer<Mock<int>> mockIndexer = new MockGotIndexer<int, Mock<int>>(verify);
-			IMockGotIndexer<Mock<int>> @protected = new MockGotIndexer<int, Mock<int>>.Protected(verify);
+			IMockGotIndexer<MockVerify<int, Mock<int>>> mockIndexer = new MockGotIndexer<int, Mock<int>>(verify);
+			IMockGotIndexer<MockVerify<int, Mock<int>>> @protected = new MockGotIndexer<int, Mock<int>>.Protected(verify);
 			interactions.RegisterInteraction(new IndexerGetterAccess(0, ["foo.bar"]));
 			interactions.RegisterInteraction(new IndexerGetterAccess(1, ["foo.bar"]));
 
-			VerificationResult<Mock<int>> result1 = mockIndexer.Got(With.Any<string>());
-			VerificationResult<Mock<int>> result2 = @protected.Got(With.Any<string>());
+			var result1 = mockIndexer.Got(With.Any<string>());
+			var result2 = @protected.Got(With.Any<string>());
 
 			await That(result1).Exactly(2);
 			await That(result2).Exactly(2);

--- a/Tests/Mockolate.Tests/Verify/MockGotTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockGotTests.ProtectedTests.cs
@@ -15,13 +15,13 @@ public sealed partial class MockGotTests
 			IMockInteractions interactions = mockInteractions;
 			MyMock<int> mock = new(1);
 			MockVerify<int, Mock<int>> verify = new(mockInteractions, mock);
-			IMockGot<Mock<int>> mockGot = new MockGot<int, Mock<int>>(verify);
-			IMockGot<Mock<int>> @protected = new MockGot<int, Mock<int>>.Protected(verify);
+			IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
+			IMockGot<MockVerify<int, Mock<int>>> @protected = new MockGot<int, Mock<int>>.Protected(verify);
 			interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
 			interactions.RegisterInteraction(new PropertyGetterAccess(1, "foo.bar"));
 
-			VerificationResult<Mock<int>> result1 = mockGot.Property("foo.bar");
-			VerificationResult<Mock<int>> result2 = @protected.Property("foo.bar");
+			VerificationResult<MockVerify<int, Mock<int>>> result1 = mockGot.Property("foo.bar");
+			VerificationResult<MockVerify<int, Mock<int>>> result2 = @protected.Property("foo.bar");
 
 			await That(result1).Exactly(2);
 			await That(result2).Exactly(2);

--- a/Tests/Mockolate.Tests/Verify/MockGotTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockGotTests.cs
@@ -12,10 +12,10 @@ public sealed partial class MockGotTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockGot<Mock<int>> mockGot = new MockGot<int, Mock<int>>(verify);
+		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
 
-		VerificationResult<Mock<int>> result = mockGot.Property("baz.bar");
+		var result = mockGot.Property("baz.bar");
 
 		await That(result).Never();
 	}
@@ -26,10 +26,10 @@ public sealed partial class MockGotTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockGot<Mock<int>> mockGot = new MockGot<int, Mock<int>>(verify);
+		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
 
-		VerificationResult<Mock<int>> result = mockGot.Property("foo.bar");
+		var result = mockGot.Property("foo.bar");
 
 		await That(result).Once();
 	}
@@ -39,9 +39,9 @@ public sealed partial class MockGotTests
 	{
 		MockInteractions mockInteractions = new();
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockGot<Mock<int>> mockGot = new MockGot<int, Mock<int>>(verify);
+		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 
-		VerificationResult<Mock<int>> result = mockGot.Property("foo.bar");
+		var result = mockGot.Property("foo.bar");
 
 		await That(result).Never();
 		await That(result.Expectation).IsEqualTo("got property bar");

--- a/Tests/Mockolate.Tests/Verify/MockInvokedTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockInvokedTests.ProtectedTests.cs
@@ -15,14 +15,14 @@ public sealed partial class MockInvokedTests
 			IMockInteractions interactions = mockInteractions;
 			MyMock<int> mock = new(1);
 			MockVerify<int, Mock<int>> verify = new(mockInteractions, mock);
-			IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(verify);
-			IMockInvoked<Mock<int>> @protected =
+			IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
+			IMockInvoked<MockVerify<int, Mock<int>>> @protected =
 				new MockInvoked<int, Mock<int>>.Protected(verify);
 			interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [1,]));
 			interactions.RegisterInteraction(new MethodInvocation(1, "foo.bar", [2,]));
 
-			VerificationResult<Mock<int>> result1 = invoked.Method("foo.bar", With.Any<int>());
-			VerificationResult<Mock<int>> result2 = @protected.Method("foo.bar", With.Any<int>());
+			var result1 = invoked.Method("foo.bar", With.Any<int>());
+			var result2 = @protected.Method("foo.bar", With.Any<int>());
 
 			await That(result1).Exactly(2);
 			await That(result2).Exactly(2);

--- a/Tests/Mockolate.Tests/Verify/MockInvokedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockInvokedTests.cs
@@ -12,10 +12,10 @@ public sealed partial class MockInvokedTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(verify);
+		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4,]));
 
-		VerificationResult<Mock<int>> result = invoked.Method("foo.bar", With.Any<int>());
+		var result = invoked.Method("foo.bar", With.Any<int>());
 
 		await That(result).Once();
 	}
@@ -26,10 +26,10 @@ public sealed partial class MockInvokedTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(verify);
+		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4,]));
 
-		VerificationResult<Mock<int>> result = invoked.Method("foo.bar", With.Any<string>());
+		var result = invoked.Method("foo.bar", With.Any<string>());
 
 		await That(result).Never();
 	}
@@ -40,10 +40,10 @@ public sealed partial class MockInvokedTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(verify);
+		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4,]));
 
-		VerificationResult<Mock<int>> result = invoked.Method("baz.bar", With.Any<int>());
+		var result = invoked.Method("baz.bar", With.Any<int>());
 
 		await That(result).Never();
 	}
@@ -53,9 +53,9 @@ public sealed partial class MockInvokedTests
 	{
 		MockInteractions mockInteractions = new();
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockInvoked<Mock<int>> invoked = new MockInvoked<int, Mock<int>>(verify);
+		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 
-		VerificationResult<Mock<int>> result = invoked.Method("foo.bar", With.Any<int>());
+		var result = invoked.Method("foo.bar", With.Any<int>());
 
 		await That(result).Never();
 		await That(result.Expectation).IsEqualTo("invoked method bar(With.Any<int>())");

--- a/Tests/Mockolate.Tests/Verify/MockSetIndexerTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockSetIndexerTests.ProtectedTests.cs
@@ -15,13 +15,13 @@ public sealed partial class MockSetIndexerTests
 			IMockInteractions interactions = mockInteractions;
 			MyMock<int> mock = new(1);
 			MockVerify<int, Mock<int>> verify = new(mockInteractions, mock);
-			IMockSetIndexer<Mock<int>> mockIndexer = new MockSetIndexer<int, Mock<int>>(verify);
-			IMockSetIndexer<Mock<int>> @protected = new MockSetIndexer<int, Mock<int>>.Protected(verify);
+			IMockSetIndexer<MockVerify<int, Mock<int>>> mockIndexer = new MockSetIndexer<int, Mock<int>>(verify);
+			IMockSetIndexer<MockVerify<int, Mock<int>>> @protected = new MockSetIndexer<int, Mock<int>>.Protected(verify);
 			interactions.RegisterInteraction(new IndexerSetterAccess(0, ["foo.bar"], 4));
 			interactions.RegisterInteraction(new IndexerSetterAccess(1, ["foo.bar"], 4));
 
-			VerificationResult<Mock<int>> result1 = mockIndexer.Set(With.Any<int>(), With.Any<string>());
-			VerificationResult<Mock<int>> result2 = @protected.Set(With.Any<int>(), With.Any<string>());
+			var result1 = mockIndexer.Set(With.Any<int>(), With.Any<string>());
+			var result2 = @protected.Set(With.Any<int>(), With.Any<string>());
 
 			await That(result1).Exactly(2);
 			await That(result2).Exactly(2);

--- a/Tests/Mockolate.Tests/Verify/MockSetTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockSetTests.ProtectedTests.cs
@@ -15,13 +15,13 @@ public sealed partial class MockSetTests
 			IMockInteractions interactions = mockInteractions;
 			MyMock<int> mock = new(1);
 			MockVerify<int, Mock<int>> verify = new(mockInteractions, mock);
-			IMockSet<Mock<int>> mockSet = new MockSet<int, Mock<int>>(verify);
-			IMockSet<Mock<int>> @protected = new MockSet<int, Mock<int>>.Protected(verify);
+			IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
+			IMockSet<MockVerify<int, Mock<int>>> @protected = new MockSet<int, Mock<int>>.Protected(verify);
 			interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 1));
 			interactions.RegisterInteraction(new PropertySetterAccess(1, "foo.bar", 2));
 
-			VerificationResult<Mock<int>> result1 = mockSet.Property("foo.bar", With.Any<int>());
-			VerificationResult<Mock<int>> result2 = @protected.Property("foo.bar", With.Any<int>());
+			var result1 = mockSet.Property("foo.bar", With.Any<int>());
+			var result2 = @protected.Property("foo.bar", With.Any<int>());
 
 			await That(result1).Exactly(2);
 			await That(result2).Exactly(2);

--- a/Tests/Mockolate.Tests/Verify/MockSetTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockSetTests.cs
@@ -12,10 +12,10 @@ public sealed partial class MockSetTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockSet<Mock<int>> mockSet = new MockSet<int, Mock<int>>(verify);
+		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
 
-		VerificationResult<Mock<int>> result = mockSet.Property("foo.bar", With.Any<int>());
+		var result = mockSet.Property("foo.bar", With.Any<int>());
 
 		await That(result).Once();
 	}
@@ -26,10 +26,10 @@ public sealed partial class MockSetTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockSet<Mock<int>> mockSet = new MockSet<int, Mock<int>>(verify);
+		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
 
-		VerificationResult<Mock<int>> result = mockSet.Property("foo.bar", With.Any<string>());
+		var result = mockSet.Property("foo.bar", With.Any<string>());
 
 		await That(result).Never();
 	}
@@ -40,10 +40,10 @@ public sealed partial class MockSetTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockSet<Mock<int>> mockSet = new MockSet<int, Mock<int>>(verify);
+		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
 
-		VerificationResult<Mock<int>> result = mockSet.Property("baz.bar", With.Any<int>());
+		var result = mockSet.Property("baz.bar", With.Any<int>());
 
 		await That(result).Never();
 	}
@@ -53,9 +53,9 @@ public sealed partial class MockSetTests
 	{
 		MockInteractions mockInteractions = new();
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockSet<Mock<int>> mockSet = new MockSet<int, Mock<int>>(verify);
+		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 
-		VerificationResult<Mock<int>> result = mockSet.Property("foo.bar", With.Any<int>());
+		var result = mockSet.Property("foo.bar", With.Any<int>());
 
 		await That(result).Never();
 		await That(result.Expectation).IsEqualTo("set property bar to value With.Any<int>()");

--- a/Tests/Mockolate.Tests/Verify/MockSubscribedToTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockSubscribedToTests.ProtectedTests.cs
@@ -15,13 +15,13 @@ public sealed partial class MockSubscribedToTests
 			IMockInteractions interactions = mockInteractions;
 			MyMock<int> mock = new(1);
 			MockVerify<int, Mock<int>> verify = new(mockInteractions, mock);
-			IMockSubscribedTo<Mock<int>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
-			IMockSubscribedTo<Mock<int>> @protected = new MockSubscribedTo<int, Mock<int>>.Protected(verify);
+			IMockSubscribedTo<MockVerify<int, Mock<int>>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
+			IMockSubscribedTo<MockVerify<int, Mock<int>>> @protected = new MockSubscribedTo<int, Mock<int>>.Protected(verify);
 			interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 			interactions.RegisterInteraction(new EventSubscription(1, "foo.bar", mock, Helper.GetMethodInfo()));
 
-			VerificationResult<Mock<int>> result1 = subscribedTo.Event("foo.bar");
-			VerificationResult<Mock<int>> result2 = @protected.Event("foo.bar");
+			var result1 = subscribedTo.Event("foo.bar");
+			var result2 = @protected.Event("foo.bar");
 
 			await That(result1).Exactly(2);
 			await That(result2).Exactly(2);

--- a/Tests/Mockolate.Tests/Verify/MockSubscribedToTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockSubscribedToTests.cs
@@ -12,10 +12,10 @@ public sealed partial class MockSubscribedToTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockSubscribedTo<Mock<int>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
+		IMockSubscribedTo<MockVerify<int, Mock<int>>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		VerificationResult<Mock<int>> result = subscribedTo.Event("baz.bar");
+		var result = subscribedTo.Event("baz.bar");
 
 		await That(result).Never();
 	}
@@ -26,10 +26,10 @@ public sealed partial class MockSubscribedToTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockSubscribedTo<Mock<int>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
+		IMockSubscribedTo<MockVerify<int, Mock<int>>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		VerificationResult<Mock<int>> result = subscribedTo.Event("foo.bar");
+		var result = subscribedTo.Event("foo.bar");
 
 		await That(result).Once();
 	}
@@ -39,9 +39,9 @@ public sealed partial class MockSubscribedToTests
 	{
 		MockInteractions mockInteractions = new();
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockSubscribedTo<Mock<int>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
+		IMockSubscribedTo<MockVerify<int, Mock<int>>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
 
-		VerificationResult<Mock<int>> result = subscribedTo.Event("foo.bar");
+		var result = subscribedTo.Event("foo.bar");
 
 		await That(result).Never();
 		await That(result.Expectation).IsEqualTo("subscribed to event bar");

--- a/Tests/Mockolate.Tests/Verify/MockUnsubscribedFromTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockUnsubscribedFromTests.ProtectedTests.cs
@@ -15,13 +15,13 @@ public sealed partial class MockUnsubscribedFromTests
 			IMockInteractions interactions = mockInteractions;
 			MyMock<int> mock = new(1);
 			MockVerify<int, Mock<int>> verify = new(mockInteractions, mock);
-			IMockUnsubscribedFrom<Mock<int>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
-			IMockUnsubscribedFrom<Mock<int>> @protected = new MockUnsubscribedFrom<int, Mock<int>>.Protected(verify);
+			IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
+			IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> @protected = new MockUnsubscribedFrom<int, Mock<int>>.Protected(verify);
 			interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 			interactions.RegisterInteraction(new EventUnsubscription(1, "foo.bar", mock, Helper.GetMethodInfo()));
 
-			VerificationResult<Mock<int>> result1 = unsubscribedFrom.Event("foo.bar");
-			VerificationResult<Mock<int>> result2 = @protected.Event("foo.bar");
+			var result1 = unsubscribedFrom.Event("foo.bar");
+			var result2 = @protected.Event("foo.bar");
 
 			await That(result1).Exactly(2);
 			await That(result2).Exactly(2);

--- a/Tests/Mockolate.Tests/Verify/MockUnsubscribedFromTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockUnsubscribedFromTests.cs
@@ -12,10 +12,10 @@ public sealed partial class MockUnsubscribedFromTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockUnsubscribedFrom<Mock<int>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
+		IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		VerificationResult<Mock<int>> result = unsubscribedFrom.Event("baz.bar");
+		var result = unsubscribedFrom.Event("baz.bar");
 
 		await That(result).Never();
 	}
@@ -26,10 +26,10 @@ public sealed partial class MockUnsubscribedFromTests
 		MockInteractions mockInteractions = new();
 		IMockInteractions interactions = mockInteractions;
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockUnsubscribedFrom<Mock<int>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
+		IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		VerificationResult<Mock<int>> result = unsubscribedFrom.Event("foo.bar");
+		var result = unsubscribedFrom.Event("foo.bar");
 
 		await That(result).Once();
 	}
@@ -39,9 +39,9 @@ public sealed partial class MockUnsubscribedFromTests
 	{
 		MockInteractions mockInteractions = new();
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
-		IMockUnsubscribedFrom<Mock<int>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
+		IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
 
-		VerificationResult<Mock<int>> result = unsubscribedFrom.Event("foo.bar");
+		var result = unsubscribedFrom.Event("foo.bar");
 
 		await That(result).Never();
 		await That(result.Expectation).IsEqualTo("unsubscribed from event bar");

--- a/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
@@ -187,13 +187,13 @@ public class VerificationResultExtensionsTests
 		mock.Subject.DoSomething(3);
 		mock.Subject.DoSomething(4);
 
-		mock.Verify.Invoked.DoSomething(3).Then(m => m.Verify.Invoked.DoSomething(4));
+		mock.Verify.Invoked.DoSomething(3).Then(m => m.Invoked.DoSomething(4));
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(2).Then(m => m.Verify.Invoked.DoSomething(1));
+			=> mock.Verify.Invoked.DoSomething(2).Then(m => m.Invoked.DoSomething(1));
 
 		await That(Act).Throws<MockVerificationException>()
 			.WithMessage($"Expected that mock invoked method DoSomething(2), then invoked method DoSomething(1) in order, but it invoked method DoSomething(1) too early.");
-		mock.Verify.Invoked.DoSomething(1).Then(m => m.Verify.Invoked.DoSomething(2));
+		mock.Verify.Invoked.DoSomething(1).Then(m => m.Invoked.DoSomething(2));
 	}
 
 	[Fact]
@@ -205,15 +205,15 @@ public class VerificationResultExtensionsTests
 		mock.Subject.DoSomething(3);
 		mock.Subject.DoSomething(4);
 
-		await That(void () => mock.Verify.Invoked.DoSomething(6).Then(m => m.Verify.Invoked.DoSomething(4)))
+		await That(void () => mock.Verify.Invoked.DoSomething(6).Then(m => m.Invoked.DoSomething(4)))
 			.Throws<MockVerificationException>()
 			.WithMessage($"Expected that mock invoked method DoSomething(6), then invoked method DoSomething(4) in order, but it invoked method DoSomething(6) not at all.");
 		
-		await That(void () => mock.Verify.Invoked.DoSomething(1).Then(m => m.Verify.Invoked.DoSomething(6), m => m.Verify.Invoked.DoSomething(3)))
+		await That(void () => mock.Verify.Invoked.DoSomething(1).Then(m => m.Invoked.DoSomething(6), m => m.Invoked.DoSomething(3)))
 			.Throws<MockVerificationException>()
 			.WithMessage($"Expected that mock invoked method DoSomething(1), then invoked method DoSomething(6), then invoked method DoSomething(3) in order, but it invoked method DoSomething(6) not at all.");
 		
-		await That(void () => mock.Verify.Invoked.DoSomething(1).Then(m => m.Verify.Invoked.DoSomething(2), m => m.Verify.Invoked.DoSomething(6)))
+		await That(void () => mock.Verify.Invoked.DoSomething(1).Then(m => m.Invoked.DoSomething(2), m => m.Invoked.DoSomething(6)))
 			.Throws<MockVerificationException>()
 			.WithMessage($"Expected that mock invoked method DoSomething(1), then invoked method DoSomething(2), then invoked method DoSomething(6) in order, but it invoked method DoSomething(6) not at all.");
 	}

--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
@@ -10,7 +10,7 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		VerificationResult<Mock<IMyService>> check = sut.Verify.SubscribedTo.SomethingHappened();
+		var check = sut.Verify.SubscribedTo.SomethingHappened();
 
 		await That(check.Expectation).IsEqualTo("subscribed to event SomethingHappened");
 	}
@@ -20,7 +20,7 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		VerificationResult<Mock<IMyService>> check = sut.Verify.UnsubscribedFrom.SomethingHappened();
+		var check = sut.Verify.UnsubscribedFrom.SomethingHappened();
 
 		await That(check.Expectation).IsEqualTo("unsubscribed from event SomethingHappened");
 	}
@@ -30,7 +30,7 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		VerificationResult<Mock<IMyService>> check = sut.Verify.Invoked.DoSomething(With.Any<int?>(), "foo");
+		var check = sut.Verify.Invoked.DoSomething(With.Any<int?>(), "foo");
 
 		await That(check.Expectation).IsEqualTo("invoked method DoSomething(With.Any<int?>(), \"foo\")");
 	}
@@ -40,7 +40,7 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		VerificationResult<Mock<IMyService>> check = sut.Verify.Got.MyProperty();
+		var check = sut.Verify.Got.MyProperty();
 
 		await That(check.Expectation).IsEqualTo("got property MyProperty");
 	}
@@ -50,7 +50,7 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		VerificationResult<Mock<IMyService>> check = sut.Verify.Set.MyProperty(With.Any<int>());
+		var check = sut.Verify.Set.MyProperty(With.Any<int>());
 
 		await That(check.Expectation).IsEqualTo("set property MyProperty to value With.Any<int>()");
 	}


### PR DESCRIPTION
This PR refactors the verification result object structure to change the generic type parameter from the mock type to the verification type. The primary goal is to update the `VerificationResult<T>` class and related interfaces to use `MockVerify<T, TMock>` instead of just `TMock` as the type parameter.

### Key changes:
- Updated `VerificationResult` generic parameter from `TMock` to `TVerify` with corresponding interface implementation
- Modified all mock verification classes to implement interfaces with `MockVerify<T, TMock>` instead of `TMock`