### PR TITLE
feat: add `ThrowingWhenNotSetup` extension method

### DIFF
--- a/Source/Mockolate/MockBehaviorExtensions.cs
+++ b/Source/Mockolate/MockBehaviorExtensions.cs
@@ -5,16 +5,32 @@ namespace Mockolate;
 /// </summary>
 public static class MockBehaviorExtensions
 {
-	/// <summary>
-	///     Specifies if the base class implementation should be called, and
-	///     its return values used as default values.
-	/// </summary>
-	/// <remarks>
-	///     Sets the <see cref="MockBehavior.CallBaseClass" /> to <paramref name="callBaseClass" />.
-	/// </remarks>
-	public static MockBehavior CallingBaseClass(this MockBehavior mockBehavior, bool callBaseClass = true)
-		=> mockBehavior with
-		{
-			CallBaseClass = callBaseClass,
-		};
+	/// <inheritdoc cref="MockBehaviorExtensions" />
+	extension(MockBehavior mockBehavior)
+	{
+		/// <summary>
+		///     Specifies if the base class implementation should be called, and
+		///     its return values used as default values.
+		/// </summary>
+		/// <remarks>
+		///     Sets the <see cref="MockBehavior.CallBaseClass" /> to <paramref name="callBaseClass" />.
+		/// </remarks>
+		public MockBehavior CallingBaseClass(bool callBaseClass = true)
+			=> mockBehavior with
+			{
+				CallBaseClass = callBaseClass,
+			};
+
+		/// <summary>
+		///     Specifies whether an exception is thrown when an operation is attempted without prior setup.
+		/// </summary>
+		/// <remarks>
+		///     Sets the <see cref="MockBehavior.ThrowWhenNotSetup" /> to <paramref name="throwWhenNotSetup" />.
+		/// </remarks>
+		public MockBehavior ThrowingWhenNotSetup(bool throwWhenNotSetup = true)
+			=> mockBehavior with
+			{
+				ThrowWhenNotSetup = throwWhenNotSetup,
+			};
+	}
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -114,7 +114,11 @@ namespace Mockolate
     }
     public static class MockBehaviorExtensions
     {
-        public static Mockolate.MockBehavior CallingBaseClass(this Mockolate.MockBehavior mockBehavior, bool callBaseClass = true) { }
+        extension(Mockolate.MockBehavior mockBehavior)
+        {
+            public Mockolate.MockBehavior CallingBaseClass(bool callBaseClass = true) { }
+            public Mockolate.MockBehavior ThrowingWhenNotSetup(bool throwWhenNotSetup = true) { }
+        }
     }
     public static class MockExtensions
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -113,7 +113,11 @@ namespace Mockolate
     }
     public static class MockBehaviorExtensions
     {
-        public static Mockolate.MockBehavior CallingBaseClass(this Mockolate.MockBehavior mockBehavior, bool callBaseClass = true) { }
+        extension(Mockolate.MockBehavior mockBehavior)
+        {
+            public Mockolate.MockBehavior CallingBaseClass(bool callBaseClass = true) { }
+            public Mockolate.MockBehavior ThrowingWhenNotSetup(bool throwWhenNotSetup = true) { }
+        }
     }
     public static class MockExtensions
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -104,7 +104,11 @@ namespace Mockolate
     }
     public static class MockBehaviorExtensions
     {
-        public static Mockolate.MockBehavior CallingBaseClass(this Mockolate.MockBehavior mockBehavior, bool callBaseClass = true) { }
+        extension(Mockolate.MockBehavior mockBehavior)
+        {
+            public Mockolate.MockBehavior CallingBaseClass(bool callBaseClass = true) { }
+            public Mockolate.MockBehavior ThrowingWhenNotSetup(bool throwWhenNotSetup = true) { }
+        }
     }
     public static class MockExtensions
     {

--- a/Tests/Mockolate.Tests/MockBehaviorExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorExtensionsTests.cs
@@ -13,7 +13,7 @@ public sealed class MockBehaviorExtensionsTests
 	}
 
 	[Fact]
-	public async Task IgnoringBaseClass_ShouldSetIgnoreBaseClass()
+	public async Task CallingBaseClass_WithFalse_ShouldUpdateCallBaseClass()
 	{
 		bool initializedValue = true;
 		MockBehavior sut = MockBehavior.Default.CallingBaseClass(initializedValue);
@@ -21,5 +21,26 @@ public sealed class MockBehaviorExtensionsTests
 		MockBehavior result = sut.CallingBaseClass(false);
 
 		await That(result.CallBaseClass).IsFalse();
+	}
+
+	[Fact]
+	public async Task ThrowingWhenNotSetup_ShouldSetThrowWhenNotSetup()
+	{
+		MockBehavior sut = MockBehavior.Default;
+
+		MockBehavior result = sut.ThrowingWhenNotSetup();
+
+		await That(result.ThrowWhenNotSetup).IsTrue();
+	}
+
+	[Fact]
+	public async Task ThrowingWhenNotSetup_WithFalse_ShouldUpdateThrowWhenNotSetup()
+	{
+		bool initializedValue = true;
+		MockBehavior sut = MockBehavior.Default.ThrowingWhenNotSetup(initializedValue);
+
+		MockBehavior result = sut.ThrowingWhenNotSetup(false);
+
+		await That(result.ThrowWhenNotSetup).IsFalse();
 	}
 }


### PR DESCRIPTION
This PR introduces a new `ThrowingWhenNotSetup` extension method for `MockBehavior`, allowing users to configure whether mocks should throw exceptions when operations are attempted without prior setup. The implementation follows the existing pattern established by `CallingBaseClass` and leverages C# 10's extension method syntax.

### Key Changes:
- Added `ThrowingWhenNotSetup` extension method to `MockBehaviorExtensions`
- Refactored to use C# 10 extension syntax for cleaner code organization
- Added comprehensive test coverage for the new method