### PR TITLE
refactor!: rename `WithAny` to `Any`

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/HappyCaseBenchmarks.Simple.cs
+++ b/Benchmarks/Mockolate.Benchmarks/HappyCaseBenchmarks.Simple.cs
@@ -21,11 +21,11 @@ public partial class HappyCaseBenchmarks
 	public void Simple_Mockolate()
 	{
 		IMyInterface mock = Mock.Create<IMyInterface>();
-		mock.SetupMock.Method.MyFunc(WithAny<int>()).Returns(true);
+		mock.SetupMock.Method.MyFunc(Any<int>()).Returns(true);
 
 		mock.MyFunc(42);
 
-		mock.VerifyMock.Invoked.MyFunc(WithAny<int>()).Once();
+		mock.VerifyMock.Invoked.MyFunc(Any<int>()).Once();
 	}
 
 	/// <summary>

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -30,7 +30,7 @@ Framework 4.8.
    // Setup: Initial stock of 10 for Dark chocolate
    mock.Setup.Indexer("Dark").InitializeWith(10);
    // Setup: Dispense decreases Dark chocolate if enough, returns true/false
-   mock.Setup.Method.Dispense(With("Dark"), WithAny<int>())
+   mock.Setup.Method.Dispense(With("Dark"), Any<int>())
        .Returns((type, amount) =>
        {
            var current = mock.Subject[type];
@@ -53,7 +53,7 @@ Framework 4.8.
    bool gotChoc3 = mock.Subject.Dispense("Dark", 6); // false
    
    // Verify: Check interactions
-   mock.Verify.Invoked.Dispense(With("Dark"), WithAny<int>()).Exactly(3);
+   mock.Verify.Invoked.Dispense(With("Dark"), Any<int>()).Exactly(3);
    
    // Output: "Dispensed amount: 9. Got chocolate? True, True, False"
    Console.WriteLine($"Dispensed amount: {dispensedAmount}. Got chocolate? {gotChoc1}, {gotChoc2}, {gotChoc3}");

--- a/Docs/pages/02-setup.md
+++ b/Docs/pages/02-setup.md
@@ -9,7 +9,7 @@ Use `mock.Setup.Method.MethodName(…)` to set up methods. You can specify argum
 
 ```csharp
 // Setup Dispense to decrease stock and raise event
-mock.Setup.Method.Dispense(With("Dark"), WithAny<int>())
+mock.Setup.Method.Dispense(With("Dark"), Any<int>())
     .Returns((type, amount) =>
     {
         var current = mock.Subject[type];
@@ -23,11 +23,11 @@ mock.Setup.Method.Dispense(With("Dark"), WithAny<int>())
     });
 
 // Setup method with callback
-mock.Setup.Method.Dispense(With("White"), WithAny<int>())
+mock.Setup.Method.Dispense(With("White"), Any<int>())
     .Callback((type, amount) => Console.WriteLine($"Dispensed {amount} {type} chocolate."));
 
 // Setup method to throw
-mock.Setup.Method.Dispense(With("Green"), WithAny<int>())
+mock.Setup.Method.Dispense(With("Green"), Any<int>())
     .Throws<InvalidChocolateException>();
 ```
 
@@ -45,7 +45,7 @@ mock.Setup.Method.Dispense(With("Green"), WithAny<int>())
 For `Task<T>` or `ValueTask<T>` methods, use `.ReturnsAsync(…)`:
 
 ```csharp
-mock.Setup.Method.DispenseAsync(WithAny<string>(), WithAny<int>())
+mock.Setup.Method.DispenseAsync(Any<string>(), Any<int>())
     .ReturnsAsync(true);
 ```
 
@@ -53,7 +53,7 @@ mock.Setup.Method.DispenseAsync(WithAny<string>(), WithAny<int>())
 
 Mockolate provides flexible argument matching for method setups and verifications:
 
-- `Match.WithAny<T>()`: Matches any value of type `T`.
+- `Match.Any<T>()`: Matches any value of type `T`.
 - `Match.With<T>(predicate)`: Matches values based on a predicate.
 - `Match.With<T>(value)`: Matches a specific value.
 - `Match.Null<T>()`: Matches null.
@@ -99,7 +99,7 @@ mock.Setup.Property.TotalDispensed.OnSet((oldValue, newValue) => Console.WriteLi
 Set up indexers with argument matchers. Supports initialization, returns/throws sequences, and callbacks.
 
 ```csharp
-mock.Setup.Indexer(WithAny<string>())
+mock.Setup.Indexer(Any<string>())
     .InitializeWith(type => 20)
     .OnGet(type => Console.WriteLine($"Stock for {type} was read"));
 

--- a/Docs/pages/04-verify-interactions.md
+++ b/Docs/pages/04-verify-interactions.md
@@ -25,17 +25,17 @@ You can verify that methods were invoked with specific arguments and how many ti
 mock.Verify.Invoked.Dispense(With("Dark"), With(5)).AtLeastOnce();
 
 // Verify that Dispense was never invoked with "White" and any amount
-mock.Verify.Invoked.Dispense(With("White"), WithAny<int>()).Never();
+mock.Verify.Invoked.Dispense(With("White"), Any<int>()).Never();
 
 // Verify that Dispense was invoked exactly twice with any type and any amount
-mock.Verify.Invoked.Dispense(WithAnyParameters()).Exactly(2);
+mock.Verify.Invoked.Dispense(AnyParameters()).Exactly(2);
 ```
 
 ### Argument Matchers
 
 You can use argument matchers from the `Match` class to verify calls with flexible conditions:
 
-- `Match.WithAny<T>()`: matches any value of type `T`
+- `Match.Any<T>()`: matches any value of type `T`
 - `Match.Null<T>()`: matches `null`
 - `Match.With<T>(predicate)`: matches values satisfying a predicate
 - `Match.With(value)`: matches a specific value
@@ -45,8 +45,8 @@ You can use argument matchers from the `Match` class to verify calls with flexib
 **Example:**
 
 ```csharp
-mock.Verify.Invoked.Dispense(With<string>(t => t.StartsWith("D")), WithAny<int>()).Once();
-mock.Verify.Invoked.Dispense(With("Milk"), WithAny<int>()).AtLeastOnce();
+mock.Verify.Invoked.Dispense(With<string>(t => t.StartsWith("D")), Any<int>()).Once();
+mock.Verify.Invoked.Dispense(With("Milk"), Any<int>()).AtLeastOnce();
 ```
 
 ## Properties

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Framework 4.8.
    // Setup: Initial stock of 10 for Dark chocolate
    mock.Setup.Indexer("Dark").InitializeWith(10);
    // Setup: Dispense decreases Dark chocolate if enough, returns true/false
-   mock.Setup.Method.Dispense(With("Dark"), WithAny<int>())
+   mock.Setup.Method.Dispense(With("Dark"), Any<int>())
        .Returns((type, amount) =>
        {
            var current = mock.Subject[type];
@@ -57,7 +57,7 @@ Framework 4.8.
    bool gotChoc3 = mock.Subject.Dispense("Dark", 6); // false
    
    // Verify: Check interactions
-   mock.Verify.Invoked.Dispense(With("Dark"), WithAny<int>()).Exactly(3);
+   mock.Verify.Invoked.Dispense(With("Dark"), Any<int>()).Exactly(3);
    
    // Output: "Dispensed amount: 9. Got chocolate? True, True, False"
    Console.WriteLine($"Dispensed amount: {dispensedAmount}. Got chocolate? {gotChoc1}, {gotChoc2}, {gotChoc3}");
@@ -148,7 +148,7 @@ Use `mock.Setup.Method.MethodName(…)` to set up methods. You can specify argum
 
 ```csharp
 // Setup Dispense to decrease stock and raise event
-mock.Setup.Method.Dispense(With("Dark"), WithAny<int>())
+mock.Setup.Method.Dispense(With("Dark"), Any<int>())
     .Returns((type, amount) =>
     {
         var current = mock.Subject[type];
@@ -162,11 +162,11 @@ mock.Setup.Method.Dispense(With("Dark"), WithAny<int>())
     });
 
 // Setup method with callback
-mock.Setup.Method.Dispense(With("White"), WithAny<int>())
+mock.Setup.Method.Dispense(With("White"), Any<int>())
     .Callback((type, amount) => Console.WriteLine($"Dispensed {amount} {type} chocolate."));
 
 // Setup method to throw
-mock.Setup.Method.Dispense(With("Green"), WithAny<int>())
+mock.Setup.Method.Dispense(With("Green"), Any<int>())
     .Throws<InvalidChocolateException>();
 ```
 
@@ -184,7 +184,7 @@ mock.Setup.Method.Dispense(With("Green"), WithAny<int>())
 For `Task<T>` or `ValueTask<T>` methods, use `.ReturnsAsync(…)`:
 
 ```csharp
-mock.Setup.Method.DispenseAsync(WithAny<string>(), WithAny<int>())
+mock.Setup.Method.DispenseAsync(Any<string>(), Any<int>())
     .ReturnsAsync(true);
 ```
 
@@ -192,7 +192,7 @@ mock.Setup.Method.DispenseAsync(WithAny<string>(), WithAny<int>())
 
 Mockolate provides flexible argument matching for method setups and verifications:
 
-- `Match.WithAny<T>()`: Matches any value of type `T`.
+- `Match.Any<T>()`: Matches any value of type `T`.
 - `Match.With<T>(predicate)`: Matches values based on a predicate.
 - `Match.With<T>(value)`: Matches a specific value.
 - `Match.Null<T>()`: Matches null.
@@ -238,7 +238,7 @@ mock.Setup.Property.TotalDispensed.OnSet((oldValue, newValue) => Console.WriteLi
 Set up indexers with argument matchers. Supports initialization, returns/throws sequences, and callbacks.
 
 ```csharp
-mock.Setup.Indexer(WithAny<string>())
+mock.Setup.Indexer(Any<string>())
     .InitializeWith(type => 20)
     .OnGet(type => Console.WriteLine($"Stock for {type} was read"));
 
@@ -318,17 +318,17 @@ You can verify that methods were invoked with specific arguments and how many ti
 mock.Verify.Invoked.Dispense(With("Dark"), With(5)).AtLeastOnce();
 
 // Verify that Dispense was never invoked with "White" and any amount
-mock.Verify.Invoked.Dispense(With("White"), WithAny<int>()).Never();
+mock.Verify.Invoked.Dispense(With("White"), Any<int>()).Never();
 
 // Verify that Dispense was invoked exactly twice with any type and any amount
-mock.Verify.Invoked.Dispense(WithAnyParameters()()).Exactly(2);
+mock.Verify.Invoked.Dispense(AnyParameters()()).Exactly(2);
 ```
 
 #### Argument Matchers
 
 You can use argument matchers from the `With` class to verify calls with flexible conditions:
 
-- `Match.WithAny<T>()`: matches any value of type `T`
+- `Match.Any<T>()`: matches any value of type `T`
 - `Match.Null<T>()`: matches `null`
 - `Match.With<T>(predicate)`: matches values satisfying a predicate
 - `Match.With(value)`: matches a specific value
@@ -338,8 +338,8 @@ You can use argument matchers from the `With` class to verify calls with flexibl
 **Example:**
 
 ```csharp
-mock.Verify.Invoked.Dispense(With<string>(t => t.StartsWith("D")), WithAny<int>()).Once();
-mock.Verify.Invoked.Dispense(With("Milk"), WithAny<int>()).AtLeastOnce();
+mock.Verify.Invoked.Dispense(With<string>(t => t.StartsWith("D")), Any<int>()).Once();
+mock.Verify.Invoked.Dispense(With("Milk"), Any<int>()).AtLeastOnce();
 ```
 
 ### Properties

--- a/Source/Mockolate/Match.Any.cs
+++ b/Source/Mockolate/Match.Any.cs
@@ -9,15 +9,15 @@ public partial class Match
 	///     Matches any parameter of type <typeparamref name="T" />.
 	/// </summary>
 	/// <remarks>Also matches, if the method parameter is <see langword="null" />.</remarks>
-	public static IParameter<T> WithAny<T>()
-		=> new AnyParameter<T>();
+	public static IParameter<T> Any<T>()
+		=> new AnyParameterMatch<T>();
 
-	private sealed class AnyParameter<T> : TypedParameter<T>
+	private sealed class AnyParameterMatch<T> : TypedMatch<T>
 	{
 		protected override bool Matches(T value) => true;
 
 		/// <inheritdoc cref="object.ToString()" />
-		public override string ToString() => $"WithAny<{typeof(T).FormatType()}>()";
+		public override string ToString() => $"Any<{typeof(T).FormatType()}>()";
 	}
 }
 #pragma warning restore S3453 // This class can't be instantiated; make its constructor 'public'.

--- a/Source/Mockolate/Match.AnyParameters.cs
+++ b/Source/Mockolate/Match.AnyParameters.cs
@@ -6,17 +6,17 @@ public partial class Match
 	/// <summary>
 	///     Matches any parameter combination.
 	/// </summary>
-	public static IParameters WithAnyParameters()
-		=> new AnyParameters();
+	public static IParameters AnyParameters()
+		=> new AnyParametersMatch();
 
-	private sealed class AnyParameters : IParameters
+	private sealed class AnyParametersMatch : IParameters
 	{
 		/// <inheritdoc cref="IParameters.Matches(object?[])" />
 		public bool Matches(object?[] values)
 			=> true;
 
 		/// <inheritdoc cref="object.ToString()" />
-		public override string ToString() => "WithAnyParameters()";
+		public override string ToString() => "AnyParameters()";
 	}
 }
 #pragma warning restore S3453 // This class can't be instantiated; make its constructor 'public'.

--- a/Source/Mockolate/Match.Null.cs
+++ b/Source/Mockolate/Match.Null.cs
@@ -9,9 +9,9 @@ public partial class Match
 	///     Matches any parameter that is <see langword="null" />.
 	/// </summary>
 	public static IParameter<T> Null<T>()
-		=> new NullParameter<T>();
+		=> new NullParameterMatch<T>();
 
-	private sealed class NullParameter<T> : TypedParameter<T>
+	private sealed class NullParameterMatch<T> : TypedMatch<T>
 	{
 		protected override bool Matches(T value) => value is null;
 

--- a/Source/Mockolate/Match.Out.cs
+++ b/Source/Mockolate/Match.Out.cs
@@ -11,7 +11,7 @@ public partial class Match
 	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" />.
 	/// </summary>
 	public static IVerifyOutParameter<T> Out<T>()
-		=> new InvokedOutParameter<T>();
+		=> new InvokedOutParameterMatch<T>();
 
 	/// <summary>
 	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" /> and
@@ -19,12 +19,12 @@ public partial class Match
 	/// </summary>
 	public static IOutParameter<T> Out<T>(Func<T> setter,
 		[CallerArgumentExpression("setter")] string doNotPopulateThisValue = "")
-		=> new OutParameter<T>(setter, doNotPopulateThisValue);
+		=> new OutParameterMatch<T>(setter, doNotPopulateThisValue);
 
 	/// <summary>
 	///     Matches an <see langword="out" /> parameter against an expectation.
 	/// </summary>
-	private sealed class OutParameter<T>(Func<T> setter, string setterExpression) : IOutParameter<T>
+	private sealed class OutParameterMatch<T>(Func<T> setter, string setterExpression) : IOutParameter<T>
 	{
 		/// <inheritdoc cref="IParameter.Matches(object?)" />
 		public bool Matches(object? value) => true;
@@ -39,7 +39,7 @@ public partial class Match
 	/// <summary>
 	///     Matches any <see langword="out" /> parameter.
 	/// </summary>
-	private sealed class InvokedOutParameter<T> : IVerifyOutParameter<T>
+	private sealed class InvokedOutParameterMatch<T> : IVerifyOutParameter<T>
 	{
 		/// <inheritdoc cref="IParameter.Matches(object?)" />
 		public bool Matches(object? value) => true;

--- a/Source/Mockolate/Match.Ref.cs
+++ b/Source/Mockolate/Match.Ref.cs
@@ -13,7 +13,7 @@ public partial class Match
 	/// </summary>
 	public static IRefParameter<T> Ref<T>(Func<T, T> setter,
 		[CallerArgumentExpression("setter")] string doNotPopulateThisValue = "")
-		=> new RefParameter<T>(_ => true, setter, null, doNotPopulateThisValue);
+		=> new RefParameterMatch<T>(_ => true, setter, null, doNotPopulateThisValue);
 
 	/// <summary>
 	///     Matches a <see langword="ref" /> parameter of type <typeparamref name="T" /> that satisfies the
@@ -24,7 +24,7 @@ public partial class Match
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue1 = "",
 		[CallerArgumentExpression("setter")] string doNotPopulateThisValue2 = "")
-		=> new RefParameter<T>(predicate, setter, doNotPopulateThisValue1, doNotPopulateThisValue2);
+		=> new RefParameterMatch<T>(predicate, setter, doNotPopulateThisValue1, doNotPopulateThisValue2);
 
 	/// <summary>
 	///     Matches a <see langword="ref" /> parameter of type <typeparamref name="T" /> that satisfies the
@@ -33,18 +33,18 @@ public partial class Match
 	public static IRefParameter<T> Ref<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> new RefParameter<T>(predicate, null, doNotPopulateThisValue, null);
+		=> new RefParameterMatch<T>(predicate, null, doNotPopulateThisValue, null);
 
 	/// <summary>
 	///     Matches any <see langword="ref" /> parameter of type <typeparamref name="T" />.
 	/// </summary>
 	public static IVerifyRefParameter<T> Ref<T>()
-		=> new InvokedRefParameter<T>();
+		=> new InvokedRefParameterMatch<T>();
 
 	/// <summary>
 	///     Matches a method <see langword="ref" /> parameter against an expectation.
 	/// </summary>
-	private sealed class RefParameter<T>(
+	private sealed class RefParameterMatch<T>(
 		Func<T, bool> predicate,
 		Func<T, T>? setter,
 		string? predicateExpression,
@@ -78,7 +78,7 @@ public partial class Match
 	/// <summary>
 	///     Matches a method <see langword="out" /> parameter against an expectation.
 	/// </summary>
-	private sealed class InvokedRefParameter<T> : IVerifyRefParameter<T>
+	private sealed class InvokedRefParameterMatch<T> : IVerifyRefParameter<T>
 	{
 		/// <inheritdoc cref="IParameter.Matches(object?)" />
 		public bool Matches(object? value) => true;

--- a/Source/Mockolate/Match.With.cs
+++ b/Source/Mockolate/Match.With.cs
@@ -14,7 +14,7 @@ public partial class Match
 	public static IParameter<T> With<T>(T value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
-		=> new ParameterEquals<T>(value, doNotPopulateThisValue);
+		=> new ParameterEqualsMatch<T>(value, doNotPopulateThisValue);
 
 	/// <summary>
 	///     Matches a parameter that is equal to <paramref name="value" /> according to the <paramref name="comparer" />.
@@ -24,7 +24,7 @@ public partial class Match
 		string doNotPopulateThisValue1 = "",
 		[CallerArgumentExpression(nameof(comparer))]
 		string doNotPopulateThisValue2 = "")
-		=> new ParameterEquals<T>(value, doNotPopulateThisValue1, comparer, doNotPopulateThisValue2);
+		=> new ParameterEqualsMatch<T>(value, doNotPopulateThisValue1, comparer, doNotPopulateThisValue2);
 
 	/// <summary>
 	///     Matches a parameter of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
@@ -32,16 +32,16 @@ public partial class Match
 	public static IParameter<T> With<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> new PredicateParameter<T>(predicate, doNotPopulateThisValue);
+		=> new PredicateParameterMatch<T>(predicate, doNotPopulateThisValue);
 
-	private sealed class ParameterEquals<T> : TypedParameter<T>
+	private sealed class ParameterEqualsMatch<T> : TypedMatch<T>
 	{
 		private readonly IEqualityComparer<T>? _comparer;
 		private readonly string? _comparerExpression;
 		private readonly T _value;
 		private readonly string _valueExpression;
 
-		public ParameterEquals(T value, string valueExpression, IEqualityComparer<T>? comparer = null,
+		public ParameterEqualsMatch(T value, string valueExpression, IEqualityComparer<T>? comparer = null,
 			string? comparerExpression = null)
 		{
 			_value = value;
@@ -72,7 +72,7 @@ public partial class Match
 		}
 	}
 
-	private sealed class PredicateParameter<T>(Func<T, bool> predicate, string predicateExpression) : TypedParameter<T>
+	private sealed class PredicateParameterMatch<T>(Func<T, bool> predicate, string predicateExpression) : TypedMatch<T>
 	{
 		protected override bool Matches(T value) => predicate(value);
 		public override string ToString() => $"With<{typeof(T).FormatType()}>({predicateExpression})";

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -103,7 +103,7 @@ public partial class Match
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
-	private abstract class TypedParameter<T> : IParameter<T>
+	private abstract class TypedMatch<T> : IParameter<T>
 	{
 		/// <summary>
 		///     Checks if the <paramref name="value" /> is a matching parameter.

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -30,6 +30,8 @@ namespace Mockolate
     }
     public class Match
     {
+        public static Mockolate.Match.IParameter<T> Any<T>() { }
+        public static Mockolate.Match.IParameters AnyParameters() { }
         public static Mockolate.Match.IParameter<T> Null<T>() { }
         public static Mockolate.Match.IVerifyOutParameter<T> Out<T>() { }
         public static Mockolate.Match.IOutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
@@ -40,8 +42,6 @@ namespace Mockolate
         public static Mockolate.Match.IParameter<T> With<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("comparer")] string doNotPopulateThisValue2 = "") { }
-        public static Mockolate.Match.IParameter<T> WithAny<T>() { }
-        public static Mockolate.Match.IParameters WithAnyParameters() { }
         public static Mockolate.Match.IDefaultEventParameters WithDefaultParameters() { }
         public interface IDefaultEventParameters { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -29,6 +29,8 @@ namespace Mockolate
     }
     public class Match
     {
+        public static Mockolate.Match.IParameter<T> Any<T>() { }
+        public static Mockolate.Match.IParameters AnyParameters() { }
         public static Mockolate.Match.IParameter<T> Null<T>() { }
         public static Mockolate.Match.IVerifyOutParameter<T> Out<T>() { }
         public static Mockolate.Match.IOutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
@@ -39,8 +41,6 @@ namespace Mockolate
         public static Mockolate.Match.IParameter<T> With<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("comparer")] string doNotPopulateThisValue2 = "") { }
-        public static Mockolate.Match.IParameter<T> WithAny<T>() { }
-        public static Mockolate.Match.IParameters WithAnyParameters() { }
         public static Mockolate.Match.IDefaultEventParameters WithDefaultParameters() { }
         public interface IDefaultEventParameters { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -28,6 +28,8 @@ namespace Mockolate
     }
     public class Match
     {
+        public static Mockolate.Match.IParameter<T> Any<T>() { }
+        public static Mockolate.Match.IParameters AnyParameters() { }
         public static Mockolate.Match.IParameter<T> Null<T>() { }
         public static Mockolate.Match.IVerifyOutParameter<T> Out<T>() { }
         public static Mockolate.Match.IOutParameter<T> Out<T>(System.Func<T> setter, [System.Runtime.CompilerServices.CallerArgumentExpression("setter")] string doNotPopulateThisValue = "") { }
@@ -38,8 +40,6 @@ namespace Mockolate
         public static Mockolate.Match.IParameter<T> With<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Match.IParameter<T> With<T>(T value, System.Collections.Generic.IEqualityComparer<T> comparer, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("comparer")] string doNotPopulateThisValue2 = "") { }
-        public static Mockolate.Match.IParameter<T> WithAny<T>() { }
-        public static Mockolate.Match.IParameters WithAnyParameters() { }
         public static Mockolate.Match.IDefaultEventParameters WithDefaultParameters() { }
         public interface IDefaultEventParameters { }
         public interface IOutParameter<out T> : Mockolate.Match.IParameter

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -15,11 +15,11 @@ public class ExampleTests
 	{
 		MyClass mock = Mock.Create<MyClass>(BaseClass.WithConstructorParameters(3));
 
-		mock.SetupMock.Method.MyMethod(WithAny<int>()).Returns(5);
+		mock.SetupMock.Method.MyMethod(Any<int>()).Returns(5);
 
 		int result = mock.MyMethod(3);
 
-		VerificationResult<MyClass> check = mock.VerifyMock.Invoked.MyMethod(WithAny<int>());
+		VerificationResult<MyClass> check = mock.VerifyMock.Invoked.MyMethod(Any<int>());
 		await That(result).IsEqualTo(5);
 		check.Once();
 	}
@@ -33,7 +33,7 @@ public class ExampleTests
 	{
 		HttpMessageHandler httpMessageHandler = Mock.Create<HttpMessageHandler>();
 		httpMessageHandler.SetupMock.Protected.Method
-			.SendAsync(WithAny<HttpRequestMessage>(), WithAny<CancellationToken>())
+			.SendAsync(Any<HttpRequestMessage>(), Any<CancellationToken>())
 			.ReturnsAsync(new HttpResponseMessage(statusCode));
 
 		HttpClient httpClient = new(httpMessageHandler);
@@ -49,11 +49,11 @@ public class ExampleTests
 		Guid id = Guid.NewGuid();
 		IExampleRepository mock = Mock.Create<IExampleRepository, IOrderRepository>();
 		mock.SetupMock.Method
-			.AddUser(WithAny<string>())
+			.AddUser(Any<string>())
 			.Returns(new User(id, "Alice"));
 		User result = mock.AddUser("Bob");
 		await That(result).IsEqualTo(new User(id, "Alice"));
-		mock.VerifyMock.Invoked.AddUser(WithAny<string>()).Once();
+		mock.VerifyMock.Invoked.AddUser(Any<string>()).Once();
 	}
 
 	[Fact]
@@ -62,7 +62,7 @@ public class ExampleTests
 		Guid id = Guid.NewGuid();
 		IExampleRepository mock = Mock.Create<IExampleRepository, IOrderRepository>();
 		mock.SetupIOrderRepositoryMock.Method
-			.AddOrder(WithAny<string>())
+			.AddOrder(Any<string>())
 			.Returns(new Order(id, "Order1"));
 
 		Order result = ((IOrderRepository)mock).AddOrder("foo");
@@ -79,7 +79,7 @@ public class ExampleTests
 		Guid id = Guid.NewGuid();
 		IExampleRepository mock = Mock.Create<IExampleRepository, IOrderRepository>();
 		mock.SetupIOrderRepositoryMock.Method
-			.AddOrder(WithAny<string>())
+			.AddOrder(Any<string>())
 			.Returns(new Order(id, "Order1"));
 
 		Order result = ((IOrderRepository)mock).AddOrder("foo");
@@ -96,7 +96,7 @@ public class ExampleTests
 		Guid id = Guid.NewGuid();
 		IExampleRepository mock = Mock.Create<IExampleRepository, IOrderRepository>();
 		((IOrderRepository)mock).SetupMock.Method
-			.AddOrder(WithAny<string>())
+			.AddOrder(Any<string>())
 			.Returns(new Order(id, "Order1"));
 
 		Order result = ((IOrderRepository)mock).AddOrder("foo");
@@ -108,13 +108,13 @@ public class ExampleTests
 	}
 
 	[Fact]
-	public async Task WithAny_ShouldAlwaysMatch()
+	public async Task Any_ShouldAlwaysMatch()
 	{
 		Guid id = Guid.NewGuid();
 		MyClass mock =
 			Mock.Create<MyClass, IExampleRepository, IOrderRepository>(BaseClass.WithConstructorParameters(3));
 		mock.SetupIExampleRepositoryMock.Method.AddUser(
-				WithAny<string>())
+				Any<string>())
 			.Returns(new User(id, "Alice"));
 
 		User result = ((IExampleRepository)mock).AddUser("Bob");
@@ -175,7 +175,7 @@ public class ExampleTests
 		IExampleRepository mock = Mock.Create<IExampleRepository>();
 
 		mock.SetupMock.Method.TryDelete(
-				WithAny<Guid>(),
+				Any<Guid>(),
 				Out<User?>(() => new User(id, "Alice")))
 			.Returns(returnValue);
 

--- a/Tests/Mockolate.Tests/MatchTests.WithAnyParametersTests.cs
+++ b/Tests/Mockolate.Tests/MatchTests.WithAnyParametersTests.cs
@@ -2,7 +2,7 @@ namespace Mockolate.Tests;
 
 public sealed partial class MatchTests
 {
-	public sealed class WithAnyParametersTests
+	public sealed class AnyParametersTests
 	{
 		[Theory]
 		[InlineData(null, null)]
@@ -10,7 +10,7 @@ public sealed partial class MatchTests
 		[InlineData("foo", null)]
 		public async Task ShouldAlwaysMatch(params object?[] values)
 		{
-			IParameters sut = WithAnyParameters();
+			IParameters sut = AnyParameters();
 
 			bool result = sut.Matches(values);
 
@@ -20,8 +20,8 @@ public sealed partial class MatchTests
 		[Fact]
 		public async Task ToString_ShouldReturnExpectedValue()
 		{
-			IParameters sut = WithAnyParameters();
-			string expectedValue = "WithAnyParameters()";
+			IParameters sut = AnyParameters();
+			string expectedValue = "AnyParameters()";
 
 			string? result = sut.ToString();
 

--- a/Tests/Mockolate.Tests/MatchTests.WithAnyTests.cs
+++ b/Tests/Mockolate.Tests/MatchTests.WithAnyTests.cs
@@ -2,7 +2,7 @@ namespace Mockolate.Tests;
 
 public sealed partial class MatchTests
 {
-	public sealed class WithAnyTests
+	public sealed class AnyTests
 	{
 		[Theory]
 		[InlineData(null)]
@@ -10,7 +10,7 @@ public sealed partial class MatchTests
 		[InlineData("foo")]
 		public async Task ShouldAlwaysMatch(string? value)
 		{
-			IParameter<string> sut = WithAny<string>();
+			IParameter<string> sut = Any<string>();
 
 			bool result = sut.Matches(value);
 
@@ -20,8 +20,8 @@ public sealed partial class MatchTests
 		[Fact]
 		public async Task ToString_ShouldReturnExpectedValue()
 		{
-			IParameter<string> sut = WithAny<string>();
-			string expectedValue = "WithAny<string>()";
+			IParameter<string> sut = Any<string>();
+			string expectedValue = "Any<string>()";
 
 			string? result = sut.ToString();
 

--- a/Tests/Mockolate.Tests/MockBehaviorTests.BaseClassBehaviorTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.BaseClassBehaviorTests.cs
@@ -242,7 +242,7 @@ public sealed partial class MockBehaviorTests
 			{
 				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
 			});
-			mock.SetupMock.Indexer(WithAny<int>()).Returns(15);
+			mock.SetupMock.Indexer(Any<int>()).Returns(15);
 
 			int result = mock[1];
 			mock[1] = 42;

--- a/Tests/Mockolate.Tests/MockDelegates/DelegateTests.cs
+++ b/Tests/Mockolate.Tests/MockDelegates/DelegateTests.cs
@@ -33,7 +33,7 @@ public class DelegateTests
 	public async Task WithCustomDelegate_SetupShouldWork()
 	{
 		DoSomething mock = Mock.Create<DoSomething>();
-		mock.SetupMock.Invoke(WithAny<int>(), WithAny<string>())
+		mock.SetupMock.Invoke(Any<int>(), Any<string>())
 			.Returns(1)
 			.Throws(new Exception("foobar"))
 			.Returns(3);
@@ -54,7 +54,7 @@ public class DelegateTests
 		_ = mock(1, "foo");
 		_ = mock(2, "bar");
 
-		await That(mock.VerifyMock.Invoke(WithAny<int>(), WithAny<string>())).Twice();
+		await That(mock.VerifyMock.Invoke(Any<int>(), Any<string>())).Twice();
 	}
 
 	[Fact]
@@ -62,11 +62,11 @@ public class DelegateTests
 	{
 		DoSomethingWithRefAndOut mock = Mock.Create<DoSomethingWithRefAndOut>();
 		int value = 5;
-		mock.SetupMock.Invoke(WithAny<int>(), Ref<int>(v => v + 1), Out(() => 10));
+		mock.SetupMock.Invoke(Any<int>(), Ref<int>(v => v + 1), Out(() => 10));
 
 		mock(1, ref value, out int value2);
 
-		await That(mock.VerifyMock.Invoke(WithAny<int>(), Ref<int>(), Out<int>())).Once();
+		await That(mock.VerifyMock.Invoke(Any<int>(), Ref<int>(), Out<int>())).Once();
 		await That(value).IsEqualTo(6);
 		await That(value2).IsEqualTo(10);
 	}
@@ -79,7 +79,7 @@ public class DelegateTests
 
 		mock(1, ref value, out int _);
 
-		await That(mock.VerifyMock.Invoke(WithAny<int>(), Ref<int>(), Out<int>())).Once();
+		await That(mock.VerifyMock.Invoke(Any<int>(), Ref<int>(), Out<int>())).Once();
 		await That(value).IsEqualTo(5);
 	}
 
@@ -87,7 +87,7 @@ public class DelegateTests
 	public async Task WithCustomGenericDelegate_SetupShouldWork()
 	{
 		DoGeneric<long, string> mock = Mock.Create<DoGeneric<long, string>>();
-		mock.SetupMock.Invoke(WithAny<long>(), WithAny<string>())
+		mock.SetupMock.Invoke(Any<long>(), Any<string>())
 			.Returns(1)
 			.Throws(new Exception("foobar"))
 			.Returns(3);
@@ -108,7 +108,7 @@ public class DelegateTests
 		_ = mock(1, "foo");
 		_ = mock(2, "bar");
 
-		await That(mock.VerifyMock.Invoke(WithAny<short>(), WithAny<string>())).Twice();
+		await That(mock.VerifyMock.Invoke(Any<short>(), Any<string>())).Twice();
 	}
 
 	internal delegate int DoSomething(int x, string y);

--- a/Tests/Mockolate.Tests/MockEvents/RaiseTests.ProtectedTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/RaiseTests.ProtectedTests.cs
@@ -47,7 +47,7 @@ public sealed partial class RaiseTests
 		}
 
 		[Fact]
-		public async Task WhenUsingRaise_WithAnyParameters_ShouldInvokeEvent()
+		public async Task WhenUsingRaise_AnyParameters_ShouldInvokeEvent()
 		{
 			int callCount = 0;
 			MyRaiseEvent mock = Mock.Create<MyRaiseEvent>();

--- a/Tests/Mockolate.Tests/MockEvents/RaiseTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/RaiseTests.cs
@@ -97,7 +97,7 @@ public sealed partial class RaiseTests
 	}
 
 	[Fact]
-	public async Task WhenUsingRaise_WithAnyParameters_ShouldInvokeEvent()
+	public async Task WhenUsingRaise_AnyParameters_ShouldInvokeEvent()
 	{
 		int callCount = 0;
 		IRaiseEvent mock = Mock.Create<IRaiseEvent>();

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.CallbackTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.CallbackTests.cs
@@ -9,7 +9,7 @@ public sealed partial class SetupIndexerTests
 		{
 			int callCount = 0;
 			IIndexerService mock = Mock.Create<IIndexerService>();
-			mock.SetupMock.Indexer(WithAny<int>())
+			mock.SetupMock.Indexer(Any<int>())
 				.OnGet(() => { callCount++; });
 
 			_ = mock[1];
@@ -46,7 +46,7 @@ public sealed partial class SetupIndexerTests
 			int callCount2 = 0;
 			int callCount3 = 0;
 			IIndexerService mock = Mock.Create<IIndexerService>();
-			mock.SetupMock.Indexer(WithAny<int>())
+			mock.SetupMock.Indexer(Any<int>())
 				.OnSet(() => { callCount1++; })
 				.OnSet((_, v) => { callCount2 += v; })
 				.OnSet(_ => { callCount3++; });
@@ -136,7 +136,7 @@ public sealed partial class SetupIndexerTests
 			{
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>())
 					.OnGet(() => { callCount++; });
 
 				_ = mock[1];
@@ -153,7 +153,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>())
 					.OnGet(() => { callCount1++; })
 					.OnGet((v1, v2) => { callCount2 += v1 * v2; })
 					.OnGet(() => { callCount3++; });
@@ -173,7 +173,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>())
 					.OnSet(() => { callCount1++; })
 					.OnSet((value, v1, v2) => { callCount2 += (v1 * v2) + value.Length; })
 					.OnSet(v => { callCount3 += v.Length; });
@@ -269,7 +269,7 @@ public sealed partial class SetupIndexerTests
 			{
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.OnGet(() => { callCount++; });
 
 				_ = mock[1];
@@ -287,7 +287,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.OnGet(() => { callCount1++; })
 					.OnGet((v1, v2, v3) => { callCount2 += v1 * v2 * v3; })
 					.OnGet(() => { callCount3++; });
@@ -307,7 +307,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.OnSet(() => { callCount1++; })
 					.OnSet((value, v1, v2, v3) => { callCount2 += (v1 * v2 * v3) + value.Length; })
 					.OnSet(v => { callCount3 += v.Length; });
@@ -410,7 +410,7 @@ public sealed partial class SetupIndexerTests
 			{
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.OnGet(() => { callCount++; });
 
 				_ = mock[1];
@@ -428,7 +428,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.OnGet(() => { callCount1++; })
 					.OnGet((v1, v2, v3, v4) => { callCount2 += v1 * v2 * v3 * v4; })
 					.OnGet(() => { callCount3++; });
@@ -448,7 +448,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.OnSet(() => { callCount1++; })
 					.OnSet((value, v1, v2, v3, v4) => { callCount2 += (v1 * v2 * v3 * v4) + value.Length; })
 					.OnSet(v => { callCount3 += v.Length; });
@@ -552,7 +552,7 @@ public sealed partial class SetupIndexerTests
 			{
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.OnGet(() => { callCount++; });
 
 				_ = mock[1];
@@ -571,7 +571,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.OnGet(() => { callCount1++; })
 					.OnGet((v1, v2, v3, v4, v5) => { callCount2 += v1 * v2 * v3 * v4 * v5; })
 					.OnGet(() => { callCount3++; });
@@ -591,7 +591,7 @@ public sealed partial class SetupIndexerTests
 				int callCount2 = 0;
 				int callCount3 = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				mock.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.OnSet(() => { callCount1++; })
 					.OnSet((value, v1, v2, v3, v4, v5) => { callCount2 += (v1 * v2 * v3 * v4 * v5) + value.Length; })
 					.OnSet(v => { callCount3 += v.Length; });

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.InitializeWithTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.InitializeWithTests.cs
@@ -27,7 +27,7 @@ public sealed partial class SetupIndexerTests
 		public async Task InitializeWith_Callback_Twice_ShouldThrowMockException()
 		{
 			IIndexerService mock = Mock.Create<IIndexerService>();
-			IndexerSetup<string, int> setup = mock.SetupMock.Indexer(WithAny<int>())
+			IndexerSetup<string, int> setup = mock.SetupMock.Indexer(Any<int>())
 				.InitializeWith("foo");
 
 			void Act()
@@ -59,7 +59,7 @@ public sealed partial class SetupIndexerTests
 		public async Task InitializeWith_ShouldSupportNull()
 		{
 			IIndexerService mock = Mock.Create<IIndexerService>();
-			mock.SetupMock.Indexer(WithAny<string?>(), With(1), With(2))
+			mock.SetupMock.Indexer(Any<string?>(), With(1), With(2))
 				.InitializeWith(42);
 			mock.SetupMock.Indexer(With("foo"), With(1), With(2))
 				.InitializeWith((int?)null);
@@ -75,7 +75,7 @@ public sealed partial class SetupIndexerTests
 		public async Task InitializeWith_Twice_ShouldThrowMockException()
 		{
 			IIndexerService mock = Mock.Create<IIndexerService>();
-			IndexerSetup<string, int> setup = mock.SetupMock.Indexer(WithAny<int>())
+			IndexerSetup<string, int> setup = mock.SetupMock.Indexer(Any<int>())
 				.InitializeWith("foo");
 
 			void Act()
@@ -111,7 +111,7 @@ public sealed partial class SetupIndexerTests
 			public async Task InitializeWith_Callback_Twice_ShouldThrowMockException()
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				IndexerSetup<string, int, int> setup = mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				IndexerSetup<string, int, int> setup = mock.SetupMock.Indexer(Any<int>(), Any<int>())
 					.InitializeWith("foo");
 
 				void Act()
@@ -145,7 +145,7 @@ public sealed partial class SetupIndexerTests
 			public async Task InitializeWith_Twice_ShouldThrowMockException()
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				IndexerSetup<string, int, int> setup = mock.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				IndexerSetup<string, int, int> setup = mock.SetupMock.Indexer(Any<int>(), Any<int>())
 					.InitializeWith("foo");
 
 				void Act()
@@ -186,7 +186,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				IndexerSetup<string, int, int, int> setup = mock.SetupMock
-					.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+					.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("foo");
 
 				void Act()
@@ -224,7 +224,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				IndexerSetup<string, int, int, int> setup = mock.SetupMock
-					.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+					.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("foo");
 
 				void Act()
@@ -267,7 +267,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				IndexerSetup<string, int, int, int, int> setup = mock.SetupMock
-					.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+					.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("foo");
 
 				void Act()
@@ -307,7 +307,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				IndexerSetup<string, int, int, int, int> setup = mock.SetupMock
-					.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+					.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("foo");
 
 				void Act()
@@ -351,9 +351,9 @@ public sealed partial class SetupIndexerTests
 			public async Task InitializeWith_Callback_Twice_ShouldThrowMockException()
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				IndexerSetup<string, int, int, int, int, int> setup = mock.SetupMock.Indexer(WithAny<int>(),
-						WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				IndexerSetup<string, int, int, int, int, int> setup = mock.SetupMock.Indexer(Any<int>(),
+						Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.InitializeWith("foo");
 
 				void Act()
@@ -394,9 +394,9 @@ public sealed partial class SetupIndexerTests
 			public async Task InitializeWith_Twice_ShouldThrowMockException()
 			{
 				IIndexerService mock = Mock.Create<IIndexerService>();
-				IndexerSetup<string, int, int, int, int, int> setup = mock.SetupMock.Indexer(WithAny<int>(),
-						WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				IndexerSetup<string, int, int, int, int, int> setup = mock.SetupMock.Indexer(Any<int>(),
+						Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.InitializeWith("foo");
 
 				void Act()

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
@@ -9,7 +9,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.Returns("a")
 				.Throws(new Exception("foo"))
 				.Returns(() => "b");
@@ -28,7 +28,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.Returns("a")
 				.Returns(() => "b")
 				.Returns(p1 => $"foo-{p1}");
@@ -47,7 +47,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.Returns(() => "foo");
 
 			string result = sut[1];
@@ -60,7 +60,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.InitializeWith("a")
 				.Returns(p1 => $"foo-{p1}");
 
@@ -74,7 +74,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.InitializeWith("init")
 				.Returns((v, p1) => $"foo-{v}-{p1}");
 
@@ -88,7 +88,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.Returns("foo");
 
 			string result = sut[3];
@@ -111,7 +111,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.Throws(() => new Exception("foo"));
 
 			void Act()
@@ -127,7 +127,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.InitializeWith("init")
 				.Throws(p1 => new Exception($"foo-{p1}"));
 
@@ -144,7 +144,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.InitializeWith("init")
 				.Throws((v, p1) => new Exception($"foo-{v}-{p1}"));
 
@@ -161,7 +161,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.Throws<ArgumentNullException>();
 
 			void Act()
@@ -177,7 +177,7 @@ public sealed partial class SetupIndexerTests
 		{
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
-			sut.SetupMock.Indexer(WithAny<int>())
+			sut.SetupMock.Indexer(Any<int>())
 				.Throws(new Exception("foo"));
 
 			void Act()
@@ -195,7 +195,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.Returns("a")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -214,7 +214,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.Returns("a")
 					.Returns(() => "b")
 					.Returns((p1, p2) => $"foo-{p1}-{p2}");
@@ -233,7 +233,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.Returns(() => "foo");
 
 				string result = sut[1, 2];
@@ -246,7 +246,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.InitializeWith("a")
 					.Returns((p1, p2) => $"foo-{p1}-{p2}");
 
@@ -260,7 +260,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Returns((v, p1, p2) => $"foo-{v}-{p1}-{p2}");
 
@@ -274,7 +274,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.Returns("foo");
 
 				string result = sut[1, 2];
@@ -297,7 +297,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -313,7 +313,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((p1, p2) => new Exception($"foo-{p1}-{p2}"));
 
@@ -330,7 +330,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((v, p1, p2) => new Exception($"foo-{v}-{p1}-{p2}"));
 
@@ -347,7 +347,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -363,7 +363,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -382,7 +382,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.Returns("a")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -401,7 +401,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.Returns("a")
 					.Returns(() => "b")
 					.Returns((p1, p2, p3) => $"foo-{p1}-{p2}-{p3}");
@@ -421,7 +421,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.Returns(() => "foo");
 
 				string result = sut[1, 2, 3];
@@ -434,7 +434,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("a")
 					.Returns((p1, p2, p3) => $"foo-{p1}-{p2}-{p3}");
 
@@ -448,7 +448,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Returns((v, p1, p2, p3) => $"foo-{v}-{p1}-{p2}-{p3}");
 
@@ -462,7 +462,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.Returns("foo");
 
 				string result = sut[1, 2, 3];
@@ -485,7 +485,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -501,7 +501,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((p1, p2, p3) => new Exception($"foo-{p1}-{p2}-{p3}"));
 
@@ -518,7 +518,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((v, p1, p2, p3) => new Exception($"foo-{v}-{p1}-{p2}-{p3}"));
 
@@ -535,7 +535,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -551,7 +551,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -570,7 +570,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("a")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -589,7 +589,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("a")
 					.Returns(() => "b")
 					.Returns((p1, p2, p3, p4) => $"foo-{p1}-{p2}-{p3}-{p4}");
@@ -610,7 +610,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns(() => "foo");
 
 				string result = sut[1, 2, 3, 4];
@@ -623,7 +623,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("a")
 					.Returns((p1, p2, p3, p4) => $"foo-{p1}-{p2}-{p3}-{p4}");
 
@@ -637,7 +637,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Returns((v, p1, p2, p3, p4) => $"foo-{v}-{p1}-{p2}-{p3}-{p4}");
 
@@ -651,7 +651,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("foo");
 
 				string result = sut[1, 2, 3, 4];
@@ -674,7 +674,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -690,7 +690,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((p1, p2, p3, p4) => new Exception($"foo-{p1}-{p2}-{p3}-{p4}"));
 
@@ -707,7 +707,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((v, p1, p2, p3, p4) => new Exception($"foo-{v}-{p1}-{p2}-{p3}-{p4}"));
 
@@ -724,7 +724,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -740,7 +740,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -759,7 +759,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("a")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -778,7 +778,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("a")
 					.Returns(() => "b")
 					.Returns((p1, p2, p3, p4, p5) => $"foo-{p1}-{p2}-{p3}-{p4}-{p5}");
@@ -799,7 +799,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns(() => "foo");
 
 				string result = sut[1, 2, 3, 4, 5];
@@ -812,7 +812,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("a")
 					.Returns((p1, p2, p3, p4, p5) => $"foo-{p1}-{p2}-{p3}-{p4}-{p5}");
 
@@ -826,7 +826,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Returns((v, p1, p2, p3, p4, p5) => $"foo-{v}-{p1}-{p2}-{p3}-{p4}-{p5}");
 
@@ -840,7 +840,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("foo");
 
 				string result = sut[1, 2, 3, 4, 5];
@@ -863,7 +863,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -879,7 +879,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((p1, p2, p3, p4, p5) => new Exception($"foo-{p1}-{p2}-{p3}-{p4}-{p5}"));
 
@@ -896,7 +896,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.InitializeWith("init")
 					.Throws((v, p1, p2, p3, p4, p5) => new Exception($"foo-{v}-{p1}-{p2}-{p3}-{p4}-{p5}"));
 
@@ -913,7 +913,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -929,7 +929,7 @@ public sealed partial class SetupIndexerTests
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
-				sut.SetupMock.Indexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Indexer(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -8,7 +8,7 @@ public sealed partial class SetupIndexerTests
 	public async Task OverlappingSetups_ShouldUseLatestMatchingSetup()
 	{
 		IIndexerService mock = Mock.Create<IIndexerService>();
-		mock.SetupMock.Indexer(WithAny<int>()).InitializeWith("foo");
+		mock.SetupMock.Indexer(Any<int>()).InitializeWith("foo");
 		mock.SetupMock.Indexer(With(2)).InitializeWith("bar");
 
 		string result1 = mock[1];
@@ -25,7 +25,7 @@ public sealed partial class SetupIndexerTests
 	{
 		IIndexerService mock = Mock.Create<IIndexerService>();
 		mock.SetupMock.Indexer(With(2)).InitializeWith("bar");
-		mock.SetupMock.Indexer(WithAny<int>()).InitializeWith("foo");
+		mock.SetupMock.Indexer(Any<int>()).InitializeWith("foo");
 
 		string result1 = mock[1];
 		string result2 = mock[2];
@@ -140,7 +140,7 @@ public sealed partial class SetupIndexerTests
 	public async Task WhenTypeOfGetIndexerDoesNotMatch_ShouldReturnDefaultValue()
 	{
 		IIndexerService mock = Mock.Create<IIndexerService>();
-		mock.SetupMock.Indexer(WithAny<int>()).Returns("foo");
+		mock.SetupMock.Indexer(Any<int>()).Returns("foo");
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 
 		string result1 = registration.GetIndexer<string>(null, 1);

--- a/Tests/Mockolate.Tests/MockIndexers/VerifyGotIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/VerifyGotIndexerTests.cs
@@ -10,7 +10,7 @@ public sealed class VerifyGotIndexerTests
 		IMyService mock = Mock.Create<IMyService>();
 		_ = mock[null, null, null, null];
 
-		await That(mock.VerifyMock.GotIndexer(WithAny<int?>(), null, Null<int?>(), WithAny<int?>())).Once();
+		await That(mock.VerifyMock.GotIndexer(Any<int?>(), null, Null<int?>(), Any<int?>())).Once();
 	}
 
 	[Fact]
@@ -19,9 +19,9 @@ public sealed class VerifyGotIndexerTests
 		IMyService mock = Mock.Create<IMyService>();
 		_ = mock[1, 2];
 
-		await That(mock.VerifyMock.GotIndexer(WithAny<int>())).Never();
-		await That(mock.VerifyMock.GotIndexer(WithAny<int>(), WithAny<int>())).Once();
-		await That(mock.VerifyMock.GotIndexer(WithAny<int>(), WithAny<int>(), WithAny<int>())).Never();
+		await That(mock.VerifyMock.GotIndexer(Any<int>())).Never();
+		await That(mock.VerifyMock.GotIndexer(Any<int>(), Any<int>())).Once();
+		await That(mock.VerifyMock.GotIndexer(Any<int>(), Any<int>(), Any<int>())).Never();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockIndexers/VerifySetIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/VerifySetIndexerTests.cs
@@ -10,7 +10,7 @@ public sealed class VerifySetIndexerTests
 		IMyService mock = Mock.Create<IMyService>();
 		mock[null, null, null, null] = null;
 
-		await That(mock.VerifyMock.SetIndexer(WithAny<int?>(), null, Null<int?>(), WithAny<int?>(), null)).Once();
+		await That(mock.VerifyMock.SetIndexer(Any<int?>(), null, Null<int?>(), Any<int?>(), null)).Once();
 	}
 
 	[Fact]
@@ -19,9 +19,9 @@ public sealed class VerifySetIndexerTests
 		IMyService mock = Mock.Create<IMyService>();
 		mock[1, 2] = "foo";
 
-		await That(mock.VerifyMock.SetIndexer(WithAny<int>(), With("foo"))).Never();
-		await That(mock.VerifyMock.SetIndexer(WithAny<int>(), WithAny<int>(), With("foo"))).Once();
-		await That(mock.VerifyMock.SetIndexer(WithAny<int>(), WithAny<int>(), WithAny<int>(), With("foo"))).Never();
+		await That(mock.VerifyMock.SetIndexer(Any<int>(), With("foo"))).Never();
+		await That(mock.VerifyMock.SetIndexer(Any<int>(), Any<int>(), With("foo"))).Once();
+		await That(mock.VerifyMock.SetIndexer(Any<int>(), Any<int>(), Any<int>(), With("foo"))).Never();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockMethods/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/InteractionsTests.cs
@@ -13,7 +13,7 @@ public sealed class InteractionsTests
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 		registration.Execute("foo.bar", 4);
 
-		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "foo.bar", WithAny<int>());
+		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "foo.bar", Any<int>());
 
 		await That(result).Once();
 	}
@@ -25,7 +25,7 @@ public sealed class InteractionsTests
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 		registration.Execute("foo.bar", 4);
 
-		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "foo.bar", WithAny<string>());
+		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "foo.bar", Any<string>());
 
 		await That(result).Never();
 	}
@@ -37,7 +37,7 @@ public sealed class InteractionsTests
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 		registration.Execute("foo.bar", 4);
 
-		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "baz.bar", WithAny<int>());
+		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "baz.bar", Any<int>());
 
 		await That(result).Never();
 	}
@@ -48,10 +48,10 @@ public sealed class InteractionsTests
 		IChocolateDispenser mock = Mock.Create<IChocolateDispenser>();
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 
-		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "foo.bar", WithAny<int>());
+		VerificationResult<IChocolateDispenser> result = registration.Method(mock, "foo.bar", Any<int>());
 
 		await That(result).Never();
-		await That(((IVerificationResult)result).Expectation).IsEqualTo("invoked method bar(WithAny<int>())");
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("invoked method bar(Any<int>())");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallbackTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallbackTests.cs
@@ -63,7 +63,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns("a");
 
@@ -78,7 +78,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method0();
@@ -108,7 +108,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(v =>
 					{
 						callCount++;
@@ -127,7 +127,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(v => { callCount++; });
 
 				sut.Method0();
@@ -157,7 +157,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback(v => { callCount2 += v; })
 					.Returns("a");
@@ -178,7 +178,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns("a");
 
@@ -210,7 +210,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method1(1);
@@ -227,7 +227,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue2 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback((v1, v2) =>
 					{
 						callCount++;
@@ -266,7 +266,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback((v1, v2) => { callCount++; });
 
 				sut.Method1(1);
@@ -282,7 +282,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2) => { callCount2 += v1 * v2; })
 					.Returns("a");
@@ -303,7 +303,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns("a");
 
@@ -338,7 +338,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method2(1, 2);
@@ -356,7 +356,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue3 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3) =>
 					{
 						callCount++;
@@ -400,7 +400,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3) => { callCount++; });
 
 				sut.Method2(1, 2);
@@ -416,7 +416,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2, v3) => { callCount2 += v1 * v2 * v3; })
 					.Returns("a");
@@ -437,7 +437,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns("a");
 
@@ -473,7 +473,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method3(1, 2, 3);
@@ -492,7 +492,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue4 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3, v4) =>
 					{
 						callCount++;
@@ -539,7 +539,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3, v4) => { callCount++; });
 
 				sut.Method3(1, 2, 3);
@@ -555,7 +555,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2, v3, v4) => { callCount2 += v1 * v2 * v3 * v4; })
 					.Returns("a");
@@ -576,8 +576,8 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns("a");
 
@@ -615,8 +615,8 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method4(1, 2, 3, 4);
@@ -636,8 +636,8 @@ public sealed partial class SetupMethodTests
 				int receivedValue5 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback((v1, v2, v3, v4, v5) =>
 					{
 						callCount++;
@@ -688,8 +688,8 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback((v1, v2, v3, v4, v5) => { callCount++; });
 
 				sut.Method4(1, 2, 3, 4);
@@ -705,8 +705,8 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2, v3, v4, v5) => { callCount2 += v1 * v2 * v3 * v4 * v5; })
 					.Returns("a");
@@ -775,7 +775,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method1(3);
@@ -789,7 +789,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method0();
@@ -819,7 +819,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(v =>
 					{
 						callCount++;
@@ -838,7 +838,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(v => { callCount++; });
 
 				sut.Method0();
@@ -868,7 +868,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback(v => { callCount2 += v; });
 
@@ -888,7 +888,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method2(1, 2);
@@ -919,7 +919,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method1(1);
@@ -936,7 +936,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue2 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback((v1, v2) =>
 					{
 						callCount++;
@@ -975,7 +975,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback((v1, v2) => { callCount++; });
 
 				sut.Method1(1);
@@ -991,7 +991,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2) => { callCount2 += v1 * v2; });
 
@@ -1011,7 +1011,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method3(1, 2, 3);
@@ -1045,7 +1045,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method2(1, 2);
@@ -1063,7 +1063,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue3 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3) =>
 					{
 						callCount++;
@@ -1107,7 +1107,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3) => { callCount++; });
 
 				sut.Method2(1, 2);
@@ -1123,7 +1123,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2, v3) => { callCount2 += v1 * v2 * v3; });
 
@@ -1143,7 +1143,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method4(1, 2, 3, 4);
@@ -1178,7 +1178,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method3(1, 2, 3);
@@ -1197,7 +1197,7 @@ public sealed partial class SetupMethodTests
 				int receivedValue4 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3, v4) =>
 					{
 						callCount++;
@@ -1244,7 +1244,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback((v1, v2, v3, v4) => { callCount++; });
 
 				sut.Method3(1, 2, 3);
@@ -1260,7 +1260,7 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2, v3, v4) => { callCount2 += v1 * v2 * v3 * v4; });
 
@@ -1280,8 +1280,8 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method5(1, 2, 3, 4, 5);
@@ -1318,8 +1318,8 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback(() => { callCount++; });
 
 				sut.Method4(1, 2, 3, 4);
@@ -1339,8 +1339,8 @@ public sealed partial class SetupMethodTests
 				int receivedValue5 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback((v1, v2, v3, v4, v5) =>
 					{
 						callCount++;
@@ -1391,8 +1391,8 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback((v1, v2, v3, v4, v5) => { callCount++; });
 
 				sut.Method4(1, 2, 3, 4);
@@ -1408,8 +1408,8 @@ public sealed partial class SetupMethodTests
 				int callCount2 = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback(() => { callCount1++; })
 					.Callback((v1, v2, v3, v4, v5) => { callCount2 += v1 * v2 * v3 * v4 * v5; });
 

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.OutRefParameterTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.OutRefParameterTests.cs
@@ -125,13 +125,13 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue = 0;
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method1WithOutParameter(AnyParameters())
 					.Callback(v =>
 					{
 						callCount++;
@@ -168,13 +168,13 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue = 0;
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method1WithRefParameter(AnyParameters())
 					.Callback(v =>
 					{
 						callCount++;
@@ -222,8 +222,8 @@ public sealed partial class SetupMethodTests
 					=> base.GetReturnValue<T>(invocation, MockBehavior.Default);
 			}
 
-			private class MyReturnMethodSetupWithAnyParameterCombination<T>(string name)
-				: ReturnMethodSetup<Task, string>(name, WithAnyParameters())
+			private class MyReturnMethodSetupAnyParameterCombination<T>(string name)
+				: ReturnMethodSetup<Task, string>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -317,14 +317,14 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method2WithOutParameter(AnyParameters())
 					.Callback((v1, v2) =>
 					{
 						callCount++;
@@ -369,14 +369,14 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method2WithRefParameter(AnyParameters())
 					.Callback((v1, v2) =>
 					{
 						callCount++;
@@ -430,8 +430,8 @@ public sealed partial class SetupMethodTests
 					=> base.GetReturnValue<T>(invocation, MockBehavior.Default);
 			}
 
-			private class MyReturnMethodSetupWithAnyParameterCombination<T>(string name)
-				: ReturnMethodSetup<Task, string, long>(name, WithAnyParameters())
+			private class MyReturnMethodSetupAnyParameterCombination<T>(string name)
+				: ReturnMethodSetup<Task, string, long>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -547,7 +547,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -555,7 +555,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method3WithOutParameter(AnyParameters())
 					.Callback((v1, v2, v3) =>
 					{
 						callCount++;
@@ -609,7 +609,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -617,7 +617,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method3WithRefParameter(AnyParameters())
 					.Callback((v1, v2, v3) =>
 					{
 						callCount++;
@@ -676,8 +676,8 @@ public sealed partial class SetupMethodTests
 					=> base.GetReturnValue<T>(invocation, MockBehavior.Default);
 			}
 
-			private class MyReturnMethodSetupWithAnyParameterCombination<T>(string name)
-				: ReturnMethodSetup<Task, string, long, int>(name, WithAnyParameters())
+			private class MyReturnMethodSetupAnyParameterCombination<T>(string name)
+				: ReturnMethodSetup<Task, string, long, int>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -816,7 +816,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -825,7 +825,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method4WithOutParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4) =>
 					{
 						callCount++;
@@ -887,7 +887,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -896,7 +896,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method4WithRefParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4) =>
 					{
 						callCount++;
@@ -960,8 +960,8 @@ public sealed partial class SetupMethodTests
 					=> base.GetReturnValue<T>(invocation, MockBehavior.Default);
 			}
 
-			private class MyReturnMethodSetupWithAnyParameterCombination<T>(string name)
-				: ReturnMethodSetup<Task, string, long, int, int>(name, WithAnyParameters())
+			private class MyReturnMethodSetupAnyParameterCombination<T>(string name)
+				: ReturnMethodSetup<Task, string, long, int, int>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -1123,7 +1123,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -1133,7 +1133,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method5WithOutParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4, v5) =>
 					{
 						callCount++;
@@ -1204,7 +1204,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -1214,7 +1214,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method5WithRefParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4, v5) =>
 					{
 						callCount++;
@@ -1283,8 +1283,8 @@ public sealed partial class SetupMethodTests
 					=> base.GetReturnValue<T>(invocation, MockBehavior.Default);
 			}
 
-			private class MyReturnMethodSetupWithAnyParameterCombination<T>(string name)
-				: ReturnMethodSetup<Task, string, long, int, int, int>(name, WithAnyParameters())
+			private class MyReturnMethodSetupAnyParameterCombination<T>(string name)
+				: ReturnMethodSetup<Task, string, long, int, int, int>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -1351,13 +1351,13 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue = 0;
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method1WithOutParameter(AnyParameters())
 					.Callback(v =>
 					{
 						callCount++;
@@ -1394,13 +1394,13 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue = 0;
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method1WithRefParameter(AnyParameters())
 					.Callback(v =>
 					{
 						callCount++;
@@ -1446,7 +1446,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			private class MyVoidMethodSetupWithParameters(string name)
-				: VoidMethodSetup<string>(name, WithAnyParameters())
+				: VoidMethodSetup<string>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -1484,14 +1484,14 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method2WithOutParameter(AnyParameters())
 					.Callback((v1, v2) =>
 					{
 						callCount++;
@@ -1536,14 +1536,14 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method2WithRefParameter(AnyParameters())
 					.Callback((v1, v2) =>
 					{
 						callCount++;
@@ -1595,7 +1595,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			private class MyVoidMethodSetupWithParameters(string name)
-				: VoidMethodSetup<string, long>(name, WithAnyParameters())
+				: VoidMethodSetup<string, long>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -1637,7 +1637,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -1645,7 +1645,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method3WithOutParameter(AnyParameters())
 					.Callback((v1, v2, v3) =>
 					{
 						callCount++;
@@ -1699,7 +1699,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -1707,7 +1707,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method3WithRefParameter(AnyParameters())
 					.Callback((v1, v2, v3) =>
 					{
 						callCount++;
@@ -1764,7 +1764,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			private class MyVoidMethodSetupWithParameters(string name)
-				: VoidMethodSetup<string, long, int>(name, WithAnyParameters())
+				: VoidMethodSetup<string, long, int>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -1811,7 +1811,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -1820,7 +1820,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method4WithOutParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4) =>
 					{
 						callCount++;
@@ -1882,7 +1882,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -1891,7 +1891,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method4WithRefParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4) =>
 					{
 						callCount++;
@@ -1953,7 +1953,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			private class MyVoidMethodSetupWithParameters(string name)
-				: VoidMethodSetup<string, long, int, int>(name, WithAnyParameters())
+				: VoidMethodSetup<string, long, int, int>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);
@@ -2005,7 +2005,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task OutParameter_WithAnyParameters_ShouldSetToDefaultValue()
+			public async Task OutParameter_AnyParameters_ShouldSetToDefaultValue()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -2015,7 +2015,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5WithOutParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method5WithOutParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4, v5) =>
 					{
 						callCount++;
@@ -2086,7 +2086,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
-			public async Task RefParameter_WithAnyParameters_ShouldRemainUnchanged()
+			public async Task RefParameter_AnyParameters_ShouldRemainUnchanged()
 			{
 				int receivedValue1 = 0;
 				int receivedValue2 = 0;
@@ -2096,7 +2096,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5WithRefParameter(WithAnyParameters())
+				sut.SetupMock.Method.Method5WithRefParameter(AnyParameters())
 					.Callback((v1, v2, v3, v4, v5) =>
 					{
 						callCount++;
@@ -2163,7 +2163,7 @@ public sealed partial class SetupMethodTests
 			}
 
 			private class MyVoidMethodSetupWithParameters(string name)
-				: VoidMethodSetup<string, long, int, int, int>(name, WithAnyParameters())
+				: VoidMethodSetup<string, long, int, int, int>(name, AnyParameters())
 			{
 				public TValue HiddenSetOutParameter<TValue>(string parameterName, MockBehavior behavior)
 					=> SetOutParameter<TValue>(parameterName, behavior);

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.ReturnsThrowsTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.ReturnsThrowsTests.cs
@@ -131,7 +131,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Returns("d")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -150,7 +150,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Returns("d")
 					.Returns(() => "c")
 					.Returns(v => $"foo-{v}");
@@ -169,7 +169,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>()).Returns(() => "d");
+				sut.SetupMock.Method.Method1(Any<int>()).Returns(() => "d");
 
 				string result = sut.Method1(3);
 
@@ -181,7 +181,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>()).Returns(x => $"foo-{x}");
+				sut.SetupMock.Method.Method1(Any<int>()).Returns(x => $"foo-{x}");
 
 				string result = sut.Method1(3);
 
@@ -193,7 +193,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>()).Returns("d");
+				sut.SetupMock.Method.Method1(Any<int>()).Returns("d");
 
 				string result = sut.Method1(3);
 
@@ -215,7 +215,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -231,7 +231,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Throws(v1 => new Exception("foo-" + v1));
 
 				void Act()
@@ -247,7 +247,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -263,7 +263,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -280,7 +280,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns((string?)null!);
 
@@ -298,7 +298,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Returns("d")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -317,7 +317,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Returns("d")
 					.Returns(() => "c")
 					.Returns((v1, v2) => $"foo-{v1}-{v2}");
@@ -336,7 +336,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>()).Returns(() => "d");
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>()).Returns(() => "d");
 
 				string result = sut.Method2(2, 3);
 
@@ -348,7 +348,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>()).Returns((x, y) => $"foo-{x}-{y}");
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>()).Returns((x, y) => $"foo-{x}-{y}");
 
 				string result = sut.Method2(2, 3);
 
@@ -360,7 +360,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>()).Returns("d");
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>()).Returns("d");
 
 				string result = sut.Method2(2, 3);
 
@@ -382,7 +382,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -398,7 +398,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws((v1, v2) => new Exception($"foo-{v1}-{v2}"));
 
 				void Act()
@@ -414,7 +414,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -430,7 +430,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -447,7 +447,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns((string?)null!);
 
@@ -465,7 +465,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Returns("d")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -484,7 +484,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Returns("d")
 					.Returns(() => "c")
 					.Returns((v1, v2, v3) => $"foo-{v1}-{v2}-{v3}");
@@ -504,7 +504,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Returns(() => "d");
 
 				string result = sut.Method3(1, 2, 3);
@@ -517,7 +517,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Returns((x, y, z) => $"foo-{x}-{y}-{z}");
 
 				string result = sut.Method3(2, 3, 4);
@@ -530,7 +530,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Returns("d");
 
 				string result = sut.Method3(1, 2, 3);
@@ -553,7 +553,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -569,7 +569,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws((v1, v2, v3) => new Exception($"foo-{v1}-{v2}-{v3}"));
 
 				void Act()
@@ -585,7 +585,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -601,7 +601,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -618,7 +618,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns((string?)null!);
 
@@ -636,7 +636,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("d")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -655,7 +655,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("d")
 					.Returns(() => "c")
 					.Returns((v1, v2, v3, v4) => $"foo-{v1}-{v2}-{v3}-{v4}");
@@ -676,7 +676,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns(() => "d");
 
 				string result = sut.Method4(1, 2, 3, 4);
@@ -689,7 +689,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns((x, y, z, a) => $"foo-{x}-{y}-{z}-{a}");
 
 				string result = sut.Method4(2, 3, 4, 5);
@@ -702,7 +702,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Returns("d");
 
 				string result = sut.Method4(1, 2, 3, 4);
@@ -725,7 +725,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -741,7 +741,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws((v1, v2, v3, v4) => new Exception($"foo-{v1}-{v2}-{v3}-{v4}"));
 
 				void Act()
@@ -757,7 +757,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -773,7 +773,7 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -790,7 +790,7 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns((string?)null!);
 
@@ -808,8 +808,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Returns("d")
 					.Throws(new Exception("foo"))
 					.Returns(() => "b");
@@ -828,8 +828,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Returns("d")
 					.Returns(() => "c")
 					.Returns((v1, v2, v3, v4, v5) => $"foo-{v1}-{v2}-{v3}-{v4}-{v5}");
@@ -850,8 +850,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Returns(() => "d");
 
 				string result = sut.Method5(1, 2, 3, 4, 5);
@@ -864,8 +864,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Returns((x, y, z, a, b) => $"foo-{x}-{y}-{z}-{a}-{b}");
 
 				string result = sut.Method5(2, 3, 4, 5, 6);
@@ -878,8 +878,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Returns("d");
 
 				string result = sut.Method5(1, 2, 3, 4, 5);
@@ -902,8 +902,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -919,8 +919,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws((v1, v2, v3, v4, v5) => new Exception($"foo-{v1}-{v2}-{v3}-{v4}-{v5}"));
 
 				void Act()
@@ -936,8 +936,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -953,8 +953,8 @@ public sealed partial class SetupMethodTests
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -971,8 +971,8 @@ public sealed partial class SetupMethodTests
 				int callCount = 0;
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Callback(() => { callCount++; })
 					.Returns((string?)null!);
 
@@ -1059,7 +1059,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.DoesNotThrow()
 					.Throws(new Exception("foo"))
 					.DoesNotThrow();
@@ -1080,7 +1080,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>()).Throws(() => new Exception("foo"));
+				sut.SetupMock.Method.Method1(Any<int>()).Throws(() => new Exception("foo"));
 
 				void Act()
 				{
@@ -1095,7 +1095,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>()).Throws(v1 => new Exception($"foo-{v1}"));
+				sut.SetupMock.Method.Method1(Any<int>()).Throws(v1 => new Exception($"foo-{v1}"));
 
 				void Act()
 				{
@@ -1110,7 +1110,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -1126,7 +1126,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method1(WithAny<int>())
+				sut.SetupMock.Method.Method1(Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -1145,7 +1145,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.DoesNotThrow()
 					.Throws(new Exception("foo"))
 					.DoesNotThrow();
@@ -1166,7 +1166,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -1182,7 +1182,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws((v1, v2) => new Exception($"foo-{v1}-{v2}"));
 
 				void Act()
@@ -1198,7 +1198,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -1214,7 +1214,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -1233,7 +1233,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.DoesNotThrow()
 					.Throws(new Exception("foo"))
 					.DoesNotThrow();
@@ -1254,7 +1254,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -1270,7 +1270,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws((v1, v2, v3) => new Exception($"foo-{v1}-{v2}-{v3}"));
 
 				void Act()
@@ -1286,7 +1286,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -1302,7 +1302,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -1321,7 +1321,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.DoesNotThrow()
 					.Throws(new Exception("foo"))
 					.DoesNotThrow();
@@ -1342,7 +1342,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -1358,7 +1358,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws((v1, v2, v3, v4) => new Exception($"foo-{v1}-{v2}-{v3}-{v4}"));
 
 				void Act()
@@ -1374,7 +1374,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -1390,7 +1390,7 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+				sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()
@@ -1409,8 +1409,8 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.DoesNotThrow()
 					.Throws(new Exception("foo"))
 					.DoesNotThrow();
@@ -1431,8 +1431,8 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws(() => new Exception("foo"));
 
 				void Act()
@@ -1448,8 +1448,8 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws((v1, v2, v3, v4, v5) => new Exception($"foo-{v1}-{v2}-{v3}-{v4}-{v5}"));
 
 				void Act()
@@ -1465,8 +1465,8 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws<ArgumentNullException>();
 
 				void Act()
@@ -1482,8 +1482,8 @@ public sealed partial class SetupMethodTests
 			{
 				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 
-				sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-						WithAny<int>())
+				sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+						Any<int>())
 					.Throws(new Exception("foo"));
 
 				void Act()

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -12,7 +12,7 @@ public sealed partial class SetupMethodTests
 	{
 		object obj = new();
 		IMethodService mock = Mock.Create<IMethodService>();
-		mock.SetupMock.Method.Equals(WithAny<object?>()).Returns(true);
+		mock.SetupMock.Method.Equals(Any<object?>()).Returns(true);
 
 		bool result = mock.Equals(obj);
 
@@ -28,7 +28,7 @@ public sealed partial class SetupMethodTests
 		int result1 = mock.MyGenericMethod(0, "foo");
 		int result2 = mock.MyGenericMethod(0L, "foo");
 
-		await That(mock.VerifyMock.Invoked.MyGenericMethod(WithAny<long>(), WithAny<string>())).Once();
+		await That(mock.VerifyMock.Invoked.MyGenericMethod(Any<long>(), Any<string>())).Once();
 		await That(result1).IsEqualTo(42);
 		await That(result2).IsEqualTo(0);
 	}
@@ -62,7 +62,7 @@ public sealed partial class SetupMethodTests
 	public async Task OverlappingSetups_ShouldUseLatestMatchingSetup()
 	{
 		IMethodService mock = Mock.Create<IMethodService>();
-		mock.SetupMock.Method.MyIntMethodWithParameters(WithAny<int>(), WithAny<string>()).Returns(1);
+		mock.SetupMock.Method.MyIntMethodWithParameters(Any<int>(), Any<string>()).Returns(1);
 		mock.SetupMock.Method.MyIntMethodWithParameters(With(0), With("foo")).Returns(2);
 
 		int result1 = mock.MyIntMethodWithParameters(1, "foo");
@@ -79,7 +79,7 @@ public sealed partial class SetupMethodTests
 	{
 		IMethodService mock = Mock.Create<IMethodService>();
 		mock.SetupMock.Method.MyIntMethodWithParameters(With(0), With("foo")).Returns(2);
-		mock.SetupMock.Method.MyIntMethodWithParameters(WithAny<int>(), WithAny<string>()).Returns(1);
+		mock.SetupMock.Method.MyIntMethodWithParameters(Any<int>(), Any<string>()).Returns(1);
 
 		int result1 = mock.MyIntMethodWithParameters(1, "foo");
 		int result2 = mock.MyIntMethodWithParameters(0, "foo");
@@ -110,7 +110,7 @@ public sealed partial class SetupMethodTests
 		int callCount = 0;
 		IReturnMethodSetupWithParametersTest sut = Mock.Create<IReturnMethodSetupWithParametersTest>();
 
-		sut.SetupMock.Method.MethodWithoutOtherOverloads(WithAnyParameters())
+		sut.SetupMock.Method.MethodWithoutOtherOverloads(AnyParameters())
 			.Callback(() => { callCount++; })
 			.Returns("foo");
 
@@ -126,7 +126,7 @@ public sealed partial class SetupMethodTests
 		int callCount = 0;
 		IReturnMethodSetupWithParametersTest sut = Mock.Create<IReturnMethodSetupWithParametersTest>();
 
-		sut.SetupMock.Method.MethodWithoutOtherOverloads(WithAny<int>(), WithAny<int>(), WithAny<int>())
+		sut.SetupMock.Method.MethodWithoutOtherOverloads(Any<int>(), Any<int>(), Any<int>())
 			.Callback(() => { callCount++; })
 			.Returns("foo");
 
@@ -134,7 +134,7 @@ public sealed partial class SetupMethodTests
 
 		await That(callCount).IsEqualTo(1);
 		await That(result).IsEqualTo("foo");
-		await That(sut.VerifyMock.Invoked.MethodWithoutOtherOverloads(WithAnyParameters())).Once();
+		await That(sut.VerifyMock.Invoked.MethodWithoutOtherOverloads(AnyParameters())).Once();
 	}
 
 	[Fact]
@@ -143,7 +143,7 @@ public sealed partial class SetupMethodTests
 		int callCount = 0;
 		IReturnMethodSetupWithParametersTest sut = Mock.Create<IReturnMethodSetupWithParametersTest>();
 
-		sut.SetupMock.Method.MethodWithoutOtherOverloads(WithAnyParameters())
+		sut.SetupMock.Method.MethodWithoutOtherOverloads(AnyParameters())
 			.Callback(() => { callCount++; })
 			.Returns((string?)null!);
 
@@ -201,11 +201,11 @@ public sealed partial class SetupMethodTests
 	public async Task Setup_ShouldUseNewestMatchingSetup()
 	{
 		IMethodService mock = Mock.Create<IMethodService>();
-		mock.SetupMock.Method.MyIntMethodWithParameters(WithAny<int>(), WithAny<string>()).Returns(10);
+		mock.SetupMock.Method.MyIntMethodWithParameters(Any<int>(), Any<string>()).Returns(10);
 
 		await That(mock.MyIntMethodWithParameters(1, "")).IsEqualTo(10);
 
-		mock.SetupMock.Method.MyIntMethodWithParameters(WithAny<int>(), WithAny<string>()).Returns(20);
+		mock.SetupMock.Method.MyIntMethodWithParameters(Any<int>(), Any<string>()).Returns(20);
 
 		await That(mock.MyIntMethodWithParameters(1, "")).IsEqualTo(20);
 	}
@@ -367,7 +367,7 @@ public sealed partial class SetupMethodTests
 		int callCount = 0;
 		IVoidMethodSetupWithParametersTest sut = Mock.Create<IVoidMethodSetupWithParametersTest>();
 
-		sut.SetupMock.Method.MethodWithoutOtherOverloads(WithAnyParameters())
+		sut.SetupMock.Method.MethodWithoutOtherOverloads(AnyParameters())
 			.Callback(() => { callCount++; });
 
 		sut.MethodWithoutOtherOverloads(1, 2, 3);
@@ -388,11 +388,11 @@ public sealed partial class SetupMethodTests
 		MockRegistration registration = ((IHasMockRegistration)sut).Registrations;
 
 		sut.SetupMock.Method.Method0();
-		sut.SetupMock.Method.Method1(WithAny<int>());
-		sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>());
-		sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>());
-		sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>());
-		sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>());
+		sut.SetupMock.Method.Method1(Any<int>());
+		sut.SetupMock.Method.Method2(Any<int>(), Any<int>());
+		sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>());
+		sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>());
+		sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(), Any<int>());
 
 		void Act()
 		{
@@ -411,13 +411,13 @@ public sealed partial class SetupMethodTests
 		int callCount = 0;
 		IVoidMethodSetupWithParametersTest sut = Mock.Create<IVoidMethodSetupWithParametersTest>();
 
-		sut.SetupMock.Method.MethodWithoutOtherOverloads(WithAny<int>(), WithAny<int>(), WithAny<int>())
+		sut.SetupMock.Method.MethodWithoutOtherOverloads(Any<int>(), Any<int>(), Any<int>())
 			.Callback(() => { callCount++; });
 
 		sut.MethodWithoutOtherOverloads(1, 2, 3);
 
 		await That(callCount).IsEqualTo(1);
-		await That(sut.VerifyMock.Invoked.MethodWithoutOtherOverloads(WithAnyParameters())).Once();
+		await That(sut.VerifyMock.Invoked.MethodWithoutOtherOverloads(AnyParameters())).Once();
 	}
 
 	[Fact]
@@ -426,7 +426,7 @@ public sealed partial class SetupMethodTests
 		IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
 		MockRegistration registration = ((IHasMockRegistration)sut).Registrations;
 
-		sut.SetupMock.Method.UniqueMethodWithParameters(WithAnyParameters());
+		sut.SetupMock.Method.UniqueMethodWithParameters(AnyParameters());
 
 		void Act()
 		{
@@ -540,11 +540,11 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string> setup = new("Foo", new NamedParameter("bar", WithAny<string>()));
+			ReturnMethodSetup<int, string> setup = new("Foo", new NamedParameter("bar", Any<string>()));
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("int Foo(WithAny<string>() bar)");
+			await That(result).IsEqualTo("int Foo(Any<string>() bar)");
 		}
 
 		[Fact]
@@ -553,7 +553,7 @@ public sealed partial class SetupMethodTests
 			int callCount = 0;
 			IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-			sut.SetupMock.Method.Method1(WithAny<int>())
+			sut.SetupMock.Method.Method1(Any<int>())
 				.Callback(() => { callCount++; })
 				.Returns((string?)null!);
 
@@ -569,22 +569,22 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long> setup = new("Foo", new NamedParameter("p1", WithAny<string>()),
-				new NamedParameter("p2", WithAny<long>()));
+			ReturnMethodSetup<int, string, long> setup = new("Foo", new NamedParameter("p1", Any<string>()),
+				new NamedParameter("p2", Any<long>()));
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("int Foo(WithAny<string>() p1, WithAny<long>() p2)");
+			await That(result).IsEqualTo("int Foo(Any<string>() p1, Any<long>() p2)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long> setup = new("Foo", WithAnyParameters());
+			ReturnMethodSetup<int, string, long> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("int Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("int Foo(AnyParameters())");
 		}
 
 		[Fact]
@@ -593,7 +593,7 @@ public sealed partial class SetupMethodTests
 			int callCount = 0;
 			IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-			sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.Method2(Any<int>(), Any<int>())
 				.Callback(() => { callCount++; })
 				.Returns((string?)null!);
 
@@ -610,22 +610,22 @@ public sealed partial class SetupMethodTests
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
 			ReturnMethodSetup<int, string, long, int> setup = new("Foo",
-				new NamedParameter("p1", WithAny<string>()), new NamedParameter("p2", WithAny<long>()),
-				new NamedParameter("p3", WithAny<int>()));
+				new NamedParameter("p1", Any<string>()), new NamedParameter("p2", Any<long>()),
+				new NamedParameter("p3", Any<int>()));
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("int Foo(WithAny<string>() p1, WithAny<long>() p2, WithAny<int>() p3)");
+			await That(result).IsEqualTo("int Foo(Any<string>() p1, Any<long>() p2, Any<int>() p3)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int> setup = new("Foo", WithAnyParameters());
+			ReturnMethodSetup<int, string, long, int> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("int Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("int Foo(AnyParameters())");
 		}
 
 		[Fact]
@@ -634,7 +634,7 @@ public sealed partial class SetupMethodTests
 			int callCount = 0;
 			IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-			sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 				.Callback(() => { callCount++; })
 				.Returns((string?)null!);
 
@@ -651,24 +651,24 @@ public sealed partial class SetupMethodTests
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
 			ReturnMethodSetup<int, string, long, int, int> setup = new("Foo",
-				new NamedParameter("p1", WithAny<string>()), new NamedParameter("p2", WithAny<long>()),
-				new NamedParameter("p3", WithAny<int>()), new NamedParameter("p4", WithAny<int>()));
+				new NamedParameter("p1", Any<string>()), new NamedParameter("p2", Any<long>()),
+				new NamedParameter("p3", Any<int>()), new NamedParameter("p4", Any<int>()));
 
 			string result = setup.ToString();
 
 			await That(result)
 				.IsEqualTo(
-					"int Foo(WithAny<string>() p1, WithAny<long>() p2, WithAny<int>() p3, WithAny<int>() p4)");
+					"int Foo(Any<string>() p1, Any<long>() p2, Any<int>() p3, Any<int>() p4)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int, int> setup = new("Foo", WithAnyParameters());
+			ReturnMethodSetup<int, string, long, int, int> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("int Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("int Foo(AnyParameters())");
 		}
 
 		[Fact]
@@ -677,7 +677,7 @@ public sealed partial class SetupMethodTests
 			int callCount = 0;
 			IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-			sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 				.Callback(() => { callCount++; })
 				.Returns((string?)null!);
 
@@ -694,25 +694,25 @@ public sealed partial class SetupMethodTests
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
 			ReturnMethodSetup<int, string, long, int, int, int> setup = new("Foo",
-				new NamedParameter("p1", WithAny<string>()), new NamedParameter("p2", WithAny<long>()),
-				new NamedParameter("p3", WithAny<int>()), new NamedParameter("p4", WithAny<int>()),
-				new NamedParameter("p5", WithAny<int>()));
+				new NamedParameter("p1", Any<string>()), new NamedParameter("p2", Any<long>()),
+				new NamedParameter("p3", Any<int>()), new NamedParameter("p4", Any<int>()),
+				new NamedParameter("p5", Any<int>()));
 
 			string result = setup.ToString();
 
 			await That(result)
 				.IsEqualTo(
-					"int Foo(WithAny<string>() p1, WithAny<long>() p2, WithAny<int>() p3, WithAny<int>() p4, WithAny<int>() p5)");
+					"int Foo(Any<string>() p1, Any<long>() p2, Any<int>() p3, Any<int>() p4, Any<int>() p5)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int, int, int> setup = new("Foo", WithAnyParameters());
+			ReturnMethodSetup<int, string, long, int, int, int> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("int Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("int Foo(AnyParameters())");
 		}
 
 		[Fact]
@@ -721,8 +721,8 @@ public sealed partial class SetupMethodTests
 			int callCount = 0;
 			IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
 
-			sut.SetupMock.Method.Method5(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>(),
-					WithAny<int>())
+			sut.SetupMock.Method.Method5(Any<int>(), Any<int>(), Any<int>(), Any<int>(),
+					Any<int>())
 				.Callback(() => { callCount++; })
 				.Returns((string?)null!);
 
@@ -751,11 +751,11 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string> setup = new("Foo", new NamedParameter("bar", WithAny<string>()));
+			VoidMethodSetup<string> setup = new("Foo", new NamedParameter("bar", Any<string>()));
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("void Foo(WithAny<string>() bar)");
+			await That(result).IsEqualTo("void Foo(Any<string>() bar)");
 		}
 	}
 
@@ -764,22 +764,22 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long> setup = new("Foo", new NamedParameter("p1", WithAny<string>()),
-				new NamedParameter("p2", WithAny<long>()));
+			VoidMethodSetup<string, long> setup = new("Foo", new NamedParameter("p1", Any<string>()),
+				new NamedParameter("p2", Any<long>()));
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("void Foo(WithAny<string>() p1, WithAny<long>() p2)");
+			await That(result).IsEqualTo("void Foo(Any<string>() p1, Any<long>() p2)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long> setup = new("Foo", WithAnyParameters());
+			VoidMethodSetup<string, long> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("void Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("void Foo(AnyParameters())");
 		}
 	}
 
@@ -788,22 +788,22 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int> setup = new("Foo", new NamedParameter("p1", WithAny<string>()),
-				new NamedParameter("p2", WithAny<long>()), new NamedParameter("p3", WithAny<int>()));
+			VoidMethodSetup<string, long, int> setup = new("Foo", new NamedParameter("p1", Any<string>()),
+				new NamedParameter("p2", Any<long>()), new NamedParameter("p3", Any<int>()));
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("void Foo(WithAny<string>() p1, WithAny<long>() p2, WithAny<int>() p3)");
+			await That(result).IsEqualTo("void Foo(Any<string>() p1, Any<long>() p2, Any<int>() p3)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int> setup = new("Foo", WithAnyParameters());
+			VoidMethodSetup<string, long, int> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("void Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("void Foo(AnyParameters())");
 		}
 	}
 
@@ -813,24 +813,24 @@ public sealed partial class SetupMethodTests
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
 			VoidMethodSetup<string, long, int, int> setup = new("Foo",
-				new NamedParameter("p1", WithAny<string>()), new NamedParameter("p2", WithAny<long>()),
-				new NamedParameter("p3", WithAny<int>()), new NamedParameter("p4", WithAny<int>()));
+				new NamedParameter("p1", Any<string>()), new NamedParameter("p2", Any<long>()),
+				new NamedParameter("p3", Any<int>()), new NamedParameter("p4", Any<int>()));
 
 			string result = setup.ToString();
 
 			await That(result)
 				.IsEqualTo(
-					"void Foo(WithAny<string>() p1, WithAny<long>() p2, WithAny<int>() p3, WithAny<int>() p4)");
+					"void Foo(Any<string>() p1, Any<long>() p2, Any<int>() p3, Any<int>() p4)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int, int> setup = new("Foo", WithAnyParameters());
+			VoidMethodSetup<string, long, int, int> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("void Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("void Foo(AnyParameters())");
 		}
 	}
 
@@ -840,25 +840,25 @@ public sealed partial class SetupMethodTests
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
 			VoidMethodSetup<string, long, int, int, int> setup = new("Foo",
-				new NamedParameter("p1", WithAny<string>()), new NamedParameter("p2", WithAny<long>()),
-				new NamedParameter("p3", WithAny<int>()), new NamedParameter("p4", WithAny<int>()),
-				new NamedParameter("p5", WithAny<int>()));
+				new NamedParameter("p1", Any<string>()), new NamedParameter("p2", Any<long>()),
+				new NamedParameter("p3", Any<int>()), new NamedParameter("p4", Any<int>()),
+				new NamedParameter("p5", Any<int>()));
 
 			string result = setup.ToString();
 
 			await That(result)
 				.IsEqualTo(
-					"void Foo(WithAny<string>() p1, WithAny<long>() p2, WithAny<int>() p3, WithAny<int>() p4, WithAny<int>() p5)");
+					"void Foo(Any<string>() p1, Any<long>() p2, Any<int>() p3, Any<int>() p4, Any<int>() p5)");
 		}
 
 		[Fact]
-		public async Task ToString_WithAnyParameterCombination_ShouldReturnMethodSignature()
+		public async Task ToString_AnyParameterCombination_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int, int, int> setup = new("Foo", WithAnyParameters());
+			VoidMethodSetup<string, long, int, int, int> setup = new("Foo", AnyParameters());
 
 			string result = setup.ToString();
 
-			await That(result).IsEqualTo("void Foo(WithAnyParameters())");
+			await That(result).IsEqualTo("void Foo(AnyParameters())");
 		}
 	}
 

--- a/Tests/Mockolate.Tests/MockMethods/VerifyInvokedTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/VerifyInvokedTests.cs
@@ -32,14 +32,14 @@ public sealed class VerifyInvokedTests
 	public async Task MethodWithReturnValue_ShouldBeRegistered(int numberOfInvocations)
 	{
 		MockTests.IMyService sut = Mock.Create<MockTests.IMyService>();
-		sut.SetupMock.Method.Multiply(WithAny<int>(), WithAny<int?>()).Returns(1);
+		sut.SetupMock.Method.Multiply(Any<int>(), Any<int?>()).Returns(1);
 
 		for (int i = 0; i < numberOfInvocations; i++)
 		{
 			sut.Multiply(i, 4);
 		}
 
-		await That(sut.VerifyMock.Invoked.Multiply(WithAny<int>(), WithAny<int?>())).Exactly(numberOfInvocations);
+		await That(sut.VerifyMock.Invoked.Multiply(Any<int>(), Any<int?>())).Exactly(numberOfInvocations);
 	}
 
 	[Fact]
@@ -58,14 +58,14 @@ public sealed class VerifyInvokedTests
 	public async Task VoidMethod_ShouldBeRegistered(int numberOfInvocations)
 	{
 		MockTests.IMyService sut = Mock.Create<MockTests.IMyService>();
-		sut.SetupMock.Method.SetIsValid(WithAny<bool>(), WithAny<Func<bool>?>());
+		sut.SetupMock.Method.SetIsValid(Any<bool>(), Any<Func<bool>?>());
 
 		for (int i = 0; i < numberOfInvocations; i++)
 		{
 			sut.SetIsValid(i % 2 == 0, () => true);
 		}
 
-		await That(sut.VerifyMock.Invoked.SetIsValid(WithAny<bool>(), WithAny<Func<bool>?>()))
+		await That(sut.VerifyMock.Invoked.SetIsValid(Any<bool>(), Any<Func<bool>?>()))
 			.Exactly(numberOfInvocations);
 	}
 

--- a/Tests/Mockolate.Tests/MockProperties/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/InteractionsTests.cs
@@ -49,7 +49,7 @@ public sealed class InteractionsTests
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 		registration.Set("foo.bar", 4);
 
-		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "foo.bar", WithAny<int>());
+		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "foo.bar", Any<int>());
 
 		await That(result).Once();
 	}
@@ -61,7 +61,7 @@ public sealed class InteractionsTests
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 		registration.Set("foo.bar", 4);
 
-		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "foo.bar", WithAny<string>());
+		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "foo.bar", Any<string>());
 
 		await That(result).Never();
 	}
