### PR TITLE
fix: create method setups also for inherited methods

### DIFF
--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -51,7 +51,7 @@ public class MockGenerator : IIncrementalGenerator
 
 		HashSet<int> indexerSetups = new();
 		foreach (int item in mocksToGenerate
-					 .SelectMany(m => m.Properties)
+					 .SelectMany(m => m.AllProperties())
 					 .Where(m => m.IndexerParameters?.Count > 4)
 					 .Select(m => m.IndexerParameters!.Value.Count))
 		{
@@ -66,7 +66,7 @@ public class MockGenerator : IIncrementalGenerator
 
 		HashSet<(int, bool)> methodSetups = new();
 		foreach ((int Count, bool) item in mocksToGenerate
-			         .SelectMany(m => m.Methods)
+			         .SelectMany(m => m.AllMethods())
 			         .Where(m => m.Parameters.Count > 4)
 			         .Select(m => (m.Parameters.Count, m.ReturnType == Type.Void)))
 		{

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/MethodSetupsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/MethodSetupsTests.cs
@@ -20,10 +20,12 @@ public sealed class MethodSetupsTests
 			         {
 			             public static void Main(string[] args)
 			             {
-			     			_ = Mock.Create<IMyInterface>();
+			     			_ = Mock.Create<IMyOutermostInterface>();
 			             }
 			         }
-
+			     
+			         public interface IMyOutermostInterface : IMyOuterInterface;
+			         public interface IMyOuterInterface : IMyInterface;
 			         public interface IMyInterface
 			         {
 			             bool MyMethod1(int v1, bool v2, double v3, long v4, CancellationToken v5);


### PR DESCRIPTION
This PR fixes an issue where method setups were only being generated for directly declared methods and properties, not for inherited ones. The fix ensures that inherited members from base interfaces are also included in the generated mock setups.

### Key changes
- Create failing test
- Updated mock generator to use `AllMethods()` and `AllProperties()` instead of direct member access

---

- *Fixes #105*