### PR TITLE
feat: add `IVerificationResult` interface

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
 		<PackageVersion Include="coverlet.collector" Version="6.0.4"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.6"/>
 		<PackageVersion Include="aweXpect" Version="2.26.0"/>
-		<PackageVersion Include="aweXpect.Mockolate" Version="0.2.0"/>
+		<PackageVersion Include="aweXpect.Mockolate" Version="0.3.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Moq" Version="4.20.72"/>

--- a/Source/Mockolate/Verify/IVerificationResult.cs
+++ b/Source/Mockolate/Verify/IVerificationResult.cs
@@ -6,7 +6,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     The result of a verification containing the matching interactions.
 /// </summary>
-public interface IVerificationResult<out TVerify>
+public interface IVerificationResult
 {
 	/// <summary>
 	///     The expectation of this check result.
@@ -14,9 +14,25 @@ public interface IVerificationResult<out TVerify>
 	string Expectation { get; }
 
 	/// <summary>
+	/// Verifies that the specified <paramref name="predicate"/> holds true for the current set of interactions.
+	/// </summary>
+	bool Verify(Func<IInteraction[], bool> predicate);
+}
+
+/// <summary>
+///     The result of a verification containing the matching interactions.
+/// </summary>
+public interface IVerificationResult<out TVerify>
+{
+	/// <summary>
 	///     The verify object for which this expectation applies.
 	/// </summary>
 	TVerify Object { get; }
+
+	/// <summary>
+	///     The expectation of this check result.
+	/// </summary>
+	string Expectation { get; }
 
 	/// <summary>
 	/// Verifies that the specified <paramref name="predicate"/> holds true for the current set of interactions.

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -6,35 +6,60 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     The result of a verification containing the matching interactions.
 /// </summary>
-public class VerificationResult<TVerify> : IVerificationResult<TVerify>
+public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerificationResult
 {
+	private readonly string _expectation;
 	private readonly MockInteractions _interactions;
+	private readonly TVerify _verify;
 	private readonly IInteraction[] _matchingInteractions;
 
-	/// <summary>
-	///     The verify object for which this expectation applies.
-	/// </summary>
-	public TVerify Mock { get; }
-
 	/// <inheritdoc cref="VerificationResult{TMock}" />
-	public VerificationResult(TVerify mock, MockInteractions interactions, IInteraction[] matchingInteractions, string expectation)
+	public VerificationResult(TVerify verify, MockInteractions interactions, IInteraction[] matchingInteractions, string expectation)
 	{
-		Mock = mock;
+		_verify = verify;
 		_interactions = interactions;
 		_matchingInteractions = matchingInteractions;
-		Expectation = expectation;
+		_expectation = expectation;
+	}
+
+	/// <inheritdoc cref="IVerificationResult.Expectation" />
+	public string Expectation
+		=> _expectation;
+
+	/// <inheritdoc cref="IVerificationResult.Verify(Func{IInteraction[], Boolean})" />
+	public bool Verify(Func<IInteraction[], bool> predicate)
+	{
+		_interactions.Verified(_matchingInteractions);
+		return predicate(_matchingInteractions);
 	}
 
 	#region IVerificationResult<TVerify>
 
 	/// <inheritdoc cref="IVerificationResult{TVerify}.Expectation" />
-	public string Expectation { get; }
+	string IVerificationResult<TVerify>.Expectation
+		=> _expectation;
 
 	/// <inheritdoc cref="IVerificationResult{TVerify}.Object" />
-	TVerify IVerificationResult<TVerify>.Object => Mock;
+	TVerify IVerificationResult<TVerify>.Object
+		=> _verify;
 
 	/// <inheritdoc cref="IVerificationResult{TVerify}.Verify(Func{IInteraction[], Boolean})" />
-	public bool Verify(Func<IInteraction[], bool> predicate)
+	bool IVerificationResult<TVerify>.Verify(Func<IInteraction[], bool> predicate)
+	{
+		_interactions.Verified(_matchingInteractions);
+		return predicate(_matchingInteractions);
+	}
+
+	#endregion
+
+	#region IVerificationResult
+
+	/// <inheritdoc cref="IVerificationResult.Expectation" />
+	string IVerificationResult.Expectation
+		=> _expectation;
+
+	/// <inheritdoc cref="IVerificationResult.Verify(Func{IInteraction[], Boolean})" />
+	bool IVerificationResult.Verify(Func<IInteraction[], bool> predicate)
 	{
 		_interactions.Verified(_matchingInteractions);
 		return predicate(_matchingInteractions);

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -16,15 +16,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void AtLeast<TMock>(this VerificationResult<TMock> verificationResult, int times)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length >= times;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} at least {times.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} at least {times.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -33,15 +34,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void AtLeastOnce<TMock>(this VerificationResult<TMock> verificationResult)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length >= 1;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} at least {1.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} at least {1.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -50,15 +52,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void AtLeastTwice<TMock>(this VerificationResult<TMock> verificationResult)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length >= 2;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} at least {2.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} at least {2.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -67,15 +70,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void AtMost<TMock>(this VerificationResult<TMock> verificationResult, int times)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length <= times;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} at most {times.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} at most {times.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -84,15 +88,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void AtMostOnce<TMock>(this VerificationResult<TMock> verificationResult)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length <= 1;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} at most {1.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} at most {1.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -101,15 +106,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void AtMostTwice<TMock>(this VerificationResult<TMock> verificationResult)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length <= 2;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} at most {2.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} at most {2.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -118,15 +124,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void Exactly<TMock>(this VerificationResult<TMock> verificationResult, int times)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length == times;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} exactly {times.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} exactly {times.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -135,15 +142,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void Never<TMock>(this VerificationResult<TMock> verificationResult)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length == 0;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {0.ToTimes()} {verificationResult.Expectation}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {0.ToTimes()} {result.Expectation}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -152,15 +160,16 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void Once<TMock>(this VerificationResult<TMock> verificationResult)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length == 1;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} exactly {1.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} exactly {1.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
@@ -169,27 +178,28 @@ public static class VerificationResultExtensions
 	/// </summary>
 	public static void Twice<TMock>(this VerificationResult<TMock> verificationResult)
 	{
+		IVerificationResult result = verificationResult;
 		int found = 0;
-		if (!verificationResult.Verify(interactions =>
+		if (!result.Verify(interactions =>
 		{
 			found = interactions.Length;
 			return interactions.Length == 2;
 		}))
 		{
 			throw new MockVerificationException(
-				$"Expected that mock {verificationResult.Expectation} exactly {2.ToTimes()}, but it {found.ToTimes("did")}.");
+				$"Expected that mock {result.Expectation} exactly {2.ToTimes()}, but it {found.ToTimes("did")}.");
 		}
 	}
 
 	/// <summary>
 	///     Supports fluent chaining of verifications in a given order.
 	/// </summary>
-	public static void Then<TMock>(this VerificationResult<TMock> verificationResult, params Func<TMock, VerificationResult<TMock>>[] orderedChecks)
+	public static void Then<TMock>(this IVerificationResult<TMock> verificationResult, params Func<TMock, VerificationResult<TMock>>[] orderedChecks)
 	{
 		string? error = null;
 		bool flag = true;
 		List<string> expectations = [];
-		VerificationResult<TMock> result = verificationResult;
+		IVerificationResult<TMock> result = verificationResult;
 		int after = -1;
 		foreach (Func<TMock, VerificationResult<TMock>>? check in orderedChecks)
 		{
@@ -198,7 +208,7 @@ public static class VerificationResultExtensions
 			{
 				flag = false;
 			}
-			result = check(result.Mock);
+			result = check(result.Object);
 		}
 		expectations.Add(result.Expectation);
 		if (!result.Verify(VerifyInteractions) || !flag)

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -748,6 +748,11 @@ namespace Mockolate.Verify
         Mockolate.Interactions.MockInteractions Interactions { get; }
         TMock Mock { get; }
     }
+    public interface IVerificationResult
+    {
+        string Expectation { get; }
+        bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate);
+    }
     public interface IVerificationResult<out TVerify>
     {
         string Expectation { get; }
@@ -830,14 +835,13 @@ namespace Mockolate.Verify
         public static void Exactly<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, int times) { }
         public static void Never<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
         public static void Once<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
-        public static void Then<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
+        public static void Then<TMock>(this Mockolate.Verify.IVerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
         public static void Twice<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
     }
-    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult<TVerify>
+    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult, Mockolate.Verify.IVerificationResult<TVerify>
     {
-        public VerificationResult(TVerify mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
+        public VerificationResult(TVerify verify, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public TVerify Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -747,6 +747,11 @@ namespace Mockolate.Verify
         Mockolate.Interactions.MockInteractions Interactions { get; }
         TMock Mock { get; }
     }
+    public interface IVerificationResult
+    {
+        string Expectation { get; }
+        bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate);
+    }
     public interface IVerificationResult<out TVerify>
     {
         string Expectation { get; }
@@ -829,14 +834,13 @@ namespace Mockolate.Verify
         public static void Exactly<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, int times) { }
         public static void Never<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
         public static void Once<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
-        public static void Then<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
+        public static void Then<TMock>(this Mockolate.Verify.IVerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
         public static void Twice<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
     }
-    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult<TVerify>
+    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult, Mockolate.Verify.IVerificationResult<TVerify>
     {
-        public VerificationResult(TVerify mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
+        public VerificationResult(TVerify verify, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public TVerify Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -732,6 +732,11 @@ namespace Mockolate.Verify
         Mockolate.Interactions.MockInteractions Interactions { get; }
         TMock Mock { get; }
     }
+    public interface IVerificationResult
+    {
+        string Expectation { get; }
+        bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate);
+    }
     public interface IVerificationResult<out TVerify>
     {
         string Expectation { get; }
@@ -814,14 +819,13 @@ namespace Mockolate.Verify
         public static void Exactly<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, int times) { }
         public static void Never<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
         public static void Once<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
-        public static void Then<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
+        public static void Then<TMock>(this Mockolate.Verify.IVerificationResult<TMock> verificationResult, params System.Func<TMock, Mockolate.Verify.VerificationResult<TMock>>[] orderedChecks) { }
         public static void Twice<TMock>(this Mockolate.Verify.VerificationResult<TMock> verificationResult) { }
     }
-    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult<TVerify>
+    public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult, Mockolate.Verify.IVerificationResult<TVerify>
     {
-        public VerificationResult(TVerify mock, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
+        public VerificationResult(TVerify verify, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
         public string Expectation { get; }
-        public TVerify Mock { get; }
         public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Tests/Internals/StringExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Internals/StringExtensionsTests.cs
@@ -13,10 +13,10 @@ public sealed class StringExtensionsTests
 		MockVerify<int, Mock<int>> verify = new(interactions, new MyMock<int>(1));
 		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 
-		var result = mockGot.Property("SomeNameWithoutADot");
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockGot.Property("SomeNameWithoutADot");
 
 		result.Never();
-		await That(result.Expectation).IsEqualTo("got property SomeNameWithoutADot");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("got property SomeNameWithoutADot");
 	}
 
 	[Fact]
@@ -26,9 +26,9 @@ public sealed class StringExtensionsTests
 		MockVerify<int, Mock<int>> verify = new(interactions, new MyMock<int>(1));
 		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 
-		var result = mockGot.Property(".bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockGot.Property(".bar");
 
 		result.Never();
-		await That(result.Expectation).IsEqualTo("got property bar");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("got property bar");
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/MockGotTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockGotTests.cs
@@ -15,7 +15,7 @@ public sealed partial class MockGotTests
 		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
 
-		var result = mockGot.Property("baz.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockGot.Property("baz.bar");
 
 		await That(result).Never();
 	}
@@ -29,7 +29,7 @@ public sealed partial class MockGotTests
 		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertyGetterAccess(0, "foo.bar"));
 
-		var result = mockGot.Property("foo.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockGot.Property("foo.bar");
 
 		await That(result).Once();
 	}
@@ -41,9 +41,9 @@ public sealed partial class MockGotTests
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
 		IMockGot<MockVerify<int, Mock<int>>> mockGot = new MockGot<int, Mock<int>>(verify);
 
-		var result = mockGot.Property("foo.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockGot.Property("foo.bar");
 
 		await That(result).Never();
-		await That(result.Expectation).IsEqualTo("got property bar");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("got property bar");
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/MockInvokedTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockInvokedTests.cs
@@ -15,7 +15,7 @@ public sealed partial class MockInvokedTests
 		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4,]));
 
-		var result = invoked.Method("foo.bar", With.Any<int>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = invoked.Method("foo.bar", With.Any<int>());
 
 		await That(result).Once();
 	}
@@ -29,7 +29,7 @@ public sealed partial class MockInvokedTests
 		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4,]));
 
-		var result = invoked.Method("foo.bar", With.Any<string>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = invoked.Method("foo.bar", With.Any<string>());
 
 		await That(result).Never();
 	}
@@ -43,7 +43,7 @@ public sealed partial class MockInvokedTests
 		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new MethodInvocation(0, "foo.bar", [4,]));
 
