### PR TITLE
feat: add `WithDefaultParameters()` for events

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.SetupExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.SetupExtensions.cs
@@ -89,6 +89,31 @@ internal static partial class Sources
 			sb.AppendLine("\t\t}");
 		}
 
+		foreach (Event @event in @class.AllEvents()
+					 .Where(predicate)
+					 .GroupBy(m => m.Name)
+					 .Where(g => g.Count() == 1)
+					 .Select(g => g.Single())
+					 .Where(m => m.Delegate.Parameters.Count > 0))
+		{
+			if (count++ > 0)
+			{
+				sb.AppendLine();
+			}
+
+			sb.Append("\t\t/// <summary>").AppendLine();
+			sb.Append("\t\t///     Raise the <see cref=\"").Append(@class.ClassFullName.EscapeForXmlDoc())
+				.Append(".").Append(@event.Name.EscapeForXmlDoc())
+				.Append("\"/> event.").AppendLine();
+			sb.Append("\t\t/// </summary>").AppendLine();
+			sb.Append("\t\tpublic void ").Append(@event.Name).Append("(Match.IDefaultEventParameters parameters)").AppendLine();
+			sb.AppendLine("\t\t{");
+			sb.Append("\t\t\tMockBehavior mockBehavior = ((IMockRaises)mock).Behavior;").AppendLine();
+			sb.Append("\t\t\t((IMockRaises)mock).Raise(").Append(@event.GetUniqueNameString()).Append(", ")
+				.Append(string.Join(", ", @event.Delegate.Parameters.Select(p => $"mockBehavior.DefaultValue.Generate<{p.Type.Fullname}>()"))).Append(");").AppendLine();
+			sb.AppendLine("\t\t}");
+		}
+
 		sb.AppendLine("\t}");
 		sb.AppendLine();
 	}

--- a/Source/Mockolate/Events/IMockRaises.cs
+++ b/Source/Mockolate/Events/IMockRaises.cs
@@ -11,6 +11,11 @@ namespace Mockolate.Events;
 public interface IMockRaises
 {
 	/// <summary>
+	///     Gets the behavior settings used by this mock instance.
+	/// </summary>
+	MockBehavior Behavior { get; }
+
+	/// <summary>
 	///     The setup of the mock.
 	/// </summary>
 	IMockSetup Setup { get; }

--- a/Source/Mockolate/Events/MockRaises.cs
+++ b/Source/Mockolate/Events/MockRaises.cs
@@ -11,6 +11,10 @@ namespace Mockolate.Events;
 /// </summary>
 public class MockRaises<T>(IMockSetup setup, MockInteractions interactions) : IMockRaises
 {
+	/// <inheritdoc cref="IMockRaises.Behavior" />
+	MockBehavior IMockRaises.Behavior
+		=> setup.Mock.Behavior;
+
 	/// <inheritdoc cref="IMockRaises.Setup" />
 	IMockSetup IMockRaises.Setup
 		=> setup;

--- a/Source/Mockolate/Match.WithDefaultParameters.cs
+++ b/Source/Mockolate/Match.WithDefaultParameters.cs
@@ -1,0 +1,18 @@
+namespace Mockolate;
+
+#pragma warning disable S3453 // This class can't be instantiated; make its constructor 'public'.
+public partial class Match
+{
+	/// <summary>
+	///     Use default event parameters when raising events.
+	/// </summary>
+	public static IDefaultEventParameters WithDefaultParameters()
+		=> new DefaultEventParameters();
+
+	private sealed class DefaultEventParameters : IDefaultEventParameters
+	{
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString() => "WithDefaultParameters()";
+	}
+}
+#pragma warning restore S3453 // This class can't be instantiated; make its constructor 'public'.

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -83,6 +83,13 @@ public partial class Match
 #pragma warning restore S2326 // Unused type parameters should be removed
 
 	/// <summary>
+	///     Use default event parameters when raising events.
+	/// </summary>
+	public interface IDefaultEventParameters
+	{
+	}
+
+	/// <summary>
 	///     A named <see cref="Parameter" />.
 	/// </summary>
 	/// <param name="Name">The name of the <paramref name="Parameter" />.</param>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -47,6 +47,8 @@ namespace Mockolate
         public static Mockolate.Match.IParameter<T> With<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("comparer")] string doNotPopulateThisValue2 = "") { }
         public static Mockolate.Match.IParameter<T> WithAny<T>() { }
         public static Mockolate.Match.IParameters WithAnyParameters() { }
