### PR TITLE
fix: support setups without return values to specify `CallingBaseClass()`

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -650,7 +650,7 @@ internal static partial class Sources
 				if (parameter.RefKind == RefKind.Out)
 				{
 					sb.Append(
-							"\t\t\tif (methodExecution is not null && methodExecution.HasSetup == true)")
+							"\t\t\tif (methodExecution is not null && methodExecution.HasSetupResult == true)")
 						.AppendLine();
 					sb.Append("\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t").Append(parameter.Name).Append(" = methodExecution.SetOutParameter<")
@@ -660,7 +660,7 @@ internal static partial class Sources
 				else if (parameter.RefKind == RefKind.Ref)
 				{
 					sb.Append(
-							"\t\t\tif (methodExecution is not null && methodExecution.HasSetup == true)")
+							"\t\t\tif (methodExecution is not null && methodExecution.HasSetupResult == true)")
 						.AppendLine();
 					sb.Append("\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t").Append(parameter.Name).Append(" = methodExecution.SetRefParameter<")
@@ -671,7 +671,7 @@ internal static partial class Sources
 			}
 
 			sb.Append(
-					"\t\t\tif (methodExecution?.HasSetup != true)")
+					"\t\t\tif (methodExecution?.HasSetupResult != true)")
 				.AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\treturn baseResult;").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -331,9 +331,14 @@ internal static partial class Sources
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <inheritdoc cref=\"PropertySetup.GetCallBaseClass()\" />").AppendLine();
+		sb.Append("\t/// <inheritdoc cref=\"IndexerSetup.GetCallBaseClass()\" />").AppendLine();
 		sb.Append("\tprotected override bool? GetCallBaseClass()").AppendLine();
 		sb.Append("\t\t=> _callBaseClass;").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t/// <inheritdoc cref=\"IndexerSetup.HasReturnCalls()\" />").AppendLine();
+		sb.Append("\tprotected override bool HasReturnCalls()").AppendLine();
+		sb.Append("\t\t=> _returnCallbacks.Count > 0;").AppendLine();
 		sb.AppendLine();
 
 		sb.Append(

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -299,6 +299,11 @@ internal static partial class Sources
 		sb.Append("\t\t=> _callBaseClass;").AppendLine();
 		sb.AppendLine();
 
+		sb.Append("\t/// <inheritdoc cref=\"MethodSetup.HasReturnCalls()\" />").AppendLine();
+		sb.Append("\tprotected override bool HasReturnCalls()").AppendLine();
+		sb.Append("\t\t=> _returnCallbacks.Count > 0;").AppendLine();
+		sb.AppendLine();
+
 		sb.Append("\t/// <inheritdoc cref=\"MethodSetup.SetOutParameter{T}(string, MockBehavior)\" />").AppendLine();
 		sb.Append("\tprotected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)")
 			.AppendLine();
@@ -637,6 +642,11 @@ internal static partial class Sources
 		sb.Append("\t/// <inheritdoc cref=\"MethodSetup.GetCallBaseClass()\" />").AppendLine();
 		sb.Append("\tprotected override bool? GetCallBaseClass()").AppendLine();
 		sb.Append("\t\t=> _callBaseClass;").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t/// <inheritdoc cref=\"MethodSetup.HasReturnCalls()\" />").AppendLine();
+		sb.Append("\tprotected override bool HasReturnCalls()").AppendLine();
+		sb.Append("\t\t=> _returnCallbacks.Count > 0;").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t/// <inheritdoc cref=\"MethodSetup.SetOutParameter{T}(string, MockBehavior)\" />").AppendLine();

--- a/Source/Mockolate/MockRegistration.Setup.cs
+++ b/Source/Mockolate/MockRegistration.Setup.cs
@@ -55,7 +55,7 @@ public partial class MockRegistration
 		}
 		else if (defaultValueGenerator is not null && (matchingSetup.CallBaseClass() ?? Behavior.CallBaseClass))
 		{
-			defaultValueGenerator();
+			matchingSetup.InitializeWith(defaultValueGenerator());
 		}
 
 		return matchingSetup;

