### PR TITLE
fix: add missing System namespace specification

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
@@ -196,7 +196,7 @@ internal static partial class Sources
 			              """);
 			sb.AppendLine();
 			sb.AppendLine("""
-			              	private static Mock<T> GetMockOrThrow<T>(T subject) where T : Delegate
+			              	private static Mock<T> GetMockOrThrow<T>(T subject) where T : System.Delegate
 			              	{
 			              		var target = subject.Target;
 			              		if (target is IMockSubject<T> mock)


### PR DESCRIPTION
This PR adds the `System` namespace prefix to the `Delegate` type constraint in a generated code method signature to ensure proper type resolution and avoid potential ambiguity.