@@ -73,7 +73,7 @@ public sealed class InteractionsTests
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 		registration.Set("foo.bar", 4);
 
-		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "baz.bar", WithAny<int>());
+		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "baz.bar", Any<int>());
 
 		await That(result).Never();
 	}
@@ -84,10 +84,10 @@ public sealed class InteractionsTests
 		IChocolateDispenser mock = Mock.Create<IChocolateDispenser>();
 		MockRegistration registration = ((IHasMockRegistration)mock).Registrations;
 
-		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "foo.bar", WithAny<int>());
+		VerificationResult<IChocolateDispenser> result = registration.Property(mock, "foo.bar", Any<int>());
 
 		await That(result).Never();
-		await That(((IVerificationResult)result).Expectation).IsEqualTo("set property bar to value WithAny<int>()");
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("set property bar to value Any<int>()");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockProperties/VerifyGotTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/VerifyGotTests.cs
@@ -12,7 +12,7 @@ public sealed class VerifyGotTests
 		_ = sut.Counter;
 
 		await That(sut.VerifyMock.Got.Counter()).Once();
-		await That(sut.VerifyMock.Set.Counter(WithAny<int>())).Never();
+		await That(sut.VerifyMock.Set.Counter(Any<int>())).Never();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockProperties/VerifySetTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/VerifySetTests.cs
@@ -12,7 +12,7 @@ public sealed class VerifySetTests
 		sut.Counter = 42;
 
 		await That(sut.VerifyMock.Got.Counter()).Never();