--- a/Source/Mockolate/Setup/IIndexerSetup.cs
+++ b/Source/Mockolate/Setup/IIndexerSetup.cs
@@ -15,6 +15,11 @@ public interface IIndexerSetup
 	bool? CallBaseClass();
 
 	/// <summary>
+	///     Gets a value indicating whether this setup has return calls configured.
+	/// </summary>
+	bool HasReturnCalls();
+
+	/// <summary>
 	///     Checks if the <paramref name="indexerAccess" /> matches the setup.
 	/// </summary>
 	bool Matches(IndexerAccess indexerAccess);

--- a/Source/Mockolate/Setup/IMethodSetup.cs
+++ b/Source/Mockolate/Setup/IMethodSetup.cs
@@ -19,6 +19,11 @@ public interface IMethodSetup
 	bool? CallBaseClass();
 
 	/// <summary>
+	///     Gets a value indicating whether this setup has return calls configured.
+	/// </summary>
+	bool HasReturnCalls();
+
+	/// <summary>
 	///     Sets an <see langword="out" /> parameter with the specified name and returns its generated value of type
 	///     <typeparamref name="T" />.
 	/// </summary>

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
@@ -13,6 +12,10 @@ namespace Mockolate.Setup;
 /// </summary>
 public abstract class IndexerSetup : IIndexerSetup
 {
+	/// <inheritdoc cref="IIndexerSetup.HasReturnCalls()" />
+	bool IIndexerSetup.HasReturnCalls()
+		=> HasReturnCalls();
+
 	/// <inheritdoc cref="IIndexerSetup.Matches(IndexerAccess)" />
 	bool IIndexerSetup.Matches(IndexerAccess indexerAccess)
 		=> IsMatch(indexerAccess.Parameters);
@@ -103,6 +106,11 @@ public abstract class IndexerSetup : IIndexerSetup
 	protected abstract bool? GetCallBaseClass();
 
 	/// <summary>
+	///     Gets a value indicating whether this setup has return calls configured.
+	/// </summary>
+	protected abstract bool HasReturnCalls();
+
+	/// <summary>
 	///     Attempts to retrieve the initial <paramref name="value" /> for the <paramref name="parameters" />, if an
 	///     initialization is set up.
 	/// </summary>
@@ -122,9 +130,13 @@ public class IndexerSetup<TValue, T1>(Match.IParameter<T1> match1) : IndexerSetu
 	private int _currentReturnCallbackIndex = -1;
 	private Func<T1, TValue>? _initialization;
 
-	/// <inheritdoc cref="PropertySetup.GetCallBaseClass()" />
+	/// <inheritdoc cref="IndexerSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
@@ -302,7 +314,7 @@ public class IndexerSetup<TValue, T1>(Match.IParameter<T1> match1) : IndexerSetu
 		    TryCast(indexerGetterAccess.Parameters[0], out T1 p1, behavior))
 		{
 			_getterCallbacks.ForEach(callback => callback.Invoke(p1));
-			if (_returnCallbacks.Any())
+			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 				Func<TValue, T1, TValue> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
@@ -363,9 +375,13 @@ public class IndexerSetup<TValue, T1, T2>(Match.IParameter<T1> match1, Match.IPa
 	private int _currentReturnCallbackIndex = -1;
 	private Func<T1, T2, TValue>? _initialization;
 
-	/// <inheritdoc cref="PropertySetup.GetCallBaseClass()" />
+	/// <inheritdoc cref="IndexerSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
@@ -544,7 +560,7 @@ public class IndexerSetup<TValue, T1, T2>(Match.IParameter<T1> match1, Match.IPa
 		    TryCast(indexerGetterAccess.Parameters[1], out T2 p2, behavior))
 		{
 			_getterCallbacks.ForEach(callback => callback.Invoke(p1, p2));
-			if (_returnCallbacks.Any())
+			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 				Func<TValue, T1, T2, TValue> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
@@ -611,9 +627,13 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	private int _currentReturnCallbackIndex = -1;
 	private Func<T1, T2, T3, TValue>? _initialization;
 
-	/// <inheritdoc cref="PropertySetup.GetCallBaseClass()" />
+	/// <inheritdoc cref="IndexerSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
@@ -793,7 +813,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		    TryCast(indexerGetterAccess.Parameters[2], out T3 p3, behavior))
 		{
 			_getterCallbacks.ForEach(callback => callback.Invoke(p1, p2, p3));
-			if (_returnCallbacks.Any())
+			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 				Func<TValue, T1, T2, T3, TValue> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
@@ -864,9 +884,13 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	private int _currentReturnCallbackIndex = -1;
 	private Func<T1, T2, T3, T4, TValue>? _initialization;
 
-	/// <inheritdoc cref="PropertySetup.GetCallBaseClass()" />
+	/// <inheritdoc cref="IndexerSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.

--- a/Source/Mockolate/Setup/IndexerSetupResult.cs
+++ b/Source/Mockolate/Setup/IndexerSetupResult.cs
@@ -11,12 +11,6 @@ namespace Mockolate.Setup;
 public class IndexerSetupResult(IIndexerSetup? setup, MockBehavior behavior)
 {
 	/// <summary>
-	///     Flag indicating if the method setup result has an underlying setup.
-	/// </summary>
-	public bool HasSetup
-		=> setup is not null;
-
-	/// <summary>
 	///     Gets the flag indicating if the base class implementation should be called, and its return values used as default
 	///     values.
 	/// </summary>

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -10,6 +10,10 @@ namespace Mockolate.Setup;
 /// </summary>
 public abstract class MethodSetup : IMethodSetup
 {
+	/// <inheritdoc cref="IMethodSetup.HasReturnCalls()" />
+	bool IMethodSetup.HasReturnCalls()
+		=> HasReturnCalls();
+
 	/// <inheritdoc cref="IMethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	T IMethodSetup.SetOutParameter<T>(string parameterName, MockBehavior behavior)
 		=> SetOutParameter<T>(parameterName, behavior);
@@ -46,6 +50,11 @@ public abstract class MethodSetup : IMethodSetup
 	///     values.
 	/// </summary>
 	protected abstract bool? GetCallBaseClass();
+
+	/// <summary>
+	///     Gets a value indicating whether this setup has return calls configured.
+	/// </summary>
+	protected abstract bool HasReturnCalls();
 
 	/// <summary>
 	///     Sets an <see langword="out" /> parameter with the specified name and returns its generated value of type

--- a/Source/Mockolate/Setup/MethodSetupResult.cs
+++ b/Source/Mockolate/Setup/MethodSetupResult.cs
@@ -8,8 +8,8 @@ public class MethodSetupResult(IMethodSetup? setup, MockBehavior behavior)
 	/// <summary>
 	///     Flag indicating if the method setup result has an underlying setup.
 	/// </summary>
-	public bool HasSetup
-		=> setup is not null;
+	public bool HasSetupResult
+		=> setup is not null && setup.HasReturnCalls();
 
 	/// <summary>
 	///     Gets the flag indicating if the base class implementation should be called, and its return values

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -122,6 +122,10 @@ public class ReturnMethodSetup<TReturn>(string name) : MethodSetup
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
 
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
+
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
 		=> behavior.DefaultValue.Generate<T>();
@@ -300,13 +304,16 @@ public class ReturnMethodSetup<TReturn, T1> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
@@ -515,13 +522,16 @@ public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!, _match2!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!, _match2!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
@@ -743,13 +753,16 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!, _match2!, _match3!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!, _match2!, _match3!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
@@ -982,13 +995,16 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!, _match2!, _match3!, _match4!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!, _match2!, _match3!, _match4!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -81,7 +81,7 @@ public class VoidMethodSetup(string name) : MethodSetup
 		if (_returnCallbacks.Count > 0)
 		{
 			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-			Action? returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
+			Action returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
 			returnCallback();
 		}
 	}
@@ -98,6 +98,10 @@ public class VoidMethodSetup(string name) : MethodSetup
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
@@ -223,7 +227,7 @@ public class VoidMethodSetup<T1> : MethodSetup
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				Action<T1>? returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
+				Action<T1> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
 				returnCallback(p1);
 			}
 		}
@@ -237,13 +241,16 @@ public class VoidMethodSetup<T1> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
@@ -392,7 +399,7 @@ public class VoidMethodSetup<T1, T2> : MethodSetup
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				Action<T1, T2>? returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
+				Action<T1, T2> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
 				returnCallback(p1, p2);
 			}
 		}