-		var result = invoked.Method("baz.bar", With.Any<int>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = invoked.Method("baz.bar", With.Any<int>());
 
 		await That(result).Never();
 	}
@@ -55,9 +55,9 @@ public sealed partial class MockInvokedTests
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
 		IMockInvoked<MockVerify<int, Mock<int>>> invoked = new MockInvoked<int, Mock<int>>(verify);
 
-		var result = invoked.Method("foo.bar", With.Any<int>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = invoked.Method("foo.bar", With.Any<int>());
 
 		await That(result).Never();
-		await That(result.Expectation).IsEqualTo("invoked method bar(With.Any<int>())");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("invoked method bar(With.Any<int>())");
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/MockSetTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockSetTests.cs
@@ -15,7 +15,7 @@ public sealed partial class MockSetTests
 		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
 
-		var result = mockSet.Property("foo.bar", With.Any<int>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockSet.Property("foo.bar", With.Any<int>());
 
 		await That(result).Once();
 	}
@@ -29,7 +29,7 @@ public sealed partial class MockSetTests
 		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
 
-		var result = mockSet.Property("foo.bar", With.Any<string>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockSet.Property("foo.bar", With.Any<string>());
 
 		await That(result).Never();
 	}
@@ -43,7 +43,7 @@ public sealed partial class MockSetTests
 		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new PropertySetterAccess(0, "foo.bar", 4));
 