-		await That(sut.VerifyMock.Set.Counter(WithAny<int>())).Once();
+		await That(sut.VerifyMock.Set.Counter(Any<int>())).Once();
 	}
 
 	[Theory]

--- a/Tests/Mockolate.Tests/MockSetupsTests.cs
+++ b/Tests/Mockolate.Tests/MockSetupsTests.cs
@@ -40,7 +40,7 @@ public sealed class MockSetupsTests
 
 		for (int i = 0; i < indexerCount; i++)
 		{
-			sut.Registrations.SetupIndexer(new IndexerSetup<string, int>(WithAny<int>()));
+			sut.Registrations.SetupIndexer(new IndexerSetup<string, int>(Any<int>()));
 		}
 
 		string result = sut.Registrations.ToString();

--- a/Tests/Mockolate.Tests/MockTests.CreateTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.CreateTests.cs
@@ -11,9 +11,9 @@ public sealed partial class MockTests
 		public async Task With2Arguments_WithSetups_ShouldApplySetups()
 		{
 			IMyService mock = Mock.Create<IMyService, IMyService>(
-				setup => setup.Method.Multiply(With(1), WithAny<int?>()).Returns(2),
-				setup => setup.Method.Multiply(With(2), WithAny<int?>()).Returns(4),
-				setup => setup.Method.Multiply(With(3), WithAny<int?>()).Returns(8));
+				setup => setup.Method.Multiply(With(1), Any<int?>()).Returns(2),
+				setup => setup.Method.Multiply(With(2), Any<int?>()).Returns(4),
+				setup => setup.Method.Multiply(With(3), Any<int?>()).Returns(8));
 
 			int result1 = mock.Multiply(1, null);
 			int result2 = mock.Multiply(2, null);