+        public static Mockolate.Match.IDefaultEventParameters WithDefaultParameters() { }
+        public interface IDefaultEventParameters { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter
         {
             T GetValue(Mockolate.MockBehavior mockBehavior);
@@ -205,6 +207,7 @@ namespace Mockolate.Events
 {
     public interface IMockRaises
     {
+        Mockolate.MockBehavior Behavior { get; }
         Mockolate.Interactions.MockInteractions Interactions { get; }
         Mockolate.Setup.IMockSetup Setup { get; }
         void AddEvent(string name, object? target, System.Reflection.MethodInfo? method);

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -46,6 +46,8 @@ namespace Mockolate
         public static Mockolate.Match.IParameter<T> With<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("comparer")] string doNotPopulateThisValue2 = "") { }
         public static Mockolate.Match.IParameter<T> WithAny<T>() { }
         public static Mockolate.Match.IParameters WithAnyParameters() { }
+        public static Mockolate.Match.IDefaultEventParameters WithDefaultParameters() { }
+        public interface IDefaultEventParameters { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter
         {
             T GetValue(Mockolate.MockBehavior mockBehavior);
@@ -204,6 +206,7 @@ namespace Mockolate.Events
 {
     public interface IMockRaises
     {
+        Mockolate.MockBehavior Behavior { get; }
         Mockolate.Interactions.MockInteractions Interactions { get; }
         Mockolate.Setup.IMockSetup Setup { get; }
         void AddEvent(string name, object? target, System.Reflection.MethodInfo? method);

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -45,6 +45,8 @@ namespace Mockolate
         public static Mockolate.Match.IParameter<T> With<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("comparer")] string doNotPopulateThisValue2 = "") { }
         public static Mockolate.Match.IParameter<T> WithAny<T>() { }
         public static Mockolate.Match.IParameters WithAnyParameters() { }
+        public static Mockolate.Match.IDefaultEventParameters WithDefaultParameters() { }
+        public interface IDefaultEventParameters { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter
         {
             T GetValue(Mockolate.MockBehavior mockBehavior);
@@ -189,6 +191,7 @@ namespace Mockolate.Events
 {
     public interface IMockRaises
     {
+        Mockolate.MockBehavior Behavior { get; }
         Mockolate.Interactions.MockInteractions Interactions { get; }
         Mockolate.Setup.IMockSetup Setup { get; }
         void AddEvent(string name, object? target, System.Reflection.MethodInfo? method);

--- a/Tests/Mockolate.Tests/MockEvents/RaiseTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/RaiseTests.ProtectedTests.cs
@@ -75,6 +75,23 @@ public sealed partial class RaiseTests
 			await That(callCount).IsEqualTo(2);
 		}
 
+		[Fact]
+		public async Task WhenUsingRaise_WithAnyParameters_ShouldInvokeEvent()
+		{
+			int callCount = 0;
+			Mock<MyRaiseEvent> mock = Mock.Create<MyRaiseEvent>();
+			EventHandler handler = (s, e) => { callCount++; };
+
+			mock.Subject.SubscribeToSomeEvent += handler;
+			mock.Raise.Protected.SomeEvent(WithDefaultParameters());
+			mock.Raise.Protected.SomeEvent(WithDefaultParameters());
+			mock.Subject.SubscribeToSomeEvent -= handler;
+			mock.Raise.Protected.SomeEvent(WithDefaultParameters());
+			mock.Raise.Protected.SomeEvent(WithDefaultParameters());
+
+			await That(callCount).IsEqualTo(2);
+		}
+
 #pragma warning disable CS0067 // Event is never used
 #pragma warning disable CA1070 // Do not declare event fields as virtual
 		public class MyRaiseEvent

--- a/Tests/Mockolate.Tests/MockEvents/RaiseTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/RaiseTests.cs
@@ -90,6 +90,23 @@ public sealed partial class RaiseTests
 		await That(callCount).IsEqualTo(2);
 	}
 
+	[Fact]
+	public async Task WhenUsingRaise_WithAnyParameters_ShouldInvokeEvent()
+	{
+		int callCount = 0;
+		Mock<IRaiseEvent> mock = Mock.Create<IRaiseEvent>();
+		EventHandler handler = (s, e) => { callCount++; };
+
+		mock.Subject.SomeEvent += handler;
+		mock.Raise.SomeEvent(WithDefaultParameters());
+		mock.Raise.SomeEvent(WithDefaultParameters());
+		mock.Subject.SomeEvent -= handler;
+		mock.Raise.SomeEvent(WithDefaultParameters());
+		mock.Raise.SomeEvent(WithDefaultParameters());
+
+		await That(callCount).IsEqualTo(2);
+	}
+
 	public interface IMyEventService : IMyEventServiceBase1
 	{
 		new event EventHandler<string> SomeEvent;


### PR DESCRIPTION
This PR adds a new `WithDefaultParameters()` method for raising events with default parameter values, providing a convenient way to trigger events without explicitly specifying arguments.

### Key Changes:
- Introduces `WithDefaultParameters()` API method and `IDefaultEventParameters` interface
- Generates overloaded event raise methods that accept `IDefaultEventParameters` and use mock behavior's default value generator
- Exposes `MockBehavior` property on `IMockRaises` interface to support default value generation

---

- *Fixes #165*