### PR TITLE
refactor!: consolidate callback signatures between property and indexer setups

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -145,6 +145,9 @@ internal static partial class Sources
 				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
 			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
 			.Append(typeParams)
 			.Append("> callback);").AppendLine();
@@ -155,9 +158,25 @@ internal static partial class Sources
 				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
 			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
+			.Append(typeParams)
+			.Append(", TValue> callback);").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<int, ")
 			.Append(typeParams)
-			.Append("> callback);").AppendLine();
+			.Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <summary>").AppendLine();
@@ -174,6 +193,9 @@ internal static partial class Sources
 				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
 			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the value the indexer is set to as single parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> OnSet(Action<TValue> callback);").AppendLine();
 		sb.AppendLine();
@@ -183,8 +205,11 @@ internal static partial class Sources
 				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
 			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnSet(Action<TValue, ")
-			.Append(typeParams).Append("> callback);").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnSet(Action<")
+			.Append(typeParams).Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <summary>").AppendLine();
@@ -192,25 +217,18 @@ internal static partial class Sources
 				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
 			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnSet(Action<int, TValue, ")
-			.Append(typeParams).Append("> callback);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<TValue, ")
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnSet(Action<int, ")
 			.Append(typeParams).Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
+		sb.Append("\t\t///     Registers the <paramref name=\"returnValue\" /> for this indexer.").AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
-			.Append(typeParams)
-			.Append(", TValue> callback);").AppendLine();
+		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(TValue returnValue);")
+			.AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <summary>").AppendLine();
@@ -223,10 +241,26 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers the <paramref name=\"returnValue\" /> for this indexer.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(TValue returnValue);")
+		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
 			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
+			.Append(typeParams)
+			.Append(", TValue> callback);").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
+			.Append(typeParams).Append(", TValue, TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <summary>").AppendLine();
@@ -261,6 +295,9 @@ internal static partial class Sources
 				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
 			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams)
 			.Append(", Exception> callback);").AppendLine();
@@ -271,8 +308,11 @@ internal static partial class Sources
 				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
 			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<TValue, ")
-			.Append(typeParams).Append(", Exception> callback);").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<")
+			.Append(typeParams).Append(", TValue, Exception> callback);").AppendLine();
 
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
@@ -444,13 +484,13 @@ internal static partial class Sources
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.Append("\t\tprivate readonly List<Callback<Action<int, ").Append(typeParams)
-			.Append(">>> _getterCallbacks = [];")
+			.Append(", TValue>>> _getterCallbacks = [];")
 			.AppendLine();
-		sb.Append("\t\tprivate readonly List<Callback<Action<int, TValue, ").Append(typeParams)
-			.Append(">>> _setterCallbacks = [];")
+		sb.Append("\t\tprivate readonly List<Callback<Action<int, ").Append(typeParams)
+			.Append(", TValue>>> _setterCallbacks = [];")
 			.AppendLine();
-		sb.Append("\t\tprivate readonly List<Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>> _returnCallbacks = [];")
+		sb.Append("\t\tprivate readonly List<Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>> _returnCallbacks = [];")
 			.AppendLine();
 		sb.Append("\t\tprivate bool? _callBaseClass;").AppendLine();
 		sb.Append("\t\tprivate Callback? _currentCallback;").AppendLine();
@@ -461,14 +501,7 @@ internal static partial class Sources
 		sb.Append("\t\tprivate Func<").Append(typeParams).Append(", TValue>? _initialization;").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Flag indicating if the base class implementation should be called, and its return values used as default values.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.CallingBaseClass(bool)\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetup<TValue, ").Append(typeParams)
 			.Append("> CallingBaseClass(bool callBaseClass = true)")
 			.AppendLine();
@@ -478,9 +511,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Initializes the indexer with the given <paramref name=\"value\" />.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.InitializeWith(TValue)\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetup<TValue, ").Append(typeParams).Append("> InitializeWith(TValue value)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -496,10 +527,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Initializes the according to the given <paramref name=\"valueGenerator\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.InitializeWith(Func{").Append(typeParams).Append(", TValue})\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetup<TValue, ").Append(typeParams).Append("> InitializeWith(Func<")
 			.Append(typeParams).Append(", TValue> valueGenerator)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -515,49 +543,50 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action)\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> OnGet(Action callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ")
-			.Append(discards).Append(") => callback());").AppendLine();
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
+			.Append(discards).Append(", _) => callback());").AppendLine();
 		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action{").Append(typeParams).Append("})\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
 			.Append(typeParams)
 			.Append("> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ")
-			.Append(parameters).Append(") => callback(").Append(parameters).Append("));").AppendLine();
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
+			.Append(parameters).Append(", _) => callback(").Append(parameters).Append("));").AppendLine();
 		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action{").Append(typeParams).Append(", TValue})\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
+			.Append(typeParams)
+			.Append(", TValue> callback)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
+			.Append(parameters).Append(", v) => callback(").Append(parameters).Append(", v));").AppendLine();
+		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\treturn this;").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<int, ")
 			.Append(typeParams)
-			.Append("> callback)").AppendLine();
+			.Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(">>? currentCallback = new(callback);")
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new(callback);")
 			.AppendLine();
 		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
@@ -565,15 +594,11 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action)\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> OnSet(Action callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tCallback<Action<int, TValue, ").Append(typeParams).Append(">>? currentCallback = new((_, _, ")
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, _, ")
 			.Append(discards).Append(") => callback());").AppendLine();
 		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
@@ -581,182 +606,145 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action{TValue})\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> OnSet(Action<TValue> callback)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tCallback<Action<int, TValue, ").Append(typeParams).Append(">>? currentCallback = new((_, v, ")
-			.Append(discards).Append(") => callback(v));").AppendLine();
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
+			.Append(discards).Append(", v) => callback(v));").AppendLine();
 		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action{").Append(typeParams).Append(", TValue})\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnSet(Action<TValue, ")
-			.Append(typeParams).Append("> callback)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tCallback<Action<int, TValue, ").Append(typeParams).Append(">>? currentCallback = new((_, v, ")
-			.Append(parameters).Append(") => callback(v, ").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
-		sb.Append("\t\t\treturn this;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnSet(Action<int, TValue, ")
-			.Append(typeParams).Append("> callback)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tCallback<Action<int, TValue, ").Append(typeParams)
-			.Append(">>? currentCallback = new(callback);")
-			.AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
-		sb.Append("\t\t\treturn this;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<TValue, ")
+			.Append("> OnSet(Action<")
 			.Append(typeParams).Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, v, ").Append(parameters).Append(") => callback(v, ").Append(parameters)
-			.Append("));").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
+			.Append(parameters).Append(", v) => callback(").Append(parameters).Append(", v));").AppendLine();
+		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
-			.Append(typeParams)
-			.Append(", TValue> callback)").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+			.Append("> OnSet(Action<int, ")
+			.Append(typeParams).Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, _, ").Append(parameters).Append(") => callback(").Append(parameters).Append("));")
+		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams)
+			.Append(", TValue>>? currentCallback = new(callback);")
 			.AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
-			.Append("> Returns(Func<TValue> callback)")
-			.AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, _, ").Append(discards).Append(") => callback());").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
-		sb.Append("\t\t\treturn this;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers the <paramref name=\"returnValue\" /> for this indexer.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Returns(TValue)\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
 			.Append("> Returns(TValue returnValue)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, _, ").Append(discards).Append(") => returnValue);").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => returnValue);").AppendLine();
 		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <typeparamref name=\"TException\" /> to throw when the indexer is read.")
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Returns(Func{TValue})\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
+			.Append("> Returns(Func<TValue> callback)")
 			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => callback());").AppendLine();