--- a/Tests/Mockolate.Tests/MockTests.FactoryTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.FactoryTests.cs
@@ -174,8 +174,8 @@ public sealed partial class MockTests
 			MyServiceBase mock =
 				factory.Create<MyServiceBase, IMyService, TestHelpers.IMyService, TestHelpers.Other.IMyService>();
 
-			mock.SetupIMyServiceMock.Method.DoSomething(WithAny<int>()).Callback(() => isDoSomethingCalled1 = true);
-			mock.SetupIMyService__2Mock.Method.DoSomething(WithAny<int>()).Callback(() => isDoSomethingCalled2 = true);
+			mock.SetupIMyServiceMock.Method.DoSomething(Any<int>()).Callback(() => isDoSomethingCalled1 = true);
+			mock.SetupIMyService__2Mock.Method.DoSomething(Any<int>()).Callback(() => isDoSomethingCalled2 = true);
 
 			((TestHelpers.IMyService)mock).DoSomething(1);
 
@@ -214,10 +214,10 @@ public sealed partial class MockTests
 			Mock.Factory factory = new(behavior);
 
 			IMyService mock1 = factory.Create<IMyService>(
-				setup => setup.Method.Multiply(WithAny<int>(), WithAny<int?>()).Returns(42));
+				setup => setup.Method.Multiply(Any<int>(), Any<int?>()).Returns(42));
 			MyServiceBase mock2 = factory.Create<MyServiceBase, IMyService>(BaseClass.WithConstructorParameters(),
-				setup => setup.Method.DoSomething(WithAny<int>(), With(true)).Returns(5),
-				setup => setup.Method.DoSomething(WithAny<int>(), With(false)).Returns(6));
+				setup => setup.Method.DoSomething(Any<int>(), With(true)).Returns(5),
+				setup => setup.Method.DoSomething(Any<int>(), With(false)).Returns(6));
 
 			int result = mock1.Multiply(2, null);
 			int result21 = mock2.DoSomething(1, true);

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -255,9 +255,9 @@ public sealed partial class MockTests
 	public async Task Create_WithSetups_ShouldApplySetups()
 	{
 		IMyService mock = Mock.Create<IMyService>(
-			setup => setup.Method.Multiply(With(1), WithAny<int?>()).Returns(2),
-			setup => setup.Method.Multiply(With(2), WithAny<int?>()).Returns(4),
-			setup => setup.Method.Multiply(With(3), WithAny<int?>()).Returns(8));
+			setup => setup.Method.Multiply(With(1), Any<int?>()).Returns(2),
+			setup => setup.Method.Multiply(With(2), Any<int?>()).Returns(4),
+			setup => setup.Method.Multiply(With(3), Any<int?>()).Returns(8));
 
 		int result1 = mock.Multiply(1, null);
 		int result2 = mock.Multiply(2, null);