@@ -406,13 +413,16 @@ public class VoidMethodSetup<T1, T2> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!, _match2!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!, _match2!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
@@ -568,7 +578,7 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				Action<T1, T2, T3>? returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
+				Action<T1, T2, T3> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
 				returnCallback(p1, p2, p3);
 			}
 		}
@@ -582,13 +592,16 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!, _match2!, _match3!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!, _match2!, _match3!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)
@@ -748,7 +761,7 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup
 			if (_returnCallbacks.Count > 0)
 			{
 				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				Action<T1, T2, T3, T4>? returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
+				Action<T1, T2, T3, T4> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];
 				returnCallback(p1, p2, p3, p4);
 			}
 		}
@@ -762,13 +775,16 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup
 	/// <inheritdoc cref="MethodSetup.IsMatch(MethodInvocation)" />
 	protected override bool IsMatch(MethodInvocation invocation)
 		=> invocation.Name.Equals(_name) &&
-		   (_matches is not null
-			   ? _matches.Matches(invocation.Parameters)
-			   : Matches([_match1!, _match2!, _match3!, _match4!,], invocation.Parameters));
+		   (_matches?.Matches(invocation.Parameters)
+		    ?? Matches([_match1!, _match2!, _match3!, _match4!,], invocation.Parameters));
 
 	/// <inheritdoc cref="MethodSetup.GetCallBaseClass()" />
 	protected override bool? GetCallBaseClass()
 		=> _callBaseClass;
