### PR TITLE
feat: support creating `Lazy<T>`

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockRegistration.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockRegistration.cs
@@ -90,9 +90,9 @@ internal static partial class Sources
 					.Append(")));").AppendLine();
 			}
 			else if (type.Fullname.StartsWith("System.Threading.Tasks.Task<") && type.Fullname.EndsWith(">")
-			                                                                  && type.GenericTypeParameters?.Count ==
-			                                                                  1 && !type.GenericTypeParameters.Value
-				                                                                  .Single().IsTypeParameter)
+																			  && type.GenericTypeParameters?.Count ==
+																			  1 && !type.GenericTypeParameters.Value
+																				  .Single().IsTypeParameter)
 			{
 				sb.Append("\t\tDefaultValueGenerator.Register(new CallbackDefaultValueFactory<").Append(type.Fullname)
 					.Append(">(defaultValueGenerator => System.Threading.Tasks.Task.FromResult<")
@@ -101,6 +101,20 @@ internal static partial class Sources
 					.Append(type.GenericTypeParameters.Value.Single().Fullname)
 					.Append(
 						">()), type => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>) && type.GenericTypeArguments[0] == typeof(")
+					.Append(type.GenericTypeParameters.Value.Single().Fullname).Append(")));").AppendLine();
+			}
+			else if (type.Fullname.StartsWith("System.Lazy<") && type.Fullname.EndsWith(">")
+																			  && type.GenericTypeParameters?.Count ==
+																			  1 && !type.GenericTypeParameters.Value
+																				  .Single().IsTypeParameter)
+			{
+				sb.Append("\t\tDefaultValueGenerator.Register(new CallbackDefaultValueFactory<").Append(type.Fullname)
+					.Append(">(defaultValueGenerator => new System.Lazy<")
+					.Append(type.GenericTypeParameters.Value.Single().Fullname)
+					.Append(">(() => defaultValueGenerator.Generate<")
+					.Append(type.GenericTypeParameters.Value.Single().Fullname)
+					.Append(
+						">()), type => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Lazy<>) && type.GenericTypeArguments[0] == typeof(")
 					.Append(type.GenericTypeParameters.Value.Single().Fullname).Append(")));").AppendLine();
 			}
 			else if (type.Fullname.StartsWith("System.Threading.Tasks.ValueTask<") && type.Fullname.EndsWith(">")

--- a/Tests/Mockolate.Tests/MockBehaviorTests.DefaultValueTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.DefaultValueTests.cs
@@ -49,6 +49,26 @@ public sealed partial class MockBehaviorTests
 		}
 
 		[Fact]
+		public async Task WithLazyInt_ShouldReturnLazyWithZero()
+		{
+			Mock<IDefaultValueGeneratorProperties> mock = Mock.Create<IDefaultValueGeneratorProperties>();
+
+			Lazy<int> result = mock.Subject.LazyInt;
+
+			await That(result.Value).IsEqualTo(0);
+		}
+
+		[Fact]
+		public async Task WithLazyString_ShouldReturnLazyWithEmptyString()
+		{
+			Mock<IDefaultValueGeneratorProperties> mock = Mock.Create<IDefaultValueGeneratorProperties>();
+
+			Lazy<string> result = mock.Subject.LazyString;
+
+			await That(result.Value).IsEmpty();
+		}
+
+		[Fact]
 		public async Task WithInt_ShouldReturnZero()
 		{
 			MockBehavior sut = MockBehavior.Default;
@@ -201,6 +221,8 @@ public sealed partial class MockBehaviorTests
 			IEnumerable<int> IEnumerableOfInt { get; }
 			(int V1, string V2) NamedValueTuple { get; }
 			(int, string, int, string, int, string, int, string) ValueTuple8 { get; }
+			Lazy<int> LazyInt { get; }
+			Lazy<string> LazyString { get; }
 			Task<int> IntTask { get; }
 			Task<int[]> IntArrayTask { get; }
 			ValueTask<int> IntValueTask { get; }


### PR DESCRIPTION
This PR adds support for creating `Lazy<T>` instances in the mocking framework. When a mocked interface returns a `Lazy<T>` property, the framework will now automatically generate a `Lazy<T>` instance that lazily provides the default value for type `T`.

### Key changes:
- Adds factory registration for `Lazy<T>` types in the source generator
- Includes test coverage for `Lazy<int>` and `Lazy<string>` to verify the behavior

---

- *Fixes #184*