+		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\treturn this;").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Returns(Func{").Append(typeParams).Append(", TValue})\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
+			.Append(typeParams)
+			.Append(", TValue> callback)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", _) => callback(").Append(parameters).Append("));")
+			.AppendLine();
+		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\treturn this;").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Returns(Func{").Append(typeParams).Append(", TValue, TValue})\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
+			.Append(typeParams).Append(", TValue, TValue> callback)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, v, ").Append(parameters).Append(") => callback(v, ").Append(parameters)
+			.Append("));").AppendLine();
+		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\treturn this;").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Throws{TException}()\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws<TException>()")
 			.AppendLine();
 		sb.Append("\t\t\twhere TException : Exception, new()").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, _, ").Append(discards).Append(") => throw new TException());").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw new TException());").AppendLine();
 		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <paramref name=\"exception\" /> to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Throws(Exception)\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
 			.Append("> Throws(Exception exception)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, _, ").Append(discards).Append(") => throw exception);").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw exception);").AppendLine();
 		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Throws(Func{Exception})\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
 			.Append("> Throws(Func<Exception> callback)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, _, ").Append(discards).Append(") => throw callback());").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw callback());").AppendLine();
 		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Throws(Func{").Append(typeParams).Append(", Exception})\" />").AppendLine();
 		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams)
 			.Append(", Exception> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, _, ").Append(parameters).Append(") => throw callback(").Append(parameters)
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", _) => throw callback(").Append(parameters)
 			.Append("));").AppendLine();
 		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
@@ -764,17 +752,13 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<TValue, ")
-			.Append(typeParams).Append(", Exception> callback)").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.Throws(Func{").Append(typeParams).Append(", TValue, Exception})\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<")
+			.Append(typeParams).Append(", TValue, Exception> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, TValue, ").Append(typeParams)
-			.Append(", TValue>>((_, v, ").Append(parameters).Append(") => throw callback(v, ").Append(parameters)
-			.Append("));").AppendLine();
+		sb.Append("\t\t\tvar currentCallback = new Callback<Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", v) => throw callback(").Append(parameters)
+			.Append(", v));").AppendLine();
 		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
@@ -883,13 +867,13 @@ internal static partial class Sources
 		sb.Append("\t\t\t\tint currentGetterCallbacksIndex = _currentGetterCallbacksIndex;").AppendLine();
 		sb.Append("\t\t\t\tfor (int i = 0; i < _getterCallbacks.Count; i++)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\tCallback<Action<int, ").Append(typeParams).Append(">> getterCallback =").AppendLine();
+		sb.Append("\t\t\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>> getterCallback =").AppendLine();
 		sb.Append("\t\t\t\t\t\t_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];")
 			.AppendLine();
 		sb.Append(
 				"\t\t\t\t\tif (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)")
 			.AppendLine();
-		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(")))")
+		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", resultValue)))")
 			.AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();
@@ -898,15 +882,15 @@ internal static partial class Sources
 		sb.AppendLine();
 		sb.Append("\t\t\t\tforeach (var _ in _returnCallbacks)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\tCallback<Func<int, TValue, ").Append(typeParams)
+		sb.Append("\t\t\t\t\tCallback<Func<int, ").Append(typeParams)
 			.Append(
-				", TValue>> returnCallback = _returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];")
+				", TValue, TValue>> returnCallback = _returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];")
 			.AppendLine();
 		sb.Append(
 				"\t\t\t\t\tif (returnCallback.Invoke<TValue>(ref _currentReturnCallbackIndex, (invocationCount, @delegate)")
 			.AppendLine();
-		sb.Append("\t\t\t\t\t\t\t=> @delegate(invocationCount, resultValue, ").Append(parameters)
-			.Append("), out TValue? newValue) &&").AppendLine();
+		sb.Append("\t\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters)
+			.Append(", resultValue), out TValue? newValue) &&").AppendLine();
 		sb.Append("\t\t\t\t\t\tTryCast(newValue, out T returnValue, behavior))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\treturn returnValue;").AppendLine();
@@ -951,14 +935,14 @@ internal static partial class Sources
 		sb.Append("\t\t\t\tint currentSetterCallbacksIndex = _currentSetterCallbacksIndex;").AppendLine();
 		sb.Append("\t\t\t\tfor (int i = 0; i < _setterCallbacks.Count; i++)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\tCallback<Action<int, TValue, ").Append(typeParams).Append(">> setterCallback =")
+		sb.Append("\t\t\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>> setterCallback =")
 			.AppendLine();
 		sb.Append("\t\t\t\t\t\t_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];")
 			.AppendLine();
 		sb.Append(
 				"\t\t\t\t\tif (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)")
 			.AppendLine();
-		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, resultValue, ").Append(parameters).Append(")))")
+		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", resultValue)))")
 			.AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -132,9 +132,9 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 public class IndexerSetup<TValue, T1>(IParameter match1)
 	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1>, IIndexerSetupReturnBuilder<TValue, T1>
 {
-	private readonly List<Callback<Action<int, T1>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, TValue, T1, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, TValue, T1>>> _setterCallbacks = [];
+	private readonly List<Callback<Action<int, T1, TValue>>> _getterCallbacks = [];
+	private readonly List<Callback<Func<int, T1, TValue, TValue>>> _returnCallbacks = [];
+	private readonly List<Callback<Action<int, T1, TValue>>> _setterCallbacks = [];
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private int _currentGetterCallbacksIndex;
@@ -150,9 +150,7 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer with the given <paramref name="value" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.InitializeWith(TValue)" />
 	public IIndexerSetup<TValue, T1> InitializeWith(TValue value)
 	{
 		if (_initialization is not null)
@@ -164,9 +162,7 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.InitializeWith(Func{T1, TValue})" />
 	public IIndexerSetup<TValue, T1> InitializeWith(Func<T1, TValue> valueGenerator)
 	{
 		if (_initialization is not null)
@@ -178,178 +174,155 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action callback)
 	{
-		Callback<Action<int, T1>> currentCallback = new((_, _) => callback());
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => callback());
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action{T1})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1> callback)
 	{
-		Callback<Action<int, T1>> currentCallback = new((_, p1) => callback(p1));
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, _) => callback(p1));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<int, T1> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action{T1, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1, TValue> callback)
 	{
-		Callback<Action<int, T1>> currentCallback = new(callback);
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, v) => callback(p1, v));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action{int, T1, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<int, T1, TValue> callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action callback)
 	{
-		Callback<Action<int, TValue, T1>> currentCallback = new((_, _, _) => callback());
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => callback());
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action{TValue})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<TValue> callback)
 	{
-		Callback<Action<int, TValue, T1>> currentCallback = new((_, v, _) => callback(v));
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, v) => callback(v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<TValue, T1> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action{T1, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<T1, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1>> currentCallback = new((_, v, p1) => callback(v, p1));
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, v) => callback(p1, v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<int, TValue, T1> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action{int, T1, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<int, T1, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1>> currentCallback = new(callback);
+		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<TValue, T1, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, v, p1) => callback(v, p1));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, _, p1) => callback(p1));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, _, _) => callback());
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this property.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue)
 	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, _, _) => returnValue);
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, _, _) => returnValue);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Returns(Func{TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<TValue> callback)
+	{
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, _, _) => callback());
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Returns(Func{T1, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue> callback)
+	{
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, p1, _) => callback(p1));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Returns(Func{T1, TValue, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue, TValue> callback)
+	{
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, p1, v) => callback(p1, v));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws{TException}()" />
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws<TException>()
 		where TException : Exception, new()
 	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, _, _) => throw new TException());
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, _, _) => throw new TException());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws(Exception)" />
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Exception exception)
 	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, _, _) => throw exception);
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, _, _) => throw exception);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws(Func{Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, _, _) => throw callback());
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, _, _) => throw callback());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws(Func{T1, Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, _, p1) => throw callback(p1));
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, p1, _) => throw callback(p1));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<TValue, T1, Exception> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws(Func{T1, TValue, Exception})" />
+	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, TValue, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, TValue>> currentCallback = new((_, v, p1) => throw callback(v, p1));
+		Callback<Func<int, T1, TValue, TValue>> currentCallback = new((_, p1, v) => throw callback(p1, v));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
@@ -425,21 +398,21 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 			int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
 			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				Callback<Action<int, T1>> getterCallback =
