### PR TITLE
fix: avoid race-condition with incrementing return/throw callbacks

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -356,7 +356,7 @@ internal static partial class Sources
 		sb.Append("\tprivate bool? _callBaseClass;").AppendLine();
 		sb.Append("\tprivate Callback? _currentCallback;").AppendLine();
 		sb.Append("\tprivate Callback? _currentReturnCallback;").AppendLine();
-		sb.Append("\tprivate int _currentReturnCallbackIndex = -1;").AppendLine();
+		sb.Append("\tprivate int _currentReturnCallbackIndex;").AppendLine();
 		sb.Append("\tprivate Func<").Append(typeParams).Append(", TValue>? _initialization;").AppendLine();
 		sb.AppendLine();
 
@@ -726,9 +726,8 @@ internal static partial class Sources
 			.AppendLine();
 		sb.Append("\t\t\tforeach (var _ in _returnCallbacks)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tint index = Interlocked.Increment(ref _currentReturnCallbackIndex);").AppendLine();
 		sb.Append("\t\t\t\tCallback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>> returnCallback = _returnCallbacks[index % _returnCallbacks.Count];").AppendLine();
+			.Append(", TValue>> returnCallback = _returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];").AppendLine();
 		sb.Append("\t\t\t\tif (returnCallback.Invoke<TValue>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)").AppendLine();
 		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, resultValue, ").Append(parameters).Append("), out TValue? newValue) &&").AppendLine();
 		sb.Append("\t\t\t\t\tTryCast(newValue, out T returnValue, behavior))").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -278,7 +278,7 @@ internal static partial class Sources
 		sb.Append("\tprivate bool? _callBaseClass;").AppendLine();
 		sb.Append("\tprivate Callback? _currentCallback;").AppendLine();
 		sb.Append("\tprivate Callback? _currentReturnCallback;").AppendLine();
-		sb.Append("\tprivate int _currentReturnCallbackIndex = -1;").AppendLine();
+		sb.Append("\tprivate int _currentReturnCallbackIndex;").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t/// <inheritdoc cref=\"VoidMethodSetup{")
@@ -523,8 +523,7 @@ internal static partial class Sources
 			.AppendLine();
 		sb.Append("\t\t\tforeach (var _ in _returnCallbacks)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tvar index = Interlocked.Increment(ref _currentReturnCallbackIndex);").AppendLine();
-		sb.Append("\t\t\t\tvar returnCallback = _returnCallbacks[index % _returnCallbacks.Count];").AppendLine();
+		sb.Append("\t\t\t\tvar returnCallback = _returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];").AppendLine();
 		sb.Append("\t\t\t\tif (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)").AppendLine();
 		sb.Append("\t\t\t\t\t=> @delegate(invocationCount, ")
 			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}"))).Append(")))").AppendLine();
@@ -851,7 +850,7 @@ internal static partial class Sources
 		sb.Append("\tprivate bool? _callBaseClass;").AppendLine();
 		sb.Append("\tprivate Callback? _currentCallback;").AppendLine();
 		sb.Append("\tprivate Callback? _currentReturnCallback;").AppendLine();
-		sb.Append("\tprivate int _currentReturnCallbackIndex = -1;").AppendLine();
+		sb.Append("\tprivate int _currentReturnCallbackIndex;").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t/// <inheritdoc cref=\"ReturnMethodSetup{TReturn, ")
@@ -1156,8 +1155,7 @@ internal static partial class Sources
 
 		sb.Append("\t\tforeach (var _ in _returnCallbacks)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar index = Interlocked.Increment(ref _currentReturnCallbackIndex);").AppendLine();
-		sb.Append("\t\t\tvar returnCallback = _returnCallbacks[index % _returnCallbacks.Count];").AppendLine();
+		sb.Append("\t\t\tvar returnCallback = _returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];").AppendLine();
 		sb.Append("\t\t\tif (returnCallback.Invoke<TReturn>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)").AppendLine();
 		sb.Append("\t\t\t\t=> @delegate(invocationCount, ")
 			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}")))

--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -90,9 +90,9 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 		{
 			if (CheckMatching(_matchingCount))
 			{
-				if (HasForSpecified && CheckMatching(_matchingCount + 1))
+				if (!HasForSpecified || !CheckMatching(_matchingCount + 1))
 				{
-					Interlocked.Decrement(ref index);
+					Interlocked.Increment(ref index);
 				}
 
 				_invocationCount++;
@@ -105,6 +105,7 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 		}
 
 		_invocationCount++;
+		Interlocked.Increment(ref index);
 		return false;
 	}
 
