### PR TITLE
feat: add `BaseClassBehavior` for methods

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -9,6 +9,7 @@ internal record Method
 	{
 		Accessibility = methodSymbol.DeclaredAccessibility;
 		UseOverride = methodSymbol.IsVirtual || methodSymbol.IsAbstract;
+		IsAbstract = methodSymbol.IsAbstract;
 		ReturnType = methodSymbol.ReturnsVoid ? Type.Void : new Type(methodSymbol.ReturnType);
 		Name = methodSymbol.Name;
 		ContainingType = methodSymbol.ContainingType.ToDisplayString();
@@ -36,7 +37,7 @@ internal record Method
 	public EquatableArray<GenericParameter>? GenericParameters { get; }
 
 	public bool UseOverride { get; }
-
+	public bool IsAbstract { get; }
 	public Accessibility Accessibility { get; }
 	public Type ReturnType { get; }
 	public string Name { get; }

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -13,6 +13,7 @@ internal readonly record struct Property
 		Type = new Type(propertySymbol.Type);
 		ContainingType = propertySymbol.ContainingType.ToDisplayString();
 		IsIndexer = propertySymbol.IsIndexer;
+		IsAbstract = propertySymbol.IsAbstract;
 		if (IsIndexer && propertySymbol.Parameters.Length > 0)
 		{
 			IndexerParameters = new EquatableArray<MethodParameter>(
@@ -24,6 +25,7 @@ internal readonly record struct Property
 	}
 
 	public bool IsIndexer { get; }
+	public bool IsAbstract { get; }
 	public EquatableArray<MethodParameter>? IndexerParameters { get; }
 	public Type Type { get; }
 	public string ContainingType { get; }

--- a/Source/Mockolate/BaseClassBehavior.cs
+++ b/Source/Mockolate/BaseClassBehavior.cs
@@ -1,0 +1,22 @@
+namespace Mockolate;
+
+/// <summary>
+///     Specifies the behavior to use when interacting with members of a base class in the mock.
+/// </summary>
+public enum BaseClassBehavior
+{
+	/// <summary>
+	///     (Default) Does not call the base class implementation.
+	/// </summary>
+	DoNotCallBaseClass,
+
+	/// <summary>
+	///     Calls the base class implementation, but ignores its values.
+	/// </summary>
+	OnlyCallBaseClass,
+
+	/// <summary>
+	///     Calls the base class implementation, and uses its return values as default values.
+	/// </summary>
+	UseBaseClassAsDefaultValue
+}

--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -24,6 +24,11 @@ public record MockBehavior
 	public bool ThrowWhenNotSetup { get; init; }
 
 	/// <summary>
+	///     Specifies whether the mock should call the base class implementation for methods or properties.
+	/// </summary>
+	public BaseClassBehavior BaseClassBehavior { get; init; }
+
+	/// <summary>
 	///     The generator for default values when not specified by a setup.
 	/// </summary>
 	/// <remarks>

--- a/Source/Mockolate/Setup/MethodSetupResult.cs
+++ b/Source/Mockolate/Setup/MethodSetupResult.cs
@@ -34,8 +34,13 @@ public class MethodSetupResult(IMethodSetup? setup, MockBehavior behavior)
 			return setup.SetRefParameter(parameterName, value, behavior);
 		}
 
-		return behavior.DefaultValue.Generate<T>();
+		return value;
 	}
+
+	/// <summary>
+	///     Flag indicating if the method setup result has an underlying setup.
+	/// </summary>
+	public bool HasSetup => setup is not null;
 }
 
 /// <summary>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -13,6 +13,12 @@ namespace Mockolate
             public object?[] Parameters { get; init; }
         }
     }
