### PR TITLE
feat!: simplify `BaseClassBehavior`

### DIFF
--- a/Docs/pages/01-create-mocks.md
+++ b/Docs/pages/01-create-mocks.md
@@ -45,9 +45,8 @@ var classMock = Mock.Create<MyChocolateDispenser>(
 	- If `false`, the mock will return a default value (see `DefaultValue`).
 - `BaseClassBehavior` (enum):
 	- Controls how the mock interacts with base class members. Options:
-		- `DoNotCallBaseClass`: Do not call base class implementation (default).
-		- `OnlyCallBaseClass`: Only call base class implementation.
-		- `UseBaseClassAsDefaultValue`: Use base class as a fallback for default values.
+		- `IgnoreBaseClass`: Do not call base class implementation (default).
+		- `CallBaseClass`: Call base class implementation.
 - `DefaultValue` (IDefaultValueGenerator):
 	- Customizes how default values are generated for methods/properties that are not set up.
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,8 @@ var classMock = Mock.Create<MyChocolateDispenser>(
 	- If `false`, the mock will return a default value (see `DefaultValue`).
 - `BaseClassBehavior` (enum):
 	- Controls how the mock interacts with base class members. Options:
-		- `DoNotCallBaseClass`: Do not call base class implementation (default).
-		- `OnlyCallBaseClass`: Only call base class implementation.
-		- `UseBaseClassAsDefaultValue`: Use base class as a fallback for default values.
+		- `IgnoreBaseClass`: Do not call base class implementation (default).
+		- `CallBaseClass`: Call base class implementation.
 - `DefaultValue` (IDefaultValueGenerator):
 	- Customizes how default values are generated for methods/properties that are not set up.
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -387,7 +387,7 @@ internal static partial class Sources
 			if (!isClassInterface && !property.IsAbstract)
 			{
 				sb.Append(
-						"\t\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)")
+						"\t\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)")
 					.AppendLine();
 				sb.Append("\t\t\t{").AppendLine();
 				if (property is { IsIndexer: true, IndexerParameters: not null, })
@@ -396,10 +396,7 @@ internal static partial class Sources
 						.Append(string.Join(", ", property.IndexerParameters.Value.Select(p => p.Name)))
 						.AppendLine("];");
 					sb.Append(
-							"\t\t\t\tif (MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)")
-						.AppendLine();
-					sb.Append("\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\treturn MockRegistrations.GetIndexer<").Append(property.Type.Fullname)
+							"\t\t\t\treturn MockRegistrations.GetIndexer<").Append(property.Type.Fullname)
 						.Append(">(() => baseResult, ")
 						.Append(string.Join(", ", property.IndexerParameters.Value.Select(p => (p.IsSpan, p.IsReadOnlySpan) switch
 						{
@@ -408,18 +405,13 @@ internal static partial class Sources
 							(_, _) => p.Name,
 						})))
 						.AppendLine(");");
-					sb.Append("\t\t\t\t}").AppendLine();
 				}
 				else
 				{
 					sb.Append("\t\t\t\tvar baseResult = base.").Append(property.Name).Append(";").AppendLine();
 					sb.Append(
-							"\t\t\t\tif (MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)")
-						.AppendLine();
-					sb.Append("\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\treturn MockRegistrations.GetProperty<").Append(property.Type.Fullname).Append(">(")
+							"\t\t\t\treturn MockRegistrations.GetProperty<").Append(property.Type.Fullname).Append(">(")
 						.Append(property.GetUniqueNameString()).AppendLine(", () => baseResult);");
-					sb.Append("\t\t\t\t}").AppendLine();
 				}
 
 				sb.Append("\t\t\t}").AppendLine().AppendLine();
@@ -460,7 +452,7 @@ internal static partial class Sources
 			if (!isClassInterface && !property.IsAbstract)
 			{
 				sb.Append(
-						"\t\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)")
+						"\t\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)")
 					.AppendLine();
 				sb.Append("\t\t\t{").AppendLine();
 				if (property is { IsIndexer: true, IndexerParameters: not null, })
@@ -633,7 +625,7 @@ internal static partial class Sources
 		else if (method.ReturnType != Type.Void)
 		{
 			sb.Append(
-					"\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)")
+					"\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)")
 				.AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tvar baseResult = base.").Append(method.Name).Append('(')
@@ -644,7 +636,7 @@ internal static partial class Sources
 				if (parameter.RefKind == RefKind.Out)
 				{
 					sb.Append(
-							"\t\t\tif (methodExecution is not null && (methodExecution.HasSetup == true || MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.UseBaseClassAsDefaultValue))")
+							"\t\t\tif (methodExecution is not null && methodExecution.HasSetup == true)")
 						.AppendLine();
 					sb.Append("\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t").Append(parameter.Name).Append(" = methodExecution.SetOutParameter<")
@@ -654,7 +646,7 @@ internal static partial class Sources
 				else if (parameter.RefKind == RefKind.Ref)
 				{
 					sb.Append(
-							"\t\t\tif (methodExecution is not null && (methodExecution.HasSetup == true || MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.UseBaseClassAsDefaultValue))")
+							"\t\t\tif (methodExecution is not null && methodExecution.HasSetup == true)")
 						.AppendLine();
 					sb.Append("\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t").Append(parameter.Name).Append(" = methodExecution.SetRefParameter<")