+				Callback<Action<int, T1, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
 				if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1)))
+					    => @delegate(invocationCount, p1, resultValue)))
 				{
 					wasInvoked = true;
 				}
 			}
 
-			foreach (Callback<Func<int, TValue, T1, TValue>> _ in _returnCallbacks)
+			foreach (Callback<Func<int, T1, TValue, TValue>> _ in _returnCallbacks)
 			{
-				Callback<Func<int, TValue, T1, TValue>> returnCallback =
+				Callback<Func<int, T1, TValue, TValue>> returnCallback =
 					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1), out TValue? newValue) &&
+					    => @delegate(invocationCount, p1, resultValue), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))
 				{
 					return returnValue;
@@ -462,10 +435,10 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 			int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
 			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				Callback<Action<int, TValue, T1>> setterCallback =
+				Callback<Action<int, T1, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
 				if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1)))
+					    => @delegate(invocationCount, p1, resultValue)))
 				{
 					wasInvoked = true;
 				}
@@ -502,9 +475,9 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetupReturnBuilder<TValue, T1, T2>
 {
-	private readonly List<Callback<Action<int, T1, T2>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, TValue, T1, T2, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, TValue, T1, T2>>> _setterCallbacks = [];
+	private readonly List<Callback<Action<int, T1, T2, TValue>>> _getterCallbacks = [];
+	private readonly List<Callback<Func<int, T1, T2, TValue, TValue>>> _returnCallbacks = [];
+	private readonly List<Callback<Action<int, T1, T2, TValue>>> _setterCallbacks = [];
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private int _currentGetterCallbacksIndex;
@@ -520,9 +493,7 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer with the given <paramref name="value" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.InitializeWith(TValue)" />
 	public IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value)
 	{
 		if (_initialization is not null)
@@ -534,9 +505,7 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.InitializeWith(Func{T1, T2, TValue})" />
 	public IIndexerSetup<TValue, T1, T2> InitializeWith(Func<T1, T2, TValue> valueGenerator)
 	{
 		if (_initialization is not null)
@@ -548,180 +517,157 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action callback)
 	{
-		Callback<Action<int, T1, T2>> currentCallback = new((_, _, _) => callback());
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => callback());
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action{T1, T2})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2> callback)
 	{
-		Callback<Action<int, T1, T2>> currentCallback = new((_, p1, p2) => callback(p1, p2));
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, _) => callback(p1, p2));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<int, T1, T2> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action{T1, T2, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2, TValue> callback)
 	{
-		Callback<Action<int, T1, T2>> currentCallback = new(callback);
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, v) => callback(p1, p2, v));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action{int, T1, T2, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<int, T1, T2, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action callback)
 	{
-		Callback<Action<int, TValue, T1, T2>> currentCallback = new((_, _, _, _) => callback());
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => callback());
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action{TValue})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2>> currentCallback = new((_, v, _, _) => callback(v));
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, v) => callback(v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<TValue, T1, T2> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action{T1, T2, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<T1, T2, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2>> currentCallback = new((_, v, p1, p2) => callback(v, p1, p2));
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, v) => callback(p1, p2, v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<int, TValue, T1, T2> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action{int, T1, T2, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<int, T1, T2, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2>> currentCallback = new(callback);
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue, T1, T2, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback = new((_, v, p1, p2) => callback(v, p1, p2));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback = new((_, _, p1, p2) => callback(p1, p2));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback = new((_, _, _, _) => callback());
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this property.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue)
 	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback = new((_, _, _, _) => returnValue);
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new((_, _, _, _) => returnValue);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Returns(Func{TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue> callback)
+	{
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new((_, _, _, _) => callback());
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Returns(Func{T1, T2, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue> callback)
+	{
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new((_, p1, p2, _) => callback(p1, p2));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Returns(Func{T1, T2, TValue, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue, TValue> callback)
+	{
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new((_, p1, p2, v) => callback(p1, p2, v));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws{TException}()" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws<TException>()
 		where TException : Exception, new()
 	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback = new((_, _, _, _) => throw new TException());
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new((_, _, _, _) => throw new TException());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws(Exception)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Exception exception)
 	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback = new((_, _, _, _) => throw exception);
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new((_, _, _, _) => throw exception);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws(Func{Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback = new((_, _, _, _) => throw callback());
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new((_, _, _, _) => throw callback());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws(Func{T1, T2, Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback =
-			new((_, _, p1, p2) => throw callback(p1, p2));
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback =
+			new((_, p1, p2, _) => throw callback(p1, p2));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<TValue, T1, T2, Exception> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws(Func{T1, T2, TValue, Exception})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, TValue, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, TValue>> currentCallback =
-			new((_, v, p1, p2) => throw callback(v, p1, p2));
+		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback =
+			new((_, p1, p2, v) => throw callback(p1, p2, v));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
@@ -799,21 +745,21 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 			int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
 			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				Callback<Action<int, T1, T2>> getterCallback =
+				Callback<Action<int, T1, T2, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
 				if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2)))
+					    => @delegate(invocationCount, p1, p2, resultValue)))
 				{
 					wasInvoked = true;
 				}
 			}
 
-			foreach (Callback<Func<int, TValue, T1, T2, TValue>> _ in _returnCallbacks)
+			foreach (Callback<Func<int, T1, T2, TValue, TValue>> _ in _returnCallbacks)
 			{
-				Callback<Func<int, TValue, T1, T2, TValue>> returnCallback =
+				Callback<Func<int, T1, T2, TValue, TValue>> returnCallback =
 					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1, p2), out TValue? newValue) &&
+					    => @delegate(invocationCount, p1, p2, resultValue), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))
 				{
 					return returnValue;
@@ -837,10 +783,10 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 			int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
 			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				Callback<Action<int, TValue, T1, T2>> setterCallback =
+				Callback<Action<int, T1, T2, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
 				if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1, p2)))
