### PR TITLE
docs: document and test behavior for overlapping setups

### DIFF
--- a/Docs/pages/02-setup.md
+++ b/Docs/pages/02-setup.md
@@ -38,6 +38,7 @@ mock.Setup.Method.Dispense(With("Green"), WithAny<int>())
   parameters.
 - Use `.Returns(…)` and `.Throws(…)` repeatedly to define a sequence of return values or exceptions (cycled on each
   call).
+- When you specify overlapping setups, the most recently defined setup takes precedence.
 
 **Async Methods**
 
@@ -113,3 +114,4 @@ mock.Setup.Indexer(With("Dark"))
 - `.OnGet(…)` and `.OnSet(…)` support callbacks with or without parameters.
 - `.Returns(…)` and `.Throws(…)` can be chained to define a sequence of behaviors, which are cycled through on each
   call.
+- When you specify overlapping setups, the most recently defined setup takes precedence.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ mock.Setup.Method.Dispense(With("Green"), WithAny<int>())
   parameters.
 - Use `.Returns(…)` and `.Throws(…)` repeatedly to define a sequence of return values or exceptions (cycled on each
   call).
+- When you specify overlapping setups, the most recently defined setup takes precedence.
 
 **Async Methods**
 
@@ -252,6 +253,7 @@ mock.Setup.Indexer(With("Dark"))
 - `.OnGet(…)` and `.OnSet(…)` support callbacks with or without parameters.
 - `.Returns(…)` and `.Throws(…)` can be chained to define a sequence of behaviors, which are cycled through on each
   call.
+- When you specify overlapping setups, the most recently defined setup takes precedence.
 
 ## Mock events
 

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -5,6 +5,38 @@ namespace Mockolate.Tests.MockIndexers;
 public sealed partial class SetupIndexerTests
 {
 	[Fact]
+	public async Task OverlappingSetups_ShouldUseLatestMatchingSetup()
+	{
+		Mock<IIndexerService> mock = Mock.Create<IIndexerService>();
+		mock.Setup.Indexer(WithAny<int>()).InitializeWith("foo");
+		mock.Setup.Indexer(With(2)).InitializeWith("bar");
+
+		string result1 = mock.Subject[1];
+		string result2 = mock.Subject[2];
+		string result3 = mock.Subject[3];
+
+		await That(result1).IsEqualTo("foo");
+		await That(result2).IsEqualTo("bar");
+		await That(result3).IsEqualTo("foo");
+	}
+
+	[Fact]
+	public async Task OverlappingSetups_WhenGeneralSetupIsLater_ShouldOnlyUseGeneralSetup()
+	{
+		Mock<IIndexerService> mock = Mock.Create<IIndexerService>();
+		mock.Setup.Indexer(With(2)).InitializeWith("bar");
+		mock.Setup.Indexer(WithAny<int>()).InitializeWith("foo");
+
+		string result1 = mock.Subject[1];
+		string result2 = mock.Subject[2];
+		string result3 = mock.Subject[3];
+
+		await That(result1).IsEqualTo("foo");
+		await That(result2).IsEqualTo("foo");
+		await That(result3).IsEqualTo("foo");
+	}
+
+	[Fact]
 	public async Task SetOnDifferentLevel_ShouldNotBeUsed()
 	{
 		Mock<IIndexerService> mock = Mock.Create<IIndexerService>();

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -34,6 +34,38 @@ public sealed partial class SetupMethodTests
 	}
 
 	[Fact]
+	public async Task OverlappingSetups_ShouldUseLatestMatchingSetup()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyIntMethodWithParameters(WithAny<int>(), WithAny<string>()).Returns(1);
+		mock.Setup.Method.MyIntMethodWithParameters(With(0), With("foo")).Returns(2);
+
+		int result1 = mock.Subject.MyIntMethodWithParameters(1, "foo");
+		int result2 = mock.Subject.MyIntMethodWithParameters(0, "foo");
+		int result3 = mock.Subject.MyIntMethodWithParameters(0, "bar");
+
+		await That(result1).IsEqualTo(1);
+		await That(result2).IsEqualTo(2);
+		await That(result3).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task OverlappingSetups_WhenGeneralSetupIsLater_ShouldOnlyUseGeneralSetup()
+	{
+		Mock<IMethodService> mock = Mock.Create<IMethodService>();
+		mock.Setup.Method.MyIntMethodWithParameters(With(0), With("foo")).Returns(2);
+		mock.Setup.Method.MyIntMethodWithParameters(WithAny<int>(), WithAny<string>()).Returns(1);
+
+		int result1 = mock.Subject.MyIntMethodWithParameters(1, "foo");
+		int result2 = mock.Subject.MyIntMethodWithParameters(0, "foo");
+		int result3 = mock.Subject.MyIntMethodWithParameters(0, "bar");
+
+		await That(result1).IsEqualTo(1);
+		await That(result2).IsEqualTo(1);
+		await That(result3).IsEqualTo(1);
+	}
+
+	[Fact]
 	public async Task Register_AfterInvocation_ShouldBeAppliedForFutureUse()
 	{
 		Mock<IMethodService> mock = Mock.Create<IMethodService>();


### PR DESCRIPTION
This PR documents and tests the behavior when multiple mock setups overlap, establishing that the most recently defined setup takes precedence. The changes add test coverage for overlapping setup scenarios and update documentation to clarify this behavior.

### Key changes:
- Added test cases demonstrating overlapping setup behavior for both methods and indexers
- Updated documentation to explicitly state that the most recently defined setup takes precedence

---

- *Fixes #175*