### PR TITLE
fix: include namespace in generic arguments

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -34,30 +34,12 @@ internal record MockClass : Class
 	public IEnumerable<Class> DistinctAdditionalImplementations()
 		=> AdditionalImplementations.Distinct().Where(x => x.GetFullName() != GetFullName());
 
-	public string[] GetAllNamespaces() => EnumerateAllNamespaces().Where(n => !n.StartsWith("<")).Distinct().OrderBy(n => n).ToArray();
-
 	internal IEnumerable<Class> GetAllClasses()
 	{
 		yield return this;
 		foreach (Class implementation in DistinctAdditionalImplementations())
 		{
 			yield return implementation;
-		}
-	}
-
-	private IEnumerable<string> EnumerateAllNamespaces()
-	{
-		foreach (string? @namespace in EnumerateNamespaces())
-		{
-			yield return @namespace;
-		}
-
-		foreach (Class? implementation in AdditionalImplementations)
-		{
-			foreach (string? @namespace in implementation.EnumerateNamespaces())
-			{
-				yield return @namespace;
-			}
 		}
 	}
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -105,6 +105,37 @@ public class GeneralTests
 	}
 
 	[Fact]
+	public async Task MockOfIList_ShouldIncludeFullNameAsGenericParameter()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+
+			     namespace MyCode
+			     {
+			         public class Program
+			         {
+			             public static void Main(string[] args)
+			             {
+			     			var x = Mockolate.Mock.Create<IList<MyOtherCode.MyRecord>>();
+			             }
+			         }
+			     }
+
+			     namespace MyOtherCode
+			     {
+			         public record MyRecord(int Id, string Name);
+			     }
+
+			     """, typeof(IList<>));
+
+		await That(result.Diagnostics).IsEmpty();
+
+		await That(result.Sources).ContainsKey("ForIListMyRecord.g.cs").WhoseValue
+			.Contains("public class MockSubject : System.Collections.Generic.IList<MyOtherCode.MyRecord>");
+	}
+
+	[Fact]
 	public async Task SameMethodInMultipleInterfaces_ShouldUseExplicitImplementation()
 	{
 		GeneratorResult result = Generator


### PR DESCRIPTION
This PR fixes an issue with namespace handling in generic type arguments by ensuring that full namespace qualifications are included when generating mock classes for generic types.

### Key changes:
- Refactored type name generation to separate simple names from fully qualified names
- Removed complex namespace enumeration logic in favor of direct full name generation
- Added test coverage for generic types with namespaced type arguments

---

- *Fixes #100*