+					    => @delegate(invocationCount, p1, p2, resultValue)))
 				{
 					wasInvoked = true;
 				}
@@ -882,9 +828,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IParameter match3)
 	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3>
 {
-	private readonly List<Callback<Action<int, T1, T2, T3>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, TValue, T1, T2, T3, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, TValue, T1, T2, T3>>> _setterCallbacks = [];
+	private readonly List<Callback<Action<int, T1, T2, T3, TValue>>> _getterCallbacks = [];
+	private readonly List<Callback<Func<int, T1, T2, T3, TValue, TValue>>> _returnCallbacks = [];
+	private readonly List<Callback<Action<int, T1, T2, T3, TValue>>> _setterCallbacks = [];
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private int _currentGetterCallbacksIndex;
@@ -900,9 +846,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer with the given <paramref name="value" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.InitializeWith(TValue)" />
 	public IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value)
 	{
 		if (_initialization is not null)
@@ -914,9 +858,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.InitializeWith(Func{T1, T2, T3, TValue})" />
 	public IIndexerSetup<TValue, T1, T2, T3> InitializeWith(Func<T1, T2, T3, TValue> valueGenerator)
 	{
 		if (_initialization is not null)
@@ -928,184 +870,161 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action callback)
 	{
-		Callback<Action<int, T1, T2, T3>> currentCallback = new((_, _, _, _) => callback());
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => callback());
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action{T1, T2, T3})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3> callback)
 	{
-		Callback<Action<int, T1, T2, T3>> currentCallback = new((_, p1, p2, p3) => callback(p1, p2, p3));
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, _) => callback(p1, p2, p3));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<int, T1, T2, T3> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action{T1, T2, T3, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3, TValue> callback)
 	{
-		Callback<Action<int, T1, T2, T3>> currentCallback = new(callback);
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, v) => callback(p1, p2, p3, v));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action{int, T1, T2, T3, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<int, T1, T2, T3, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3>> currentCallback = new((_, _, _, _, _) => callback());
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => callback());
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action{TValue})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3>> currentCallback = new((_, v, _, _, _) => callback(v));
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, v) => callback(v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<TValue, T1, T2, T3> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action{T1, T2, T3, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<T1, T2, T3, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3>> currentCallback = new((_, v, p1, p2, p3) => callback(v, p1, p2, p3));
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, v) => callback(p1, p2, p3, v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<int, TValue, T1, T2, T3> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action{int, T1, T2, T3, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<int, T1, T2, T3, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3>> currentCallback = new(callback);
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue, T1, T2, T3, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback =
-			new((_, v, p1, p2, p3) => callback(v, p1, p2, p3));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback =
-			new((_, _, p1, p2, p3) => callback(p1, p2, p3));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => callback());
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this property.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => returnValue);
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new((_, _, _, _, _) => returnValue);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Returns(Func{TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue> callback)
+	{
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new((_, _, _, _, _) => callback());
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Returns(Func{T1, T2, T3, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue> callback)
+	{
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, _) => callback(p1, p2, p3));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Returns(Func{T1, T2, T3, TValue, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue, TValue> callback)
+	{
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, v) => callback(p1, p2, p3, v));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws{TException}()" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
 		where TException : Exception, new()
 	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback =
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback =
 			new((_, _, _, _, _) => throw new TException());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws(Exception)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Exception exception)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => throw exception);
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new((_, _, _, _, _) => throw exception);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws(Func{Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>>
+		Callback<Func<int, T1, T2, T3, TValue, TValue>>
 			currentCallback = new((_, _, _, _, _) => throw callback());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws(Func{T1, T2, T3, Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback =
-			new((_, _, p1, p2, p3) => throw callback(p1, p2, p3));
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, _) => throw callback(p1, p2, p3));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<TValue, T1, T2, T3, Exception> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws(Func{T1, T2, T3, TValue, Exception})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, TValue, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, TValue>> currentCallback =
-			new((_, v, p1, p2, p3) => throw callback(v, p1, p2, p3));
+		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, v) => throw callback(p1, p2, p3, v));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
@@ -1185,21 +1104,21 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 			int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
 			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				Callback<Action<int, T1, T2, T3>> getterCallback =
+				Callback<Action<int, T1, T2, T3, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
 				if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3)))
+					    => @delegate(invocationCount, p1, p2, p3, resultValue)))
 				{
 					wasInvoked = true;
 				}
 			}
 
-			foreach (Callback<Func<int, TValue, T1, T2, T3, TValue>> _ in _returnCallbacks)
+			foreach (Callback<Func<int, T1, T2, T3, TValue, TValue>> _ in _returnCallbacks)
 			{
-				Callback<Func<int, TValue, T1, T2, T3, TValue>> returnCallback =
+				Callback<Func<int, T1, T2, T3, TValue, TValue>> returnCallback =
 					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1, p2, p3), out TValue? newValue) &&
+					    => @delegate(invocationCount, p1, p2, p3, resultValue), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))
 				{
 					return returnValue;
@@ -1224,10 +1143,10 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 			int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
 			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				Callback<Action<int, TValue, T1, T2, T3>> setterCallback =
+				Callback<Action<int, T1, T2, T3, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
 				if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1, p2, p3)))
+					    => @delegate(invocationCount, p1, p2, p3, resultValue)))
 				{
 					wasInvoked = true;
 				}
@@ -1273,9 +1192,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>,
 		IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>
 {
-	private readonly List<Callback<Action<int, T1, T2, T3, T4>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, TValue, T1, T2, T3, T4, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, TValue, T1, T2, T3, T4>>> _setterCallbacks = [];
+	private readonly List<Callback<Action<int, T1, T2, T3, T4, TValue>>> _getterCallbacks = [];
+	private readonly List<Callback<Func<int, T1, T2, T3, T4, TValue, TValue>>> _returnCallbacks = [];
+	private readonly List<Callback<Action<int, T1, T2, T3, T4, TValue>>> _setterCallbacks = [];
 	private bool? _callBaseClass;
 	private Callback? _currentCallback;
 	private int _currentGetterCallbacksIndex;
@@ -1291,9 +1210,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer with the given <paramref name="value" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.InitializeWith(TValue)" />
 	public IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value)
 	{
 		if (_initialization is not null)
@@ -1305,9 +1222,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		return this;
 	}
 
