### PR TITLE
refactor: rename interactive setup interfaces

### DIFF
--- a/Source/Mockolate/MockRegistration.Setup.cs
+++ b/Source/Mockolate/MockRegistration.Setup.cs
@@ -24,7 +24,7 @@ public partial class MockRegistration
 	///     or returns <see langword="null" /> if no matching setup is found.
 	/// </summary>
 	private MethodSetup? GetMethodSetup(MethodInvocation methodInvocation)
-		=> _methodSetups.GetLatestOrDefault(setup => ((IMethodSetup)setup).Matches(methodInvocation));
+		=> _methodSetups.GetLatestOrDefault(setup => ((IInteractiveMethodSetup)setup).Matches(methodInvocation));
 
 	/// <summary>
 	///     Retrieves the setup configuration for the specified property name, creating a default setup if none exists.
@@ -51,8 +51,8 @@ public partial class MockRegistration
 		}
 		else
 		{
-			((IPropertySetup)matchingSetup).InitializeWith(
-				defaultValueGenerator(((IPropertySetup)matchingSetup).CallBaseClass() ?? Behavior.CallBaseClass));
+			((IInteractivePropertySetup)matchingSetup).InitializeWith(
+				defaultValueGenerator(((IInteractivePropertySetup)matchingSetup).CallBaseClass() ?? Behavior.CallBaseClass));
 		}
 
 		return matchingSetup;
@@ -63,12 +63,12 @@ public partial class MockRegistration
 	///     or returns <see langword="null" /> if no matching setup is found.
 	/// </summary>
 	private IndexerSetup? GetIndexerSetup(IndexerAccess interaction)
-		=> _indexerSetups.GetLastestOrDefault(setup => ((IIndexerSetup)setup).Matches(interaction));
+		=> _indexerSetups.GetLastestOrDefault(setup => ((IInteractiveIndexerSetup)setup).Matches(interaction));
 
 	/// <summary>
 	///     Gets the indexer value for the given <paramref name="parameters" />.
 	/// </summary>
-	private TValue GetIndexerValue<TValue>(IIndexerSetup? setup, Func<TValue> defaultValueGenerator,
+	private TValue GetIndexerValue<TValue>(IInteractiveIndexerSetup? setup, Func<TValue> defaultValueGenerator,
 		object?[] parameters)
 		=> _indexerSetups.GetOrAddValue(parameters, defaultValueGenerator);
 
@@ -121,7 +121,7 @@ public partial class MockRegistration
 
 			return _storage.Where(methodSetup => interactions.Interactions.All(interaction
 				=> interaction is not MethodInvocation methodInvocation
-				   || !((IMethodSetup)methodSetup).Matches(methodInvocation)));
+				   || !((IInteractiveMethodSetup)methodSetup).Matches(methodInvocation)));
 		}
 
 		/// <inheritdoc cref="object.ToString()" />
@@ -135,7 +135,7 @@ public partial class MockRegistration
 
 			StringBuilder sb = new();
 			sb.Append(_storage.Count).Append(_storage.Count == 1 ? " method:" : " methods:").AppendLine();
-			foreach (IMethodSetup methodSetup in _storage)
+			foreach (IInteractiveMethodSetup methodSetup in _storage)
 			{
 				sb.Append(methodSetup).AppendLine();
 			}
@@ -174,7 +174,7 @@ public partial class MockRegistration
 
 			return _storage.Values.Where(propertySetup => interactions.Interactions.All(interaction
 				=> interaction is not PropertyAccess propertyAccess
-				   || !((IPropertySetup)propertySetup).Matches(propertyAccess)));
+				   || !((IInteractivePropertySetup)propertySetup).Matches(propertyAccess)));
 		}
 
 		/// <inheritdoc cref="object.ToString()" />
@@ -291,7 +291,7 @@ public partial class MockRegistration
 
 			return _storage.Where(indexerSetup => interactions.Interactions.All(interaction
 				=> interaction is not IndexerAccess indexerAccess
-				   || !((IIndexerSetup)indexerSetup).Matches(indexerAccess)));
+				   || !((IInteractiveIndexerSetup)indexerSetup).Matches(indexerAccess)));
 		}
 
 		private sealed class ValueStorage

