### PR TITLE
refactor: add missing newline to generated code

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -249,7 +249,7 @@ internal static partial class Sources
 			sb.Append(",").AppendLine();
 			sb.Append("\t\t").Append(additional.ClassFullName);
 		}
-
+		sb.AppendLine();
 		sb.AppendLine("""
 		              	{
 		              		private IMock _mock;


### PR DESCRIPTION
This PR adds a missing newline to improve the formatting of generated mock code. The change ensures proper spacing between the interface list and the opening brace of the generated mock class.