### PR TITLE
fix: possible duplicate questionmark on event types

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -268,7 +268,7 @@ internal static partial class Sources
 				.AppendLine("\" />");
 			if (explicitInterfaceImplementation)
 			{
-				sb.Append("\t\tevent ").Append(@event.Type.GetMinimizedString(namespaces))
+				sb.Append("\t\tevent ").Append(@event.Type.GetMinimizedString(namespaces).TrimEnd('?'))
 					.Append("? ").Append(@class.GetFullName()).Append('.').Append(@event.Name).AppendLine();
 			}
 			else


### PR DESCRIPTION
This PR fixes a code generation issue where event types could end up with a duplicated nullable marker (??) in explicit interface implementations.

### Key changes:
- Strip any trailing ? from the minimized event type before appending a single ?.
- Scope: one line change in the generator to ensure only one ? is emitted for event types.