@@ -117,9 +118,9 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 		{
 			if (CheckMatching(_matchingCount))
 			{
-				if (HasForSpecified && CheckMatching(_matchingCount + 1))
+				if (!HasForSpecified || !CheckMatching(_matchingCount + 1))
 				{
-					Interlocked.Decrement(ref index);
+					Interlocked.Increment(ref index);
 				}
 
 				_invocationCount++;
@@ -134,6 +135,7 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 
 		_invocationCount++;
 		returnValue = default;
+		Interlocked.Increment(ref index);
 		return false;
 	}
 }

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -135,7 +135,7 @@ public class IndexerSetup<TValue, T1>(Match.IParameter match1)
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 	private Func<T1, TValue>? _initialization;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.CallingBaseClass(bool)" />
@@ -399,9 +399,8 @@ public class IndexerSetup<TValue, T1>(Match.IParameter match1)
 				=> @delegate(invocationCount, p1)));
 			foreach (Callback<Func<int, TValue, T1, TValue>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 				Callback<Func<int, TValue, T1, TValue>> returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke<TValue>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, resultValue, p1), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))
@@ -461,7 +460,7 @@ public class IndexerSetup<TValue, T1, T2>(Match.IParameter match1, Match.IParame
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 	private Func<T1, T2, TValue>? _initialization;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.CallingBaseClass(bool)" />
@@ -729,9 +728,8 @@ public class IndexerSetup<TValue, T1, T2>(Match.IParameter match1, Match.IParame
 				=> @delegate(invocationCount, p1, p2)));
 			foreach (Callback<Func<int, TValue, T1, T2, TValue>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 				Callback<Func<int, TValue, T1, T2, TValue>> returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke<TValue>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, resultValue, p1, p2), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))
@@ -797,7 +795,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 	private Func<T1, T2, T3, TValue>? _initialization;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.CallingBaseClass(bool)" />
@@ -1070,9 +1068,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 				=> @delegate(invocationCount, p1, p2, p3)));
 			foreach (Callback<Func<int, TValue, T1, T2, T3, TValue>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 				Callback<Func<int, TValue, T1, T2, T3, TValue>> returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke<TValue>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, resultValue, p1, p2, p3), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))
@@ -1143,7 +1140,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 	private Func<T1, T2, T3, T4, TValue>? _initialization;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.CallingBaseClass(bool)" />
@@ -1421,9 +1418,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 				=> @delegate(invocationCount, p1, p2, p3, p4)));
 			foreach (Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 				Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke<TValue>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, resultValue, p1, p2, p3, p4), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
 using Mockolate.Internals;
@@ -98,7 +97,7 @@ public class PropertySetup<T> : PropertySetup, IPropertySetupCallbackBuilder<T>,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 	private bool _isInitialized;
 	private T _value = default!;
 
