### PR TITLE
refactor: use `IChocolateDispenser` in tests

### DIFF
--- a/Tests/Mockolate.Tests/TestHelpers/IChocolateDispenser.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/IChocolateDispenser.cs
@@ -1,0 +1,11 @@
+﻿namespace Mockolate.Tests.TestHelpers;
+
+public delegate void ChocolateDispensedDelegate(string type, int amount);
+
+public interface IChocolateDispenser
+{
+	int this[string type] { get; set; }
+	int TotalDispensed { get; set; }
+	bool Dispense(string type, int amount);
+	event ChocolateDispensedDelegate ChocolateDispensed;
+}

--- a/Tests/Mockolate.Tests/Verify/MockVerifyTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockVerifyTests.cs
@@ -1,11 +1,13 @@
-﻿namespace Mockolate.Tests.Verify;
+﻿using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests.Verify;
 
 public class MockVerifyTests
 {
 	[Fact]
 	public async Task AllInteractionsVerified_WithoutInteractions_ShouldReturnTrue()
 	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
 
 		await That(sut.Verify.ThatAllInteractionsAreVerified()).IsTrue();
 	}
@@ -13,29 +15,24 @@ public class MockVerifyTests
 	[Fact]
 	public async Task AllInteractionsVerified_WithUnverifiedInteractions_ShouldReturnFalse()
 	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
 
-		sut.Subject.DoSomething(1);
-		sut.Subject.DoSomething(2);
+		sut.Subject.Dispense("Dark", 1);
+		sut.Subject.Dispense("Dark", 2);
 
-		await That(sut.Verify.Invoked.DoSomething(1)).Once();
+		await That(sut.Verify.Invoked.Dispense("Dark", 1)).Once();
 		await That(sut.Verify.ThatAllInteractionsAreVerified()).IsFalse();
 	}
 
 	[Fact]
 	public async Task AllInteractionsVerified_WithVerifiedInteractions_ShouldReturnTrue()
 	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
 
-		sut.Subject.DoSomething(1);
-		sut.Subject.DoSomething(2);
+		sut.Subject.Dispense("Dark", 1);
+		sut.Subject.Dispense("Dark", 2);
 
-		await That(sut.Verify.Invoked.DoSomething(With.Any<int>())).AtLeastOnce();
+		await That(sut.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>())).AtLeastOnce();
 		await That(sut.Verify.ThatAllInteractionsAreVerified()).IsTrue();
-	}
-
-	public interface IMyService
-	{
-		void DoSomething(int value);
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
@@ -1,5 +1,4 @@
 using Mockolate.Exceptions;
-using Mockolate.Interactions;
 using Mockolate.Tests.TestHelpers;
 using Mockolate.Verify;
 
@@ -14,15 +13,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(2, 1, true)]
 	public async Task AtLeast_ShouldReturnExpectedResult(int count, int times, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).AtLeast(times);
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).AtLeast(times);
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				"Expected that mock invoked method DoSomething(With.Any<int>()) at least 3 times, but it did twice.");
+				"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) at least 3 times, but it did twice.");
 	}
 
 	[Theory]
@@ -32,15 +31,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(3, true)]
 	public async Task AtLeastOnce_ShouldReturnExpectedResult(int count, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).AtLeastOnce();
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).AtLeastOnce();
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				"Expected that mock invoked method DoSomething(With.Any<int>()) at least once, but it never did.");
+				"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) at least once, but it never did.");
 	}
 
 	[Theory]
@@ -50,15 +49,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(3, true)]
 	public async Task AtLeastTwice_ShouldReturnExpectedResult(int count, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).AtLeastTwice();
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).AtLeastTwice();
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method DoSomething(With.Any<int>()) at least twice, but it {count switch { 0 => "never did", _ => "did once", }}.");
+				$"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) at least twice, but it {count switch { 0 => "never did", _ => "did once", }}.");
 	}
 
 	[Theory]
@@ -68,15 +67,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(2, 3, true)]
 	public async Task AtMost_ShouldReturnExpectedResult(int count, int times, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).AtMost(times);
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).AtMost(times);
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				"Expected that mock invoked method DoSomething(With.Any<int>()) at most once, but it did twice.");
+				"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) at most once, but it did twice.");
 	}
 
 	[Theory]
