### PR TITLE
fix: return new `MockBehavior` instance when initializing

### DIFF
--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -55,7 +55,7 @@ public record MockBehavior
 	{
 		MockBehavior behavior = this with
 		{
-			_initializers = _initializers ?? [],
+			_initializers = new ConcurrentStack<IInitializer>(_initializers ?? []),
 		};
 		behavior._initializers.Push(new SimpleInitializer<T>(setups));
 		return behavior;
@@ -71,7 +71,7 @@ public record MockBehavior
 	{
 		MockBehavior behavior = this with
 		{
-			_initializers = _initializers ?? [],
+			_initializers = new ConcurrentStack<IInitializer>(_initializers ?? []),
 		};
 		behavior._initializers.Push(new CounterInitializer<T>(setups));
 		return behavior;
@@ -98,7 +98,7 @@ public record MockBehavior
 
 	private interface IInitializer;
 
-	private interface IInitializer<T> : IInitializer
+	private interface IInitializer<in T> : IInitializer
 	{
 		Action<IMockSetup<T>>[] GetSetups();
 	}


### PR DESCRIPTION
This PR fixes the `Initialize` methods in `MockBehavior` to return new instances instead of mutating and returning the current instance, which is important for maintaining immutability in a record type.

### Key changes:
- Changed `Initialize<T>` methods to create and return a new `MockBehavior` instance using the `with` expression
- Preserved the initializer stack by ensuring it's initialized before pushing new initializers