### PR TITLE
feat: use released .NET 10 version

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -19,7 +19,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<LangVersion>preview</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<NoWarn>$(NoWarn);1701;1702</NoWarn>
 		<WarningsNotAsErrors>CS1591;NU5104</WarningsNotAsErrors>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<LangVersion>preview</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "10.0.100-rc.1",
+		"version": "10.0.100",
 		"rollForward": "latestMinor"
 	}
 }


### PR DESCRIPTION
This PR updates the project from .NET 10 RC1 to the released .NET 10 version by updating the SDK version and language version settings.

### Key changes:
- Updated SDK version from `10.0.100-rc.1` to `10.0.100`
- Changed `LangVersion` from `preview` to `latest` in both source and test projects