### PR TITLE
chore: bump aweXpect to v2.29.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,8 +33,8 @@
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.4"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.6"/>
-		<PackageVersion Include="aweXpect" Version="2.26.0"/>
-		<PackageVersion Include="aweXpect.Mockolate" Version="0.4.0"/>
+		<PackageVersion Include="aweXpect" Version="2.29.0"/>
+		<PackageVersion Include="aweXpect.Mockolate" Version="0.5.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Moq" Version="4.20.72"/>

--- a/Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj
+++ b/Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj
@@ -13,7 +13,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<InternalsVisibleTo Include="Mockolate.Analyzers.Tests" PublicKey="$(PublicKey)"/>
 		<InternalsVisibleTo Include="Mockolate.Analyzers.CodeFixers" PublicKey="$(PublicKey)"/>
 	</ItemGroup>
 

--- a/Source/Mockolate.Analyzers/Rules.cs
+++ b/Source/Mockolate.Analyzers/Rules.cs
@@ -2,10 +2,16 @@
 
 namespace Mockolate.Analyzers;
 
-internal static class Rules
+/// <summary>
+///     The rules for mockolate analyzers.
+/// </summary>
+public static class Rules
 {
 	private const string UsageCategory = "Usage";
 
+	/// <summary>
+	///     Verifications must be used.
+	/// </summary>
 	public static readonly DiagnosticDescriptor UseVerificationRule =
 		CreateDescriptor("Mockolate0001", UsageCategory, DiagnosticSeverity.Error);
 


### PR DESCRIPTION
This PR updates the aweXpect testing library from version 2.26.0 to 2.29.0 and its companion package aweXpect.Mockolate from 0.4.0 to 0.5.0. To accommodate breaking changes in the updated packages, the `Rules` class is made public with added XML documentation.

### Key changes:
- Updated aweXpect package versions in Directory.Packages.props
- Made `Rules` class public and added XML documentation
- Removed InternalsVisibleTo attribute for Mockolate.Analyzers.Tests