-		var result = mockSet.Property("baz.bar", With.Any<int>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockSet.Property("baz.bar", With.Any<int>());
 
 		await That(result).Never();
 	}
@@ -55,9 +55,9 @@ public sealed partial class MockSetTests
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
 		IMockSet<MockVerify<int, Mock<int>>> mockSet = new MockSet<int, Mock<int>>(verify);
 
-		var result = mockSet.Property("foo.bar", With.Any<int>());
+		VerificationResult<MockVerify<int, Mock<int>>> result = mockSet.Property("foo.bar", With.Any<int>());
 
 		await That(result).Never();
-		await That(result.Expectation).IsEqualTo("set property bar to value With.Any<int>()");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("set property bar to value With.Any<int>()");
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/MockSubscribedToTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockSubscribedToTests.cs
@@ -15,7 +15,7 @@ public sealed partial class MockSubscribedToTests
 		IMockSubscribedTo<MockVerify<int, Mock<int>>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		var result = subscribedTo.Event("baz.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = subscribedTo.Event("baz.bar");
 
 		await That(result).Never();
 	}
@@ -29,7 +29,7 @@ public sealed partial class MockSubscribedToTests
 		IMockSubscribedTo<MockVerify<int, Mock<int>>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventSubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		var result = subscribedTo.Event("foo.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = subscribedTo.Event("foo.bar");
 
 		await That(result).Once();
 	}