--- a/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
+++ b/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
@@ -24,7 +24,7 @@ public sealed class ProtectedMockTests
 	{
 		MyProtectedClass mock = Mock.Create<MyProtectedClass>();
 
-		mock.SetupMock.Protected.Method.MyProtectedMethod(WithAny<string>())
+		mock.SetupMock.Protected.Method.MyProtectedMethod(Any<string>())
 			.Returns(v => $"Hello, {v}!");
 
 		string result = mock.InvokeMyProtectedMethod("foo");
@@ -52,7 +52,7 @@ public sealed class ProtectedMockTests
 		int callCount = 0;
 		MyProtectedClass mock = Mock.Create<MyProtectedClass>();
 
-		mock.SetupMock.Protected.Indexer(WithAny<int>()).InitializeWith(42).OnGet(() => callCount++);
+		mock.SetupMock.Protected.Indexer(Any<int>()).InitializeWith(42).OnGet(() => callCount++);
 
 		int result = mock.GetMyProtectedIndexer(3);
 
@@ -67,7 +67,7 @@ public sealed class ProtectedMockTests
 		int callCount = 0;
 		MyProtectedClass mock = Mock.Create<MyProtectedClass>();
 
-		mock.SetupMock.Protected.Indexer(WithAny<int>()).OnSet(() => callCount++);
+		mock.SetupMock.Protected.Indexer(Any<int>()).OnSet(() => callCount++);
 
 		mock.SetMyProtectedIndexer(3, 4);
 

--- a/Tests/Mockolate.Tests/ReturnsAsyncExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/ReturnsAsyncExtensionsTests.cs
@@ -8,7 +8,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_1Parameter_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method1(WithAny<int>()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.Method1(Any<int>()).ReturnsAsync(() => 42);
 
 			int result = await sut.Method1(1);
 
@@ -19,7 +19,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_1Parameter_CallbackWithValue_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method1(WithAny<int>()).ReturnsAsync(v1 => v1 + 10);
+			sut.SetupMock.Method.Method1(Any<int>()).ReturnsAsync(v1 => v1 + 10);
 
 			int result = await sut.Method1(2);
 
@@ -30,7 +30,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_1Parameter_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method1(WithAny<int>()).ReturnsAsync(42);
+			sut.SetupMock.Method.Method1(Any<int>()).ReturnsAsync(42);
 
 			int result = await sut.Method1(1);
 
@@ -41,7 +41,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_2Parameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.Method2(Any<int>(), Any<int>()).ReturnsAsync(() => 42);
 
 			int result = await sut.Method2(1, 2);
 
@@ -52,7 +52,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_2Parameters_CallbackWithValues_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>()).ReturnsAsync((v1, v2) => v1 + v2 + 10);
+			sut.SetupMock.Method.Method2(Any<int>(), Any<int>()).ReturnsAsync((v1, v2) => v1 + v2 + 10);
 
 			int result = await sut.Method2(1, 2);
 
@@ -63,7 +63,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_2Parameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method2(WithAny<int>(), WithAny<int>()).ReturnsAsync(42);
+			sut.SetupMock.Method.Method2(Any<int>(), Any<int>()).ReturnsAsync(42);
 
 			int result = await sut.Method2(1, 2);
 
@@ -74,7 +74,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_3Parameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>()).ReturnsAsync(() => 42);
 
 			int result = await sut.Method3(1, 2, 3);
 