@@ -153,9 +152,8 @@ public class PropertySetup<T> : PropertySetup, IPropertySetupCallbackBuilder<T>,
 		bool foundCallback = false;
 		foreach (Callback<Func<int, T, T>> _ in _returnCallbacks)
 		{
-			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 			Callback<Func<int, T, T>> returnCallback =
-				_returnCallbacks[index % _returnCallbacks.Count];
+				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 			if (returnCallback.Invoke<T>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount, _value), out T? newValue))
 			{

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
 
@@ -17,7 +16,7 @@ public class ReturnMethodSetup<TReturn>(string name) : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="IReturnMethodSetup{TReturn}.CallingBaseClass(bool)" />
 	public IReturnMethodSetup<TReturn> CallingBaseClass(bool callBaseClass = true)
@@ -146,9 +145,8 @@ public class ReturnMethodSetup<TReturn>(string name) : MethodSetup,
 	{
 		foreach (Callback<Func<int, TReturn>> _ in _returnCallbacks)
 		{
-			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 			Callback<Func<int, TReturn>> returnCallback =
-				_returnCallbacks[index % _returnCallbacks.Count];
+				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 			if (returnCallback.Invoke<TReturn>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount), out TReturn? newValue))
 			{
@@ -214,7 +212,7 @@ public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
 	public ReturnMethodSetup(string name, Match.NamedParameter match1)
@@ -406,9 +404,8 @@ public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 
 		foreach (Callback<Func<int, T1, TReturn>> _ in _returnCallbacks)
 		{
-			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 			Callback<Func<int, T1, TReturn>> returnCallback =
-				_returnCallbacks[index % _returnCallbacks.Count];
+				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 			if (returnCallback.Invoke<TReturn>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount, p1), out TReturn? newValue))
 			{
@@ -416,7 +413,7 @@ public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 				{
 					return default!;
 				}
-				
+
 				if (!TryCast(newValue, out TResult returnValue, behavior))
 				{
 					throw new MockException(
@@ -495,7 +492,7 @@ public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}" />
 	public ReturnMethodSetup(string name, Match.NamedParameter match1, Match.NamedParameter match2)
@@ -695,9 +692,8 @@ public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 
 		foreach (Callback<Func<int, T1, T2, TReturn>> _ in _returnCallbacks)
 		{
-			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 			Callback<Func<int, T1, T2, TReturn>> returnCallback =
-				_returnCallbacks[index % _returnCallbacks.Count];
+				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 			if (returnCallback.Invoke<TReturn>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount, p1, p2), out TReturn? newValue))
 			{
@@ -785,7 +781,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}" />
 	public ReturnMethodSetup(
@@ -998,9 +994,8 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 
 		foreach (Callback<Func<int, T1, T2, T3, TReturn>> _ in _returnCallbacks)
 		{
-			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 			Callback<Func<int, T1, T2, T3, TReturn>> returnCallback =
-				_returnCallbacks[index % _returnCallbacks.Count];
+				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 			if (returnCallback.Invoke<TReturn>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount, p1, p2, p3), out TReturn? newValue))
 			{
@@ -1090,7 +1085,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}" />
 	public ReturnMethodSetup(
@@ -1316,9 +1311,8 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 
 		foreach (Callback<Func<int, T1, T2, T3, T4, TReturn>> _ in _returnCallbacks)
 		{
-			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
 			Callback<Func<int, T1, T2, T3, T4, TReturn>> returnCallback =
-				_returnCallbacks[index % _returnCallbacks.Count];
+				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 			if (returnCallback.Invoke<TReturn>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount, p1, p2, p3, p4), out TReturn? newValue))
 			{

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
 
@@ -16,7 +15,7 @@ public class VoidMethodSetup(string name) : MethodSetup, IVoidMethodSetupCallbac
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
@@ -131,12 +130,11 @@ public class VoidMethodSetup(string name) : MethodSetup, IVoidMethodSetupCallbac
 	{
 		_callbacks.ForEach(callback => callback.Invoke((invocationCount, @delegate)
 			=> @delegate(invocationCount)));
-		
-		foreach (var _ in _returnCallbacks)
+
+		foreach (Callback<Action<int>> _ in _returnCallbacks)
 		{
-			int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-			var returnCallback =
-				_returnCallbacks[index % _returnCallbacks.Count];
+			Callback<Action<int>> returnCallback =
+				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 			if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount)))
 			{
@@ -194,7 +192,7 @@ public class VoidMethodSetup<T1> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="VoidMethodSetup{T1}" />
 	public VoidMethodSetup(string name, Match.NamedParameter match1)
@@ -346,11 +344,10 @@ public class VoidMethodSetup<T1> : MethodSetup,
 		{
 			_callbacks.ForEach(callback => callback.Invoke((invocationCount, @delegate)
 				=> @delegate(invocationCount, p1)));
-			foreach (var _ in _returnCallbacks)
+			foreach (Callback<Action<int, T1>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				var returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+				Callback<Action<int, T1>> returnCallback =
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, p1)))
 				{
@@ -430,7 +427,7 @@ public class VoidMethodSetup<T1, T2> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="VoidMethodSetup{T1, T2}" />
 	public VoidMethodSetup(string name, Match.NamedParameter match1, Match.NamedParameter match2)
@@ -584,11 +581,10 @@ public class VoidMethodSetup<T1, T2> : MethodSetup,
 		{
 			_callbacks.ForEach(callback => callback.Invoke((invocationCount, @delegate)
 				=> @delegate(invocationCount, p1, p2)));
-			foreach (var _ in _returnCallbacks)
+			foreach (Callback<Action<int, T1, T2>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				var returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+				Callback<Action<int, T1, T2>> returnCallback =
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, p1, p2)))
 				{
@@ -669,7 +665,7 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}" />
 	public VoidMethodSetup(
@@ -793,7 +789,8 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	}
 
 	/// <inheritdoc cref="IVoidMethodSetupCallbackBuilder{T1, T2, T3}.When(Func{int, bool})" />
-	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> IVoidMethodSetupCallbackBuilder<T1, T2, T3>.When(Func<int, bool> predicate)
+	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> IVoidMethodSetupCallbackBuilder<T1, T2, T3>.When(
+		Func<int, bool> predicate)
 	{
 		_currentCallback?.When(predicate);
 		return this;
@@ -807,7 +804,8 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	}
 
 	/// <inheritdoc cref="IVoidMethodSetupReturnBuilder{T1, T2, T3}.When(Func{int, bool})" />
-	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> IVoidMethodSetupReturnBuilder<T1, T2, T3>.When(Func<int, bool> predicate)
+	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> IVoidMethodSetupReturnBuilder<T1, T2, T3>.When(
+		Func<int, bool> predicate)
 	{
 		_currentReturnCallback?.When(predicate);
 		return this;
@@ -829,11 +827,10 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 		{
 			_callbacks.ForEach(callback => callback.Invoke((invocationCount, @delegate)
 				=> @delegate(invocationCount, p1, p2, p3)));
-			foreach (var _ in _returnCallbacks)
+			foreach (Callback<Action<int, T1, T2, T3>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				var returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+				Callback<Action<int, T1, T2, T3>> returnCallback =
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, p1, p2, p3)))
 				{
@@ -915,7 +912,7 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex = -1;
+	private int _currentReturnCallbackIndex;
 
 	/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}" />
 	public VoidMethodSetup(
@@ -1034,14 +1031,16 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	/// </summary>
 	public IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback)
 	{
-		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new((_, p1, p2, p3, p4) => throw callback(p1, p2, p3, p4));
+		Callback<Action<int, T1, T2, T3, T4>> currentCallback =
+			new((_, p1, p2, p3, p4) => throw callback(p1, p2, p3, p4));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
 	/// <inheritdoc cref="IVoidMethodSetupCallbackBuilder{T1, T2, T3, T4}.When(Func{int, bool})" />
-	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>.When(Func<int, bool> predicate)
+	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>.When(
+		Func<int, bool> predicate)
 	{
 		_currentCallback?.When(predicate);
 		return this;
@@ -1055,7 +1054,8 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	}
 
 	/// <inheritdoc cref="IVoidMethodSetupReturnBuilder{T1, T2, T3, T4}.When(Func{int, bool})" />
-	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>.When(Func<int, bool> predicate)
+	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>.When(
+		Func<int, bool> predicate)
 	{
 		_currentReturnCallback?.When(predicate);
 		return this;
@@ -1078,11 +1078,10 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 		{
 			_callbacks.ForEach(callback => callback.Invoke((invocationCount, @delegate)
 				=> @delegate(invocationCount, p1, p2, p3, p4)));
-			foreach (var _ in _returnCallbacks)
+			foreach (Callback<Action<int, T1, T2, T3, T4>> _ in _returnCallbacks)
 			{
-				int index = Interlocked.Increment(ref _currentReturnCallbackIndex);
-				var returnCallback =
-					_returnCallbacks[index % _returnCallbacks.Count];
+				Callback<Action<int, T1, T2, T3, T4>> returnCallback =
+					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 					    => @delegate(invocationCount, p1, p2, p3, p4)))
 				{


### PR DESCRIPTION
This pull request addresses a race condition in the callback index increment logic for return and throw callbacks. The changes move the responsibility of incrementing the callback index from the caller (setup classes) to the callee (`Callback.Invoke` methods), eliminating the race condition where multiple threads could simultaneously read and increment the index.

### Key changes:
- Removed `Interlocked.Increment` from setup classes and moved increment logic into `Callback.Invoke` methods
- Changed initialization of `_currentReturnCallbackIndex` from `-1` to `0` (default value)
- Inverted the logic in `Callback.Invoke` methods to increment the index at appropriate points

---

*Issue from #261*