@@ -41,9 +41,9 @@ public sealed partial class MockSubscribedToTests
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
 		IMockSubscribedTo<MockVerify<int, Mock<int>>> subscribedTo = new MockSubscribedTo<int, Mock<int>>(verify);
 
-		var result = subscribedTo.Event("foo.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = subscribedTo.Event("foo.bar");
 
 		await That(result).Never();
-		await That(result.Expectation).IsEqualTo("subscribed to event bar");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("subscribed to event bar");
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/MockUnsubscribedFromTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockUnsubscribedFromTests.cs
@@ -15,7 +15,7 @@ public sealed partial class MockUnsubscribedFromTests
 		IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		var result = unsubscribedFrom.Event("baz.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = unsubscribedFrom.Event("baz.bar");
 
 		await That(result).Never();
 	}
@@ -29,7 +29,7 @@ public sealed partial class MockUnsubscribedFromTests
 		IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
 		interactions.RegisterInteraction(new EventUnsubscription(0, "foo.bar", this, Helper.GetMethodInfo()));
 
-		var result = unsubscribedFrom.Event("foo.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = unsubscribedFrom.Event("foo.bar");
 
 		await That(result).Once();
 	}
@@ -41,9 +41,9 @@ public sealed partial class MockUnsubscribedFromTests
 		MockVerify<int, Mock<int>> verify = new(mockInteractions, new MyMock<int>(1));
 		IMockUnsubscribedFrom<MockVerify<int, Mock<int>>> unsubscribedFrom = new MockUnsubscribedFrom<int, Mock<int>>(verify);
 
-		var result = unsubscribedFrom.Event("foo.bar");
+		VerificationResult<MockVerify<int, Mock<int>>> result = unsubscribedFrom.Event("foo.bar");
 
 		await That(result).Never();
-		await That(result.Expectation).IsEqualTo("unsubscribed from event bar");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("unsubscribed from event bar");
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
@@ -10,9 +10,9 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		var check = sut.Verify.SubscribedTo.SomethingHappened();
+		VerificationResult<MockVerify<IMyService, Mock<IMyService>>> result = sut.Verify.SubscribedTo.SomethingHappened();
 
-		await That(check.Expectation).IsEqualTo("subscribed to event SomethingHappened");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("subscribed to event SomethingHappened");
 	}
 
 	[Fact]