@@ -85,7 +85,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_3Parameters_CallbackWithValues_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync((v1, v2, v3) => v1 + v2 + v3 + 10);
 
 			int result = await sut.Method3(1, 2, 3);
@@ -97,7 +97,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_3Parameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method3(WithAny<int>(), WithAny<int>(), WithAny<int>()).ReturnsAsync(42);
+			sut.SetupMock.Method.Method3(Any<int>(), Any<int>(), Any<int>()).ReturnsAsync(42);
 
 			int result = await sut.Method3(1, 2, 3);
 
@@ -108,7 +108,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_4Parameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync(() => 42);
 
 			int result = await sut.Method4(1, 2, 3, 4);
@@ -120,7 +120,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_4Parameters_CallbackWithValues_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync((v1, v2, v3, v4) => v1 + v2 + v3 + v4 + 10);
 
 			int result = await sut.Method4(1, 2, 3, 4);
@@ -132,7 +132,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_4Parameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.Method4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync(42);
 
 			int result = await sut.Method4(1, 2, 3, 4);
@@ -166,7 +166,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_WithParameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method2(WithAnyParameters()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.Method2(AnyParameters()).ReturnsAsync(() => 42);
 
 			int result = await sut.Method2(1, 2);
 
@@ -177,7 +177,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_WithParameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.Method2(WithAnyParameters()).ReturnsAsync(42);
+			sut.SetupMock.Method.Method2(AnyParameters()).ReturnsAsync(42);
 
 			int result = await sut.Method2(1, 2);
 
@@ -192,7 +192,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_1Parameter_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT1(WithAny<int>()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.MethodVT1(Any<int>()).ReturnsAsync(() => 42);
 
 			int result = await sut.MethodVT1(1);
 
@@ -203,7 +203,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_1Parameter_CallbackWithValue_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT1(WithAny<int>()).ReturnsAsync(v1 => v1 + 10);
+			sut.SetupMock.Method.MethodVT1(Any<int>()).ReturnsAsync(v1 => v1 + 10);
 
 			int result = await sut.MethodVT1(2);
 
@@ -214,7 +214,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_1Parameter_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT1(WithAny<int>()).ReturnsAsync(42);
+			sut.SetupMock.Method.MethodVT1(Any<int>()).ReturnsAsync(42);
 
 			int result = await sut.MethodVT1(1);
 
@@ -225,7 +225,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_2Parameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT2(WithAny<int>(), WithAny<int>()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.MethodVT2(Any<int>(), Any<int>()).ReturnsAsync(() => 42);
 
 			int result = await sut.MethodVT2(1, 2);
 
@@ -236,7 +236,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_2Parameters_CallbackWithValues_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT2(WithAny<int>(), WithAny<int>()).ReturnsAsync((v1, v2) => v1 + v2 + 10);
+			sut.SetupMock.Method.MethodVT2(Any<int>(), Any<int>()).ReturnsAsync((v1, v2) => v1 + v2 + 10);
 
 			int result = await sut.MethodVT2(1, 2);
 
@@ -247,7 +247,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_2Parameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT2(WithAny<int>(), WithAny<int>()).ReturnsAsync(42);
+			sut.SetupMock.Method.MethodVT2(Any<int>(), Any<int>()).ReturnsAsync(42);
 
 			int result = await sut.MethodVT2(1, 2);
 
@@ -258,7 +258,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_3Parameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT3(WithAny<int>(), WithAny<int>(), WithAny<int>()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.MethodVT3(Any<int>(), Any<int>(), Any<int>()).ReturnsAsync(() => 42);
 
 			int result = await sut.MethodVT3(1, 2, 3);
 
@@ -269,7 +269,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_3Parameters_CallbackWithValues_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT3(WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.MethodVT3(Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync((v1, v2, v3) => v1 + v2 + v3 + 10);
 
 			int result = await sut.MethodVT3(1, 2, 3);
@@ -281,7 +281,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_3Parameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT3(WithAny<int>(), WithAny<int>(), WithAny<int>()).ReturnsAsync(42);
+			sut.SetupMock.Method.MethodVT3(Any<int>(), Any<int>(), Any<int>()).ReturnsAsync(42);
 
 			int result = await sut.MethodVT3(1, 2, 3);
 
@@ -292,7 +292,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_4Parameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.MethodVT4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync(() => 42);
 
 			int result = await sut.MethodVT4(1, 2, 3, 4);
@@ -304,7 +304,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_4Parameters_CallbackWithValues_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.MethodVT4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync((v1, v2, v3, v4) => v1 + v2 + v3 + v4 + 10);
 
 			int result = await sut.MethodVT4(1, 2, 3, 4);
@@ -316,7 +316,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_4Parameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT4(WithAny<int>(), WithAny<int>(), WithAny<int>(), WithAny<int>())
+			sut.SetupMock.Method.MethodVT4(Any<int>(), Any<int>(), Any<int>(), Any<int>())
 				.ReturnsAsync(42);
 
 			int result = await sut.MethodVT4(1, 2, 3, 4);
@@ -350,7 +350,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_WithParameters_Callback_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT2(WithAnyParameters()).ReturnsAsync(() => 42);
+			sut.SetupMock.Method.MethodVT2(AnyParameters()).ReturnsAsync(() => 42);
 
 			int result = await sut.MethodVT2(1, 2);
 
@@ -361,7 +361,7 @@ public sealed class ReturnsAsyncExtensionsTests
 		public async Task ReturnsAsync_WithParameters_ReturnsConfiguredValue()
 		{
 			IReturnsAsyncExtensionsSetupTest sut = Mock.Create<IReturnsAsyncExtensionsSetupTest>();
-			sut.SetupMock.Method.MethodVT2(WithAnyParameters()).ReturnsAsync(42);
+			sut.SetupMock.Method.MethodVT2(AnyParameters()).ReturnsAsync(42);
 
 			int result = await sut.MethodVT2(1, 2);
 

--- a/Tests/Mockolate.Tests/Verify/MockVerifyTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockVerifyTests.cs
@@ -32,7 +32,7 @@ public class MockVerifyTests
 		sut.Dispense("Dark", 1);
 		sut.Dispense("Dark", 2);
 
-		await That(sut.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>())).AtLeastOnce();
+		await That(sut.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>())).AtLeastOnce();
 		await That(sut.VerifyMock.ThatAllInteractionsAreVerified()).IsTrue();
 	}
 }

--- a/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
@@ -20,12 +20,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).AtLeast(times);
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).AtLeast(times);
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) at least 3 times, but it did twice.");
+				"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) at least 3 times, but it did twice.");
 	}
 
 	[Theory]
