### PR TITLE
feat: use newest method setup

### DIFF
--- a/Source/Mockolate/Setup/MockSetup.cs
+++ b/Source/Mockolate/Setup/MockSetup.cs
@@ -85,7 +85,7 @@ public class MockSetup<T>(IMock mock) : IMockSetup
 	///     or returns <see langword="null" /> if no matching setup is found.
 	/// </summary>
 	internal MethodSetup? GetMethodSetup(IInteraction invocation)
-		=> _methodSetups.FirstOrDefault(setup => ((IMethodSetup)setup).Matches(invocation));
+		=> _methodSetups.GetNewest(setup => ((IMethodSetup)setup).Matches(invocation));
 
 	/// <summary>
 	///     Retrieves the setup configuration for the specified property name, creating a default setup if none exists.
@@ -373,15 +373,15 @@ public class MockSetup<T>(IMock mock) : IMockSetup
 	[DebuggerDisplay("{ToString()}")]
 	private sealed class MethodSetups
 	{
-		private ConcurrentQueue<MethodSetup>? _storage;
+		private ConcurrentStack<MethodSetup>? _storage;
 
 		public void Add(MethodSetup setup)
 		{
-			_storage ??= new ConcurrentQueue<MethodSetup>();
-			_storage.Enqueue(setup);
+			_storage ??= new ConcurrentStack<MethodSetup>();
+			_storage.Push(setup);
 		}
 
-		public MethodSetup? FirstOrDefault(Func<MethodSetup, bool> predicate)
+		public MethodSetup? GetNewest(Func<MethodSetup, bool> predicate)
 		{
 			if (_storage is null)
 			{

--- a/Tests/Mockolate.Tests/Setup/MockSetupsTests.MethodsTests.cs
+++ b/Tests/Mockolate.Tests/Setup/MockSetupsTests.MethodsTests.cs
@@ -22,6 +22,19 @@ public sealed partial class MockSetupsTests
 		}
 
 		[Fact]
+		public async Task Setup_ShouldUseNewestMatchingSetup()
+		{
+			Mock<IMethodService> mock = Mock.Create<IMethodService>();
+			mock.Setup.Method.MyIntMethodWithParameters(With.Any<int>(), With.Any<string>()).Returns(10);
+
+			await That(mock.Subject.MyIntMethodWithParameters(1, "")).IsEqualTo(10);
+
+			mock.Setup.Method.MyIntMethodWithParameters(With.Any<int>(), With.Any<string>()).Returns(20);
+
+			await That(mock.Subject.MyIntMethodWithParameters(1, "")).IsEqualTo(20);
+		}
+
+		[Fact]
 		public async Task GenericMethods_ShouldConsiderGenericParameter()
 		{
 			Mock<IMethodService> mock = Mock.Create<IMethodService>();


### PR DESCRIPTION
This pull request modifies the mock setup behavior to prioritize the most recently registered setup when multiple setups match the same method signature. The change ensures that newer setups override older ones rather than using the first registered setup.

### Key Changes:
- Changed internal storage from `ConcurrentQueue` to `ConcurrentStack` to enable LIFO (last-in-first-out) retrieval
- Renamed `FirstOrDefault` to `GetNewest` to better reflect the new semantics
- Added test coverage to verify that the newest matching setup takes precedence

---

- *Fixes #120*