@@ -665,7 +657,7 @@ internal static partial class Sources
 			}
 
 			sb.Append(
-					"\t\t\tif (methodExecution?.HasSetup != true && MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)")
+					"\t\t\tif (methodExecution?.HasSetup != true)")
 				.AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\treturn baseResult;").AppendLine();
@@ -722,7 +714,7 @@ internal static partial class Sources
 		else
 		{
 			sb.Append(
-					"\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)")
+					"\t\tif (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)")
 				.AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tbase.").Append(method.Name).Append('(')

--- a/Source/Mockolate/BaseClassBehavior.cs
+++ b/Source/Mockolate/BaseClassBehavior.cs
@@ -8,15 +8,10 @@ public enum BaseClassBehavior
 	/// <summary>
 	///     (Default) Does not call the base class implementation.
 	/// </summary>
-	DoNotCallBaseClass,
-
-	/// <summary>
-	///     Calls the base class implementation, but ignores its values.
-	/// </summary>
-	OnlyCallBaseClass,
+	IgnoreBaseClass,
 
 	/// <summary>
 	///     Calls the base class implementation, and uses its return values as default values.
 	/// </summary>
-	UseBaseClassAsDefaultValue,
+	CallBaseClass,
 }

--- a/Source/Mockolate/MockBehaviorExtensions.cs
+++ b/Source/Mockolate/MockBehaviorExtensions.cs
@@ -1,0 +1,31 @@
+namespace Mockolate;
+
+/// <summary>
+///     Extension methods for <see cref="MockBehavior" />.
+/// </summary>
+public static class MockBehaviorExtensions
+{
+	/// <summary>
+	///     Calls the base class implementation, and uses its return values as default values.
+	/// </summary>
+	/// <remarks>
+	///     Sets the <see cref="MockBehavior.BaseClassBehavior" /> to <see cref="BaseClassBehavior.CallBaseClass" />.
+	/// </remarks>
+	public static MockBehavior CallingBaseClass(this MockBehavior mockBehavior)
+		=> mockBehavior with
+		{
+			BaseClassBehavior = BaseClassBehavior.CallBaseClass,
+		};
+
+	/// <summary>
+	///     Does not call the base class implementation.
+	/// </summary>
+	/// <remarks>
+	///     Sets the <see cref="MockBehavior.BaseClassBehavior" /> to <see cref="BaseClassBehavior.IgnoreBaseClass" />.
+	/// </remarks>
+	public static MockBehavior IgnoringBaseClass(this MockBehavior mockBehavior)
+		=> mockBehavior with
+		{
+			BaseClassBehavior = BaseClassBehavior.IgnoreBaseClass,
+		};
+}

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -15,9 +15,8 @@ namespace Mockolate
     }
     public enum BaseClassBehavior
     {
-        DoNotCallBaseClass = 0,
-        OnlyCallBaseClass = 1,
-        UseBaseClassAsDefaultValue = 2,
+        IgnoreBaseClass = 0,
+        CallBaseClass = 1,
     }
     public interface IHasMockRegistration
     {
@@ -86,6 +85,11 @@ namespace Mockolate
         public Mockolate.DefaultValues.IDefaultValueGenerator DefaultValue { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public static Mockolate.MockBehavior Default { get; }
+    }
+    public static class MockBehaviorExtensions
+    {
+        public static Mockolate.MockBehavior CallingBaseClass(this Mockolate.MockBehavior mockBehavior) { }
+        public static Mockolate.MockBehavior IgnoringBaseClass(this Mockolate.MockBehavior mockBehavior) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MockRegistration

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -14,9 +14,8 @@ namespace Mockolate
     }
     public enum BaseClassBehavior
     {
-        DoNotCallBaseClass = 0,
-        OnlyCallBaseClass = 1,
-        UseBaseClassAsDefaultValue = 2,
+        IgnoreBaseClass = 0,
+        CallBaseClass = 1,
     }
     public interface IHasMockRegistration
     {
@@ -85,6 +84,11 @@ namespace Mockolate
         public Mockolate.DefaultValues.IDefaultValueGenerator DefaultValue { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public static Mockolate.MockBehavior Default { get; }
+    }
+    public static class MockBehaviorExtensions
+    {
+        public static Mockolate.MockBehavior CallingBaseClass(this Mockolate.MockBehavior mockBehavior) { }
+        public static Mockolate.MockBehavior IgnoringBaseClass(this Mockolate.MockBehavior mockBehavior) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MockRegistration

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -13,9 +13,8 @@ namespace Mockolate
     }
     public enum BaseClassBehavior
     {
-        DoNotCallBaseClass = 0,
-        OnlyCallBaseClass = 1,
-        UseBaseClassAsDefaultValue = 2,
+        IgnoreBaseClass = 0,
+        CallBaseClass = 1,
     }
     public interface IHasMockRegistration
     {
@@ -76,6 +75,11 @@ namespace Mockolate
         public Mockolate.DefaultValues.IDefaultValueGenerator DefaultValue { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public static Mockolate.MockBehavior Default { get; }
+    }
+    public static class MockBehaviorExtensions
+    {
+        public static Mockolate.MockBehavior CallingBaseClass(this Mockolate.MockBehavior mockBehavior) { }
+        public static Mockolate.MockBehavior IgnoringBaseClass(this Mockolate.MockBehavior mockBehavior) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MockRegistration

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
@@ -308,20 +308,17 @@ public sealed partial class ForMockTests
 				          	{
 				          		get
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				var baseResult = base[index];
-				          				if (MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)
-				          				{
-				          					return MockRegistrations.GetIndexer<int>(() => baseResult, index);
-				          				}
+				          				return MockRegistrations.GetIndexer<int>(() => baseResult, index);
 				          			}
 
 				          			return MockRegistrations.GetIndexer<int>(null, index);
 				          		}
 				          		set
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				base[index] = value;
 				          			}
@@ -336,13 +333,10 @@ public sealed partial class ForMockTests
 				          	{
 				          		get
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				var baseResult = base[index, isReadOnly];
-				          				if (MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)
-				          				{
-				          					return MockRegistrations.GetIndexer<int>(() => baseResult, index, isReadOnly);
-				          				}
+				          				return MockRegistrations.GetIndexer<int>(() => baseResult, index, isReadOnly);
 				          			}
 
 				          			return MockRegistrations.GetIndexer<int>(null, index, isReadOnly);
@@ -355,7 +349,7 @@ public sealed partial class ForMockTests
 				          	{
 				          		set
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				base[index, isWriteOnly] = value;
 				          			}
@@ -694,7 +688,7 @@ public sealed partial class ForMockTests
 				          	public override void MyMethod1(int index)
 				          	{
 				          		MethodSetupResult? methodExecution = MockRegistrations.InvokeMethod("MyCode.MyService.MyMethod1", index);
-				          		if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          		if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          		{
 				          			base.MyMethod1(index);
 				          		}
@@ -705,10 +699,10 @@ public sealed partial class ForMockTests
 				          	protected override bool MyMethod2(int index, bool isReadOnly)
 				          	{
 				          		MethodSetupResult<bool>? methodExecution = MockRegistrations.InvokeMethod<bool>("MyCode.MyService.MyMethod2", index, isReadOnly);
-				          		if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          		if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          		{
 				          			var baseResult = base.MyMethod2(index, isReadOnly);
-				          			if (methodExecution?.HasSetup != true && MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)
+				          			if (methodExecution?.HasSetup != true)
 				          			{
 				          				return baseResult;
 				          			}
@@ -1041,20 +1035,17 @@ public sealed partial class ForMockTests
 				          	{
 				          		protected get
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				var baseResult = base.SomeProperty1;
-				          				if (MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)
-				          				{
-				          					return MockRegistrations.GetProperty<int>("MyCode.MyService.SomeProperty1", () => baseResult);
-				          				}
+				          				return MockRegistrations.GetProperty<int>("MyCode.MyService.SomeProperty1", () => baseResult);
 				          			}
 
 				          			return MockRegistrations.GetProperty<int>("MyCode.MyService.SomeProperty1");
 				          		}
 				          		set
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				base.SomeProperty1 = value;
 				          			}
@@ -1069,20 +1060,17 @@ public sealed partial class ForMockTests
 				          	{
 				          		get
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				var baseResult = base.SomeProperty2;
-				          				if (MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)
-				          				{
-				          					return MockRegistrations.GetProperty<int>("MyCode.MyService.SomeProperty2", () => baseResult);
-				          				}
+				          				return MockRegistrations.GetProperty<int>("MyCode.MyService.SomeProperty2", () => baseResult);
 				          			}
 
 				          			return MockRegistrations.GetProperty<int>("MyCode.MyService.SomeProperty2");
 				          		}
 				          		protected set
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				base.SomeProperty2 = value;
 				          			}
@@ -1097,13 +1085,10 @@ public sealed partial class ForMockTests
 				          	{
 				          		get
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				var baseResult = base.SomeReadOnlyProperty;
-				          				if (MockRegistrations.Behavior.BaseClassBehavior == BaseClassBehavior.UseBaseClassAsDefaultValue)
-				          				{
-				          					return MockRegistrations.GetProperty<bool?>("MyCode.MyService.SomeReadOnlyProperty", () => baseResult);
-				          				}
+				          				return MockRegistrations.GetProperty<bool?>("MyCode.MyService.SomeReadOnlyProperty", () => baseResult);
 				          			}
 
 				          			return MockRegistrations.GetProperty<bool?>("MyCode.MyService.SomeReadOnlyProperty");
@@ -1116,7 +1101,7 @@ public sealed partial class ForMockTests
 				          	{
 				          		set
 				          		{
-				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.DoNotCallBaseClass)
+				          			if (MockRegistrations.Behavior.BaseClassBehavior != BaseClassBehavior.IgnoreBaseClass)
 				          			{
 				          				base.SomeWriteOnlyProperty = value;
 				          			}

--- a/Tests/Mockolate.Tests/MockBehaviorExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorExtensionsTests.cs
@@ -1,0 +1,24 @@
+namespace Mockolate.Tests;
+
+public sealed class MockBehaviorExtensionsTests
+{
+	[Fact]
+	public async Task CallingBaseClass_ShouldSetCallBaseClass()
+	{
+		MockBehavior sut = MockBehavior.Default;
+
+		MockBehavior result = sut.CallingBaseClass();
+
+		await That(result.BaseClassBehavior).IsEqualTo(BaseClassBehavior.CallBaseClass);
+	}
+
+	[Fact]
+	public async Task IgnoringBaseClass_ShouldSetIgnoreBaseClass()
+	{
+		MockBehavior sut = MockBehavior.Default.CallingBaseClass();
+
+		MockBehavior result = sut.IgnoringBaseClass();
+
+		await That(result.BaseClassBehavior).IsEqualTo(BaseClassBehavior.IgnoreBaseClass);
+	}
+}

--- a/Tests/Mockolate.Tests/MockBehaviorTests.BaseClassBehaviorTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.BaseClassBehaviorTests.cs
@@ -6,6 +6,136 @@ public sealed partial class MockBehaviorTests
 	{
 		[Fact]
 		public async Task
+			WithCallBaseClass_ForRefAndOutParameter_WhenMethodNotSetup_ShouldUseBaseClassValues()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+			int value1 = 5;
+
+			int sum = mock.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
+
+			await That(value1).IsEqualTo(15);
+			await That(value2).IsEqualTo(30);
+			await That(sum).IsEqualTo(45);
+			await That(mock.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task WithCallBaseClass_ForRefAndOutParameter_WhenMethodSetup_ShouldUseSetupValues()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+			int value1 = 5;
+			mock.SetupMock.Method.VirtualMethodWithRefAndOutParameters(Ref<int>(x => x + 1), Out(() => 8))
+				.Returns(10);
+
+			int sum = mock.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
+
+			await That(value1).IsEqualTo(16);
+			await That(value2).IsEqualTo(8);
+			await That(sum).IsEqualTo(10);
+			await That(mock.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task
+			WithCallBaseClass_WhenIndexerNotSetup_ShouldInitializeIndexerValuesFromBaseClass()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+
+			int result = mock[4];
+			mock[4] = 42;
+			int result2 = mock[4];
+			int result3 = mock[3];
+
+			await That(result).IsEqualTo(8);
+			await That(result2).IsEqualTo(42);
+			await That(result3).IsEqualTo(6);
+			await That(mock.VirtualIndexerGetterCallCount).IsEqualTo(3);
+			await That(mock.VirtualIndexerSetterCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task WithCallBaseClass_WhenIndexerSetup_ShouldUseSetupValues()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+			mock.SetupMock.Indexer(Any<int>()).Returns(15);
+
+			int result = mock[1];
+			mock[1] = 42;
+			int result2 = mock[1];
+
+			await That(result).IsEqualTo(15);
+			await That(result2).IsEqualTo(15);
+			await That(mock.VirtualIndexerGetterCallCount).IsEqualTo(2);
+			await That(mock.VirtualIndexerSetterCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task WithCallBaseClass_WhenMethodNotSetup_ShouldReturnBaseValues()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+
+			int[] value = mock.VirtualMethod();
+
+			await That(value).IsEqualTo([4, 5,]);
+			await That(mock.VirtualMethodCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task WithCallBaseClass_WhenMethodSetup_ShouldReturnSetupValues()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+			mock.SetupMock.Method.VirtualMethod().Returns([10, 20,]);
+
+			int[] value = mock.VirtualMethod();
+
+			await That(value).IsEqualTo([10, 20,]);
+			await That(mock.VirtualMethodCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task
+			WithCallBaseClass_WhenPropertyNotSetup_ShouldInitializePropertyWithValueFromBaseClass()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+
+			int result = mock.VirtualProperty;
+			mock.VirtualProperty = 42;
+			int result2 = mock.VirtualProperty;
+
+			await That(result).IsEqualTo(8);
+			await That(mock.VirtualPropertyValue).IsEqualTo(42);
+			await That(result2).IsEqualTo(42);
+			await That(mock.VirtualPropertyGetterCallCount).IsEqualTo(2);
+			await That(mock.VirtualPropertySetterCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task WithCallBaseClass_WhenPropertySetup_ShouldUseSetupValues()
+		{
+			MyBaseClassWithVirtualCalls mock =
+				Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default.CallingBaseClass());
+			mock.SetupMock.Property.VirtualProperty.Returns(15);
+
+			int result = mock.VirtualProperty;
+			mock.VirtualProperty = 42;
+			int result2 = mock.VirtualProperty;
+
+			await That(result).IsEqualTo(15);
+			await That(mock.VirtualPropertyValue).IsEqualTo(42);
+			await That(result2).IsEqualTo(15);
+			await That(mock.VirtualPropertyGetterCallCount).IsEqualTo(2);
+			await That(mock.VirtualPropertySetterCallCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task
 			WithDefaultBehavior_ForRefAndOutParameter_WhenMethodNotSetup_ShouldSetToPreviousOrDefaultValues()
 		{
 			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default);
@@ -57,270 +187,6 @@ public sealed partial class MockBehaviorTests
 			await That(result2).IsEqualTo(42);
 			await That(mock.VirtualPropertyGetterCallCount).IsEqualTo(0);
 			await That(mock.VirtualPropertySetterCallCount).IsEqualTo(0);
-		}
-
-		[Fact]
-		public async Task WithOnlyCallBaseClass_ForRefAndOutParameter_WhenMethodNotSetup_ShouldUseBaseClassValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass,
-			});
-			int value1 = 5;
-
-			int sum = mock.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
-
-			await That(value1).IsEqualTo(15);
-			await That(value2).IsEqualTo(0);
-			await That(sum).IsEqualTo(0);
-			await That(mock.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithOnlyCallBaseClass_ForRefAndOutParameter_WhenMethodSetup_ShouldUseSetupValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass,
-			});
-			int value1 = 5;
-			mock.SetupMock.Method.VirtualMethodWithRefAndOutParameters(Ref<int>(x => x + 1), Out(() => 8))
-				.Returns(10);
-
-			int sum = mock.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
-
-			await That(value1).IsEqualTo(16);
-			await That(value2).IsEqualTo(8);
-			await That(sum).IsEqualTo(10);
-			await That(mock.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithOnlyCallBaseClass_ShouldCallIndexersOfBaseClass()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass,
-			});
-
-			int result = mock[1];
-			mock[1] = 42;
-			int result2 = mock[1];
-
-			await That(result).IsEqualTo(0);
-			await That(result2).IsEqualTo(42);
-			await That(mock.VirtualIndexerGetterCallCount).IsEqualTo(2);
-			await That(mock.VirtualIndexerSetterCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithOnlyCallBaseClass_ShouldCallMethodsOfBaseClass()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass,
-			});
-
-			mock.VirtualVoidMethod(2);
-			mock.VirtualVoidMethod(4);
-			int result = mock.Sum;
-
-			await That(result).IsEqualTo(6);
-			await That(mock.VirtualMethodCallCount).IsEqualTo(0);
-		}
-
-		[Fact]
-		public async Task WithOnlyCallBaseClass_ShouldCallPropertiesOfBaseClass()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass,
-			});
-
-			int result = mock.VirtualProperty;
-			mock.VirtualProperty = 42;
-			int result2 = mock.VirtualProperty;
-
-			await That(result).IsEqualTo(0);
-			await That(mock.VirtualPropertyValue).IsEqualTo(42);
-			await That(result2).IsEqualTo(42);
-			await That(mock.VirtualPropertyGetterCallCount).IsEqualTo(2);
-			await That(mock.VirtualPropertySetterCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithOnlyCallBaseClass_WhenMethodNotSetup_ShouldReturnDefaultValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass,
-			});
-
-			int[] value = mock.VirtualMethod();
-
-			await That(value).IsEmpty();
-			await That(mock.VirtualMethodCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithOnlyCallBaseClass_WhenMethodSetup_ShouldReturnSetupValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.OnlyCallBaseClass,
-			});
-			mock.SetupMock.Method.VirtualMethod().Returns([10, 20,]);
-
-			int[] value = mock.VirtualMethod();
-
-			await That(value).IsEqualTo([10, 20,]);
-			await That(mock.VirtualMethodCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task
-			WithUseBaseClassAsDefaultValue_ForRefAndOutParameter_WhenMethodNotSetup_ShouldUseBaseClassValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-			int value1 = 5;
-
-			int sum = mock.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
-
-			await That(value1).IsEqualTo(15);
-			await That(value2).IsEqualTo(30);
-			await That(sum).IsEqualTo(45);
-			await That(mock.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithUseBaseClassAsDefaultValue_ForRefAndOutParameter_WhenMethodSetup_ShouldUseSetupValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-			int value1 = 5;
-			mock.SetupMock.Method.VirtualMethodWithRefAndOutParameters(Ref<int>(x => x + 1), Out(() => 8))
-				.Returns(10);
-
-			int sum = mock.VirtualMethodWithRefAndOutParameters(ref value1, out int value2);
-
-			await That(value1).IsEqualTo(16);
-			await That(value2).IsEqualTo(8);
-			await That(sum).IsEqualTo(10);
-			await That(mock.VirtualMethodWithRefAndOutParametersCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task
-			WithUseBaseClassAsDefaultValue_WhenIndexerNotSetup_ShouldInitializeIndexerValuesFromBaseClass()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-
-			int result = mock[4];
-			mock[4] = 42;
-			int result2 = mock[4];
-			int result3 = mock[3];
-
-			await That(result).IsEqualTo(8);
-			await That(result2).IsEqualTo(42);
-			await That(result3).IsEqualTo(6);
-			await That(mock.VirtualIndexerGetterCallCount).IsEqualTo(3);
-			await That(mock.VirtualIndexerSetterCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithUseBaseClassAsDefaultValue_WhenIndexerSetup_ShouldUseSetupValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-			mock.SetupMock.Indexer(Any<int>()).Returns(15);
-
-			int result = mock[1];
-			mock[1] = 42;
-			int result2 = mock[1];
-
-			await That(result).IsEqualTo(15);
-			await That(result2).IsEqualTo(15);
-			await That(mock.VirtualIndexerGetterCallCount).IsEqualTo(2);
-			await That(mock.VirtualIndexerSetterCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithUseBaseClassAsDefaultValue_WhenMethodNotSetup_ShouldReturnBaseValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-
-			int[] value = mock.VirtualMethod();
-
-			await That(value).IsEqualTo([4, 5,]);
-			await That(mock.VirtualMethodCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithUseBaseClassAsDefaultValue_WhenMethodSetup_ShouldReturnSetupValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-			mock.SetupMock.Method.VirtualMethod().Returns([10, 20,]);
-
-			int[] value = mock.VirtualMethod();
-
-			await That(value).IsEqualTo([10, 20,]);
-			await That(mock.VirtualMethodCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task
-			WithUseBaseClassAsDefaultValue_WhenPropertyNotSetup_ShouldInitializePropertyWithValueFromBaseClass()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-
-			int result = mock.VirtualProperty;
-			mock.VirtualProperty = 42;
-			int result2 = mock.VirtualProperty;
-
-			await That(result).IsEqualTo(8);
-			await That(mock.VirtualPropertyValue).IsEqualTo(42);
-			await That(result2).IsEqualTo(42);
-			await That(mock.VirtualPropertyGetterCallCount).IsEqualTo(2);
-			await That(mock.VirtualPropertySetterCallCount).IsEqualTo(1);
-		}
-
-		[Fact]
-		public async Task WithUseBaseClassAsDefaultValue_WhenPropertySetup_ShouldUseSetupValues()
-		{
-			MyBaseClassWithVirtualCalls mock = Mock.Create<MyBaseClassWithVirtualCalls>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
-			mock.SetupMock.Property.VirtualProperty.Returns(15);
-
-			int result = mock.VirtualProperty;
-			mock.VirtualProperty = 42;
-			int result2 = mock.VirtualProperty;
-
-			await That(result).IsEqualTo(15);
-			await That(mock.VirtualPropertyValue).IsEqualTo(42);
-			await That(result2).IsEqualTo(15);
-			await That(mock.VirtualPropertyGetterCallCount).IsEqualTo(2);
-			await That(mock.VirtualPropertySetterCallCount).IsEqualTo(1);
 		}
 
 		public class MyBaseClassWithVirtualCalls

--- a/Tests/Mockolate.Tests/MockBehaviorTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.cs
@@ -11,7 +11,7 @@ public sealed partial class MockBehaviorTests
 		IMyService mock = Mock.Create<IMyService>();
 		MockBehavior sut = ((IHasMockRegistration)mock).Registrations.Behavior;
 
-		await That(sut.BaseClassBehavior).IsEqualTo(BaseClassBehavior.DoNotCallBaseClass);
+		await That(sut.BaseClassBehavior).IsEqualTo(BaseClassBehavior.IgnoreBaseClass);
 		await That(sut.ThrowWhenNotSetup).IsFalse();
 		await That(sut.DefaultValue).Is<DefaultValueGenerator>();
 	}
@@ -21,12 +21,12 @@ public sealed partial class MockBehaviorTests
 	{
 		MockBehavior sut = MockBehavior.Default with
 		{
-			BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
+			BaseClassBehavior = BaseClassBehavior.CallBaseClass,
 			ThrowWhenNotSetup = true,
 			DefaultValue = new MyDefaultValueGenerator(),
 		};
 
-		await That(sut.BaseClassBehavior).IsEqualTo(BaseClassBehavior.UseBaseClassAsDefaultValue);
+		await That(sut.BaseClassBehavior).IsEqualTo(BaseClassBehavior.CallBaseClass);
 		await That(sut.ThrowWhenNotSetup).IsTrue();
 		await That(sut.DefaultValue.Generate<string>()).IsEqualTo("foo");
 		await That(sut.DefaultValue.Generate<int>()).IsEqualTo(0);

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.SpanTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.SpanTests.cs
@@ -9,10 +9,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task Memory_WhenPredicateDoesNotMatch_ShouldUseDefaultValue()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(With<Memory<int>>(v => v.Length == 2)).Returns(4);
 
 			int result = mock[new Memory<int>([1, 2, 3,])];
@@ -23,10 +20,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task Memory_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(With<Memory<int>>(v => v.Length == 3)).Returns(42);
 
 			int result = mock[new Memory<int>([1, 2, 3,])];
@@ -37,10 +31,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task Memory_WithoutPredicate_ShouldMatchAnySpan()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(Any<Memory<int>>()).Returns(42);
 
 			int result = mock[new Memory<int>([1, 2, 3,])];
@@ -51,10 +42,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task ReadOnlySpan_WhenPredicateDoesNotMatch_ShouldUseDefaultValue()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(WithReadOnlySpan<int>(v => v.Length == 2)).Returns(4);
 
 			int result = mock[new ReadOnlySpan<int>([1, 2, 3,])];
@@ -65,10 +53,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task ReadOnlySpan_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(WithReadOnlySpan<int>(v => v.Length == 3 && v[0] == 1)).Returns(42);
 
 			int result = mock[new ReadOnlySpan<int>([1, 2, 3,])];
@@ -79,10 +64,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task ReadOnlySpan_WithoutPredicate_ShouldMatchAnySpan()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(AnyReadOnlySpan<int>()).Returns(42);
 
 			int result = mock[new ReadOnlySpan<int>([1, 2, 3,])];
@@ -93,10 +75,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task Span_WhenPredicateDoesNotMatch_ShouldUseDefaultValue()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(WithSpan<int>(v => v.Length == 2)).Returns(4);
 
 			int result = mock[new Span<int>([1, 2, 3,])];
@@ -107,10 +86,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task Span_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(WithSpan<int>(v => v.Length == 3 && v[0] == 1)).Returns(42);
 
 			int result = mock[new Span<int>([1, 2, 3,])];
@@ -121,10 +97,7 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task Span_WithoutPredicate_ShouldMatchAnySpan()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Indexer(AnySpan<int>()).Returns(42);
 
 			int result = mock[new Span<int>([1, 2, 3,])];

--- a/Tests/Mockolate.Tests/MockIndexers/VerifyGotIndexerTests.SpanTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/VerifyGotIndexerTests.SpanTests.cs
@@ -9,10 +9,7 @@ public sealed partial class VerifyGotIndexerTests
 		[Fact]
 		public async Task Memory_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			_ = mock[new Memory<int>([1, 2, 3,])];
 
@@ -24,10 +21,7 @@ public sealed partial class VerifyGotIndexerTests
 		[Fact]
 		public async Task Memory_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			_ = mock[new Memory<int>()];
 			_ = mock[new Span<int>([1, 2, 3,])];
@@ -39,10 +33,7 @@ public sealed partial class VerifyGotIndexerTests
 		[Fact]
 		public async Task ReadOnlySpan_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			_ = mock[new ReadOnlySpan<int>([1, 2, 3,])];
 
@@ -54,10 +45,7 @@ public sealed partial class VerifyGotIndexerTests
 		[Fact]
 		public async Task ReadOnlySpan_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			_ = mock[new ReadOnlySpan<int>()];
 			_ = mock[new Span<int>([1, 2, 3,])];
@@ -69,10 +57,7 @@ public sealed partial class VerifyGotIndexerTests
 		[Fact]
 		public async Task Span_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			_ = mock[new Span<int>([1, 2, 3,])];
 
@@ -84,10 +69,7 @@ public sealed partial class VerifyGotIndexerTests
 		[Fact]
 		public async Task Span_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			_ = mock[new Span<int>()];
 			_ = mock[new ReadOnlySpan<int>([1, 2, 3,])];

--- a/Tests/Mockolate.Tests/MockIndexers/VerifySetIndexerTests.SpanTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/VerifySetIndexerTests.SpanTests.cs
@@ -9,10 +9,7 @@ public sealed partial class VerifySetIndexerTests
 		[Fact]
 		public async Task Memory_WhenPredicateMatches_ShouldApplySetup()
 		{
-			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock[new Memory<int>([1, 2, 3,])] = 3;
 
@@ -24,10 +21,7 @@ public sealed partial class VerifySetIndexerTests
 		[Fact]
 		public async Task Memory_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock[new Memory<int>()] = 3;
 			mock[new Span<int>([1, 2, 3,])] = 3;
@@ -39,10 +33,7 @@ public sealed partial class VerifySetIndexerTests
 		[Fact]
 		public async Task ReadOnlySpan_WhenPredicateMatches_ShouldApplySetup()
 		{
-			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock[new ReadOnlySpan<int>([1, 2, 3,])] = 3;
 
@@ -54,10 +45,7 @@ public sealed partial class VerifySetIndexerTests
 		[Fact]
 		public async Task ReadOnlySpan_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock[new ReadOnlySpan<int>()] = 3;
 			mock[new Span<int>([1, 2, 3,])] = 3;
@@ -69,10 +57,7 @@ public sealed partial class VerifySetIndexerTests
 		[Fact]
 		public async Task Span_WhenPredicateMatches_ShouldApplySetup()
 		{
-			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock[new Span<int>([1, 2, 3,])] = 3;
 
@@ -84,10 +69,7 @@ public sealed partial class VerifySetIndexerTests
 		[Fact]
 		public async Task Span_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			ISpanMock mock = Mock.Create<ISpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock[new Span<int>()] = 3;
 			mock[new ReadOnlySpan<int>([1, 2, 3,])] = 3;

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.SpanTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.SpanTests.cs
@@ -9,10 +9,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task Memory_WhenPredicateDoesNotMatch_ShouldUseDefaultValue()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(With<Memory<int>>(v => v.Length == 2)).Returns(4);
 
 			int result = mock.MyMethod(new Memory<int>([1, 2, 3,]));
@@ -23,10 +20,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task Memory_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(With<Memory<int>>(v => v.Length == 3)).Returns(42);
 
 			int result = mock.MyMethod(new Memory<int>([1, 2, 3,]));
@@ -37,10 +31,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task Memory_WithoutPredicate_ShouldMatchAnySpan()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(Any<Memory<int>>()).Returns(42);
 
 			int result = mock.MyMethod(new Memory<int>([1, 2, 3,]));
@@ -51,10 +42,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ReadOnlySpan_WhenPredicateDoesNotMatch_ShouldUseDefaultValue()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(WithReadOnlySpan<int>(v => v.Length == 2)).Returns(4);
 
 			int result = mock.MyMethod(new ReadOnlySpan<int>([1, 2, 3,]));
@@ -65,10 +53,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ReadOnlySpan_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(WithReadOnlySpan<int>(v => v.Length == 3 && v[0] == 1)).Returns(42);
 
 			int result = mock.MyMethod(new ReadOnlySpan<int>([1, 2, 3,]));
@@ -79,10 +64,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ReadOnlySpan_WithoutPredicate_ShouldMatchAnySpan()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(AnyReadOnlySpan<int>()).Returns(42);
 
 			int result = mock.MyMethod(new ReadOnlySpan<int>([1, 2, 3,]));
@@ -93,10 +75,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task Span_WhenPredicateDoesNotMatch_ShouldUseDefaultValue()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(WithSpan<int>(v => v.Length == 2)).Returns(4);
 
 			int result = mock.MyMethod(new Span<int>([1, 2, 3,]));
@@ -107,10 +86,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task Span_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(WithSpan<int>(v => v.Length == 3 && v[0] == 1)).Returns(42);
 
 			int result = mock.MyMethod(new Span<int>([1, 2, 3,]));
@@ -121,10 +97,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task Span_WithoutPredicate_ShouldMatchAnySpan()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 			mock.SetupMock.Method.MyMethod(AnySpan<int>()).Returns(42);
 
 			int result = mock.MyMethod(new Span<int>([1, 2, 3,]));

--- a/Tests/Mockolate.Tests/MockMethods/VerifyInvokedTests.SpanTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/VerifyInvokedTests.SpanTests.cs
@@ -9,10 +9,7 @@ public sealed partial class VerifyInvokedTests
 		[Fact]
 		public async Task Memory_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock.MyMethod(new Memory<int>([1, 2, 3,]));
 
@@ -24,10 +21,7 @@ public sealed partial class VerifyInvokedTests
 		[Fact]
 		public async Task Memory_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock.MyMethod(new Memory<int>());
 			mock.MyMethod(new Span<int>([1, 2, 3,]));
@@ -39,10 +33,7 @@ public sealed partial class VerifyInvokedTests
 		[Fact]
 		public async Task ReadOnlySpan_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock.MyMethod(new ReadOnlySpan<int>([1, 2, 3,]));
 
@@ -54,10 +45,7 @@ public sealed partial class VerifyInvokedTests
 		[Fact]
 		public async Task ReadOnlySpan_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock.MyMethod(new ReadOnlySpan<int>());
 			mock.MyMethod(new Span<int>([1, 2, 3,]));
@@ -69,10 +57,7 @@ public sealed partial class VerifyInvokedTests
 		[Fact]
 		public async Task Span_WhenPredicateMatches_ShouldApplySetup()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock.MyMethod(new Span<int>([1, 2, 3,]));
 
@@ -84,10 +69,7 @@ public sealed partial class VerifyInvokedTests
 		[Fact]
 		public async Task Span_WithoutPredicate_ShouldApplyAllCalls()
 		{
-			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			SpanMock mock = Mock.Create<SpanMock>(MockBehavior.Default.CallingBaseClass());
 
 			mock.MyMethod(new Span<int>());
 			mock.MyMethod(new ReadOnlySpan<int>([1, 2, 3,]));

--- a/Tests/Mockolate.Tests/MockTests.FactoryTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.FactoryTests.cs
@@ -207,10 +207,7 @@ public sealed partial class MockTests
 		[Fact]
 		public async Task WithSetups_ShouldApplySetups()
 		{
-			MockBehavior behavior = MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			};
+			MockBehavior behavior = MockBehavior.Default.CallingBaseClass();
 			Mock.Factory factory = new(behavior);
 
 			IMyService mock1 = factory.Create<IMyService>(

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -229,10 +229,7 @@ public sealed partial class MockTests
 	public async Task Create_BaseClassWithVirtualCallsInConstructor_WithUseBaseClassAsDefaultValue_ShouldUseBaseClassValuesInConstructor()
 	{
 		MyServiceBaseWithVirtualCallsInConstructor mock =
-			Mock.Create<MyServiceBaseWithVirtualCallsInConstructor>(MockBehavior.Default with
-			{
-				BaseClassBehavior = BaseClassBehavior.UseBaseClassAsDefaultValue,
-			});
+			Mock.Create<MyServiceBaseWithVirtualCallsInConstructor>(MockBehavior.Default.CallingBaseClass());
 
 		int value = mock.VirtualProperty;
 


### PR DESCRIPTION
This PR simplifies the `BaseClassBehavior` enum by consolidating its three options into two more intuitive ones, and introduces extension methods for cleaner configuration syntax.

### Key changes:
- Renamed enum values from `DoNotCallBaseClass`/`UseBaseClassAsDefaultValue` to `IgnoreBaseClass`/`CallBaseClass`
- Removed the `OnlyCallBaseClass` option, consolidating its behavior into `CallBaseClass`
- Added `MockBehaviorExtensions` with `CallingBaseClass()` and `IgnoringBaseClass()` helper methods for fluent configuration