### PR TITLE
feat: recursively create mocks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
 		<PackageVersion Include="coverlet.collector" Version="6.0.4"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.6"/>
 		<PackageVersion Include="aweXpect" Version="2.26.0"/>
-		<PackageVersion Include="aweXpect.Mockolate" Version="0.3.1"/>
+		<PackageVersion Include="aweXpect.Mockolate" Version="0.4.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Moq" Version="4.20.72"/>

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -23,15 +23,15 @@ public class MockGenerator : IIncrementalGenerator
 			"Mock.g.cs",
 			SourceText.From(Sources.Sources.MockClass(), Encoding.UTF8)));
 
-		IncrementalValueProvider<ImmutableArray<MockClass?>> expectationsToRegister = context.SyntaxProvider
+		IncrementalValueProvider<ImmutableArray<MockClass>> expectationsToRegister = context.SyntaxProvider
 			.CreateSyntaxProvider(
 				static (s, _) => s.IsCreateMethodInvocation(),
 				(ctx, _) => ctx.Node.ExtractMockOrMockFactoryCreateSyntaxOrDefault(ctx.SemanticModel))
-			.Where(static m => m is not null)
+			.SelectMany(static (mocks, _) => mocks)
 			.Collect();
 
 		context.RegisterSourceOutput(expectationsToRegister,
-			(spc, source) => Execute([..source.Where(t => t != null).Distinct().Cast<MockClass>(),], spc));
+			(spc, source) => Execute(source.Distinct().ToImmutableArray(), spc));
 	}
 
 	private static void Execute(ImmutableArray<MockClass> mocksToGenerate, SourceProductionContext context)

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockRegistration.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockRegistration.cs
@@ -134,6 +134,7 @@ internal static partial class Sources
 					.Append(type.GenericTypeParameters.Value.Single().Fullname).Append(")));").AppendLine();
 			}
 		}
+		sb.Append("\t\tDefaultValueGenerator.Register(new RecursiveMockValueFactory());").AppendLine();
 
 		sb.AppendLine("\t}");
 		sb.AppendLine();
@@ -364,6 +365,21 @@ internal static partial class Sources
 		sb.AppendLine("\t\t/// <inheritdoc cref=\"IDefaultValueFactory.Create(Type, IDefaultValueGenerator)\" />");
 		sb.AppendLine("\t\tpublic object? Create(Type type, IDefaultValueGenerator defaultValueGenerator)");
 		sb.AppendLine("\t\t\t=> callback(defaultValueGenerator);");
+		sb.AppendLine("\t}");
+
+		sb.AppendLine();
+		sb.AppendLine(
+			"\tprivate class RecursiveMockValueFactory() : IDefaultValueFactory");
+		sb.AppendLine("\t{");
+		sb.AppendLine("\t\t/// <inheritdoc cref=\"IDefaultValueFactory.IsMatch(Type)\" />");
+		sb.AppendLine("\t\tpublic bool IsMatch(Type type)");
+		sb.AppendLine("\t\t\t=> true;");
+		sb.AppendLine();
+		sb.AppendLine("\t\t/// <inheritdoc cref=\"IDefaultValueFactory.Create(Type, IDefaultValueGenerator)\" />");
+		sb.AppendLine("\t\tpublic object? Create(Type type, IDefaultValueGenerator defaultValueGenerator)");
+		sb.AppendLine("\t\t{");
+		sb.AppendLine("\t\t\treturn new MockGenerator().Get(null, MockBehavior.Default, type);");
+		sb.AppendLine("\t\t}");
 		sb.AppendLine("\t}");
 		sb.AppendLine("}");
 		sb.AppendLine("#nullable disable");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -415,6 +415,12 @@ internal static partial class Sources
 
 		              		partial void Generate<T>(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior, Action<IMockSetup<T>>[] setups, params Type[] types);
 
+		              		public object? Get(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior, Type type)
+		              		{
+		              			Generate<object>(constructorParameters, mockBehavior, Array.Empty<Action<IMockSetup<object>>>(), type);
+		              			return _value;
+		              		}
+
 		              		public T? Get<T>(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior, Action<IMockSetup<T>>[] setups)
 		              			where T : class
 		              		{

--- a/Tests/Mockolate.Tests/MockBehaviorTests.DefaultValueTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.DefaultValueTests.cs
@@ -9,6 +9,16 @@ public sealed partial class MockBehaviorTests
 	public sealed class DefaultValueTests
 	{
 		[Fact]
+		public async Task Recursive_ShouldReturnMock()
+		{
+			IDefaultValueGeneratorProperties mock = Mock.Create<IDefaultValueGeneratorProperties>();
+
+			IMyRecursiveService result = mock.RecursiveService;
+
+			await That(result).IsNotNull();
+		}
+
+		[Fact]
 		public async Task WithArray_ShouldReturnEmptyArray()
 		{
 			IDefaultValueGeneratorProperties mock = Mock.Create<IDefaultValueGeneratorProperties>();
@@ -227,6 +237,12 @@ public sealed partial class MockBehaviorTests
 			Task<int[]> IntArrayTask { get; }
 			ValueTask<int> IntValueTask { get; }
 			ValueTask<int[]> IntArrayValueTask { get; }
+			IMyRecursiveService RecursiveService { get; }
+		}
+
+		public interface IMyRecursiveService
+		{
+			int GetCalled(int value);
 		}
 	}
 }


### PR DESCRIPTION
This PR implements recursive mock creation functionality, allowing mocks to automatically generate mock implementations for interface properties and method return types. When creating a mock of an interface, any interface-typed properties or method return values not from the "System" namespace will now automatically return mocks rather than null.

### Key changes:
- Added `RecursiveMockValueFactory` as a default value factory that creates mocks for any unmocked interface members
- Extended mock generation to recursively discover and generate mocks for all interface types referenced by properties and method return types
- Added test coverage for the recursive mock creation feature

---

- *Fixes #176*