+
+	/// <inheritdoc cref="MethodSetup.HasReturnCalls()" />
+	protected override bool HasReturnCalls()
+		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="MethodSetup.SetOutParameter{T}(string, MockBehavior)" />
 	protected override T SetOutParameter<T>(string parameterName, MockBehavior behavior)

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -316,12 +316,14 @@ namespace Mockolate.Setup
     public interface IIndexerSetup
     {
         bool? CallBaseClass();
+        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
         bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
     }
     public interface IMethodSetup
     {
         bool? CallBaseClass();
+        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.MethodInvocation methodInvocation);
         T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
@@ -354,6 +356,7 @@ namespace Mockolate.Setup
         protected abstract T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract bool? GetCallBaseClass();
+        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(object?[] parameters);
         protected abstract bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value);
         protected static bool Matches(Mockolate.Match.IParameter[] parameters, object?[] values) { }
@@ -363,7 +366,6 @@ namespace Mockolate.Setup
     {
         public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
-        public bool HasSetup { get; }
     }
     public class IndexerSetupResult<TResult> : Mockolate.Setup.IndexerSetupResult
     {
@@ -378,6 +380,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -405,6 +408,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -432,6 +436,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -459,6 +464,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -485,6 +491,7 @@ namespace Mockolate.Setup
         protected abstract void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
         protected abstract bool? GetCallBaseClass();
         protected abstract TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
+        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(Mockolate.Interactions.MethodInvocation invocation);
         protected abstract T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior);
         protected abstract T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
