### PR TITLE
fix: use setup for virtual calls from constructor

### DIFF
--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.DelegateTests.cs
@@ -23,7 +23,7 @@ public sealed partial class ForMockTests
 
 		await That(result.Sources).ContainsKey("ForFuncintbool.g.cs").WhoseValue
 			.DoesNotContain("MockSubject").IgnoringNewlineStyle().And
-			.Contains("Subject = new System.Func<int,bool>(").IgnoringNewlineStyle();
+			.Contains("_subject = new System.Func<int,bool>(").IgnoringNewlineStyle();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
@@ -81,8 +81,8 @@ public sealed partial class ForMockTests
 				          		/// <inheritdoc cref="MyCode.MyService.SomeEvent" />
 				          		public override event System.EventHandler? SomeEvent
 				          		{
-				          			add => _mock?.Raise.AddEvent("MyCode.MyService.SomeEvent", value?.Target, value?.Method);
-				          			remove => _mock?.Raise.RemoveEvent("MyCode.MyService.SomeEvent", value?.Target, value?.Method);
+				          			add => (_mock ?? _mockProvider.Value)?.Raise.AddEvent("MyCode.MyService.SomeEvent", value?.Target, value?.Method);
+				          			remove => (_mock ?? _mockProvider.Value)?.Raise.RemoveEvent("MyCode.MyService.SomeEvent", value?.Target, value?.Method);
 				          		}
 				          """).IgnoringNewlineStyle().And
 				.DoesNotContain("SomeOtherEvent").Because("The event is not virtual!").And
@@ -90,8 +90,8 @@ public sealed partial class ForMockTests
 				          		/// <inheritdoc cref="MyCode.IMyOtherService.SomeThirdEvent" />
 				          		event System.EventHandler? MyCode.IMyOtherService.SomeThirdEvent
 				          		{
-				          			add => _mock?.Raise.AddEvent("MyCode.IMyOtherService.SomeThirdEvent", value?.Target, value?.Method);
-				          			remove => _mock?.Raise.RemoveEvent("MyCode.IMyOtherService.SomeThirdEvent", value?.Target, value?.Method);
+				          			add => (_mock ?? _mockProvider.Value)?.Raise.AddEvent("MyCode.IMyOtherService.SomeThirdEvent", value?.Target, value?.Method);
+				          			remove => (_mock ?? _mockProvider.Value)?.Raise.RemoveEvent("MyCode.IMyOtherService.SomeThirdEvent", value?.Target, value?.Method);
 				          		}
 				          """).IgnoringNewlineStyle();
 		}