+    public enum BaseClassBehavior
+    {
+        DoNotCallBaseClass = 0,
+        OnlyCallBaseClass = 1,
+        UseBaseClassAsDefaultValue = 2,
+    }
     public interface IMock
     {
         Mockolate.MockBehavior Behavior { get; }
@@ -39,6 +45,7 @@ namespace Mockolate
     public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>
     {
         public MockBehavior() { }
+        public Mockolate.BaseClassBehavior BaseClassBehavior { get; init; }
         public Mockolate.DefaultValues.IDefaultValueGenerator DefaultValue { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public static Mockolate.MockBehavior Default { get; }
@@ -518,6 +525,7 @@ namespace Mockolate.Setup
     public class MethodSetupResult
     {
         public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
+        public bool HasSetup { get; }
         public T SetOutParameter<T>(string parameterName) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -12,6 +12,12 @@ namespace Mockolate
             public object?[] Parameters { get; init; }
         }
     }
+    public enum BaseClassBehavior
+    {
+        DoNotCallBaseClass = 0,
+        OnlyCallBaseClass = 1,
+        UseBaseClassAsDefaultValue = 2,
+    }
     public interface IMock
     {
         Mockolate.MockBehavior Behavior { get; }
@@ -38,6 +44,7 @@ namespace Mockolate
     public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>
     {
         public MockBehavior() { }
+        public Mockolate.BaseClassBehavior BaseClassBehavior { get; init; }
         public Mockolate.DefaultValues.IDefaultValueGenerator DefaultValue { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public static Mockolate.MockBehavior Default { get; }
@@ -517,6 +524,7 @@ namespace Mockolate.Setup
     public class MethodSetupResult
     {
         public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
+        public bool HasSetup { get; }
         public T SetOutParameter<T>(string parameterName) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -11,6 +11,12 @@ namespace Mockolate
             public object?[] Parameters { get; init; }
         }
     }
+    public enum BaseClassBehavior
+    {
+        DoNotCallBaseClass = 0,
+        OnlyCallBaseClass = 1,
+        UseBaseClassAsDefaultValue = 2,
+    }
     public interface IMock
     {
         Mockolate.MockBehavior Behavior { get; }
@@ -37,6 +43,7 @@ namespace Mockolate
     public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>
     {
         public MockBehavior() { }
+        public Mockolate.BaseClassBehavior BaseClassBehavior { get; init; }
         public Mockolate.DefaultValues.IDefaultValueGenerator DefaultValue { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public static Mockolate.MockBehavior Default { get; }
@@ -482,6 +489,7 @@ namespace Mockolate.Setup
     public class MethodSetupResult
     {
         public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
+        public bool HasSetup { get; }
         public T SetOutParameter<T>(string parameterName) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
     }

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
@@ -202,7 +202,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.GetIndexer<int>(index)
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -217,7 +217,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.GetIndexer<int>(index, isReadOnly)
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -272,7 +272,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return (_mock ?? _mockProvider.Value)?.GetIndexer<int>(index)
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -287,7 +287,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return (_mock ?? _mockProvider.Value)?.GetIndexer<int>(index, isReadOnly)
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -309,7 +309,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return (_mock ?? _mockProvider.Value)?.GetIndexer<int>(someAdditionalIndex)
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -351,7 +351,7 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult<bool>? methodExecution = _mock?.Execute<bool>("MyCode.IMyService.MyMethod1", index);
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<bool>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<bool>();
 				          			}
 
 				          			return methodExecution.Result;
@@ -492,10 +492,13 @@ public sealed partial class ForMockTests
 
 			await That(result.Sources).ContainsKey("ForMyService_IMyOtherService.g.cs").WhoseValue
 				.Contains("""
-				          		/// <inheritdoc cref="MyCode.MyService.MyMethod1(int)" />
 				          		public override void MyMethod1(int index)
 				          		{
 				          			MethodSetupResult? methodExecution = (_mock ?? _mockProvider.Value)?.Execute("MyCode.MyService.MyMethod1", index);
+				          			if (_mock is not null && _mock.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			{
+				          				base.MyMethod1(index);
+				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
 				.Contains("""
@@ -503,11 +506,20 @@ public sealed partial class ForMockTests
 				          		protected override bool MyMethod2(int index, bool isReadOnly)
 				          		{
 				          			MethodSetupResult<bool>? methodExecution = (_mock ?? _mockProvider.Value)?.Execute<bool>("MyCode.MyService.MyMethod2", index, isReadOnly);
+				          			if (_mock is not null && _mock.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			{
+				          				var baseResult = base.MyMethod2(index, isReadOnly);
+				          				if (methodExecution?.HasSetup != true && _mock.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)
+				          				{
+				          					return baseResult;
+				          				}
+				          			}
+
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<bool>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<bool>();
 				          			}
-				          
+
 				          			return methodExecution.Result;
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -519,9 +531,9 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult<int>? methodExecution = (_mock ?? _mockProvider.Value)?.Execute<int>("MyCode.IMyOtherService.SomeOtherMethod");
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<int>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
-				          
+
 				          			return methodExecution.Result;
 				          		}
 				          """).IgnoringNewlineStyle();
@@ -559,7 +571,7 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult? methodExecution = _mock?.Execute("MyCode.IMyService.MyMethod1", index);
 				          			if (methodExecution is null)
 				          			{
-				          				index = MockBehavior.Default.DefaultValue.Generate<int>();
+				          				index = (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			else
 				          			{
@@ -575,7 +587,7 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult<bool>? methodExecution = _mock?.Execute<bool>("MyCode.IMyService.MyMethod2", index, null);
 				          			if (methodExecution is null)
 				          			{
-				          				isReadOnly = MockBehavior.Default.DefaultValue.Generate<bool>();
+				          				isReadOnly = (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<bool>();
 				          			}
 				          			else
 				          			{
@@ -584,7 +596,7 @@ public sealed partial class ForMockTests
 
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<bool>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<bool>();
 				          			}
 
 				          			return methodExecution.Result;
@@ -625,7 +637,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.Get<int>("MyCode.IMyService.SomeProperty")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -640,7 +652,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.Get<bool?>("MyCode.IMyService.SomeReadOnlyProperty")
-				          					?? MockBehavior.Default.DefaultValue.Generate<bool?>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<bool?>();
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -697,7 +709,7 @@ public sealed partial class ForMockTests
 				          			protected get
 				          			{
 				          				return (_mock ?? _mockProvider.Value)?.Get<int>("MyCode.MyService.SomeProperty1")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -712,7 +724,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return (_mock ?? _mockProvider.Value)?.Get<int>("MyCode.MyService.SomeProperty2")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			protected set
 				          			{
@@ -727,7 +739,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return (_mock ?? _mockProvider.Value)?.Get<bool?>("MyCode.MyService.SomeReadOnlyProperty")
-				          					?? MockBehavior.Default.DefaultValue.Generate<bool?>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<bool?>();
 				          			}
 				          		}
 				          """).IgnoringNewlineStyle().And
@@ -749,7 +761,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return (_mock ?? _mockProvider.Value)?.Get<int>("MyCode.IMyOtherService.SomeAdditionalProperty")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -805,7 +817,7 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult<int>? methodExecution = _mock?.Execute<int>("MyCode.IMyService.MyDirectMethod", value);
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<int>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 
 				          			return methodExecution.Result;
@@ -818,7 +830,7 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult<int>? methodExecution = _mock?.Execute<int>("MyCode.IMyServiceBase1.MyBaseMethod1", value);
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<int>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          
 				          			return methodExecution.Result;
@@ -831,7 +843,7 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult<int>? methodExecution = _mock?.Execute<int>("MyCode.IMyServiceBase2.MyBaseMethod2", value);
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<int>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          
 				          			return methodExecution.Result;
@@ -844,7 +856,7 @@ public sealed partial class ForMockTests
 				          			MethodSetupResult<int>? methodExecution = _mock?.Execute<int>("MyCode.IMyServiceBase3.MyBaseMethod3", value);
 				          			if (methodExecution is null)
 				          			{
-				          				return MockBehavior.Default.DefaultValue.Generate<int>();
+				          				return (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          
 				          			return methodExecution.Result;
@@ -898,7 +910,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.Get<int>("MyCode.IMyService.MyDirectProperty")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -913,7 +925,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.Get<int>("MyCode.IMyServiceBase1.MyBaseProperty1")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -928,7 +940,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.Get<int>("MyCode.IMyServiceBase2.MyBaseProperty2")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{
@@ -943,7 +955,7 @@ public sealed partial class ForMockTests
 				          			get
 				          			{
 				          				return _mock?.Get<int>("MyCode.IMyServiceBase3.MyBaseProperty3")
-				          					?? MockBehavior.Default.DefaultValue.Generate<int>();
+				          					?? (_mock?.Behavior ?? MockBehavior.Default).DefaultValue.Generate<int>();
 				          			}
 				          			set
 				          			{

--- a/Tests/Mockolate.Tests/MockBehaviorTests.Base.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.Base.cs
@@ -1,0 +1,176 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using Mockolate.DefaultValues;
+
+namespace Mockolate.Tests;
+
+public sealed partial class MockBehaviorTests
+{
+	[Fact]
+	public async Task WithUseBaseClassAsDefaultValue_WhenNotSetup_ShouldReturnBaseValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue });
+
+		var value = mock.Subject.VirtualMethod();
+
+		await That(value).IsEqualTo([4, 5]);
+		await That(mock.Subject.VirtualMethodCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithUseBaseClassAsDefaultValue_WhenSetup_ShouldReturnSetupValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue });
+		mock.Setup.Method.VirtualMethod().Returns([10, 20]);
+
+		var value = mock.Subject.VirtualMethod();
+
+		await That(value).IsEqualTo([10, 20]);
+		await That(mock.Subject.VirtualMethodCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithOnlyCallBaseClass_WhenNotSetup_ShouldReturnDefaultValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass });
+
+		var value = mock.Subject.VirtualMethod();
+
+		await That(value).IsEmpty();
+		await That(mock.Subject.VirtualMethodCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithOnlyCallBaseClass_WhenSetup_ShouldReturnSetupValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass });
+		mock.Setup.Method.VirtualMethod().Returns([10, 20]);
+
+		var value = mock.Subject.VirtualMethod();
+
+		await That(value).IsEqualTo([10, 20]);
+		await That(mock.Subject.VirtualMethodCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithOnlyCallBaseClass_ForRefAndOutParameter_WhenNotSetup_ShouldUseBaseClassValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass });
+		int value1 = 5;
+
+		var sum = mock.Subject.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
+
+		await That(value1).IsEqualTo(15);
+		await That(value2).IsEqualTo(0);
+		await That(sum).IsEqualTo(0);
+		await That(mock.Subject.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithDefaultBehavior_ForRefAndOutParameter_WhenNotSetup_ShouldSetToPreviousOrDefaultValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default);
+		int value1 = 5;
+
+		var sum = mock.Subject.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
+
+		await That(value1).IsEqualTo(5);
+		await That(value2).IsEqualTo(0);
+		await That(sum).IsEqualTo(0);
+		await That(mock.Subject.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task WithOnlyCallBaseClass_ForRefAndOutParameter_WhenSetup_ShouldUseSetupValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass });
+		int value1 = 5;
+		mock.Setup.Method.VirtualMethodWithRefAndOutParameters(With.Ref<int>(x => x + 1), With.Out<int>(() => 8)).Returns(10);
+
+		var sum = mock.Subject.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
+
+		await That(value1).IsEqualTo(16);
+		await That(value2).IsEqualTo(8);
+		await That(sum).IsEqualTo(10);
+		await That(mock.Subject.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithUseBaseClassAsDefaultValue_ForRefAndOutParameter_WhenNotSetup_ShouldUseBaseClassValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue });
+		int value1 = 5;
+
+		var sum = mock.Subject.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
+
+		await That(value1).IsEqualTo(15);
+		await That(value2).IsEqualTo(30);
+		await That(sum).IsEqualTo(45);
+		await That(mock.Subject.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithUseBaseClassAsDefaultValue_ForRefAndOutParameter_WhenSetup_ShouldUseSetupValues()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue });
+		int value1 = 5;
+		mock.Setup.Method.VirtualMethodWithRefAndOutParameters(With.Ref<int>(x => x + 1), With.Out<int>(() => 8)).Returns(10);
+
+		var sum = mock.Subject.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
+
+		await That(value1).IsEqualTo(16);
+		await That(value2).IsEqualTo(8);
+		await That(sum).IsEqualTo(10);
+		await That(mock.Subject.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WithOnlyCallBaseClass_ShouldCallBaseClass()
+	{
+		var mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with { BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass });
+
+		mock.Subject.VirtualVoidMethod(2);
+		mock.Subject.VirtualVoidMethod(4);
+		var result = mock.Subject.Sum;
+
+		await That(result).IsEqualTo(6);
+		await That(mock.Subject.VirtualMethodCallCount).IsEqualTo(0);
+	}
+
+	public class MyBaseClassWithVirtualCalls
+	{
+		private int _sum;
+		public int Sum => _sum;
+
+		public int VirtualMethodCallCount { get; private set; }
+		public int VirtualMethodWithRefAndOutParametersCallCount { get; private set; }
+
+		public virtual int VirtualProperty
+		{
+			get
+			{
+				return VirtualMethod()[0];
+			}
+		}
+
+		public virtual int[] VirtualMethod()
+		{
+			VirtualMethodCallCount++;
+			return [4, 5];
+		}
+
+		public virtual int VirtualMethodWithRefAndOutParameters(ref int value1, out int value2)
+		{
+			VirtualMethodWithRefAndOutParametersCallCount++;
+			value1 += 10;
+			value2 = 2 * value1;
+			return value1 + value2;
+		}
+
+		public virtual void VirtualVoidMethod(int increment)
+		{
+			_sum += increment;
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/MockBehaviorTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.cs
@@ -5,7 +5,7 @@ using Mockolate.DefaultValues;
 
 namespace Mockolate.Tests;
 
-public class MockBehaviorTests
+public sealed partial class MockBehaviorTests
 {
 	public interface IDefaultValueGeneratorProperties
 	{


### PR DESCRIPTION
This PR introduces a `BaseClassBehavior` enum and supporting implementation to control how mock objects interact with base class virtual methods. The feature allows developers to configure whether mocks should call base class implementations, ignore them, or use base class return values as defaults.

### Key changes:
- Added `BaseClassBehavior` enum with three options: `DoNotCallBaseClass` (default), `OnlyCallBaseClass`, and `UseBaseClassAsDefaultValue`
- Modified source generator to emit code that conditionally calls base class methods based on the configured behavior
- Updated default value generation throughout to respect mock-specific behavior settings instead of always using `MockBehavior.Default`

---

- *Implements part of #125 (methods)*