### PR TITLE
fix: compile error when base class has multiple constructors with parameters

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -121,13 +121,15 @@ internal static partial class Sources
 			sb.Append("\t\t\t\t\t\tthrow new MockException(\"No parameterless constructor found for '").Append(mockClass.ClassFullName).Append("'. Please provide constructor parameters.\");").AppendLine();
 		}
 		sb.Append("\t\t\t\t\t}").AppendLine();
+		int constructorIndex = 0;
 		foreach (var constructorParameters in constructors.Select(constructor => constructor.Parameters))
 		{
+			constructorIndex++;
 			sb.Append("\t\t\t\t\telse if (_constructorParameters.Parameters.Length == ").Append(constructorParameters.Count);
 			int index = 0;
 			foreach (MethodParameter parameter in constructorParameters)
 			{
-				sb.AppendLine().Append("\t\t\t\t\t    && TryCast(_constructorParameters.Parameters[").Append(index++).Append("], out ").Append(parameter.Type.Fullname).Append(" p").Append(index).Append(")");
+				sb.AppendLine().Append("\t\t\t\t\t    && TryCast(_constructorParameters.Parameters[").Append(index++).Append("], out ").Append(parameter.Type.Fullname).Append(" c").Append(constructorIndex).Append('p').Append(index).Append(")");
 			}
 			sb.Append(")").AppendLine();
 			sb.Append("\t\t\t\t\t{").AppendLine();
@@ -135,7 +137,7 @@ internal static partial class Sources
 			sb.Append("\t\t\t\t\t\t_subject = new MockSubject(this");
 			for (int i = 1; i <= constructorParameters.Count; i++)
 			{
-				sb.Append(", p").Append(i);
+				sb.Append(", c").Append(constructorIndex).Append('p').Append(i);
 			}
 			sb.Append(");").AppendLine();
 			sb.Append("\t\t\t\t\t}").AppendLine();

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.cs
@@ -72,19 +72,19 @@ public sealed partial class ForMockTests
 		await That(result.Sources).ContainsKey("ForMyBaseClass.g.cs").WhoseValue
 			.Contains("""
 			          					if (_constructorParameters.Parameters.Length == 1
-			          					    && TryCast(_constructorParameters.Parameters[0], out int p1))
+			          					    && TryCast(_constructorParameters.Parameters[0], out int c1p1))
 			          					{
 			          						MockSubject._mockProvider.Value = this;
-			          						_subject = new MockSubject(this, p1);
+			          						_subject = new MockSubject(this, c1p1);
 			          					}
 			          """.TrimStart()).IgnoringNewlineStyle().And
 			.Contains("""
 			          					if (_constructorParameters.Parameters.Length == 2
-			          					    && TryCast(_constructorParameters.Parameters[0], out int p1)
-			          					    && TryCast(_constructorParameters.Parameters[1], out bool p2))
+			          					    && TryCast(_constructorParameters.Parameters[0], out int c2p1)
+			          					    && TryCast(_constructorParameters.Parameters[1], out bool c2p2))
 			          					{
 			          						MockSubject._mockProvider.Value = this;
-			          						_subject = new MockSubject(this, p1, p2);
+			          						_subject = new MockSubject(this, c2p1, c2p2);
 			          					}
 			          """.TrimStart()).IgnoringNewlineStyle().And
 			.Contains("""

--- a/Tests/Mockolate.Tests/MockTests.Create.cs
+++ b/Tests/Mockolate.Tests/MockTests.Create.cs
@@ -514,6 +514,15 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task Create_BaseClassWithMultipleConstructors()
+	{
+		void Act()
+			=> _ = Mock.Create<MyBaseClassWithMultipleConstructors>(BaseClass.WithConstructorParameters(5));
+
+		await That(Act).DoesNotThrow();
+	}
+
+	[Fact]
 	public async Task Create_BaseClassWithVirtualCallsInConstructor()
 	{
 		var mock = Mock.Create<MyBaseClassWithVirtualCallsInConstructor>();
@@ -538,6 +547,16 @@ public sealed partial class MockTests
 		public virtual int[] VirtualMethod()
 		{
 			return [0, 1];
+		}
+	}
+
+	public class MyBaseClassWithMultipleConstructors
+	{
+		public MyBaseClassWithMultipleConstructors(int initialValue)
+		{
+		}
+		public MyBaseClassWithMultipleConstructors(DateTime initialValue)
+		{
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a compile error that occurs when a base class has multiple constructors with parameters. The issue was caused by parameter naming collisions in generated code when multiple constructors were present.

### Key Changes:
- Modified the source generator to use unique parameter names for each constructor by prefixing them with the constructor index
- Added test coverage for base classes with multiple constructors