--- a/Source/Mockolate/MockRegistration.cs
+++ b/Source/Mockolate/MockRegistration.cs
@@ -68,7 +68,7 @@ public partial class MockRegistration
 			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(Interactions.GetNextIndex(),
 				methodName, parameters));
 
-		IMethodSetup? matchingSetup = GetMethodSetup(methodInvocation);
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetup(methodInvocation);
 		if (matchingSetup is null)
 		{
 			if (Behavior.ThrowWhenNotSetup)
@@ -95,7 +95,7 @@ public partial class MockRegistration
 			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(Interactions.GetNextIndex(),
 				methodName, parameters));
 
-		IMethodSetup? matchingSetup = GetMethodSetup(methodInvocation);
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetup(methodInvocation);
 		if (matchingSetup is null && Behavior.ThrowWhenNotSetup)
 		{
 			throw new MockNotSetupException(
@@ -115,7 +115,7 @@ public partial class MockRegistration
 		IInteraction interaction =
 			((IMockInteractions)Interactions).RegisterInteraction(new PropertyGetterAccess(Interactions.GetNextIndex(),
 				propertyName));
-		IPropertySetup matchingSetup = GetPropertySetup(propertyName,
+		IInteractivePropertySetup matchingSetup = GetPropertySetup(propertyName,
 			callBase => callBase && baseValueAccessor is not null
 				? baseValueAccessor.Invoke()
 				: defaultValueGenerator());
@@ -134,7 +134,7 @@ public partial class MockRegistration
 		IInteraction interaction =
 			((IMockInteractions)Interactions).RegisterInteraction(new PropertySetterAccess(Interactions.GetNextIndex(),
 				propertyName, value));
-		IPropertySetup matchingSetup = GetPropertySetup(propertyName, _ => null);
+		IInteractivePropertySetup matchingSetup = GetPropertySetup(propertyName, _ => null);
 		matchingSetup.InvokeSetter(interaction, value, Behavior);
 		return matchingSetup.CallBaseClass() ?? Behavior.CallBaseClass;
 	}
@@ -163,7 +163,7 @@ public partial class MockRegistration
 		_indexerSetups.UpdateValue(parameters, value);
 		IndexerSetup? matchingSetup = GetIndexerSetup(interaction);
 		matchingSetup?.InvokeSetter(interaction, value, Behavior);
-		return (matchingSetup as IIndexerSetup)?.CallBaseClass() ?? Behavior.CallBaseClass;
+		return (matchingSetup as IInteractiveIndexerSetup)?.CallBaseClass() ?? Behavior.CallBaseClass;
 	}
 
 	/// <summary>

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -9,24 +9,24 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for indexer setups.
 /// </summary>
-public abstract class IndexerSetup : IIndexerSetup
+public abstract class IndexerSetup : IInteractiveIndexerSetup
 {
-	/// <inheritdoc cref="IIndexerSetup.HasReturnCalls()" />
-	bool IIndexerSetup.HasReturnCalls()
+	/// <inheritdoc cref="IInteractiveIndexerSetup.HasReturnCalls()" />
+	bool IInteractiveIndexerSetup.HasReturnCalls()
 		=> HasReturnCalls();
 
-	/// <inheritdoc cref="IIndexerSetup.Matches(IndexerAccess)" />
-	bool IIndexerSetup.Matches(IndexerAccess indexerAccess)
+	/// <inheritdoc cref="IInteractiveIndexerSetup.Matches(IndexerAccess)" />
+	bool IInteractiveIndexerSetup.Matches(IndexerAccess indexerAccess)
 		=> IsMatch(indexerAccess.Parameters);
 
-	/// <inheritdoc cref="IIndexerSetup.TryGetInitialValue{TValue}(MockBehavior, Func{TValue}, object?[], out TValue)" />
-	bool IIndexerSetup.TryGetInitialValue<TValue>(MockBehavior behavior, Func<TValue> defaultValueGenerator,
+	/// <inheritdoc cref="IInteractiveIndexerSetup.TryGetInitialValue{TValue}(MockBehavior, Func{TValue}, object?[], out TValue)" />
+	bool IInteractiveIndexerSetup.TryGetInitialValue<TValue>(MockBehavior behavior, Func<TValue> defaultValueGenerator,
 		object?[] parameters,
 		[NotNullWhen(true)] out TValue value)
 		=> TryGetInitialValue(behavior, defaultValueGenerator, parameters, out value);
 
-	/// <inheritdoc cref="IIndexerSetup.CallBaseClass()" />
-	bool? IIndexerSetup.CallBaseClass()
+	/// <inheritdoc cref="IInteractiveIndexerSetup.CallBaseClass()" />
+	bool? IInteractiveIndexerSetup.CallBaseClass()
 		=> GetCallBaseClass();
 
 	internal TValue InvokeGetter<TValue>(IndexerGetterAccess getterAccess, TValue value, MockBehavior behavior)

--- a/Source/Mockolate/Setup/IndexerSetupResult.cs
+++ b/Source/Mockolate/Setup/IndexerSetupResult.cs
@@ -8,7 +8,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A result of a method setup invocation.
 /// </summary>
-public class IndexerSetupResult(IIndexerSetup? setup, MockBehavior behavior)
+public class IndexerSetupResult(IInteractiveIndexerSetup? setup, MockBehavior behavior)
 {
 	/// <summary>
 	///     Gets the flag indicating if the base class implementation should be called, and its return values used as default
@@ -22,15 +22,15 @@ public class IndexerSetupResult(IIndexerSetup? setup, MockBehavior behavior)
 ///     A result of a method setup invocation with return type <typeparamref name="TResult" />.
 /// </summary>
 public class IndexerSetupResult<TResult>(
-	IIndexerSetup? setup,
+	IInteractiveIndexerSetup? setup,
 	IndexerGetterAccess indexerAccess,
 	MockBehavior behavior,
-	Func<IIndexerSetup?, Func<TResult>, object?[], TResult> getIndexerValue,
+	Func<IInteractiveIndexerSetup?, Func<TResult>, object?[], TResult> getIndexerValue,
 	Action<object?[], TResult> setIndexerValue)
 	: IndexerSetupResult(setup, behavior)
 {
 	private readonly MockBehavior _behavior = behavior;
-	private readonly IIndexerSetup? _setup = setup;
+	private readonly IInteractiveIndexerSetup? _setup = setup;
 
 	/// <summary>
 	///     The return value of the setup method.

--- a/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Interface for hiding some implementation details of <see cref="IndexerSetup" />.
 /// </summary>
-public interface IIndexerSetup : ISetup
+public interface IInteractiveIndexerSetup : ISetup
 {
 	/// <summary>
 	///     Gets the flag indicating if the base class implementation should be called, and its return values

--- a/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
@@ -6,7 +6,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Interface for hiding some implementation details of <see cref="MethodSetup" />.
 /// </summary>
-public interface IMethodSetup : ISetup
+public interface IInteractiveMethodSetup : ISetup
 {
 	/// <summary>
 	///     Checks if the <paramref name="methodInvocation" /> matches the setup.

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -6,7 +6,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Interface for hiding some implementation details of <see cref="PropertySetup" />.
 /// </summary>
-public interface IPropertySetup : ISetup
+public interface IInteractivePropertySetup : ISetup
 {
 	/// <summary>
 	///     Invokes the setter logic for the <paramref name="invocation" /> and <paramref name="value" />.

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -8,42 +8,42 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for method setups.
 /// </summary>
-public abstract class MethodSetup : IMethodSetup
+public abstract class MethodSetup : IInteractiveMethodSetup
 {
-	/// <inheritdoc cref="IMethodSetup.HasReturnCalls()" />
-	bool IMethodSetup.HasReturnCalls()
+	/// <inheritdoc cref="IInteractiveMethodSetup.HasReturnCalls()" />
+	bool IInteractiveMethodSetup.HasReturnCalls()
 		=> HasReturnCalls();
 
-	/// <inheritdoc cref="IMethodSetup.SetOutParameter{T}(string, Func{T})" />
-	T IMethodSetup.SetOutParameter<T>(string parameterName, Func<T> defaultValueGenerator)
+	/// <inheritdoc cref="IInteractiveMethodSetup.SetOutParameter{T}(string, Func{T})" />
+	T IInteractiveMethodSetup.SetOutParameter<T>(string parameterName, Func<T> defaultValueGenerator)
 		=> SetOutParameter(parameterName, defaultValueGenerator);
 
-	/// <inheritdoc cref="IMethodSetup.SetRefParameter{T}(string, T, MockBehavior)" />
-	T IMethodSetup.SetRefParameter<T>(string parameterName, T value, MockBehavior behavior)
+	/// <inheritdoc cref="IInteractiveMethodSetup.SetRefParameter{T}(string, T, MockBehavior)" />
+	T IInteractiveMethodSetup.SetRefParameter<T>(string parameterName, T value, MockBehavior behavior)
 		=> SetRefParameter(parameterName, value, behavior);
 
-	/// <inheritdoc cref="IMethodSetup.Matches(MethodInvocation)" />
-	bool IMethodSetup.Matches(MethodInvocation methodInvocation)
+	/// <inheritdoc cref="IInteractiveMethodSetup.Matches(MethodInvocation)" />
+	bool IInteractiveMethodSetup.Matches(MethodInvocation methodInvocation)
 		=> IsMatch(methodInvocation);
 
-	/// <inheritdoc cref="IMethodSetup.CallBaseClass()" />
-	bool? IMethodSetup.CallBaseClass()
+	/// <inheritdoc cref="IInteractiveMethodSetup.CallBaseClass()" />
+	bool? IInteractiveMethodSetup.CallBaseClass()
 		=> GetCallBaseClass();
 
 
-	/// <inheritdoc cref="IMethodSetup.Invoke{TResult}(MethodInvocation, MockBehavior, Func{TResult})" />
-	TResult IMethodSetup.Invoke<TResult>(MethodInvocation methodInvocation, MockBehavior behavior,
+	/// <inheritdoc cref="IInteractiveMethodSetup.Invoke{TResult}(MethodInvocation, MockBehavior, Func{TResult})" />
+	TResult IInteractiveMethodSetup.Invoke<TResult>(MethodInvocation methodInvocation, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator)
 	{
 		ExecuteCallback(methodInvocation, behavior);
 		return GetReturnValue(methodInvocation, behavior, defaultValueGenerator);
 	}
 
-	/// <inheritdoc cref="IMethodSetup.Invoke(MethodInvocation, MockBehavior)" />
-	void IMethodSetup.Invoke(MethodInvocation methodInvocation, MockBehavior behavior)
+	/// <inheritdoc cref="IInteractiveMethodSetup.Invoke(MethodInvocation, MockBehavior)" />
+	void IInteractiveMethodSetup.Invoke(MethodInvocation methodInvocation, MockBehavior behavior)
 		=> ExecuteCallback(methodInvocation, behavior);
 
-	/// <inheritdoc cref="IMethodSetup.TriggerCallbacks(object?[])" />
+	/// <inheritdoc cref="IInteractiveMethodSetup.TriggerCallbacks(object?[])" />
 	public void TriggerCallbacks(object?[] parameters)
 		=> TriggerParameterCallbacks(parameters);
 

--- a/Source/Mockolate/Setup/MethodSetupResult.cs
+++ b/Source/Mockolate/Setup/MethodSetupResult.cs
@@ -5,7 +5,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A result of a method setup invocation.
 /// </summary>
-public class MethodSetupResult(IMethodSetup? setup, MockBehavior behavior)
+public class MethodSetupResult(IInteractiveMethodSetup? setup, MockBehavior behavior)
 {
 	/// <summary>
 	///     Flag indicating if the method setup result has an underlying setup.
@@ -62,7 +62,7 @@ public class MethodSetupResult(IMethodSetup? setup, MockBehavior behavior)
 /// <summary>
 ///     A result of a method setup invocation with return type <typeparamref name="TResult" />.
 /// </summary>
-public class MethodSetupResult<TResult>(IMethodSetup? setup, MockBehavior behavior, TResult result)
+public class MethodSetupResult<TResult>(IInteractiveMethodSetup? setup, MockBehavior behavior, TResult result)
 	: MethodSetupResult(setup, behavior)
 {
 	/// <summary>

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -10,32 +10,32 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for property setups.
 /// </summary>
-public abstract class PropertySetup : IPropertySetup
+public abstract class PropertySetup : IInteractivePropertySetup
 {
 	/// <summary>
 	///     The property name.
 	/// </summary>
 	public abstract string Name { get; }
 
-	/// <inheritdoc cref="IPropertySetup.InvokeSetter(IInteraction, object?, MockBehavior)" />
-	void IPropertySetup.InvokeSetter(IInteraction invocation, object? value, MockBehavior behavior)
+	/// <inheritdoc cref="IInteractivePropertySetup.InvokeSetter(IInteraction, object?, MockBehavior)" />
+	void IInteractivePropertySetup.InvokeSetter(IInteraction invocation, object? value, MockBehavior behavior)
 		=> InvokeSetter(value, behavior);
 
-	/// <inheritdoc cref="IPropertySetup.InvokeGetter{TResult}(IInteraction, MockBehavior, Func{TResult}?)" />
-	TResult IPropertySetup.InvokeGetter<TResult>(IInteraction invocation, MockBehavior behavior,
+	/// <inheritdoc cref="IInteractivePropertySetup.InvokeGetter{TResult}(IInteraction, MockBehavior, Func{TResult}?)" />
+	TResult IInteractivePropertySetup.InvokeGetter<TResult>(IInteraction invocation, MockBehavior behavior,
 		Func<TResult>? defaultValueGenerator)
 		=> InvokeGetter(behavior, defaultValueGenerator);
 
-	/// <inheritdoc cref="IPropertySetup.Matches(PropertyAccess)" />
-	bool IPropertySetup.Matches(PropertyAccess propertyAccess)
+	/// <inheritdoc cref="IInteractivePropertySetup.Matches(PropertyAccess)" />
+	bool IInteractivePropertySetup.Matches(PropertyAccess propertyAccess)
 		=> Matches(propertyAccess);
 
-	/// <inheritdoc cref="IPropertySetup.CallBaseClass()" />
-	bool? IPropertySetup.CallBaseClass()
+	/// <inheritdoc cref="IInteractivePropertySetup.CallBaseClass()" />
+	bool? IInteractivePropertySetup.CallBaseClass()
 		=> GetCallBaseClass();
 
-	/// <inheritdoc cref="IPropertySetup.InitializeWith(object?)" />
-	void IPropertySetup.InitializeWith(object? value)
+	/// <inheritdoc cref="IInteractivePropertySetup.InitializeWith(object?)" />
+	void IInteractivePropertySetup.InitializeWith(object? value)
 		=> InitializeValue(value);
 
 	/// <summary>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -361,13 +361,6 @@ namespace Mockolate.Setup
         public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, out TReturn? returnValue) { }
     }
-    public interface IIndexerSetup : Mockolate.Setup.ISetup
-    {
-        bool? CallBaseClass();
-        bool HasReturnCalls();
-        bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
-        bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
-    }
     public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
@@ -524,7 +517,14 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
-    public interface IMethodSetup : Mockolate.Setup.ISetup
+    public interface IInteractiveIndexerSetup : Mockolate.Setup.ISetup
+    {
+        bool? CallBaseClass();
+        bool HasReturnCalls();
+        bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
+        bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
+    }
+    public interface IInteractiveMethodSetup : Mockolate.Setup.ISetup
     {
         bool? CallBaseClass();
         bool HasReturnCalls();
@@ -534,6 +534,14 @@ namespace Mockolate.Setup
         T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
         void TriggerCallbacks(object?[] parameters);
+    }
+    public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
+    {
+        bool? CallBaseClass();
+        void InitializeWith(object? value);
+        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator);
+        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
+        bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public interface IMockMethodSetupWithEqualsWithGetHashCode<out T> : Mockolate.IInteractiveMock<T>, Mockolate.Setup.IMockMethodSetupWithEquals<T>, Mockolate.Setup.IMockMethodSetupWithGetHashCode<T>, Mockolate.Setup.IMockMethodSetup<T> { }
     public interface IMockMethodSetupWithEquals<out T> : Mockolate.IInteractiveMock<T>, Mockolate.Setup.IMockMethodSetup<T>
@@ -556,14 +564,6 @@ namespace Mockolate.Setup
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T>
     {
         T Subject { get; }
-    }
-    public interface IPropertySetup : Mockolate.Setup.ISetup
-    {
-        bool? CallBaseClass();
-        void InitializeWith(object? value);
-        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator);
-        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
-        bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -899,7 +899,7 @@ namespace Mockolate.Setup
         Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
-    public abstract class IndexerSetup : Mockolate.Setup.IIndexerSetup, Mockolate.Setup.ISetup
+    public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup() { }
         protected abstract T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior);
@@ -913,12 +913,12 @@ namespace Mockolate.Setup
     }
     public class IndexerSetupResult
     {
-        public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
+        public IndexerSetupResult(Mockolate.Setup.IInteractiveIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
     }
     public class IndexerSetupResult<TResult> : Mockolate.Setup.IndexerSetupResult
     {
-        public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.Interactions.IndexerGetterAccess indexerAccess, Mockolate.MockBehavior behavior, System.Func<Mockolate.Setup.IIndexerSetup?, System.Func<TResult>, object?[], TResult> getIndexerValue, System.Action<object?[], TResult> setIndexerValue) { }
+        public IndexerSetupResult(Mockolate.Setup.IInteractiveIndexerSetup? setup, Mockolate.Interactions.IndexerGetterAccess indexerAccess, Mockolate.MockBehavior behavior, System.Func<Mockolate.Setup.IInteractiveIndexerSetup?, System.Func<TResult>, object?[], TResult> getIndexerValue, System.Action<object?[], TResult> setIndexerValue) { }
         public TResult GetResult(System.Func<TResult> defaultValueGenerator) { }
         public TResult GetResult(TResult baseValue, System.Func<TResult> defaultValueGenerator) { }
     }
@@ -1042,7 +1042,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup
+    public abstract class MethodSetup : Mockolate.Setup.IInteractiveMethodSetup, Mockolate.Setup.ISetup
     {
         protected MethodSetup() { }
         protected abstract void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
@@ -1063,7 +1063,7 @@ namespace Mockolate.Setup
     }
     public class MethodSetupResult
     {
-        public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
+        public MethodSetupResult(Mockolate.Setup.IInteractiveMethodSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
         public bool HasSetupResult { get; }
         public T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator) { }
@@ -1072,10 +1072,10 @@ namespace Mockolate.Setup
     }
     public class MethodSetupResult<TResult> : Mockolate.Setup.MethodSetupResult
     {
-        public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior, TResult result) { }
+        public MethodSetupResult(Mockolate.Setup.IInteractiveMethodSetup? setup, Mockolate.MockBehavior behavior, TResult result) { }
         public TResult Result { get; }
     }
-    public abstract class PropertySetup : Mockolate.Setup.IPropertySetup, Mockolate.Setup.ISetup
+    public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
     {
         protected PropertySetup() { }
         public abstract string Name { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -360,13 +360,6 @@ namespace Mockolate.Setup
         public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, out TReturn? returnValue) { }
     }
-    public interface IIndexerSetup : Mockolate.Setup.ISetup
-    {
-        bool? CallBaseClass();
-        bool HasReturnCalls();
-        bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
-        bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
-    }
     public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
@@ -523,7 +516,14 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
-    public interface IMethodSetup : Mockolate.Setup.ISetup
+    public interface IInteractiveIndexerSetup : Mockolate.Setup.ISetup
+    {
+        bool? CallBaseClass();
+        bool HasReturnCalls();
+        bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
+        bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
+    }
+    public interface IInteractiveMethodSetup : Mockolate.Setup.ISetup
     {
         bool? CallBaseClass();
         bool HasReturnCalls();
@@ -533,6 +533,14 @@ namespace Mockolate.Setup
         T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
         void TriggerCallbacks(object?[] parameters);
+    }
+    public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
+    {
+        bool? CallBaseClass();
+        void InitializeWith(object? value);
+        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator);
+        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
+        bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public interface IMockMethodSetupWithEqualsWithGetHashCode<out T> : Mockolate.IInteractiveMock<T>, Mockolate.Setup.IMockMethodSetupWithEquals<T>, Mockolate.Setup.IMockMethodSetupWithGetHashCode<T>, Mockolate.Setup.IMockMethodSetup<T> { }
     public interface IMockMethodSetupWithEquals<out T> : Mockolate.IInteractiveMock<T>, Mockolate.Setup.IMockMethodSetup<T>
@@ -555,14 +563,6 @@ namespace Mockolate.Setup
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T>
     {
         T Subject { get; }
-    }
-    public interface IPropertySetup : Mockolate.Setup.ISetup
-    {
-        bool? CallBaseClass();
-        void InitializeWith(object? value);
-        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator);
-        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
-        bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -898,7 +898,7 @@ namespace Mockolate.Setup
         Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
-    public abstract class IndexerSetup : Mockolate.Setup.IIndexerSetup, Mockolate.Setup.ISetup
+    public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup() { }
         protected abstract T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior);
@@ -912,12 +912,12 @@ namespace Mockolate.Setup
     }
     public class IndexerSetupResult
     {
-        public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
+        public IndexerSetupResult(Mockolate.Setup.IInteractiveIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
     }
     public class IndexerSetupResult<TResult> : Mockolate.Setup.IndexerSetupResult
     {
-        public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.Interactions.IndexerGetterAccess indexerAccess, Mockolate.MockBehavior behavior, System.Func<Mockolate.Setup.IIndexerSetup?, System.Func<TResult>, object?[], TResult> getIndexerValue, System.Action<object?[], TResult> setIndexerValue) { }
+        public IndexerSetupResult(Mockolate.Setup.IInteractiveIndexerSetup? setup, Mockolate.Interactions.IndexerGetterAccess indexerAccess, Mockolate.MockBehavior behavior, System.Func<Mockolate.Setup.IInteractiveIndexerSetup?, System.Func<TResult>, object?[], TResult> getIndexerValue, System.Action<object?[], TResult> setIndexerValue) { }
         public TResult GetResult(System.Func<TResult> defaultValueGenerator) { }
         public TResult GetResult(TResult baseValue, System.Func<TResult> defaultValueGenerator) { }
     }
@@ -1041,7 +1041,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup
+    public abstract class MethodSetup : Mockolate.Setup.IInteractiveMethodSetup, Mockolate.Setup.ISetup
     {
         protected MethodSetup() { }
         protected abstract void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
@@ -1062,7 +1062,7 @@ namespace Mockolate.Setup
     }
     public class MethodSetupResult
     {
-        public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
+        public MethodSetupResult(Mockolate.Setup.IInteractiveMethodSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
         public bool HasSetupResult { get; }
         public T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator) { }
@@ -1071,10 +1071,10 @@ namespace Mockolate.Setup
     }
     public class MethodSetupResult<TResult> : Mockolate.Setup.MethodSetupResult
     {
-        public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior, TResult result) { }
+        public MethodSetupResult(Mockolate.Setup.IInteractiveMethodSetup? setup, Mockolate.MockBehavior behavior, TResult result) { }
         public TResult Result { get; }
     }
-    public abstract class PropertySetup : Mockolate.Setup.IPropertySetup, Mockolate.Setup.ISetup
+    public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
     {
         protected PropertySetup() { }
         public abstract string Name { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -337,13 +337,6 @@ namespace Mockolate.Setup
         public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, out TReturn? returnValue) { }
     }
-    public interface IIndexerSetup : Mockolate.Setup.ISetup
-    {
-        bool? CallBaseClass();
-        bool HasReturnCalls();
-        bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
-        bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
-    }
     public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
@@ -500,7 +493,14 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
-    public interface IMethodSetup : Mockolate.Setup.ISetup
+    public interface IInteractiveIndexerSetup : Mockolate.Setup.ISetup
+    {
+        bool? CallBaseClass();
+        bool HasReturnCalls();
+        bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
+        bool TryGetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
+    }
+    public interface IInteractiveMethodSetup : Mockolate.Setup.ISetup
     {
         bool? CallBaseClass();
         bool HasReturnCalls();
@@ -510,6 +510,14 @@ namespace Mockolate.Setup
         T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
         void TriggerCallbacks(object?[] parameters);
+    }
+    public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
+    {
+        bool? CallBaseClass();
+        void InitializeWith(object? value);
+        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator);
+        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
+        bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public interface IMockMethodSetupWithEqualsWithGetHashCode<out T> : Mockolate.IInteractiveMock<T>, Mockolate.Setup.IMockMethodSetupWithEquals<T>, Mockolate.Setup.IMockMethodSetupWithGetHashCode<T>, Mockolate.Setup.IMockMethodSetup<T> { }
     public interface IMockMethodSetupWithEquals<out T> : Mockolate.IInteractiveMock<T>, Mockolate.Setup.IMockMethodSetup<T>
@@ -532,14 +540,6 @@ namespace Mockolate.Setup
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T>
     {
         T Subject { get; }
-    }
-    public interface IPropertySetup : Mockolate.Setup.ISetup
-    {
-        bool? CallBaseClass();
-        void InitializeWith(object? value);
-        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator);
-        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
-        bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -875,7 +875,7 @@ namespace Mockolate.Setup
         Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
-    public abstract class IndexerSetup : Mockolate.Setup.IIndexerSetup, Mockolate.Setup.ISetup
+    public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup() { }
         protected abstract T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior);
@@ -889,12 +889,12 @@ namespace Mockolate.Setup
     }
     public class IndexerSetupResult
     {
-        public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
+        public IndexerSetupResult(Mockolate.Setup.IInteractiveIndexerSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
     }
     public class IndexerSetupResult<TResult> : Mockolate.Setup.IndexerSetupResult
     {
-        public IndexerSetupResult(Mockolate.Setup.IIndexerSetup? setup, Mockolate.Interactions.IndexerGetterAccess indexerAccess, Mockolate.MockBehavior behavior, System.Func<Mockolate.Setup.IIndexerSetup?, System.Func<TResult>, object?[], TResult> getIndexerValue, System.Action<object?[], TResult> setIndexerValue) { }
+        public IndexerSetupResult(Mockolate.Setup.IInteractiveIndexerSetup? setup, Mockolate.Interactions.IndexerGetterAccess indexerAccess, Mockolate.MockBehavior behavior, System.Func<Mockolate.Setup.IInteractiveIndexerSetup?, System.Func<TResult>, object?[], TResult> getIndexerValue, System.Action<object?[], TResult> setIndexerValue) { }
         public TResult GetResult(System.Func<TResult> defaultValueGenerator) { }
         public TResult GetResult(TResult baseValue, System.Func<TResult> defaultValueGenerator) { }
     }
@@ -1018,7 +1018,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup
+    public abstract class MethodSetup : Mockolate.Setup.IInteractiveMethodSetup, Mockolate.Setup.ISetup
     {
         protected MethodSetup() { }
         protected abstract void ExecuteCallback(Mockolate.Interactions.MethodInvocation invocation, Mockolate.MockBehavior behavior);
@@ -1039,7 +1039,7 @@ namespace Mockolate.Setup
     }
     public class MethodSetupResult
     {
-        public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior) { }
+        public MethodSetupResult(Mockolate.Setup.IInteractiveMethodSetup? setup, Mockolate.MockBehavior behavior) { }
         public bool CallBaseClass { get; }
         public bool HasSetupResult { get; }
         public T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator) { }
@@ -1048,10 +1048,10 @@ namespace Mockolate.Setup
     }
     public class MethodSetupResult<TResult> : Mockolate.Setup.MethodSetupResult
     {
-        public MethodSetupResult(Mockolate.Setup.IMethodSetup? setup, Mockolate.MockBehavior behavior, TResult result) { }
+        public MethodSetupResult(Mockolate.Setup.IInteractiveMethodSetup? setup, Mockolate.MockBehavior behavior, TResult result) { }
         public TResult Result { get; }
     }
-    public abstract class PropertySetup : Mockolate.Setup.IPropertySetup, Mockolate.Setup.ISetup
+    public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
     {
         protected PropertySetup() { }
         public abstract string Name { get; }

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
@@ -45,7 +45,7 @@ public sealed partial class SetupPropertyTests
 
 		int result0 = registration.GetProperty("my.other.property", () => 0, null);
 		PropertySetup<int> setup = new("my.property");
-		((IPropertySetup)setup).InitializeWith(42);
+		((IInteractivePropertySetup)setup).InitializeWith(42);
 		registration.SetupProperty(setup);
 		int result1 = registration.GetProperty("my.property", () => 0, null);
 


### PR DESCRIPTION
This PR renames internal setup interfaces to improve naming clarity by adding an "Interactive" prefix. The changes rename `IPropertySetup`, `IMethodSetup`, and `IIndexerSetup` to `IInteractivePropertySetup`, `IInteractiveMethodSetup`, and `IInteractiveIndexerSetup` respectively.

### Key Changes
- Renamed three internal interfaces to include "Interactive" prefix for better clarity
- Updated all interface implementations and references across the codebase
- Updated API baseline files to reflect the new interface names