@@ -498,7 +505,7 @@ namespace Mockolate.Setup
     {
         public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
-        public bool HasSetup { get; }
+        public bool HasSetupResult { get; }
         public T SetOutParameter<T>(string parameterName) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
     }
@@ -511,6 +518,7 @@ namespace Mockolate.Setup
     {
         protected PropertySetup() { }
         protected abstract bool? GetCallBaseClass();
+        protected abstract void InitializeValue(object? baseValue);
         protected abstract TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior);
         protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
     }
@@ -519,6 +527,7 @@ namespace Mockolate.Setup
         public PropertySetup() { }
         public Mockolate.Setup.PropertySetup<T> CallingBaseClass(bool callBaseClass = true) { }
         protected override bool? GetCallBaseClass() { }
+        protected override void InitializeValue(object? baseValue) { }
         public Mockolate.Setup.PropertySetup<T> InitializeWith(T value) { }
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior) { }
         protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
@@ -549,6 +558,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn> Returns(TReturn returnValue) { }
@@ -570,6 +580,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1> Returns(System.Func<T1, TReturn> callback) { }
@@ -593,6 +604,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2> Returns(System.Func<T1, T2, TReturn> callback) { }
@@ -616,6 +628,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3> Returns(System.Func<T1, T2, T3, TReturn> callback) { }
@@ -639,6 +652,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TReturn> callback) { }
@@ -666,6 +680,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -686,6 +701,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -707,6 +723,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -728,6 +745,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -749,6 +767,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -315,12 +315,14 @@ namespace Mockolate.Setup
     public interface IIndexerSetup
     {
         bool? CallBaseClass();
+        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
         bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
     }
     public interface IMethodSetup
     {
         bool? CallBaseClass();
+        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.MethodInvocation methodInvocation);
         T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
@@ -353,6 +355,7 @@ namespace Mockolate.Setup
         protected abstract T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract bool? GetCallBaseClass();
+        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(object?[] parameters);
         protected abstract bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value);
         protected static bool Matches(Mockolate.Match.IParameter[] parameters, object?[] values) { }
@@ -362,7 +365,6 @@ namespace Mockolate.Setup
     {
         public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
-        public bool HasSetup { get; }
     }
     public class IndexerSetupResult<TResult> : Mockolate.Setup.IndexerSetupResult
     {
@@ -377,6 +379,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -404,6 +407,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -431,6 +435,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -458,6 +463,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -484,6 +490,7 @@ namespace Mockolate.Setup
         protected abstract void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
         protected abstract bool? GetCallBaseClass();
         protected abstract TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
+        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(Mockolate.Interactions.MethodInvocation invocation);
         protected abstract T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior);
         protected abstract T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
@@ -497,7 +504,7 @@ namespace Mockolate.Setup
     {
         public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
-        public bool HasSetup { get; }
+        public bool HasSetupResult { get; }
         public T SetOutParameter<T>(string parameterName) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
     }
@@ -510,6 +517,7 @@ namespace Mockolate.Setup
     {
         protected PropertySetup() { }
         protected abstract bool? GetCallBaseClass();
+        protected abstract void InitializeValue(object? baseValue);
         protected abstract TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior);
         protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
     }
@@ -518,6 +526,7 @@ namespace Mockolate.Setup
         public PropertySetup() { }
         public Mockolate.Setup.PropertySetup<T> CallingBaseClass(bool callBaseClass = true) { }
         protected override bool? GetCallBaseClass() { }
+        protected override void InitializeValue(object? baseValue) { }
         public Mockolate.Setup.PropertySetup<T> InitializeWith(T value) { }
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior) { }
         protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
