### PR TITLE
feat: make callback in `Match.Out` optional

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -271,7 +271,7 @@ internal static partial class Sources
 			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"_match{x}")))
 			.Append("], parameterName, out Match.IOutParameter<T>? outParameter))").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\treturn outParameter.GetValue();").AppendLine();
+		sb.Append("\t\t\treturn outParameter.GetValue(behavior);").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t\treturn behavior.DefaultValue.Generate<T>();").AppendLine();
@@ -574,7 +574,7 @@ internal static partial class Sources
 			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"_match{x}")))
 			.Append("], parameterName, out Match.IOutParameter<T>? outParameter))").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\treturn outParameter.GetValue();").AppendLine();
+		sb.Append("\t\t\treturn outParameter.GetValue(behavior);").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t\treturn behavior.DefaultValue.Generate<T>();").AppendLine();

--- a/Source/Mockolate/Match.Out.cs
+++ b/Source/Mockolate/Match.Out.cs
@@ -26,19 +26,11 @@ public partial class Match
 	/// </summary>
 	private sealed class OutParameter<T>(Func<T> setter, string setterExpression) : IOutParameter<T>
 	{
-		/// <summary>
-		///     Checks if the <paramref name="value" /> is a matching parameter.
-		/// </summary>
-		/// <returns>
-		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter
-		///     of type <typeparamref name="T" />; otherwise <see langword="false" />.
-		/// </returns>
+		/// <inheritdoc cref="IParameter.Matches(object?)" />
 		public bool Matches(object? value) => true;
 
-		/// <summary>
-		///     Retrieves the value to which the <see langword="out" /> parameter should be set.
-		/// </summary>
-		public T GetValue() => setter();
+		/// <inheritdoc cref="IOutParameter{T}.GetValue(MockBehavior)" />
+		public T GetValue(MockBehavior mockBehavior) => setter();
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => $"Out<{typeof(T).FormatType()}>({setterExpression})";
@@ -49,10 +41,12 @@ public partial class Match
 	/// </summary>
 	private sealed class InvokedOutParameter<T> : IVerifyOutParameter<T>
 	{
-		/// <summary>
-		///     Matches any <paramref name="value" />.
-		/// </summary>
+		/// <inheritdoc cref="IParameter.Matches(object?)" />
 		public bool Matches(object? value) => true;
+
+		/// <inheritdoc cref="IOutParameter{T}.GetValue(MockBehavior)" />
+		public T GetValue(MockBehavior mockBehavior)
+			=> mockBehavior.DefaultValue.Generate<T>();
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => $"Out<{typeof(T).FormatType()}>()";

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -50,14 +50,14 @@ public partial class Match
 		/// <summary>
 		///     Retrieves the value to which the <see langword="out" /> parameter should be set.
 		/// </summary>
-		T GetValue();
+		T GetValue(MockBehavior mockBehavior);
 	}
 
 #pragma warning disable S2326 // Unused type parameters should be removed
 	/// <summary>
 	///     Matches any <see langword="out" /> parameter.
 	/// </summary>
-	public interface IVerifyOutParameter<out T> : IParameter
+	public interface IVerifyOutParameter<out T> : IOutParameter<T>
 	{
 	}
 #pragma warning restore S2326 // Unused type parameters should be removed
@@ -77,7 +77,7 @@ public partial class Match
 	/// <summary>
 	///     Matches any <see langword="ref" /> parameter.
 	/// </summary>
-	public interface IVerifyRefParameter<out T> : IParameter
+	public interface IVerifyRefParameter<T> : IRefParameter<T>
 	{
 	}
 #pragma warning restore S2326 // Unused type parameters should be removed

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -238,7 +238,7 @@ public class ReturnMethodSetup<TReturn, T1>(string name, Match.NamedParameter ma
 	{
 		if (HasOutParameter([match1,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();
@@ -426,7 +426,7 @@ public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup
 
 		if (HasOutParameter([_match1, _match2,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();
@@ -635,7 +635,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup
 
 		if (HasOutParameter([_match1, _match2, _match3,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();
@@ -855,7 +855,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup
 
 		if (HasOutParameter([_match1, _match2, _match3, _match4,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -176,7 +176,7 @@ public class VoidMethodSetup<T1>(string name, Match.NamedParameter match1) : Met
 	{
 		if (HasOutParameter([match1,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();
@@ -318,7 +318,7 @@ public class VoidMethodSetup<T1, T2> : MethodSetup
 
 		if (HasOutParameter([_match1, _match2,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();
@@ -475,7 +475,7 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup
 
 		if (HasOutParameter([_match1, _match2, _match3,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();
@@ -636,7 +636,7 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup
 
 		if (HasOutParameter([_match1, _match2, _match3, _match4,], parameterName, out Match.IOutParameter<T>? outParameter))
 		{
-			return outParameter.GetValue();
+			return outParameter.GetValue(behavior);
 		}
 
 		return behavior.DefaultValue.Generate<T>();

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -40,6 +40,7 @@ namespace Mockolate
         public static Mockolate.Match.IOutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IVerifyRefParameter<T> Ref<T>() { }
         public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
+        public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue2 = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
@@ -48,7 +49,7 @@ namespace Mockolate
         public static Mockolate.Match.IParameters WithAnyParameters() { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter
         {
-            T GetValue();
+            T GetValue(Mockolate.MockBehavior mockBehavior);
         }
         public interface IParameter
         {
@@ -63,8 +64,8 @@ namespace Mockolate
         {
             T GetValue(T value);
         }
-        public interface IVerifyOutParameter<out T> : Mockolate.Match.IParameter { }
-        public interface IVerifyRefParameter<out T> : Mockolate.Match.IParameter { }
+        public interface IVerifyOutParameter<out T> : Mockolate.Match.IOutParameter<T>, Mockolate.Match.IParameter { }
+        public interface IVerifyRefParameter<T> : Mockolate.Match.IParameter, Mockolate.Match.IRefParameter<T> { }
         public class NamedParameter : System.IEquatable<Mockolate.Match.NamedParameter>
         {
             public NamedParameter(string Name, Mockolate.Match.IParameter Parameter) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -39,6 +39,7 @@ namespace Mockolate
         public static Mockolate.Match.IOutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IVerifyRefParameter<T> Ref<T>() { }
         public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
+        public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue2 = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
@@ -47,7 +48,7 @@ namespace Mockolate
         public static Mockolate.Match.IParameters WithAnyParameters() { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter
         {
-            T GetValue();
+            T GetValue(Mockolate.MockBehavior mockBehavior);
         }
         public interface IParameter
         {
@@ -62,8 +63,8 @@ namespace Mockolate
         {
             T GetValue(T value);
         }
-        public interface IVerifyOutParameter<out T> : Mockolate.Match.IParameter { }
-        public interface IVerifyRefParameter<out T> : Mockolate.Match.IParameter { }
+        public interface IVerifyOutParameter<out T> : Mockolate.Match.IOutParameter<T>, Mockolate.Match.IParameter { }
+        public interface IVerifyRefParameter<T> : Mockolate.Match.IParameter, Mockolate.Match.IRefParameter<T> { }
         public class NamedParameter : System.IEquatable<Mockolate.Match.NamedParameter>
         {
             public NamedParameter(string Name, Mockolate.Match.IParameter Parameter) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -38,6 +38,7 @@ namespace Mockolate
         public static Mockolate.Match.IOutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IVerifyRefParameter<T> Ref<T>() { }
         public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
+        public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IRefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue2 = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
@@ -46,7 +47,7 @@ namespace Mockolate
         public static Mockolate.Match.IParameters WithAnyParameters() { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter
         {
-            T GetValue();
+            T GetValue(Mockolate.MockBehavior mockBehavior);
         }
         public interface IParameter
         {
@@ -61,8 +62,8 @@ namespace Mockolate
         {
             T GetValue(T value);
         }
-        public interface IVerifyOutParameter<out T> : Mockolate.Match.IParameter { }
-        public interface IVerifyRefParameter<out T> : Mockolate.Match.IParameter { }
+        public interface IVerifyOutParameter<out T> : Mockolate.Match.IOutParameter<T>, Mockolate.Match.IParameter { }
+        public interface IVerifyRefParameter<T> : Mockolate.Match.IParameter, Mockolate.Match.IRefParameter<T> { }
         public class NamedParameter : System.IEquatable<Mockolate.Match.NamedParameter>
         {
             public NamedParameter(string Name, Mockolate.Match.IParameter Parameter) { }

--- a/Tests/Mockolate.Tests/MatchTests.OutTests.cs
+++ b/Tests/Mockolate.Tests/MatchTests.OutTests.cs
@@ -45,7 +45,7 @@ public sealed partial class MatchTests
 		{
 			IOutParameter<int?> sut = Out(() => value);
 
-			int? result = sut.GetValue();
+			int? result = sut.GetValue(MockBehavior.Default);
 
 			await That(result).IsEqualTo(value);
 		}

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -171,6 +171,145 @@ public sealed partial class SetupMethodTests
 	}
 
 	[Fact]
+	public async Task Setup_WithOutParameter_ShouldUseCallbackToSetValue()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyMethodWithOutParameter(Out(() => 4));
+
+		mock.Subject.MyMethodWithOutParameter(out var value);
+
+		await That(value).IsEqualTo(4);
+	}
+
+	[Fact]
+	public async Task Setup_WithOutParameterWithoutCallback_ShouldUseDefaultValueSetValue()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyMethodWithOutParameter(Out<int>());
+
+		mock.Subject.MyMethodWithOutParameter(out var value);
+
+		await That(value).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task Setup_WithRefParameter_WithCallback_ShouldUseCallbackToSetValue()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyMethodWithRefParameter(Ref<int>(_ => 4));
+		int value = 2;
+
+		mock.Subject.MyMethodWithRefParameter(ref value);
+
+		await That(value).IsEqualTo(4);
+	}
+
+	[Fact]
+	public async Task Setup_WithRefParameter_WithPredicate_ShouldUseCallbackToSetValue()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyMethodWithRefParameter(Ref<int>(v => v > 2));
+		int value = 2;
+
+		mock.Subject.MyMethodWithRefParameter(ref value);
+
+		await That(value).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task Setup_WithRefParameter_WithPredicateAndCallback_ShouldUseCallbackToSetValueWhenPredicateMatches()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyMethodWithRefParameter(Ref<int>(v => v > 2, _ => 4));
+		int value1 = 2;
+		int value2 = 3;
+
+		mock.Subject.MyMethodWithRefParameter(ref value1);
+		mock.Subject.MyMethodWithRefParameter(ref value2);
+
+		await That(value1).IsEqualTo(2);
+		await That(value2).IsEqualTo(4);
+	}
+
+	[Fact]
+	public async Task Setup_WithRefParameter_WithoutPredicateOrCallback_ShouldNotChangeValue()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyMethodWithRefParameter(Ref<int>());
+		int value = 2;
+
+		mock.Subject.MyMethodWithRefParameter(ref value);
+
+		await That(value).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task ToString_OutParameter_ShouldReturnExpectedValue()
+	{
+		var sut = Out<int>();
+		string expectedResult = "Out<int>()";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Fact]
+	public async Task ToString_OutParameter_WithCallback_ShouldReturnExpectedValue()
+	{
+		var sut = Out<int>(() => 4);
+		string expectedResult = "Out<int>(() => 4)";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Fact]
+	public async Task ToString_RefParameter_ShouldReturnExpectedValue()
+	{
+		var sut = Ref<int>();
+		string expectedResult = "Ref<int>()";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Fact]
+	public async Task ToString_RefParameter_WithCallback_ShouldReturnExpectedValue()
+	{
+		var sut = Ref<int>(v => 4);
+		string expectedResult = "Ref<int>(v => 4)";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Fact]
+	public async Task ToString_RefParameter_WithPredicate_ShouldReturnExpectedValue()
+	{
+		var sut = Ref<int>(v => v > 4);
+		string expectedResult = "Ref<int>(v => v > 4)";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Fact]
+	public async Task ToString_RefParameter_WithPredicateAndCallback_ShouldReturnExpectedValue()
+	{
+		var sut = Ref<int>(v => v > 4, v => v * 5);
+		string expectedResult = "Ref<int>(v => v > 4, v => v * 5)";
+
+		string? result = sut.ToString();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Fact]
 	public async Task VoidMethod_Callback_ShouldExecuteWhenInvoked()
 	{
 		int callCount = 0;
@@ -735,6 +874,8 @@ public sealed partial class SetupMethodTests
 		int MyIntMethodWithParameters(int x, string y);
 		int MyGenericMethod<T1, T2>(T1 x, T2 y) where T1 : struct where T2 : class;
 		int MyGenericMethod<T>();
+		void MyMethodWithRefParameter(ref int value);
+		void MyMethodWithOutParameter(out int value);
 		string ToString();
 		bool Equals(object? obj);
 		int GetHashCode();


### PR DESCRIPTION
This PR makes the callback parameter optional in `Match.Out`, allowing users to specify out parameters without providing an explicit value. When no callback is provided, the mock will use the default value based on `MockBehavior`. The changes also enhance `Match.Ref` to support predicate-only matching and ensure both `IVerifyOutParameter<T>` and `IVerifyRefParameter<T>` properly implement their parent interfaces.

### Key changes:
- Made callback optional in `Match.Out<T>()` - defaults to `MockBehavior.DefaultValue` when omitted
- Added `Match.Ref<T>(predicate)` overload for predicate-only matching without value modification
- Updated interface hierarchy so verify interfaces inherit from their corresponding parameter interfaces

---

- *Fixes #167*