@@ -20,9 +20,9 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		var check = sut.Verify.UnsubscribedFrom.SomethingHappened();
+		var result = sut.Verify.UnsubscribedFrom.SomethingHappened();
 
-		await That(check.Expectation).IsEqualTo("unsubscribed from event SomethingHappened");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("unsubscribed from event SomethingHappened");
 	}
 
 	[Fact]
@@ -30,9 +30,9 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		var check = sut.Verify.Invoked.DoSomething(With.Any<int?>(), "foo");
+		var result = sut.Verify.Invoked.DoSomething(With.Any<int?>(), "foo");
 
-		await That(check.Expectation).IsEqualTo("invoked method DoSomething(With.Any<int?>(), \"foo\")");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("invoked method DoSomething(With.Any<int?>(), \"foo\")");
 	}
 
 	[Fact]
@@ -40,9 +40,9 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		var check = sut.Verify.Got.MyProperty();
+		var result = sut.Verify.Got.MyProperty();
 
-		await That(check.Expectation).IsEqualTo("got property MyProperty");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("got property MyProperty");
 	}
 
 	[Fact]
@@ -50,9 +50,9 @@ public class VerificationResultTests
 	{
 		Mock<IMyService> sut = Mock.Create<IMyService>();
 
-		var check = sut.Verify.Set.MyProperty(With.Any<int>());
+		var result = sut.Verify.Set.MyProperty(With.Any<int>());
 
-		await That(check.Expectation).IsEqualTo("set property MyProperty to value With.Any<int>()");
+		await That((((IVerificationResult)result).Expectation)).IsEqualTo("set property MyProperty to value With.Any<int>()");
 	}
 
 	public interface IMyService


### PR DESCRIPTION
This PR introduces a new `IVerificationResult` interface to provide a non-generic base interface for verification results, improving API design and enabling polymorphic usage of verification results.

### Key changes:
- Adds `IVerificationResult` interface with basic verification methods
- Updates `VerificationResult<TVerify>` to implement both interfaces
- Refactors test code to use explicit interface casting for accessing `Expectation` property