### PR TITLE
coverage: ensure correct behavior for indexer setup with return values

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -142,7 +142,7 @@ internal record Class
 		return GetPrefix(type) + type.Name;
 	}
 
-	private bool TryExtractSpecialName(INamedTypeSymbol namedType, [NotNullWhen(true)] out string? specialName)
+	private static bool TryExtractSpecialName(INamedTypeSymbol namedType, [NotNullWhen(true)] out string? specialName)
 	{
 		(specialName, bool hasSpecialType) = namedType.SpecialType switch
 		{

--- a/Source/Mockolate/Setup/IndexerSetupResult.cs
+++ b/Source/Mockolate/Setup/IndexerSetupResult.cs
@@ -42,11 +42,7 @@ public class IndexerSetupResult<TResult>(
 		{
 			value = indexerSetup.InvokeGetter(indexerAccess, baseValue ?? defaultValueGenerator(),
 				_behavior);
-			if (_setup.HasReturnCalls())
-			{
-				setIndexerValue(indexerAccess.Parameters, value);
-				return value;
-			}
+			setIndexerValue(indexerAccess.Parameters, value);
 		}
 		else if (_behavior.ThrowWhenNotSetup)
 		{
@@ -58,9 +54,7 @@ public class IndexerSetupResult<TResult>(
 			value = baseValue ?? defaultValueGenerator();
 		}
 
-		TResult result = getIndexerValue(_setup, () => value, indexerAccess.Parameters);
-		setIndexerValue(indexerAccess.Parameters, result);
-		return result;
+		return getIndexerValue(_setup, () => value, indexerAccess.Parameters);
 	}
 
 	/// <summary>

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Mockolate.Tests.TestHelpers;
 
 namespace Mockolate.Tests.MockIndexers;
 
@@ -10,20 +9,24 @@ public sealed partial class SetupIndexerTests
 		[Fact]
 		public async Task IndexerReturns_WithSpecificParameter_ShouldIterateThroughValues()
 		{
-			IChocolateDispenser mock = Mock.Create<IChocolateDispenser>();
-			mock.SetupMock.Indexer(With("Dark"))
-				.Returns(1)
-				.Returns(2);
+			IIndexerService mock = Mock.Create<IIndexerService>();
+			mock.SetupMock.Indexer(With(1))
+				.Returns("a")
+				.Returns("b");
 
-			int resultDark1 = mock["Dark"];
-			int resultLight1 = mock["Light"];
-			int resultDark2 = mock["Dark"];
-			int resultDark3 = mock["Dark"];
+			string result11 = mock[1];
+			string result2 = mock[2];
+			string result12 = mock[1];
+			string result13 = mock[1];
+			string result14 = mock[1];
+			string result15 = mock[1];
 
-			await That(resultDark1).IsEqualTo(1);
-			await That(resultLight1).IsEqualTo(0);
-			await That(resultDark2).IsEqualTo(2);
-			await That(resultDark3).IsEqualTo(1);
+			await That(result11).IsEqualTo("a");
+			await That(result2).IsEqualTo("");
+			await That(result12).IsEqualTo("b");
+			await That(result13).IsEqualTo("a");
+			await That(result14).IsEqualTo("b");
+			await That(result15).IsEqualTo("a");
 		}
 
 		[Fact]
@@ -286,6 +289,29 @@ public sealed partial class SetupIndexerTests
 		public sealed class With2Levels
 		{
 			[Fact]
+			public async Task IndexerReturns_WithSpecificParameter_ShouldIterateThroughValues()
+			{
+				IIndexerService mock = Mock.Create<IIndexerService>();
+				mock.SetupMock.Indexer(With(1), Any<int>())
+					.Returns("a")
+					.Returns("b");
+
+				string result11 = mock[1, 2];
+				string result2 = mock[2, 2];
+				string result12 = mock[1, 2];
+				string result13 = mock[1, 2];
+				string result14 = mock[1, 2];
+				string result15 = mock[1, 2];
+
+				await That(result11).IsEqualTo("a");
+				await That(result2).IsEqualTo("");
+				await That(result12).IsEqualTo("b");
+				await That(result13).IsEqualTo("a");
+				await That(result14).IsEqualTo("b");
+				await That(result15).IsEqualTo("a");
+			}
+
+			[Fact]
 			public async Task MixReturnsAndThrows_ShouldIterateThroughBoth()
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
@@ -545,6 +571,29 @@ public sealed partial class SetupIndexerTests
 
 		public sealed class With3Levels
 		{
+			[Fact]
+			public async Task IndexerReturns_WithSpecificParameter_ShouldIterateThroughValues()
+			{
+				IIndexerService mock = Mock.Create<IIndexerService>();
+				mock.SetupMock.Indexer(With(1), Any<int>(), Any<int>())
+					.Returns("a")
+					.Returns("b");
+
+				string result11 = mock[1, 2, 3];
+				string result2 = mock[2, 2, 3];
+				string result12 = mock[1, 2, 3];
+				string result13 = mock[1, 2, 3];
+				string result14 = mock[1, 2, 3];
+				string result15 = mock[1, 2, 3];
+
+				await That(result11).IsEqualTo("a");
+				await That(result2).IsEqualTo("");
+				await That(result12).IsEqualTo("b");
+				await That(result13).IsEqualTo("a");
+				await That(result14).IsEqualTo("b");
+				await That(result15).IsEqualTo("a");
+			}
+
 			[Fact]
 			public async Task MixReturnsAndThrows_ShouldIterateThroughBoth()
 			{
@@ -807,6 +856,29 @@ public sealed partial class SetupIndexerTests
 		public sealed class With4Levels
 		{
 			[Fact]
+			public async Task IndexerReturns_WithSpecificParameter_ShouldIterateThroughValues()
+			{
+				IIndexerService mock = Mock.Create<IIndexerService>();
+				mock.SetupMock.Indexer(With(1), Any<int>(), Any<int>(), Any<int>())
+					.Returns("a")
+					.Returns("b");
+
+				string result11 = mock[1, 2, 3, 4];
+				string result2 = mock[2, 2, 3, 4];
+				string result12 = mock[1, 2, 3, 4];
+				string result13 = mock[1, 2, 3, 4];
+				string result14 = mock[1, 2, 3, 4];
+				string result15 = mock[1, 2, 3, 4];
+
+				await That(result11).IsEqualTo("a");
+				await That(result2).IsEqualTo("");
+				await That(result12).IsEqualTo("b");
+				await That(result13).IsEqualTo("a");
+				await That(result14).IsEqualTo("b");
+				await That(result15).IsEqualTo("a");
+			}
+
+			[Fact]
 			public async Task MixReturnsAndThrows_ShouldIterateThroughBoth()
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
@@ -1068,6 +1140,29 @@ public sealed partial class SetupIndexerTests
 
 		public sealed class With5Levels
 		{
+			[Fact]
+			public async Task IndexerReturns_WithSpecificParameter_ShouldIterateThroughValues()
+			{
+				IIndexerService mock = Mock.Create<IIndexerService>();
+				mock.SetupMock.Indexer(With(1), Any<int>(), Any<int>(), Any<int>(), Any<int>())
+					.Returns("a")
+					.Returns("b");
+
+				string result11 = mock[1, 2, 3, 4, 5];
+				string result2 = mock[2, 2, 3, 4, 5];
+				string result12 = mock[1, 2, 3, 4, 5];
+				string result13 = mock[1, 2, 3, 4, 5];
+				string result14 = mock[1, 2, 3, 4, 5];
+				string result15 = mock[1, 2, 3, 4, 5];
+
+				await That(result11).IsEqualTo("a");
+				await That(result2).IsEqualTo("");
+				await That(result12).IsEqualTo("b");
+				await That(result13).IsEqualTo("a");
+				await That(result14).IsEqualTo("b");
+				await That(result15).IsEqualTo("a");
+			}
+
 			[Fact]
 			public async Task MixReturnsAndThrows_ShouldIterateThroughBoth()
 			{


### PR DESCRIPTION
This PR enhances test coverage for indexer setup behavior with return values, ensuring correct iteration through configured return values across indexers with 1-5 parameters. The changes verify that indexers properly cycle through return values when multiple calls are made, and that non-matching parameter configurations return default values.

### Key Changes
- Added comprehensive test coverage for indexer return value iteration across all supported parameter counts
- Refactored indexer value retrieval logic to eliminate redundant operations
- Improved code quality with static method modifier

---

- *Verifies #260*