@@ -86,15 +85,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(3, false)]
 	public async Task AtMostOnce_ShouldReturnExpectedResult(int count, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).AtMostOnce();
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).AtMostOnce();
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method DoSomething(With.Any<int>()) at most once, but it did {(count == 2 ? "twice" : $"{count} times")}.");
+				$"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) at most once, but it did {(count == 2 ? "twice" : $"{count} times")}.");
 	}
 
 	[Theory]
@@ -104,15 +103,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(3, false)]
 	public async Task AtMostTwice_ShouldReturnExpectedResult(int count, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).AtMostTwice();
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).AtMostTwice();
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method DoSomething(With.Any<int>()) at most twice, but it did {count} times.");
+				$"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) at most twice, but it did {count} times.");
 	}
 
 	[Theory]
@@ -122,15 +121,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(2, 1, false)]
 	public async Task Exactly_ShouldReturnExpectedResult(int count, int times, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).Exactly(times);
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).Exactly(times);
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method DoSomething(With.Any<int>()) exactly {(times == 1 ? "once" : $"{times} times")}, but it did twice.");
+				$"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) exactly {(times == 1 ? "once" : $"{times} times")}, but it did twice.");
 	}
 
 	[Theory]
@@ -140,15 +139,15 @@ public class VerificationResultExtensionsTests
 	[InlineData(3, false)]
 	public async Task Never_ShouldReturnExpectedResult(int count, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).Never();
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).Never();
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock never invoked method DoSomething(With.Any<int>()), but it did {count switch { 1 => "once", 2 => "twice", _ => $"{count} times", }}.");
+				$"Expected that mock never invoked method Dispense(With.Any<string>(), With.Any<int>()), but it did {count switch { 1 => "once", 2 => "twice", _ => $"{count} times", }}.");
 	}
 
 	[Theory]
@@ -158,62 +157,63 @@ public class VerificationResultExtensionsTests
 	[InlineData(3, false)]
 	public async Task Once_ShouldReturnExpectedResult(int count, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).Once();
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).Once();
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method DoSomething(With.Any<int>()) exactly once, but it {count switch { 0 => "never did", 2 => "did twice", _ => $"did {count} times", }}.");
+				$"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) exactly once, but it {count switch { 0 => "never did", 2 => "did twice", _ => $"did {count} times", }}.");
 	}
 
 	[Fact]
 	public async Task Then_ShouldVerifyInOrder()
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
-		mock.Subject.DoSomething(1);
-		mock.Subject.DoSomething(2);
-		mock.Subject.DoSomething(3);
-		mock.Subject.DoSomething(4);
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
+		mock.Subject.Dispense("Dark", 1);
+		mock.Subject.Dispense("Dark", 2);
+		mock.Subject.Dispense("Dark", 3);
+		mock.Subject.Dispense("Dark", 4);
 
-		mock.Verify.Invoked.DoSomething(3).Then(m => m.Invoked.DoSomething(4));
+		mock.Verify.Invoked.Dispense(With.Any<string>(), 3).Then(m => m.Invoked.Dispense(With.Any<string>(), 4));
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(2).Then(m => m.Invoked.DoSomething(1));
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), 2).Then(m => m.Invoked.Dispense(With.Any<string>(), 1));
 
 		await That(Act).Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method DoSomething(2), then invoked method DoSomething(1) in order, but it invoked method DoSomething(1) too early.");
-		mock.Verify.Invoked.DoSomething(1).Then(m => m.Invoked.DoSomething(2));
+				"Expected that mock invoked method Dispense(With.Any<string>(), 2), then invoked method Dispense(With.Any<string>(), 1) in order, but it invoked method Dispense(With.Any<string>(), 1) too early.");
+		mock.Verify.Invoked.Dispense(With.Any<string>(), 1).Then(m => m.Invoked.Dispense(With.Any<string>(), 2));
 	}
 
 	[Fact]
 	public async Task Then_WhenNoMatch_ShouldFail()
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
-		mock.Subject.DoSomething(1);
-		mock.Subject.DoSomething(2);
-		mock.Subject.DoSomething(3);
-		mock.Subject.DoSomething(4);
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
+		mock.Subject.Dispense("Dark", 1);
+		mock.Subject.Dispense("Dark", 2);
+		mock.Subject.Dispense("Dark", 3);
+		mock.Subject.Dispense("Dark", 4);
 
