### PR TITLE
fix: include generic type information in distinguishing methods

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -22,4 +22,7 @@ internal readonly record struct Event
 
 	public Accessibility Accessibility { get; }
 	public string Name { get; }
+
+	internal string GetUniqueNameString()
+		=> $"\"{ContainingType}.{Name}\"";
 }

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -48,4 +48,16 @@ internal record Method
 	{
 		ExplicitImplementation = ContainingType;
 	}
+
+	internal string GetUniqueNameString()
+	{
+		if (GenericParameters != null)
+		{
+			var name = Name.Substring(0, Name.IndexOf('<'));
+			var parameters = string.Join(", ", GenericParameters.Value.Select(genericParameter => $"{{typeof({genericParameter.Name})}}"));
+			return $"$\"{ContainingType}.{name}<{parameters}>\"";
+		}
+
+		return $"\"{ContainingType}.{Name}\"";
+	}
 }

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -35,4 +35,7 @@ internal readonly record struct Property
 
 	public Accessibility Accessibility { get; }
 	public string Name { get; }
+
+	internal string GetUniqueNameString()
+		=> $"\"{ContainingType}.{Name}\"";
 }

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
@@ -435,9 +435,7 @@ internal static partial class Sources
 					gp.AppendWhereConstraint(sb, "\t\t\t");
 				}
 			}
-			sb.Append("\t\t\t=> ((IMockInvoked<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Method(\"")
-				.Append(@class.ClassFullName).Append('.').Append(method.Name)
-				.Append("\"");
+			sb.Append("\t\t\t=> ((IMockInvoked<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Method(").Append(method.GetUniqueNameString());
 
 			foreach (MethodParameter parameter in method.Parameters)
 			{
@@ -520,7 +518,7 @@ internal static partial class Sources
 				.Append(".").Append(property.Name.EscapeForXmlDoc()).Append("\"/>.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
 			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>> ").Append(property.Name).Append("()").AppendLine();
-			sb.Append("\t\t\t=> ((IMockGot<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Property(\"").Append(@class.ClassFullName).Append('.').Append(property.Name).Append("\");").AppendLine();
+			sb.Append("\t\t\t=> ((IMockGot<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Property(").Append(property.GetUniqueNameString()).Append(");").AppendLine();
 		}
 
 		sb.AppendLine("\t}");
@@ -632,7 +630,7 @@ internal static partial class Sources
 				.Append(".").Append(property.Name.EscapeForXmlDoc()).Append("\"/>.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
 			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>> ").Append(property.Name).Append("(With.Parameter<").Append(property.Type.Fullname).Append("> value)").AppendLine();
-			sb.Append("\t\t\t=> ((IMockSet<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Property(\"").Append(@class.ClassFullName).Append('.').Append(property.Name).Append("\", value);").AppendLine();
+			sb.Append("\t\t\t=> ((IMockSet<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Property(").Append(property.GetUniqueNameString()).Append(", value);").AppendLine();
 		}
 
 		sb.AppendLine("\t}");
@@ -768,7 +766,7 @@ internal static partial class Sources
 			sb.Append("\t\t/// </summary>").AppendLine();
 			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>> ")
 				.Append(@event.Name).Append("()").AppendLine();
-			sb.Append("\t\t\t=> ((IMockSubscribedTo<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Event(\"").Append(@class.ClassFullName).Append('.').Append(@event.Name).Append("\");").AppendLine();
+			sb.Append("\t\t\t=> ((IMockSubscribedTo<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Event(").Append(@event.GetUniqueNameString()).Append(");").AppendLine();
 		}
 
 		sb.AppendLine("\t}");
@@ -789,7 +787,7 @@ internal static partial class Sources
 			sb.Append("\t\t/// </summary>").AppendLine();
 			sb.Append("\t\tpublic VerificationResult<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>> ")
 				.Append(@event.Name).Append("()").AppendLine();
-			sb.Append("\t\t\t=> ((IMockUnsubscribedFrom<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Event(\"").Append(@class.ClassFullName).Append('.').Append(@event.Name).Append("\");").AppendLine();
+			sb.Append("\t\t\t=> ((IMockUnsubscribedFrom<MockVerify<").Append(@class.ClassFullName).Append(", Mock<").Append(allClasses).Append(">>>)mock).Event(").Append(@event.GetUniqueNameString()).Append(");").AppendLine();
 		}
 
 		sb.AppendLine("\t}");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.SetupExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.SetupExtensions.cs
@@ -81,7 +81,7 @@ internal static partial class Sources
 					@event.Delegate.Parameters.Select(p => p.Type.Fullname + " " + p.Name)))
 				.Append(")").AppendLine();
 			sb.AppendLine("\t\t{");
-			sb.Append("\t\t\t((IMockRaises)mock).Raise(\"").Append(@class.ClassFullName).Append('.').Append(@event.Name).Append("\", ")
+			sb.Append("\t\t\t((IMockRaises)mock).Raise(").Append(@event.GetUniqueNameString()).Append(", ")
 				.Append(string.Join(", ", @event.Delegate.Parameters.Select(p => p.Name))).Append(");").AppendLine();
 			sb.AppendLine("\t\t}");
 		}
@@ -142,8 +142,7 @@ internal static partial class Sources
 					.Append(">();").AppendLine();
 				sb.AppendLine("\t\t\t\tif (setup is IMockSetup mockSetup)");
 				sb.AppendLine("\t\t\t\t{");