@@ -548,6 +557,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn> Returns(TReturn returnValue) { }
@@ -569,6 +579,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1> Returns(System.Func<T1, TReturn> callback) { }
@@ -592,6 +603,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2> Returns(System.Func<T1, T2, TReturn> callback) { }
@@ -615,6 +627,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3> Returns(System.Func<T1, T2, T3, TReturn> callback) { }
@@ -638,6 +651,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TReturn> callback) { }
@@ -665,6 +679,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -685,6 +700,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -706,6 +722,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -727,6 +744,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -748,6 +766,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -292,12 +292,14 @@ namespace Mockolate.Setup
     public interface IIndexerSetup
     {
         bool? CallBaseClass();
+        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
         bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
     }
     public interface IMethodSetup
     {
         bool? CallBaseClass();
+        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.MethodInvocation methodInvocation);
         T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
@@ -330,6 +332,7 @@ namespace Mockolate.Setup
         protected abstract T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract bool? GetCallBaseClass();
+        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(object?[] parameters);
         protected abstract bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value);
         protected static bool Matches(Mockolate.Match.IParameter[] parameters, object?[] values) { }
@@ -339,7 +342,6 @@ namespace Mockolate.Setup
     {
         public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
-        public bool HasSetup { get; }
     }
     public class IndexerSetupResult<TResult> : Mockolate.Setup.IndexerSetupResult
     {
@@ -354,6 +356,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -381,6 +384,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -408,6 +412,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -435,6 +440,7 @@ namespace Mockolate.Setup
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
+        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
@@ -461,6 +467,7 @@ namespace Mockolate.Setup
         protected abstract void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
         protected abstract bool? GetCallBaseClass();
         protected abstract TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
+        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(Mockolate.Interactions.MethodInvocation invocation);
         protected abstract T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior);
         protected abstract T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
@@ -474,7 +481,7 @@ namespace Mockolate.Setup
     {
         public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
-        public bool HasSetup { get; }
+        public bool HasSetupResult { get; }
         public T SetOutParameter<T>(string parameterName) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
     }
@@ -487,6 +494,7 @@ namespace Mockolate.Setup
     {
         protected PropertySetup() { }
         protected abstract bool? GetCallBaseClass();
+        protected abstract void InitializeValue(object? baseValue);
         protected abstract TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior);
         protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
     }
@@ -495,6 +503,7 @@ namespace Mockolate.Setup
         public PropertySetup() { }
         public Mockolate.Setup.PropertySetup<T> CallingBaseClass(bool callBaseClass = true) { }
         protected override bool? GetCallBaseClass() { }
+        protected override void InitializeValue(object? baseValue) { }
         public Mockolate.Setup.PropertySetup<T> InitializeWith(T value) { }
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior) { }
         protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
@@ -520,6 +529,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn> Returns(TReturn returnValue) { }
@@ -541,6 +551,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1> Returns(System.Func<T1, TReturn> callback) { }
@@ -564,6 +575,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2> Returns(System.Func<T1, T2, TReturn> callback) { }
@@ -587,6 +599,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3> Returns(System.Func<T1, T2, T3, TReturn> callback) { }
@@ -610,6 +623,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4> Returns(System.Func<TReturn> callback) { }
         public Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TReturn> callback) { }
@@ -632,6 +646,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -652,6 +667,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -673,6 +689,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -694,6 +711,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }
@@ -715,6 +733,7 @@ namespace Mockolate.Setup
         protected override void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
         protected override bool? GetCallBaseClass() { }
         protected override TResult GetReturnValue<TResult>(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior) { }
+        protected override bool HasReturnCalls() { }
         protected override bool IsMatch(Mockolate.Interactions.MethodInvocation invocation) { }
         protected override T SetOutParameter<T>(string parameterName, Mockolate.MockBehavior behavior) { }
         protected override T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior) { }

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
@@ -698,7 +698,7 @@ public sealed partial class ForMockTests
 				          		if (methodExecution.CallBaseClass)
 				          		{
 				          			var baseResult = base.MyMethod2(index, isReadOnly);
-				          			if (methodExecution?.HasSetup != true)
+				          			if (methodExecution?.HasSetupResult != true)
 				          			{
 				          				return baseResult;
 				          			}

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.CallingBaseClassTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.CallingBaseClassTests.cs
@@ -146,6 +146,18 @@ public sealed partial class SetupIndexerTests
 			await That(mock.MyIndexerWith5KeysSetterCallCount).IsEqualTo(expectedCallCount);
 		}
 