@@ -271,12 +271,12 @@ public sealed partial class ForMockTests
 				          		{
 				          			get
 				          			{
-				          				return _mock?.GetIndexer<int>(index)
+				          				return (_mock ?? _mockProvider.Value)?.GetIndexer<int>(index)
 				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
-				          				_mock?.SetIndexer<int>(value, index);
+				          				(_mock ?? _mockProvider.Value)?.SetIndexer<int>(value, index);
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -286,7 +286,7 @@ public sealed partial class ForMockTests
 				          		{
 				          			get
 				          			{
-				          				return _mock?.GetIndexer<int>(index, isReadOnly)
+				          				return (_mock ?? _mockProvider.Value)?.GetIndexer<int>(index, isReadOnly)
 				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
 				          			}
 				          		}
@@ -297,7 +297,7 @@ public sealed partial class ForMockTests
 				          		{
 				          			set
 				          			{
-				          				_mock?.SetIndexer<int>(value, index, isWriteOnly);
+				          				(_mock ?? _mockProvider.Value)?.SetIndexer<int>(value, index, isWriteOnly);
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -308,12 +308,12 @@ public sealed partial class ForMockTests
 				          		{
 				          			get
 				          			{
-				          				return _mock?.GetIndexer<int>(someAdditionalIndex)
+				          				return (_mock ?? _mockProvider.Value)?.GetIndexer<int>(someAdditionalIndex)
 				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
-				          				_mock?.SetIndexer<int>(value, someAdditionalIndex);
+				          				(_mock ?? _mockProvider.Value)?.SetIndexer<int>(value, someAdditionalIndex);
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle();
@@ -490,14 +490,14 @@ public sealed partial class ForMockTests
 				          		/// <inheritdoc cref="MyCode.MyService.MyMethod1(int)" />
 				          		public override void MyMethod1(int index)
 				          		{
-				          			MethodSetupResult? methodExecution = _mock?.Execute("MyCode.MyService.MyMethod1", index);
+				          			MethodSetupResult? methodExecution = (_mock ?? _mockProvider.Value)?.Execute("MyCode.MyService.MyMethod1", index);
 				          		}
 				          """).IgnoringNewlineStyle().And
 				.Contains("""
 				          		/// <inheritdoc cref="MyCode.MyService.MyMethod2(int, bool)" />
 				          		protected override bool MyMethod2(int index, bool isReadOnly)
 				          		{
-				          			MethodSetupResult<bool>? methodExecution = _mock?.Execute<bool>("MyCode.MyService.MyMethod2", index, isReadOnly);
+				          			MethodSetupResult<bool>? methodExecution = (_mock ?? _mockProvider.Value)?.Execute<bool>("MyCode.MyService.MyMethod2", index, isReadOnly);
 				          			return methodExecution?.Result ?? MockBehavior.Default.DefaultValue.Generate<bool>();
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -506,7 +506,7 @@ public sealed partial class ForMockTests
 				          		/// <inheritdoc cref="MyCode.IMyOtherService.SomeOtherMethod()" />
 				          		int MyCode.IMyOtherService.SomeOtherMethod()
 				          		{
-				          			MethodSetupResult<int>? methodExecution = _mock?.Execute<int>("MyCode.IMyOtherService.SomeOtherMethod");
+				          			MethodSetupResult<int>? methodExecution = (_mock ?? _mockProvider.Value)?.Execute<int>("MyCode.IMyOtherService.SomeOtherMethod");
 				          			return methodExecution?.Result ?? MockBehavior.Default.DefaultValue.Generate<int>();
 				          		}
 				          """).IgnoringNewlineStyle();
@@ -662,12 +662,12 @@ public sealed partial class ForMockTests
 				          		{
 				          			protected get
 				          			{
-				          				return _mock?.Get<int>("MyCode.MyService.SomeProperty1")
+				          				return (_mock ?? _mockProvider.Value)?.Get<int>("MyCode.MyService.SomeProperty1")
 				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
-				          				_mock?.Set("MyCode.MyService.SomeProperty1", value);
+				          				(_mock ?? _mockProvider.Value)?.Set("MyCode.MyService.SomeProperty1", value);
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -677,12 +677,12 @@ public sealed partial class ForMockTests
 				          		{
 				          			get
 				          			{
-				          				return _mock?.Get<int>("MyCode.MyService.SomeProperty2")
+				          				return (_mock ?? _mockProvider.Value)?.Get<int>("MyCode.MyService.SomeProperty2")
 				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
 				          			}
 				          			protected set
 				          			{
-				          				_mock?.Set("MyCode.MyService.SomeProperty2", value);
+				          				(_mock ?? _mockProvider.Value)?.Set("MyCode.MyService.SomeProperty2", value);
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -692,7 +692,7 @@ public sealed partial class ForMockTests
 				          		{
 				          			get
 				          			{
-				          				return _mock?.Get<bool?>("MyCode.MyService.SomeReadOnlyProperty")
+				          				return (_mock ?? _mockProvider.Value)?.Get<bool?>("MyCode.MyService.SomeReadOnlyProperty")
 				          					?? MockBehavior.Default.DefaultValue.Generate<bool?>();
 				          			}
 				          		}
@@ -703,7 +703,7 @@ public sealed partial class ForMockTests
 				          		{
 				          			set
 				          			{
-				          				_mock?.Set("MyCode.MyService.SomeWriteOnlyProperty", value);
+				          				(_mock ?? _mockProvider.Value)?.Set("MyCode.MyService.SomeWriteOnlyProperty", value);
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -714,12 +714,12 @@ public sealed partial class ForMockTests
 				          		{
 				          			get
 				          			{
-				          				return _mock?.Get<int>("MyCode.IMyOtherService.SomeAdditionalProperty")
+				          				return (_mock ?? _mockProvider.Value)?.Get<int>("MyCode.IMyOtherService.SomeAdditionalProperty")
 				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
-				          				_mock?.Set("MyCode.IMyOtherService.SomeAdditionalProperty", value);
+				          				(_mock ?? _mockProvider.Value)?.Set("MyCode.IMyOtherService.SomeAdditionalProperty", value);
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle();

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.cs
@@ -71,19 +71,21 @@ public sealed partial class ForMockTests
 
 		await That(result.Sources).ContainsKey("ForMyBaseClass.g.cs").WhoseValue
 			.Contains("""
-			          			if (constructorParameters.Parameters.Length == 1
-			          			    && TryCast(constructorParameters.Parameters[0], out int p1))
-			          			{
-			          				Subject = new MockSubject(this, p1);
-			          			}
+			          					if (_constructorParameters.Parameters.Length == 1
+			          					    && TryCast(_constructorParameters.Parameters[0], out int p1))
+			          					{
+			          						MockSubject._mockProvider.Value = this;
+			          						_subject = new MockSubject(this, p1);
+			          					}
 			          """.TrimStart()).IgnoringNewlineStyle().And
 			.Contains("""
-			          			if (constructorParameters.Parameters.Length == 2
-			          			    && TryCast(constructorParameters.Parameters[0], out int p1)
-			          			    && TryCast(constructorParameters.Parameters[1], out bool p2))
-			          			{
-			          				Subject = new MockSubject(this, p1, p2);
-			          			}
+			          					if (_constructorParameters.Parameters.Length == 2
+			          					    && TryCast(_constructorParameters.Parameters[0], out int p1)
+			          					    && TryCast(_constructorParameters.Parameters[1], out bool p2))
+			          					{
+			          						MockSubject._mockProvider.Value = this;
+			          						_subject = new MockSubject(this, p1, p2);
+			          					}
 			          """.TrimStart()).IgnoringNewlineStyle().And
 			.Contains("""
 			          		public MockSubject(IMock mock, int value)
@@ -100,10 +102,10 @@ public sealed partial class ForMockTests
 			          		}
 			          """).IgnoringNewlineStyle().And
 			.Contains("""
-			          			if (constructorParameters is null || constructorParameters.Parameters.Length == 0)
-			          			{
-			          				throw new MockException("No parameterless constructor found for 'MyCode.MyBaseClass'. Please provide constructor parameters.");
-			          			}
+			          					if (_constructorParameters is null || _constructorParameters.Parameters.Length == 0)
+			          					{
+			          						throw new MockException("No parameterless constructor found for 'MyCode.MyBaseClass'. Please provide constructor parameters.");
+			          					}
 			          """).IgnoringNewlineStyle();
 	}
 

--- a/Tests/Mockolate.Tests/MockTests.Create.cs
+++ b/Tests/Mockolate.Tests/MockTests.Create.cs
@@ -517,19 +517,27 @@ public sealed partial class MockTests
 	public async Task Create_BaseClassWithVirtualCallsInConstructor()
 	{
 		var mock = Mock.Create<MyBaseClassWithVirtualCallsInConstructor>();
+		mock.Setup.Method.VirtualMethod().Returns([5, 6]);
 
-		await That(mock.Verify.Invoked.VirtualMethod()).Never();
+		var value = mock.Subject.VirtualProperty;
+
+		await That(mock.Verify.Invoked.VirtualMethod()).Once();
+		await That(value).IsEqualTo(5);
 	}
 
 	public class MyBaseClassWithVirtualCallsInConstructor
 	{
 		public MyBaseClassWithVirtualCallsInConstructor()
 		{
-			VirtualMethod();
+			var values = VirtualMethod();
+			VirtualProperty = values[0];
 		}
 
-		public virtual void VirtualMethod()
+		public virtual int VirtualProperty { get; set; }
+
+		public virtual int[] VirtualMethod()
 		{
+			return [0, 1];
 		}
 	}
 }

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -141,8 +141,10 @@ public sealed partial class MockTests
 	[Fact]
 	public async Task Create_BaseClassWithoutConstructor_ShouldThrowMockException()
 	{
+		var mock = Mock.Create<MyBaseClassWithoutConstructor>();
+
 		void Act()
-			=> _ = Mock.Create<MyBaseClassWithoutConstructor>();
+			=> _ = mock.Subject;
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(
@@ -161,8 +163,10 @@ public sealed partial class MockTests
 	[Fact]
 	public async Task Create_WithRequiredParameters_WithEmptyParameters_ShouldThrowMockException()
 	{
+		var mock = Mock.Create<MyBaseClassWithConstructor>(WithConstructorParameters());
+
 		void Act()
-			=> _ = Mock.Create<MyBaseClassWithConstructor>(WithConstructorParameters());
+			=> _ = mock.Subject;
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(
@@ -172,8 +176,10 @@ public sealed partial class MockTests
 	[Fact]
 	public async Task Create_WithRequiredParameters_WithoutParameters_ShouldThrowMockException()
 	{
+		var mock = Mock.Create<MyBaseClassWithConstructor>();
+
 		void Act()
-			=> _ = Mock.Create<MyBaseClassWithConstructor>();
+			=> _ = mock.Subject;
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(
@@ -183,8 +189,10 @@ public sealed partial class MockTests
 	[Fact]
 	public async Task Create_WithTooManyParameters_ShouldThrowMockException()
 	{
+		var mock = Mock.Create<MyBaseClassWithConstructor>(WithConstructorParameters("foo", 1, 2));
+
 		void Act()
-			=> _ = Mock.Create<MyBaseClassWithConstructor>(WithConstructorParameters("foo", 1, 2));
+			=> _ = mock.Subject;
 
 		await That(Act).Throws<MockException>()
 			.WithMessage(


### PR DESCRIPTION
This PR fixes an issue with virtual method calls from constructors by implementing a setup mechanism that allows mocking of virtual members invoked during object construction. The key change is deferring subject initialization and using an `AsyncLocal` provider to make the mock available during constructor execution.

### Key Changes:
- Modified mock initialization to defer subject creation until first access via a lazy property getter
- Introduced `_mockProvider` using `AsyncLocal<IMock?>` to make mock instances available during constructor execution
- Updated generated code to use `(_mock ?? _mockProvider.Value)` for accessing mock instances in virtual member implementations