-				sb.Append("\t\t\t\t\tmockSetup.RegisterProperty(\"").Append(@class.ClassFullName).Append('.').Append(property.Name)
-					.Append("\", propertySetup);").AppendLine();
+				sb.Append("\t\t\t\t\tmockSetup.RegisterProperty(").Append(property.GetUniqueNameString()).Append(", propertySetup);").AppendLine();
 				sb.AppendLine("\t\t\t\t}");
 				sb.AppendLine("\t\t\t\treturn propertySetup;");
 				sb.AppendLine("\t\t\t}");
@@ -353,7 +352,7 @@ internal static partial class Sources
 					}
 				}
 
-				sb.Append("(\"").Append(@class.ClassFullName).Append('.').Append(method.Name).Append("\"");
+				sb.Append("(").Append(method.GetUniqueNameString());
 				foreach (var parameter in method.Parameters)
 				{
 					sb.Append(", new With.NamedParameter(\"").Append(parameter.Name).Append("\", ").Append(parameter.Name);

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -331,10 +331,8 @@ internal static partial class Sources
 		}
 
 		sb.AppendLine("\t\t{");
-		sb.Append("\t\t\tadd => _mock.Raise.AddEvent(\"").Append(@event.ContainingType).Append('.').Append(@event.Name)
-			.Append("\", value?.Target, value?.Method);").AppendLine();
-		sb.Append("\t\t\tremove => _mock.Raise.RemoveEvent(\"").Append(@event.ContainingType).Append('.').Append(@event.Name)
-			.Append("\", value?.Target, value?.Method);").AppendLine();
+		sb.Append("\t\t\tadd => _mock.Raise.AddEvent(").Append(@event.GetUniqueNameString()).Append(", value?.Target, value?.Method);").AppendLine();
+		sb.Append("\t\t\tremove => _mock.Raise.RemoveEvent(").Append(@event.GetUniqueNameString()).Append(", value?.Target, value?.Method);").AppendLine();
 		sb.AppendLine("\t\t}");
 	}
 
@@ -389,7 +387,7 @@ internal static partial class Sources
 			{
 				sb.Append("\t\t\t\treturn _mock.Get<")
 					.Append(property.Type.Fullname)
-					.Append(">(\"").Append(property.ContainingType).Append('.').Append(property.Name).AppendLine("\");");
+					.Append(">(").Append(property.GetUniqueNameString()).AppendLine(");");
 			}
 			sb.AppendLine("\t\t\t}");
 		}
@@ -412,7 +410,7 @@ internal static partial class Sources
 			}
 			else
 			{
-				sb.Append("\t\t\t\t_mock.Set(\"").Append(property.ContainingType).Append('.').Append(property.Name).AppendLine("\", value);");
+				sb.Append("\t\t\t\t_mock.Set(").Append(property.GetUniqueNameString()).AppendLine(", value);");
 			}
 			sb.AppendLine("\t\t\t}");
 		}
@@ -481,7 +479,7 @@ internal static partial class Sources
 		{
 			sb.Append("\t\t\tvar result = _mock.Execute<")
 				.Append(method.ReturnType.Fullname)
-				.Append(">(\"").Append(method.ContainingType).Append('.').Append(method.Name).Append("\"");
+				.Append(">(").Append(method.GetUniqueNameString());
 			foreach (MethodParameter p in method.Parameters)
 			{
 				sb.Append(", ").Append(p.RefKind == RefKind.Out ? "null" : p.Name);
@@ -491,7 +489,7 @@ internal static partial class Sources
 		}
 		else
 		{
-			sb.Append("\t\t\tvar result = _mock.Execute(\"").Append(className).Append('.').Append(method.Name).Append("\"");
+			sb.Append("\t\t\tvar result = _mock.Execute(").Append(method.GetUniqueNameString());
 			foreach (MethodParameter p in method.Parameters)
 			{
 				sb.Append(", ").Append(p.RefKind == RefKind.Out ? "null" : p.Name);

--- a/Tests/Mockolate.Tests/Setup/MockSetupsTests.MethodsTests.cs
+++ b/Tests/Mockolate.Tests/Setup/MockSetupsTests.MethodsTests.cs
@@ -22,6 +22,19 @@ public sealed partial class MockSetupsTests
 		}
 
 		[Fact]
+		public async Task GenericMethods_ShouldConsiderGenericParameter()
+		{
+			Mock<IMethodService> mock = Mock.Create<IMethodService>();
+			mock.Setup.Method.MyGenericMethod<int>().Returns(42);
+
+			int matchingResult = mock.Subject.MyGenericMethod<int>();
+			int notMatchingResult = mock.Subject.MyGenericMethod<long>();
+
+			await That(matchingResult).IsEqualTo(42);
+			await That(notMatchingResult).IsEqualTo(0);
+		}
+
+		[Fact]
 		public async Task WhenNotSetup_ShouldReturnDefault()
 		{
 			Mock<IMethodService> mock = Mock.Create<IMethodService>();
@@ -53,6 +66,7 @@ public sealed partial class MockSetupsTests
 			int MyIntMethodWithoutParameters();
 			int MyIntMethodWithParameters(int x, string y);
 			int MyGenericMethod<T1, T2>(T1 x, T2 y) where T1 : struct where T2 : class;
+			int MyGenericMethod<T>();
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where generic type parameters were not being considered when distinguishing between overloaded generic methods in the mocking framework. The fix ensures that methods with different generic type parameters (e.g., `MyGenericMethod<int>()` vs `MyGenericMethod<long>()`) are treated as distinct methods.

### Key Changes:
- Introduced `GetUniqueNameString()` methods to generate unique identifiers for methods, properties, and events that include generic type information for methods
- Replaced hardcoded string concatenation throughout the codebase with calls to these new methods
- Added test coverage to verify generic methods are properly distinguished by their type parameters