### PR TITLE
fix: change visibility of `MockGeneratorAttribute` to internal

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -466,7 +466,7 @@ internal static partial class Sources
 		              ///     Marks a method as a mock generator for its generic parameters.
 		              /// </summary>
 		              [AttributeUsage(AttributeTargets.Method)]
-		              public class MockGeneratorAttribute : Attribute
+		              internal class MockGeneratorAttribute : Attribute
 		              {
 		              }
 		              """);


### PR DESCRIPTION
This PR changes the visibility of the `MockGeneratorAttribute` class from `public` to `internal`, restricting its accessibility to within the Mockolate assembly. This attribute is used internally by the source generator to mark mock generator methods and does not need to be part of the public API surface.