@@ -40,12 +40,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).AtLeastOnce();
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).AtLeastOnce();
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) at least once, but it never did.");
+				"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) at least once, but it never did.");
 	}
 
 	[Theory]
@@ -60,12 +60,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).AtLeastTwice();
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).AtLeastTwice();
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) at least twice, but it {count switch { 0 => "never did", _ => "did once", }}.");
+				$"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) at least twice, but it {count switch { 0 => "never did", _ => "did once", }}.");
 	}
 
 	[Theory]
@@ -80,12 +80,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).AtMost(times);
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).AtMost(times);
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) at most once, but it did twice.");
+				"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) at most once, but it did twice.");
 	}
 
 	[Theory]
@@ -100,12 +100,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).AtMostOnce();
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).AtMostOnce();
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) at most once, but it did {(count == 2 ? "twice" : $"{count} times")}.");
+				$"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) at most once, but it did {(count == 2 ? "twice" : $"{count} times")}.");
 	}
 
 	[Theory]
@@ -120,12 +120,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).AtMostTwice();
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).AtMostTwice();
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) at most twice, but it did {count} times.");
+				$"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) at most twice, but it did {count} times.");
 	}
 
 	[Theory]
@@ -140,12 +140,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).Exactly(times);
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).Exactly(times);
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) exactly {(times == 1 ? "once" : $"{times} times")}, but it did twice.");
+				$"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) exactly {(times == 1 ? "once" : $"{times} times")}, but it did twice.");
 	}
 
 	[Theory]