-		await That(void () => mock.Verify.Invoked.DoSomething(6).Then(m => m.Invoked.DoSomething(4)))
+		await That(void () => mock.Verify.Invoked.Dispense(With.Any<string>(), 6)
+				.Then(m => m.Invoked.Dispense(With.Any<string>(), 4)))
 			.Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method DoSomething(6), then invoked method DoSomething(4) in order, but it invoked method DoSomething(6) not at all.");
+				"Expected that mock invoked method Dispense(With.Any<string>(), 6), then invoked method Dispense(With.Any<string>(), 4) in order, but it invoked method Dispense(With.Any<string>(), 6) not at all.");
 
-		await That(void () => mock.Verify.Invoked.DoSomething(1)
-				.Then(m => m.Invoked.DoSomething(6), m => m.Invoked.DoSomething(3)))
+		await That(void () => mock.Verify.Invoked.Dispense(With.Any<string>(), 1)
+				.Then(m => m.Invoked.Dispense(With.Any<string>(), 6), m => m.Invoked.Dispense(With.Any<string>(), 3)))
 			.Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method DoSomething(1), then invoked method DoSomething(6), then invoked method DoSomething(3) in order, but it invoked method DoSomething(6) not at all.");
+				"Expected that mock invoked method Dispense(With.Any<string>(), 1), then invoked method Dispense(With.Any<string>(), 6), then invoked method Dispense(With.Any<string>(), 3) in order, but it invoked method Dispense(With.Any<string>(), 6) not at all.");
 
-		await That(void () => mock.Verify.Invoked.DoSomething(1)
-				.Then(m => m.Invoked.DoSomething(2), m => m.Invoked.DoSomething(6)))
+		await That(void () => mock.Verify.Invoked.Dispense(With.Any<string>(), 1)
+				.Then(m => m.Invoked.Dispense(With.Any<string>(), 2), m => m.Invoked.Dispense(With.Any<string>(), 6)))
 			.Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method DoSomething(1), then invoked method DoSomething(2), then invoked method DoSomething(6) in order, but it invoked method DoSomething(6) not at all.");
+				"Expected that mock invoked method Dispense(With.Any<string>(), 1), then invoked method Dispense(With.Any<string>(), 2), then invoked method Dispense(With.Any<string>(), 6) in order, but it invoked method Dispense(With.Any<string>(), 6) not at all.");
 	}
 
 	[Theory]
@@ -223,27 +223,22 @@ public class VerificationResultExtensionsTests
 	[InlineData(3, false)]
 	public async Task Twice_ShouldReturnExpectedResult(int count, bool expectSuccess)
 	{
-		Mock<IMyService> mock = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> mock = Mock.Create<IChocolateDispenser>();
 		ExecuteDoSomethingOn(mock, count);
 
 		void Act()
-			=> mock.Verify.Invoked.DoSomething(With.Any<int>()).Twice();
+			=> mock.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>()).Twice();
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method DoSomething(With.Any<int>()) exactly twice, but it {count switch { 0 => "never did", 1 => "did once", _ => $"did {count} times", }}.");
+				$"Expected that mock invoked method Dispense(With.Any<string>(), With.Any<int>()) exactly twice, but it {count switch { 0 => "never did", 1 => "did once", _ => $"did {count} times", }}.");
 	}
 
-	internal static void ExecuteDoSomethingOn(Mock<IMyService> mock, int amount)
+	internal static void ExecuteDoSomethingOn(Mock<IChocolateDispenser> mock, int amount)
 	{
 		for (int i = 0; i < amount; i++)
 		{
-			mock.Subject.DoSomething(i);
+			mock.Subject.Dispense("Dark", i);
 		}
-	}
-
-	private class MyInteraction : IInteraction
-	{
-		public int Index => 0;
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
@@ -6,55 +6,82 @@ namespace Mockolate.Tests.Verify;
 public class VerificationResultTests
 {
 	[Fact]
-	public async Task Expectation_EventSubscription_ShouldHaveExpectedValue()
+	public async Task VerificationResult_Got_ShouldHaveExpectedValue()
 	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
 
-		VerificationResult<MockVerify<IMyService, Mock<IMyService>>> result =
-			sut.Verify.SubscribedTo.MyEvent();
+		VerificationResult<MockVerify<IChocolateDispenser, Mock<IChocolateDispenser>>> result
+			= sut.Verify.Got.TotalDispensed();
 
-		await That(((IVerificationResult)result).Expectation).IsEqualTo("subscribed to event MyEvent");
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("got property TotalDispensed");
 	}
 
 	[Fact]
-	public async Task Expectation_EventUnsubscription_ShouldHaveExpectedValue()
+	public async Task VerificationResult_GotIndexer_ShouldHaveExpectedValue()
 	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
 
-		var result = sut.Verify.UnsubscribedFrom.MyEvent();
+		VerificationResult<MockVerify<IChocolateDispenser, Mock<IChocolateDispenser>>> result
+			= sut.Verify.GotIndexer(With.Any<string>());
 
-		await That(((IVerificationResult)result).Expectation).IsEqualTo("unsubscribed from event MyEvent");
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("got indexer With.Any<string>()");
 	}
 
 	[Fact]