-	/// <summary>
-	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.InitializeWith(Func{T1, T2, T3, T4, TValue})" />
 	public IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(Func<T1, T2, T3, T4, TValue> valueGenerator)
 	{
 		if (_initialization is not null)
@@ -1319,188 +1234,165 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action callback)
 	{
-		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new((_, _, _, _, _) => callback());
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) => callback());
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action{T1, T2, T3, T4})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4> callback)
 	{
-		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new((_, p1, p2, p3, p4) => callback(p1, p2, p3, p4));
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, p1, p2, p3, p4, _) => callback(p1, p2, p3, p4));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<int, T1, T2, T3, T4> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action{T1, T2, T3, T4, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4, TValue> callback)
 	{
-		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(callback);
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, p1, p2, p3, p4, v) => callback(p1, p2, p3, p4, v));
 		_currentCallback = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action{int, T1, T2, T3, T4, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<int, T1, T2, T3, T4, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action)" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3, T4>> currentCallback = new((_, _, _, _, _, _) => callback());
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) => callback());
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action{TValue})" />
 	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3, T4>> currentCallback = new((_, v, _, _, _, _) => callback(v));
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, v) => callback(v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<TValue, T1, T2, T3, T4> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action{T1, T2, T3, T4, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<T1, T2, T3, T4, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3, T4>> currentCallback =
-			new((_, v, p1, p2, p3, p4) => callback(v, p1, p2, p3, p4));
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, v) => callback(p1, p2, p3, p4, v));
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<int, TValue, T1, T2, T3, T4> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action{int, T1, T2, T3, T4, TValue})" />
+	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<int, T1, T2, T3, T4, TValue> callback)
 	{
-		Callback<Action<int, TValue, T1, T2, T3, T4>> currentCallback = new(callback);
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
 		_currentCallback = currentCallback;
 		_setterCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue, T1, T2, T3, T4, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
-			new((_, v, p1, p2, p3, p4) => callback(v, p1, p2, p3, p4));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
-			new((_, _, p1, p2, p3, p4) => callback(p1, p2, p3, p4));
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue> callback)
-	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
-			new((_, _, _, _, _, _) => callback());
-		_currentReturnCallback = currentCallback;
-		_returnCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this property.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
 			new((_, _, _, _, _, _) => returnValue);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Returns(Func{TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue> callback)
+	{
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
+			new((_, _, _, _, _, _) => callback());
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Returns(Func{T1, T2, T3, T4, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue> callback)
+	{
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, _) => callback(p1, p2, p3, p4));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Returns(Func{T1, T2, T3, T4, TValue, TValue})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue, TValue> callback)
+	{
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, v) => callback(p1, p2, p3, p4, v));
+		_currentReturnCallback = currentCallback;
+		_returnCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws{TException}()" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
 		where TException : Exception, new()
 	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
 			new((_, _, _, _, _, _) => throw new TException());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws(Exception)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Exception exception)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
 			new((_, _, _, _, _, _) => throw exception);
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws(Func{Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
 			new((_, _, _, _, _, _) => throw callback());
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws(Func{T1, T2, T3, T4, Exception})" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
-			new((_, _, p1, p2, p3, p4) => throw callback(p1, p2, p3, p4));
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, _) => throw callback(p1, p2, p3, p4));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 	}
 
-	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
-	/// </summary>
-	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<TValue, T1, T2, T3, T4, Exception> callback)
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws(Func{T1, T2, T3, T4, TValue, Exception})" />
+	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, TValue, Exception> callback)
 	{
-		Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> currentCallback =
-			new((_, v, p1, p2, p3, p4) => throw callback(v, p1, p2, p3, p4));
+		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, v) => throw callback(p1, p2, p3, p4, v));
 		_currentReturnCallback = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
@@ -1583,21 +1475,21 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 			int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
 			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				Callback<Action<int, T1, T2, T3, T4>> getterCallback =
+				Callback<Action<int, T1, T2, T3, T4, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
 				if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3, p4)))
+					    => @delegate(invocationCount, p1, p2, p3, p4, resultValue)))
 				{
 					wasInvoked = true;
 				}
 			}
 
-			foreach (Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> _ in _returnCallbacks)
+			foreach (Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> _ in _returnCallbacks)
 			{
-				Callback<Func<int, TValue, T1, T2, T3, T4, TValue>> returnCallback =
+				Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> returnCallback =
 					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
 				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1, p2, p3, p4), out TValue? newValue) &&
+					    => @delegate(invocationCount, p1, p2, p3, p4, resultValue), out TValue? newValue) &&
 				    TryCast(newValue, out T returnValue, behavior))
 				{
 					return returnValue;
@@ -1623,10 +1515,10 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 			int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
 			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				Callback<Action<int, TValue, T1, T2, T3, T4>> setterCallback =
+				Callback<Action<int, T1, T2, T3, T4, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
 				if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, resultValue, p1, p2, p3, p4)))
+					    => @delegate(invocationCount, p1, p2, p3, p4, resultValue)))
 				{
 					wasInvoked = true;
 				}

--- a/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
@@ -64,12 +64,26 @@ public interface IIndexerSetup<TValue, out T1>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameter of the indexer.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<int, T1> callback);
+	/// <remarks>
+	///     The callback receives the parameter of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<int, T1, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -79,27 +93,31 @@ public interface IIndexerSetup<TValue, out T1>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<TValue, T1> callback);
+	/// <remarks>
+	///     The callback receives the parameter of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<T1, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<int, TValue, T1> callback);
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<int, T1, TValue> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	///     Registers the <paramref name="returnValue" /> for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<TValue, T1, TValue> callback);
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
-	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue> callback);
+	IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
@@ -107,9 +125,20 @@ public interface IIndexerSetup<TValue, out T1>
 	IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<TValue> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this indexer.
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
+	/// <remarks>
+	///     The callback receives the parameter of the indexer.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue> callback);
+
+	/// <summary>
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameter of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue, TValue> callback);
 
 	/// <summary>
 	///     Registers an <typeparamref name="TException" /> to throw when the indexer is read.
@@ -129,12 +158,18 @@ public interface IIndexerSetup<TValue, out T1>
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameter of the indexer.
+	/// </remarks>
 	IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, Exception> callback);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<TValue, T1, Exception> callback);
+	/// <remarks>
+	///     The callback receives the parameter of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, TValue, Exception> callback);
 }
 
 /// <summary>
@@ -256,12 +291,26 @@ public interface IIndexerSetup<TValue, out T1, out T2>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<int, T1, T2> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<int, T1, T2, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -271,27 +320,31 @@ public interface IIndexerSetup<TValue, out T1, out T2>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<TValue, T1, T2> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<T1, T2, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<int, TValue, T1, T2> callback);
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<int, T1, T2, TValue> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	///     Registers the <paramref name="returnValue" /> for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue, T1, T2, TValue> callback);
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
-	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue> callback);
+	IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
@@ -299,9 +352,20 @@ public interface IIndexerSetup<TValue, out T1, out T2>
 	IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this indexer.
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue> callback);
+
+	/// <summary>
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue, TValue> callback);
 
 	/// <summary>
 	///     Registers an <typeparamref name="TException" /> to throw when the indexer is read.
@@ -321,12 +385,18 @@ public interface IIndexerSetup<TValue, out T1, out T2>
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
 	IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, Exception> callback);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<TValue, T1, T2, Exception> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, TValue, Exception> callback);
 }
 
 /// <summary>
