### PR TITLE
docs: fix formatting in comparison page

### DIFF
--- a/Docs/pages/05-comparison.md
+++ b/Docs/pages/05-comparison.md
@@ -1,7 +1,9 @@
 # Comparison
 
-This page compares **Mockolate** with other .NET mocking libraries: **[Moq](https://github.com/devlooped/moq)**, *
-*[NSubstitute](https://nsubstitute.github.io/)**, and **[FakeItEasy](https://fakeiteasy.github.io/)** with the example
+This page compares **Mockolate** with other .NET mocking libraries:
+**[Moq](https://github.com/devlooped/moq)**,
+**[NSubstitute](https://nsubstitute.github.io/)**, and
+**[FakeItEasy](https://fakeiteasy.github.io/)** with the example
 interface:
 
 ```csharp


### PR DESCRIPTION
This PR fixes formatting issues in the comparison documentation page by breaking a long introductory sentence across multiple lines for improved readability.

- Reformatted the opening paragraph to span multiple lines instead of being split awkwardly mid-sentence