### PR TITLE
fix: nullability warning in source-generated code

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -724,7 +724,7 @@ internal static partial class Sources
 				if (parameter.RefKind == RefKind.Out)
 				{
 					sb.Append(
-							"\t\t\t\tif (methodExecution?.HasSetup == true || _mock.Behavior.BaseClassBehavior != BaseClassBehavior.UseBaseClassAsDefaultValue)")
+							"\t\t\t\tif (methodExecution is not null && (methodExecution.HasSetup == true || _mock.Behavior.BaseClassBehavior != BaseClassBehavior.UseBaseClassAsDefaultValue))")
 						.AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = methodExecution.SetOutParameter<")
@@ -734,7 +734,7 @@ internal static partial class Sources
 				else if (parameter.RefKind == RefKind.Ref)
 				{
 					sb.Append(
-							"\t\t\t\tif (methodExecution?.HasSetup == true || _mock.Behavior.BaseClassBehavior != BaseClassBehavior.UseBaseClassAsDefaultValue)")
+							"\t\t\t\tif (methodExecution is not null && (methodExecution.HasSetup == true || _mock.Behavior.BaseClassBehavior != BaseClassBehavior.UseBaseClassAsDefaultValue))")
 						.AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = methodExecution.SetRefParameter<")


### PR DESCRIPTION
This PR fixes a potential null reference exception in generated mock code by improving null-safety checks when accessing `methodExecution.HasSetup`. The change ensures that `methodExecution` is verified as non-null before attempting to access its properties.

### Key Changes
- Replaced `methodExecution?.HasSetup == true` with explicit null check followed by property access
- Added parentheses to properly group the logical conditions