@@ -456,12 +526,26 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<int, T1, T2, T3> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<int, T1, T2, T3, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -471,27 +555,31 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<TValue, T1, T2, T3> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<T1, T2, T3, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<int, TValue, T1, T2, T3> callback);
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<int, T1, T2, T3, TValue> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	///     Registers the <paramref name="returnValue" /> for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue, T1, T2, T3, TValue> callback);
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
-	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue> callback);
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
@@ -499,9 +587,20 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3>
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this indexer.
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue> callback);
+
+	/// <summary>
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue, TValue> callback);
 
 	/// <summary>
 	///     Registers an <typeparamref name="TException" /> to throw when the indexer is read.
@@ -521,12 +620,18 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3>
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<TValue, T1, T2, T3, Exception> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, TValue, Exception> callback);
 }
 
 /// <summary>
@@ -658,12 +763,26 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<int, T1, T2, T3, T4> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<int, T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -673,27 +792,31 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<TValue, T1, T2, T3, T4> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<int, TValue, T1, T2, T3, T4> callback);
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<int, T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	///     Registers the <paramref name="returnValue" /> for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue, T1, T2, T3, T4, TValue> callback);
-
-	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
-	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue> callback);
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
@@ -701,9 +824,20 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this indexer.
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue> callback);
+
+	/// <summary>
+	///     Registers a <paramref name="callback" /> to setup the return value for this indexer.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue, TValue> callback);
 
 	/// <summary>
 	///     Registers an <typeparamref name="TException" /> to throw when the indexer is read.
@@ -723,12 +857,18 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback);
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the indexer is read.
 	/// </summary>
-	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<TValue, T1, T2, T3, T4, Exception> callback);
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, TValue, Exception> callback);
 }
 
 /// <summary>

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -60,16 +60,13 @@ public interface IPropertySetup<T>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's getter is accessed.
 	/// </summary>
-	/// <remarks>
-	///     Use this method to perform custom logic or side effects whenever the property's value is read.
-	/// </remarks>
 	IPropertySetupCallbackBuilder<T> OnGet(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's getter is accessed.
 	/// </summary>
 	/// <remarks>
-	///     Use this method to perform custom logic or side effects whenever the property's value is read.
+	///     The callback receives the value of the property as single parameter.
 	/// </remarks>
 	IPropertySetupCallbackBuilder<T> OnGet(Action<T> callback);
 
@@ -77,36 +74,30 @@ public interface IPropertySetup<T>
 	///     Registers a callback to be invoked whenever the property's getter is accessed.
 	/// </summary>
 	/// <remarks>
-	///     Use this method to perform custom logic or side effects whenever the property's value is read.
+	///     The callback receives an incrementing access counter as first parameter and the value of the property as second parameter.
 	/// </remarks>
 	IPropertySetupCallbackBuilder<T> OnGet(Action<int, T> callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set. The callback receives the new value being
-	///     set.
+	///     Registers a callback to be invoked whenever the property's value is set.
 	/// </summary>
-	/// <remarks>
-	///     Use this method to perform custom logic or side effects whenever the property's value changes.
-	/// </remarks>
 	IPropertySetupCallbackBuilder<T> OnSet(Action callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set. The callback receives the new value being
-	///     set.
+	///     Registers a callback to be invoked whenever the property's value is set.
 	/// </summary>
 	/// <remarks>
-	///     Use this method to perform custom logic or side effects whenever the property's value changes.
+	///     The callback receives the value the property is set to as single parameter.
 	/// </remarks>
-	IPropertySetupCallbackBuilder<T> OnSet(Action<T, T> callback);
+	IPropertySetupCallbackBuilder<T> OnSet(Action<T> callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set. The callback receives the new value being
-	///     set.
+	///     Registers a callback to be invoked whenever the property's value is set.
 	/// </summary>
 	/// <remarks>
-	///     Use this method to perform custom logic or side effects whenever the property's value changes.
+	///     The callback receives an incrementing access counter as first parameter and the value the property is set to as second parameter.
 	/// </remarks>
-	IPropertySetupCallbackBuilder<T> OnSet(Action<int, T, T> callback);
+	IPropertySetupCallbackBuilder<T> OnSet(Action<int, T> callback);
 
 	/// <summary>
 	///     Registers the <paramref name="returnValue" /> for this property.
@@ -124,7 +115,7 @@ public interface IPropertySetup<T>
 	IPropertySetupReturnBuilder<T> Returns(Func<T, T> callback);
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the property is read.
+	///     Registers a <typeparamref name="TException" /> to throw when the property is read.
 	/// </summary>
 	IPropertySetupReturnBuilder<T> Throws<TException>()
 		where TException : Exception, new();

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -672,19 +672,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue, T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, TValue, T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<TValue, T1, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -695,19 +696,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue, T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, TValue, T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<TValue, T1, T2, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -718,19 +720,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue, T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, TValue, T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<TValue, T1, T2, T3, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -741,19 +744,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue, T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, TValue, T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<TValue, T1, T2, T3, T4, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -832,8 +836,8 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback);
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T, T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T, T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
@@ -1208,19 +1212,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue, T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, TValue, T1> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue, T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<TValue, T1, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1238,19 +1243,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue, T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, TValue, T1, T2> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue, T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<TValue, T1, T2, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1268,19 +1274,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue, T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, TValue, T1, T2, T3> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue, T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<TValue, T1, T2, T3, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1298,19 +1305,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue, T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, TValue, T1, T2, T3, T4> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue, T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<TValue, T1, T2, T3, T4, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1373,8 +1381,8 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback) { }
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T, T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T, T> callback) { }
+        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback) { }
+        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -671,19 +671,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue, T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, TValue, T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<TValue, T1, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -694,19 +695,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue, T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, TValue, T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<TValue, T1, T2, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -717,19 +719,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue, T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, TValue, T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<TValue, T1, T2, T3, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -740,19 +743,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue, T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, TValue, T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<TValue, T1, T2, T3, T4, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -831,8 +835,8 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback);
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T, T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T, T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
@@ -1207,19 +1211,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue, T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, TValue, T1> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue, T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<TValue, T1, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1237,19 +1242,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue, T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, TValue, T1, T2> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue, T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<TValue, T1, T2, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1267,19 +1273,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue, T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, TValue, T1, T2, T3> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue, T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<TValue, T1, T2, T3, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1297,19 +1304,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue, T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, TValue, T1, T2, T3, T4> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue, T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<TValue, T1, T2, T3, T4, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1372,8 +1380,8 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback) { }
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T, T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T, T> callback) { }
+        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback) { }
+        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -648,19 +648,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue, T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, TValue, T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<TValue, T1, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -671,19 +672,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue, T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, TValue, T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<TValue, T1, T2, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -694,19 +696,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue, T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, TValue, T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<TValue, T1, T2, T3, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -717,19 +720,20 @@ namespace Mockolate.Setup
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback);
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue, T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, TValue, T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback);
-        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<TValue, T1, T2, T3, T4, System.Exception> callback);
+        Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new ();
     }
