### PR TITLE
fix: ignore types from global namespace

### DIFF
--- a/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
+++ b/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
@@ -35,7 +35,9 @@ internal static class MockGeneratorHelpers
 				.Where(t => t is not null)
 				.Cast<ITypeSymbol>()
 				.ToArray();
-			if (genericTypes.Length == 0 || !IsMockable(genericTypes[0]))
+			if (genericTypes.Length == 0 || !IsMockable(genericTypes[0]) ||
+				// Ignore types from the global namespace, as they are not generated correctly.
+				genericTypes.Any(x => x.ContainingNamespace.IsGlobalNamespace))
 			{
 				return null;
 			}


### PR DESCRIPTION
This PR adds filtering logic to prevent mock generation for types residing in the global namespace. The change addresses an issue where the source generator fails to correctly generate mocks for such types.