+		[Fact]
+		public async Task SetupCallingBaseClassWithoutReturn_ShouldReturnBaseValue()
+		{
+			MyIndexerService mock = Mock.Create<MyIndexerService>();
+			mock.SetupMock.Indexer(Any<string>())
+				.CallingBaseClass();
+
+			int result = mock["returning 2"];
+
+			await That(result).IsEqualTo(2);
+		}
+
 		public class MyIndexerService
 		{
 			public int MyIndexerWith1KeyGetterCallCount { get; private set; }
@@ -187,6 +199,11 @@ public sealed partial class SetupIndexerTests
 			{
 				get => MyIndexerWith5KeysGetterCallCount++;
 				set => MyIndexerWith5KeysSetterCallCount += value;
+			}
+			
+			public virtual int this[string keyReturning2]
+			{
+				get => 2;
 			}
 		}
 	}

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallingBaseClassTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallingBaseClassTests.cs
@@ -180,6 +180,17 @@ public sealed partial class SetupMethodTests
 			await That(mock.MyVoidMethodWithoutParametersCallCount).IsEqualTo(expectedCallCount);
 		}
 
+		[Fact]
+		public async Task SetupCallingBaseClassWithoutReturn_ShouldReturnBaseValue()
+		{
+			MyMethodService mock = Mock.Create<MyMethodService>();
+			mock.SetupMock.Method.MyMethodReturning2().CallingBaseClass();
+
+			int result = mock.MyMethodReturning2();
+
+			await That(result).IsEqualTo(2);
+		}
+
 		public class MyMethodService
 		{
 			public int MyVoidMethodWithoutParametersCallCount { get; private set; }
@@ -231,6 +242,8 @@ public sealed partial class SetupMethodTests
 
 			public virtual int MyReturnMethodWith5Parameters(int p1, int p2, int p3, int p4, int p5)
 				=> MyReturnMethodWith5ParametersCallCount++;
+
+			public virtual int MyMethodReturning2() => 2;
 		}
 	}
 }

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.CallingBaseClassTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.CallingBaseClassTests.cs
@@ -30,6 +30,17 @@ public sealed partial class SetupPropertyTests
 			await That(mock.MyPropertySetterCallCount).IsEqualTo(expectedCallCount);
 		}
 
+		[Fact]
+		public async Task SetupCallingBaseClassWithoutReturn_ShouldReturnBaseValue()
+		{
+			MyPropertyService mock = Mock.Create<MyPropertyService>();
+			mock.SetupMock.Property.MyPropertyReturning2.CallingBaseClass();
+			
+			int result = mock.MyPropertyReturning2;
+
+			await That(result).IsEqualTo(2);
+		}
+
 		public class MyPropertyService
 		{
 			public int MyPropertyGetterCallCount { get; private set; }
@@ -40,6 +51,8 @@ public sealed partial class SetupPropertyTests
 				get => MyPropertyGetterCallCount++;
 				set => MyPropertySetterCallCount += value;
 			}
+
+			public virtual int MyPropertyReturning2 => 2;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes an issue where calling `CallingBaseClass()` on setups without explicit return values would not correctly return the base class value. The fix introduces a `HasReturnCalls()` method to distinguish between setups that have return callbacks configured versus those that simply call the base class implementation.

### Key changes:
- Introduced `HasReturnCalls()` method to track whether a setup has configured return callbacks
- Renamed `HasSetup` to `HasSetupResult` in `MethodSetupResult` to accurately reflect when a setup has return values
- Added property initialization support to use base values when `CallingBaseClass()` is specified without explicit returns
- Added test coverage for methods, properties, and indexers calling base class without return values

---

- *Fixes #209*