@@ -808,8 +812,8 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback);
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T, T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T, T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
@@ -1184,19 +1188,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue, T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, TValue, T1> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue, T1, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<TValue, T1, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1214,19 +1219,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue, T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, TValue, T1, T2> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue, T1, T2, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<TValue, T1, T2, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1244,19 +1250,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue, T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, TValue, T1, T2, T3> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue, T1, T2, T3, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<TValue, T1, T2, T3, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1274,19 +1281,20 @@ namespace Mockolate.Setup
         protected override bool IsMatch(object?[] parameters) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback) { }
         public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue, T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, TValue, T1, T2, T3, T4> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue, T1, T2, T3, T4, TValue> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback) { }
-        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<TValue, T1, T2, T3, T4, System.Exception> callback) { }
+        public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
@@ -1349,8 +1357,8 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback) { }
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T, T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T, T> callback) { }
+        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback) { }
+        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue) { }

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnSetTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnSetTests.cs
@@ -51,8 +51,8 @@ public sealed partial class SetupIndexerTests
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
 				.OnSet(() => { callCount1++; })
-				.OnSet((_, p1) => { callCount2 += p1; }).InParallel()
-				.OnSet((_, p1) => { callCount3 += p1; });
+				.OnSet((p1, _) => { callCount2 += p1; }).InParallel()
+				.OnSet((p1, _) => { callCount3 += p1; });
 
 			mock[4] = "foo";
 			mock[6] = "foo";
@@ -75,7 +75,7 @@ public sealed partial class SetupIndexerTests
 			IIndexerService mock = Mock.Create<IIndexerService>();
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet((_, p1) => { sum += p1; }).Only(times);
+				.OnSet((p1, _) => { sum += p1; }).Only(times);
 
 			mock[1] = "foo";
 			mock[2] = "foo";
@@ -95,7 +95,7 @@ public sealed partial class SetupIndexerTests
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
 				.OnSet(() => { callCount++; })
-				.OnSet((_, p1) => { sum += p1; }).OnlyOnce();
+				.OnSet((p1, _) => { sum += p1; }).OnlyOnce();
 
 			mock[1] = "foo";
 			mock[2] = "foo";
@@ -150,7 +150,7 @@ public sealed partial class SetupIndexerTests
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
 				.OnSet(() => { callCount1++; })
-				.OnSet((_, p1) => { callCount2 += p1; });
+				.OnSet((p1, _) => { callCount2 += p1; });
 
 			mock[4] = "foo";
 			mock[6] = "foo";
@@ -225,8 +225,8 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((_, p1, _) => { callCount3 += p1; });
+					.OnSet((p1, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet((p1, _, _) => { callCount3 += p1; });
 
 				mock[4, 2] = "foo";
 				mock[6, 2] = "foo";
@@ -249,7 +249,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((_, p1, _) => { sum += p1; }).Only(times);
+					.OnSet((p1, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2] = "foo";
 				mock[2, 2] = "foo";
@@ -269,7 +269,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount++; })
-					.OnSet((_, p1, _) => { sum += p1; }).OnlyOnce();
+					.OnSet((p1, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2] = "foo";
 				mock[2, 2] = "foo";
@@ -328,7 +328,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _) => { callCount2 += p1; });
+					.OnSet((p1, _, _) => { callCount2 += p1; });
 
 				mock[4, 2] = "foo";
 				mock[6, 2] = "foo";
@@ -404,8 +404,8 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((_, p1, _, _) => { callCount3 += p1; });
+					.OnSet((p1, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet((p1, _, _, _) => { callCount3 += p1; });
 
 				mock[4, 2, 3] = "foo";
 				mock[6, 2, 3] = "foo";
@@ -428,7 +428,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((_, p1, _, _) => { sum += p1; }).Only(times);
+					.OnSet((p1, _, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2, 3] = "foo";
 				mock[2, 2, 3] = "foo";
@@ -448,7 +448,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount++; })
-					.OnSet((_, p1, _, _) => { sum += p1; }).OnlyOnce();
+					.OnSet((p1, _, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2, 3] = "foo";
 				mock[2, 2, 3] = "foo";
@@ -510,7 +510,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _, _) => { callCount2 += p1; });
+					.OnSet((p1, _, _, _) => { callCount2 += p1; });
 
 				mock[4, 2, 3] = "foo";
 				mock[6, 2, 3] = "foo";
@@ -586,8 +586,8 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _, _, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((_, p1, _, _, _) => { callCount3 += p1; });
+					.OnSet((p1, _, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet((p1, _, _, _, _) => { callCount3 += p1; });
 
 				mock[4, 2, 3, 4] = "foo";
 				mock[6, 2, 3, 4] = "foo";
@@ -610,7 +610,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((_, p1, _, _, _) => { sum += p1; }).Only(times);
+					.OnSet((p1, _, _, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2, 3, 4] = "foo";
 				mock[2, 2, 3, 4] = "foo";
@@ -630,7 +630,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount++; })
-					.OnSet((_, p1, _, _, _) => { sum += p1; }).OnlyOnce();
+					.OnSet((p1, _, _, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2, 3, 4] = "foo";
 				mock[2, 2, 3, 4] = "foo";
@@ -692,7 +692,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _, _, _) => { callCount2 += p1; });
+					.OnSet((p1, _, _, _, _) => { callCount2 += p1; });
 
 				mock[4, 2, 3, 4] = "foo";
 				mock[6, 2, 3, 4] = "foo";