@@ -160,12 +160,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).Never();
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).Never();
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock never invoked method Dispense(WithAny<string>(), WithAny<int>()), but it did {count switch { 1 => "once", 2 => "twice", _ => $"{count} times", }}.");
+				$"Expected that mock never invoked method Dispense(Any<string>(), Any<int>()), but it did {count switch { 1 => "once", 2 => "twice", _ => $"{count} times", }}.");
 	}
 
 	[Theory]
@@ -180,12 +180,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).Once();
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).Once();
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) exactly once, but it {count switch { 0 => "never did", 2 => "did twice", _ => $"did {count} times", }}.");
+				$"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) exactly once, but it {count switch { 0 => "never did", 2 => "did twice", _ => $"did {count} times", }}.");
 	}
 
 	[Fact]
@@ -197,20 +197,20 @@ public class VerificationResultExtensionsTests
 		mock.Dispense("Dark", 3);
 		mock.Dispense("Dark", 4);
 
-		mock.VerifyMock.Invoked.Dispense(WithAny<string>(), With(3))
-			.Then(m => m.Invoked.Dispense(WithAny<string>(), With(4)));
+		mock.VerifyMock.Invoked.Dispense(Any<string>(), With(3))
+			.Then(m => m.Invoked.Dispense(Any<string>(), With(4)));
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), With(2))
-				.Then(m => m.Invoked.Dispense(WithAny<string>(), With(1)));
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), With(2))
+				.Then(m => m.Invoked.Dispense(Any<string>(), With(1)));
 		}
 
 		await That(Act).Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method Dispense(WithAny<string>(), 2), then invoked method Dispense(WithAny<string>(), 1) in order, but it invoked method Dispense(WithAny<string>(), 1) too early.");
-		mock.VerifyMock.Invoked.Dispense(WithAny<string>(), With(1))
-			.Then(m => m.Invoked.Dispense(WithAny<string>(), With(2)));
+				"Expected that mock invoked method Dispense(Any<string>(), 2), then invoked method Dispense(Any<string>(), 1) in order, but it invoked method Dispense(Any<string>(), 1) too early.");
+		mock.VerifyMock.Invoked.Dispense(Any<string>(), With(1))
+			.Then(m => m.Invoked.Dispense(Any<string>(), With(2)));
 	}
 
 	[Fact]
@@ -222,25 +222,25 @@ public class VerificationResultExtensionsTests
 		mock.Dispense("Dark", 3);
 		mock.Dispense("Dark", 4);
 
-		await That(void () => mock.VerifyMock.Invoked.Dispense(WithAny<string>(), With(6))
-				.Then(m => m.Invoked.Dispense(WithAny<string>(), With(4))))
+		await That(void () => mock.VerifyMock.Invoked.Dispense(Any<string>(), With(6))
+				.Then(m => m.Invoked.Dispense(Any<string>(), With(4))))
 			.Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method Dispense(WithAny<string>(), 6), then invoked method Dispense(WithAny<string>(), 4) in order, but it invoked method Dispense(WithAny<string>(), 6) not at all.");
+				"Expected that mock invoked method Dispense(Any<string>(), 6), then invoked method Dispense(Any<string>(), 4) in order, but it invoked method Dispense(Any<string>(), 6) not at all.");
 
-		await That(void () => mock.VerifyMock.Invoked.Dispense(WithAny<string>(), With(1))
-				.Then(m => m.Invoked.Dispense(WithAny<string>(), With(6)),
-					m => m.Invoked.Dispense(WithAny<string>(), With(3))))
+		await That(void () => mock.VerifyMock.Invoked.Dispense(Any<string>(), With(1))
+				.Then(m => m.Invoked.Dispense(Any<string>(), With(6)),
+					m => m.Invoked.Dispense(Any<string>(), With(3))))
 			.Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method Dispense(WithAny<string>(), 1), then invoked method Dispense(WithAny<string>(), 6), then invoked method Dispense(WithAny<string>(), 3) in order, but it invoked method Dispense(WithAny<string>(), 6) not at all.");
+				"Expected that mock invoked method Dispense(Any<string>(), 1), then invoked method Dispense(Any<string>(), 6), then invoked method Dispense(Any<string>(), 3) in order, but it invoked method Dispense(Any<string>(), 6) not at all.");
 
-		await That(void () => mock.VerifyMock.Invoked.Dispense(WithAny<string>(), With(1))
-				.Then(m => m.Invoked.Dispense(WithAny<string>(), With(2)),
-					m => m.Invoked.Dispense(WithAny<string>(), With(6))))
+		await That(void () => mock.VerifyMock.Invoked.Dispense(Any<string>(), With(1))
+				.Then(m => m.Invoked.Dispense(Any<string>(), With(2)),
+					m => m.Invoked.Dispense(Any<string>(), With(6))))
 			.Throws<MockVerificationException>()
 			.WithMessage(
-				"Expected that mock invoked method Dispense(WithAny<string>(), 1), then invoked method Dispense(WithAny<string>(), 2), then invoked method Dispense(WithAny<string>(), 6) in order, but it invoked method Dispense(WithAny<string>(), 6) not at all.");
+				"Expected that mock invoked method Dispense(Any<string>(), 1), then invoked method Dispense(Any<string>(), 2), then invoked method Dispense(Any<string>(), 6) in order, but it invoked method Dispense(Any<string>(), 6) not at all.");
 	}
 
 	[Fact]
@@ -251,7 +251,7 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			result.Then(m => m.Invoked.Dispense(WithAny<string>(), With(1)));
+			result.Then(m => m.Invoked.Dispense(Any<string>(), With(1)));
 		}
 
 		await That(Act).Throws<MockException>()
@@ -270,12 +270,12 @@ public class VerificationResultExtensionsTests
 
 		void Act()
 		{
-			mock.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>()).Twice();
+			mock.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>()).Twice();
 		}
 
 		await That(Act).Throws<MockVerificationException>().OnlyIf(!expectSuccess)
 			.WithMessage(
-				$"Expected that mock invoked method Dispense(WithAny<string>(), WithAny<int>()) exactly twice, but it {count switch { 0 => "never did", 1 => "did once", _ => $"did {count} times", }}.");
+				$"Expected that mock invoked method Dispense(Any<string>(), Any<int>()) exactly twice, but it {count switch { 0 => "never did", 1 => "did once", _ => $"did {count} times", }}.");
 	}
 
 	private class MyChocolateDispenser : IChocolateDispenser

--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
@@ -22,9 +22,9 @@ public class VerificationResultTests
 		IChocolateDispenser sut = Mock.Create<IChocolateDispenser>();
 
 		VerificationResult<IChocolateDispenser> result
-			= sut.VerifyMock.GotIndexer(WithAny<string>());
+			= sut.VerifyMock.GotIndexer(Any<string>());
 
-		await That(((IVerificationResult)result).Expectation).IsEqualTo("got indexer WithAny<string>()");
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("got indexer Any<string>()");
 	}
 
 	[Fact]
@@ -33,10 +33,10 @@ public class VerificationResultTests
 		IChocolateDispenser sut = Mock.Create<IChocolateDispenser>();
 
 		VerificationResult<IChocolateDispenser> result
-			= sut.VerifyMock.Invoked.Dispense(WithAny<string>(), WithAny<int>());
+			= sut.VerifyMock.Invoked.Dispense(Any<string>(), Any<int>());
 
 		await That(((IVerificationResult)result).Expectation)
-			.IsEqualTo("invoked method Dispense(WithAny<string>(), WithAny<int>())");
+			.IsEqualTo("invoked method Dispense(Any<string>(), Any<int>())");
 	}
 
 	[Fact]
@@ -57,10 +57,10 @@ public class VerificationResultTests
 		IChocolateDispenser sut = Mock.Create<IChocolateDispenser>();
 
 		VerificationResult<IChocolateDispenser> result
-			= sut.VerifyMock.SetIndexer(WithAny<string>(), With(5));
+			= sut.VerifyMock.SetIndexer(Any<string>(), With(5));
 
 		await That(((IVerificationResult)result).Expectation)
-			.IsEqualTo("set indexer WithAny<string>() to value 5");
+			.IsEqualTo("set indexer Any<string>() to value 5");
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR renames the `WithAny` method to `Any` and the `WithAnyParameters` method to `AnyParameters` as part of a breaking API change. This refactoring improves the API's clarity and conciseness by removing the redundant "With" prefix from these matcher methods.

### Key changes:
- Renamed `Match.WithAny<T>()` to `Match.Any<T>()`
- Renamed `Match.WithAnyParameters()` to `Match.AnyParameters()`
- Updated all test files, documentation, and examples to use the new method names