-	public async Task Expectation_Method_ShouldHaveExpectedValue()
+	public async Task VerificationResult_Invoked_ShouldHaveExpectedValue()
 	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
 
-		var result = sut.Verify.Invoked.DoSomethingAndReturn(With.Any<int>());
+		VerificationResult<MockVerify<IChocolateDispenser, Mock<IChocolateDispenser>>> result
+			= sut.Verify.Invoked.Dispense(With.Any<string>(), With.Any<int>());
 
 		await That(((IVerificationResult)result).Expectation)
-			.IsEqualTo("invoked method DoSomethingAndReturn(With.Any<int>())");
+			.IsEqualTo("invoked method Dispense(With.Any<string>(), With.Any<int>())");
 	}
 
 	[Fact]
-	public async Task Expectation_PropertyGetter_ShouldHaveExpectedValue()
+	public async Task VerificationResult_Set_ShouldHaveExpectedValue()
 	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
 
-		var result = sut.Verify.Got.SomeFlag();
-
-		await That(((IVerificationResult)result).Expectation).IsEqualTo("got property SomeFlag");
-	}
-
-	[Fact]
-	public async Task Expectation_PropertySetter_ShouldHaveExpectedValue()
-	{
-		Mock<IMyService> sut = Mock.Create<IMyService>();
-
-		var result = sut.Verify.Set.SomeFlag(With.Any<bool>());
+		VerificationResult<MockVerify<IChocolateDispenser, Mock<IChocolateDispenser>>> result
+			= sut.Verify.Set.TotalDispensed(5);
 
 		await That(((IVerificationResult)result).Expectation)
-			.IsEqualTo("set property SomeFlag to value With.Any<bool>()");
+			.IsEqualTo("set property TotalDispensed to value 5");
+	}
+
+	[Fact]
+	public async Task VerificationResult_SetIndexer_ShouldHaveExpectedValue()
+	{
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
+
+		VerificationResult<MockVerify<IChocolateDispenser, Mock<IChocolateDispenser>>> result
+			= sut.Verify.SetIndexer(With.Any<string>(), 5);
+
+		await That(((IVerificationResult)result).Expectation)
+			.IsEqualTo("set indexer With.Any<string>() to value 5");
+	}
+
+	[Fact]
+	public async Task VerificationResult_SubscribedTo_ShouldHaveExpectedValue()
+	{
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
+
+		VerificationResult<MockVerify<IChocolateDispenser, Mock<IChocolateDispenser>>> result
+			= sut.Verify.SubscribedTo.ChocolateDispensed();
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("subscribed to event ChocolateDispensed");
+	}
+
+	[Fact]
+	public async Task VerificationResult_UnsubscribedFrom_ShouldHaveExpectedValue()
+	{
+		Mock<IChocolateDispenser> sut = Mock.Create<IChocolateDispenser>();
+
+		VerificationResult<MockVerify<IChocolateDispenser, Mock<IChocolateDispenser>>> result
+			= sut.Verify.UnsubscribedFrom.ChocolateDispensed();
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("unsubscribed from event ChocolateDispensed");
 	}
 }


### PR DESCRIPTION
This PR refactors test files to use a shared `IChocolateDispenser` test interface instead of locally defined or dispersed test interfaces. The change consolidates test helper interfaces and improves consistency across verification tests.

### Key changes:
- Introduced a new `IChocolateDispenser` interface in the test helpers
- Replaced `IMyService` usage with `IChocolateDispenser` across verification test files
- Updated test method names to reflect the verification behavior being tested rather than the member types