@@ -771,8 +771,8 @@ public sealed partial class SetupIndexerTests
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _, _, _, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((_, p1, _, _, _, _) => { callCount3 += p1; });
+					.OnSet((p1, _, _, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet((p1, _, _, _, _, _) => { callCount3 += p1; });
 
 				mock[4, 2, 3, 4, 5] = "foo";
 				mock[6, 2, 3, 4, 5] = "foo";
@@ -796,7 +796,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet((_, p1, _, _, _, _) => { sum += p1; }).Only(times);
+					.OnSet((p1, _, _, _, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2, 3, 4, 5] = "foo";
 				mock[2, 2, 3, 4, 5] = "foo";
@@ -817,7 +817,7 @@ public sealed partial class SetupIndexerTests
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
 					.OnSet(() => { callCount++; })
-					.OnSet((_, p1, _, _, _, _) => { sum += p1; }).OnlyOnce();
+					.OnSet((p1, _, _, _, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2, 3, 4, 5] = "foo";
 				mock[2, 2, 3, 4, 5] = "foo";
@@ -880,7 +880,7 @@ public sealed partial class SetupIndexerTests
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
 					.OnSet(() => { callCount1++; })
-					.OnSet((_, p1, _, _, _, _) => { callCount2 += p1; });
+					.OnSet((p1, _, _, _, _, _) => { callCount2 += p1; });
 
 				mock[4, 2, 3, 4, 5] = "foo";
 				mock[6, 2, 3, 4, 5] = "foo";

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
@@ -101,7 +101,7 @@ public sealed partial class SetupIndexerTests
 
 			sut.SetupMock.Indexer(It.IsAny<int>())
 				.InitializeWith("init")
-				.Returns((v, p1) => $"foo-{v}-{p1}");
+				.Returns((p1, v) => $"foo-{v}-{p1}");
 
 			string result = sut[3];
 
@@ -244,7 +244,7 @@ public sealed partial class SetupIndexerTests
 
 			sut.SetupMock.Indexer(It.IsAny<int>())
 				.InitializeWith("init")
-				.Throws((v, p1) => new Exception($"foo-{v}-{p1}"));
+				.Throws((p1, v) => new Exception($"foo-{v}-{p1}"));
 
 			void Act()
 			{
@@ -383,7 +383,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Returns((v, p1, p2) => $"foo-{v}-{p1}-{p2}");
+					.Returns((p1, p2, v) => $"foo-{v}-{p1}-{p2}");
 
 				string result = sut[3, 4];
 
@@ -526,7 +526,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Throws((v, p1, p2) => new Exception($"foo-{v}-{p1}-{p2}"));
+					.Throws((p1, p2, v) => new Exception($"foo-{v}-{p1}-{p2}"));
 
 				void Act()
 				{
@@ -667,7 +667,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Returns((v, p1, p2, p3) => $"foo-{v}-{p1}-{p2}-{p3}");
+					.Returns((p1, p2, p3, v) => $"foo-{v}-{p1}-{p2}-{p3}");
 
 				string result = sut[3, 4, 5];
 
@@ -810,7 +810,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Throws((v, p1, p2, p3) => new Exception($"foo-{v}-{p1}-{p2}-{p3}"));
+					.Throws((p1, p2, p3, v) => new Exception($"foo-{v}-{p1}-{p2}-{p3}"));
 
 				void Act()
 				{
@@ -952,7 +952,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Returns((v, p1, p2, p3, p4) => $"foo-{v}-{p1}-{p2}-{p3}-{p4}");
+					.Returns((p1, p2, p3, p4, v) => $"foo-{v}-{p1}-{p2}-{p3}-{p4}");
 
 				string result = sut[3, 4, 5, 6];
 
@@ -1095,7 +1095,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Throws((v, p1, p2, p3, p4) => new Exception($"foo-{v}-{p1}-{p2}-{p3}-{p4}"));
+					.Throws((p1, p2, p3, p4, v) => new Exception($"foo-{v}-{p1}-{p2}-{p3}-{p4}"));
 
 				void Act()
 				{
@@ -1237,7 +1237,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Returns((v, p1, p2, p3, p4, p5) => $"foo-{v}-{p1}-{p2}-{p3}-{p4}-{p5}");
+					.Returns((p1, p2, p3, p4, p5, v) => $"foo-{v}-{p1}-{p2}-{p3}-{p4}-{p5}");
 
 				string result = sut[3, 4, 5, 6, 7];
 
@@ -1380,7 +1380,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
 					.InitializeWith("init")
-					.Throws((v, p1, p2, p3, p4, p5) => new Exception($"foo-{v}-{p1}-{p2}-{p3}-{p4}-{p5}"));
+					.Throws((p1, p2, p3, p4, p5, v) => new Exception($"foo-{v}-{p1}-{p2}-{p3}-{p4}-{p5}"));
 
 				void Act()
 				{

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnSetTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnSetTests.cs
@@ -12,7 +12,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnSet((i, _, _) => { invocations.Add(i); })
+				.OnSet((i, _) => { invocations.Add(i); })
 				.For(4);
 
 			for (int i = 0; i < 20; i++)
@@ -29,7 +29,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnSet((i, _, _) => { invocations.Add(i); })
+				.OnSet((i, _) => { invocations.Add(i); })
 				.When(x => x > 2)
 				.For(4);
 
@@ -53,16 +53,16 @@ public sealed partial class SetupPropertyTests
 				.InitializeWith(2)
 				.OnSet(() => { callCount1++; })
 				.OnSet((_, v) => { callCount2 += v; }).InParallel()
-				.OnSet((old, @new) => { callCount3 += old * @new; });
+				.OnSet((_, v) => { callCount3 += v; });
 
 			sut.MyProperty = 4;
-			sut.MyProperty = 6; // 4 * 6 = 24
+			sut.MyProperty = 6;
 			sut.MyProperty = 8;
-			sut.MyProperty = 10; // 8 * 10 = 80
+			sut.MyProperty = 10;
 
 			await That(callCount1).IsEqualTo(2);
 			await That(callCount2).IsEqualTo(4 + 6 + 8 + 10);
-			await That(callCount3).IsEqualTo(24 + 80);
+			await That(callCount3).IsEqualTo(6 + 10);
 		}
 
 		[Theory]
@@ -117,15 +117,15 @@ public sealed partial class SetupPropertyTests
 			sut.SetupMock.Property.MyProperty
 				.InitializeWith(2)
 				.OnSet(() => { callCount1++; })
-				.OnSet((old, @new) => { callCount2 += old * @new; });
+				.OnSet((_, v) => { callCount2 += v; });
 
 			sut.MyProperty = 4;
-			sut.MyProperty = 6; // 4 * 6 = 24
+			sut.MyProperty = 6;
 			sut.MyProperty = 8;
-			sut.MyProperty = 10; // 8 * 10 = 80
+			sut.MyProperty = 10;
 
 			await That(callCount1).IsEqualTo(2);
-			await That(callCount2).IsEqualTo(24 + 80);
+			await That(callCount2).IsEqualTo(6 + 10);
 		}
 
 		[Fact]
@@ -163,7 +163,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnSet((i, _, _) => { invocations.Add(i); })
+				.OnSet((i, _) => { invocations.Add(i); })
 				.When(x => x is > 3 and < 9);
 
 			for (int i = 0; i < 20; i++)
@@ -177,24 +177,21 @@ public sealed partial class SetupPropertyTests
 		[Fact]
 		public async Task WithValue_ShouldExecuteWhenPropertyIsWrittenTo()
 		{
-			int receivedOldValue = 0;
 			int receivedNewValue = 0;
 			int callCount = 0;
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
 				.InitializeWith(4)
-				.OnSet((oldValue, newValue) =>
+				.OnSet((_, v) =>
 				{
 					callCount++;
-					receivedOldValue = oldValue;
-					receivedNewValue = newValue;
+					receivedNewValue = v;
 				});
 
 			sut.MyProperty = 6;
 
 			await That(callCount).IsEqualTo(1);
-			await That(receivedOldValue).IsEqualTo(4);
 			await That(receivedNewValue).IsEqualTo(6);
 		}
 


### PR DESCRIPTION
This PR refactors the callback signature order for both property and indexer setups, moving the value parameter to the end for consistency. Previously, property `OnSet` callbacks received `(oldValue, newValue)` while indexer callbacks placed the value first. The refactoring standardizes all callbacks to place indexer parameters first, followed by the value parameter last, matching common C# patterns where input parameters precede output/state parameters.

### Key Changes
- Property `OnSet` callbacks simplified from `(oldValue, newValue)` to just `(newValue)`, removing access to the old value
- Indexer callback signatures reordered to place the value parameter last: `(TValue, T1, T2, ...)` becomes `(T1, T2, ..., TValue)`
- Updated API documentation with detailed remarks explaining parameter order
- Comprehensive test updates reflecting the new signatures

---

- *Fixes #285*