### PR TITLE
refactor!: always use `Do` for callbacks

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -93,6 +93,125 @@ internal static partial class Sources
 		string discards = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(_ => "_"));
 
 		sb.Append("\t/// <summary>").AppendLine();
+		sb.Append("\t///     Sets up a <typeparamref name=\"TValue\"/> indexer getter for ");
+		for (int i = 1; i < numberOfParameters - 1; i++)
+		{
+			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
+		}
+
+		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
+			.Append(numberOfParameters).Append("\" />.").AppendLine();
+		sb.Append("\t/// </summary>").AppendLine();
+		sb.Append("\tinternal interface IIndexerGetterSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
+		sb.Append("\t{").AppendLine();
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action callback);")
+			.AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<")
+			.Append(typeParams)
+			.Append("> callback);").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<")
+			.Append(typeParams)
+			.Append(", TValue> callback);").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<int, ")
+			.Append(typeParams)
+			.Append(", TValue> callback);").AppendLine();
+		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t/// <summary>").AppendLine();
+		sb.Append("\t///     Sets up a <typeparamref name=\"TValue\"/> indexer setter for ");
+		for (int i = 1; i < numberOfParameters - 1; i++)
+		{
+			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
+		}
+
+		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
+			.Append(numberOfParameters).Append("\" />.").AppendLine();
+		sb.Append("\t/// </summary>").AppendLine();
+		sb.Append("\tinternal interface IIndexerSetterSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
+		sb.Append("\t{").AppendLine();
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action callback);")
+			.AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the value the indexer is set to as single parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+			.Append("> Do(Action<TValue> callback);").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<")
+			.Append(typeParams).Append(", TValue> callback);").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append(
+				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
+			.AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\t/// <remarks>").AppendLine();
+		sb.Append("\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.").AppendLine();
+		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<int, ")
+			.Append(typeParams).Append(", TValue> callback);").AppendLine();
+		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t/// <summary>").AppendLine();
 		sb.Append("\t///     Sets up a <typeparamref name=\"TValue\"/> indexer for ");
 		for (int i = 1; i < numberOfParameters - 1; i++)
 		{
@@ -104,6 +223,20 @@ internal static partial class Sources
 		sb.Append("\t/// </summary>").AppendLine();
 		sb.Append("\tinternal interface IIndexerSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append("\t\t///     Sets up callbacks on the getter.").AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\tIIndexerGetterSetup<TValue, ").Append(typeParams)
+			.Append("> OnGet { get; }").AppendLine();
+		sb.AppendLine();
+		
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append("\t\t///     Sets up callbacks on the setter.").AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\tIIndexerSetterSetup<TValue, ").Append(typeParams)
+			.Append("> OnSet { get; }").AppendLine();
+		sb.AppendLine();
+		
 		sb.Append("\t\t/// <summary>").AppendLine();
 		sb.Append(
 				"\t\t///     Flag indicating if the base class implementation should be called, and its return values used as default values.")
@@ -129,99 +262,6 @@ internal static partial class Sources
 		sb.Append("\t\t/// </summary>").AppendLine();
 		sb.Append("\t\tIIndexerSetup<TValue, ").Append(typeParams).Append("> InitializeWith(Func<")
 			.Append(typeParams).Append(", TValue> valueGenerator);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action callback);")
-			.AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
-			.Append(typeParams)
-			.Append("> callback);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
-			.Append(typeParams)
-			.Append(", TValue> callback);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<int, ")
-			.Append(typeParams)
-			.Append(", TValue> callback);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnSet(Action callback);")
-			.AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the value the indexer is set to as single parameter.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnSet(Action<TValue> callback);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnSet(Action<")
-			.Append(typeParams).Append(", TValue> callback);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnSet(Action<int, ")
-			.Append(typeParams).Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <summary>").AppendLine();
@@ -481,7 +521,9 @@ internal static partial class Sources
 			.Append(") : IndexerSetup,")
 			.AppendLine();
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
-		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
+		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
+		sb.Append("\t\tIIndexerGetterSetup<TValue, ").Append(typeParams).Append(">,").AppendLine();
+		sb.Append("\t\tIIndexerSetterSetup<TValue, ").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.Append("\t\tprivate readonly List<Callback<Action<int, ").Append(typeParams)
 			.Append(", TValue>>> _getterCallbacks = [];")
@@ -543,9 +585,16 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action)\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnGet(Action callback)").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerGetterSetup<TValue, ").Append(typeParams)
+			.Append("> OnGet").AppendLine();
+		sb.Append("\t\t\t=> this;").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action)\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+			.Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", _) => callback());").AppendLine();
@@ -555,8 +604,9 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action{").Append(typeParams).Append("})\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action{").Append(typeParams).Append("})\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action<")
 			.Append(typeParams)
 			.Append("> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -568,8 +618,9 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action{").Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<")
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action{").Append(typeParams).Append(", TValue})\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action<")
 			.Append(typeParams)
 			.Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -581,8 +632,9 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnGet(Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> OnGet(Action<int, ")
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action<int, ")
 			.Append(typeParams)
 			.Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -594,9 +646,16 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action)\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnSet(Action callback)").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet\" />").AppendLine();
+		sb.Append("\t\tpublic IIndexerSetterSetup<TValue, ").Append(typeParams)
+			.Append("> OnSet").AppendLine();
+		sb.Append("\t\t\t=> this;").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action)\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, _, ")
 			.Append(discards).Append(") => callback());").AppendLine();
@@ -606,9 +665,10 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action{TValue})\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnSet(Action<TValue> callback)")
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action{TValue})\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action<TValue> callback)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
@@ -619,9 +679,10 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action{").Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnSet(Action<")
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action{").Append(typeParams).Append(", TValue})\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action<")
 			.Append(typeParams).Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
@@ -632,9 +693,10 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetup{TValue, ").Append(typeParams).Append("}.OnSet(Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tpublic IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> OnSet(Action<int, ")
+		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams).Append("}.Do(Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
+		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
+			.Append(">.Do(Action<int, ")
 			.Append(typeParams).Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<Action<int, ").Append(typeParams)

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -129,8 +129,9 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 /// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
 /// </summary>
-public class IndexerSetup<TValue, T1>(IParameter match1)
-	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1>, IIndexerSetupReturnBuilder<TValue, T1>
+public class IndexerSetup<TValue, T1>(IParameter match1) : IndexerSetup,
+	IIndexerSetupCallbackBuilder<TValue, T1>, IIndexerSetupReturnBuilder<TValue, T1>,
+	IIndexerGetterSetup<TValue, T1>, IIndexerSetterSetup<TValue, T1>
 {
 	private readonly List<Callback<Action<int, T1, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, TValue, TValue>>> _returnCallbacks = [];
@@ -142,6 +143,78 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 	private int _currentReturnCallbackIndex;
 	private int _currentSetterCallbacksIndex;
 	private Func<T1, TValue>? _initialization;
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => callback());
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action{T1})" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1> callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, _) => callback(p1));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action{T1, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, v) => callback(p1, v));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action{int, T1, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => callback());
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action{TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<TValue> callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, v) => callback(v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action{T1, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, v) => callback(p1, v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action{int, T1, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
+	{
+		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.CallingBaseClass(bool)" />
 	public IIndexerSetup<TValue, T1> CallingBaseClass(bool callBaseClass = true)
@@ -174,77 +247,13 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => callback());
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet" />
+	public IIndexerGetterSetup<TValue, T1> OnGet
+		=> this;
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action{T1})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1> callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, _) => callback(p1));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action{T1, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1, TValue> callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, v) => callback(p1, v));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet(Action{int, T1, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<int, T1, TValue> callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => callback());
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action{TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<TValue> callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, v) => callback(v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action{T1, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<T1, TValue> callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new((_, p1, v) => callback(p1, v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet(Action{int, T1, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<int, T1, TValue> callback)
-	{
-		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet" />
+	public IIndexerSetterSetup<TValue, T1> OnSet
+		=> this;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue)
@@ -472,8 +481,9 @@ public class IndexerSetup<TValue, T1>(IParameter match1)
 /// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and <typeparamref name="T2" />.
 /// </summary>
-public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
-	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetupReturnBuilder<TValue, T1, T2>
+public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2) : IndexerSetup
+	, IIndexerSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetupReturnBuilder<TValue, T1, T2>,
+	IIndexerGetterSetup<TValue, T1, T2>, IIndexerSetterSetup<TValue, T1, T2>
 {
 	private readonly List<Callback<Action<int, T1, T2, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, T2, TValue, TValue>>> _returnCallbacks = [];
@@ -485,6 +495,80 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 	private int _currentReturnCallbackIndex;
 	private int _currentSetterCallbacksIndex;
 	private Func<T1, T2, TValue>? _initialization;
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => callback());
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action{T1, T2})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2> callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, _) => callback(p1, p2));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, v) => callback(p1, p2, v));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(
+		Action<int, T1, T2, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => callback());
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action{TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<TValue> callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, v) => callback(v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, v) => callback(p1, p2, v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(
+		Action<int, T1, T2, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.CallingBaseClass(bool)" />
 	public IIndexerSetup<TValue, T1, T2> CallingBaseClass(bool callBaseClass = true)
@@ -517,77 +601,13 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => callback());
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet" />
+	public IIndexerGetterSetup<TValue, T1, T2> OnGet
+		=> this;
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action{T1, T2})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2> callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, _) => callback(p1, p2));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action{T1, T2, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, v) => callback(p1, p2, v));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet(Action{int, T1, T2, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<int, T1, T2, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => callback());
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action{TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<TValue> callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, v) => callback(v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action{T1, T2, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<T1, T2, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, p1, p2, v) => callback(p1, p2, v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet(Action{int, T1, T2, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<int, T1, T2, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet" />
+	public IIndexerSetterSetup<TValue, T1, T2> OnSet
+		=> this;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue)
@@ -825,8 +845,9 @@ public class IndexerSetup<TValue, T1, T2>(IParameter match1, IParameter match2)
 public class IndexerSetup<TValue, T1, T2, T3>(
 	IParameter match1,
 	IParameter match2,
-	IParameter match3)
-	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3>
+	IParameter match3) : IndexerSetup,
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3>,
+	IIndexerGetterSetup<TValue, T1, T2, T3>, IIndexerSetterSetup<TValue, T1, T2, T3>
 {
 	private readonly List<Callback<Action<int, T1, T2, T3, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, T2, T3, TValue, TValue>>> _returnCallbacks = [];
@@ -838,6 +859,83 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	private int _currentReturnCallbackIndex;
 	private int _currentSetterCallbacksIndex;
 	private Func<T1, T2, T3, TValue>? _initialization;
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(Action callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => callback());
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
+		Action<T1, T2, T3> callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, _) => callback(p1, p2, p3));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
+		Action<T1, T2, T3, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, v) => callback(p1, p2, p3, v));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
+		Action<int, T1, T2, T3, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(Action callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => callback());
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action{TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(Action<TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, v) => callback(v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
+		Action<T1, T2, T3, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, v) => callback(p1, p2, p3, v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
+		Action<int, T1, T2, T3, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.CallingBaseClass(bool)" />
 	public IIndexerSetup<TValue, T1, T2, T3> CallingBaseClass(bool callBaseClass = true)
@@ -870,77 +968,13 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => callback());
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet" />
+	public IIndexerGetterSetup<TValue, T1, T2, T3> OnGet
+		=> this;
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action{T1, T2, T3})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3> callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, _) => callback(p1, p2, p3));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action{T1, T2, T3, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, v) => callback(p1, p2, p3, v));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet(Action{int, T1, T2, T3, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<int, T1, T2, T3, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) => callback());
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action{TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, v) => callback(v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action{T1, T2, T3, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<T1, T2, T3, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, p1, p2, p3, v) => callback(p1, p2, p3, v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet(Action{int, T1, T2, T3, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<int, T1, T2, T3, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet" />
+	public IIndexerSetterSetup<TValue, T1, T2, T3> OnSet
+		=> this;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue)
@@ -1189,8 +1223,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IParameter match2,
 	IParameter match3,
 	IParameter match4)
-	: IndexerSetup, IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>,
-		IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>
+	: IndexerSetup,
+		IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>,
+		IIndexerGetterSetup<TValue, T1, T2, T3, T4>, IIndexerSetterSetup<TValue, T1, T2, T3, T4>
 {
 	private readonly List<Callback<Action<int, T1, T2, T3, T4, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, T2, T3, T4, TValue, TValue>>> _returnCallbacks = [];
@@ -1202,6 +1237,87 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	private int _currentReturnCallbackIndex;
 	private int _currentSetterCallbacksIndex;
 	private Func<T1, T2, T3, T4, TValue>? _initialization;
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) => callback());
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<T1, T2, T3, T4> callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, _) => callback(p1, p2, p3, p4));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<T1, T2, T3, T4, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, v) => callback(p1, p2, p3, p4, v));
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<int, T1, T2, T3, T4, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_getterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) => callback());
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action{TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, v) => callback(v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<T1, T2, T3, T4, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback =
+			new((_, p1, p2, p3, p4, v) => callback(p1, p2, p3, p4, v));
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<int, T1, T2, T3, T4, TValue> callback)
+	{
+		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
+		_currentCallback = currentCallback;
+		_setterCallbacks.Add(currentCallback);
+		return this;
+	}
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.CallingBaseClass(bool)" />
 	public IIndexerSetup<TValue, T1, T2, T3, T4> CallingBaseClass(bool callBaseClass = true)
@@ -1234,78 +1350,13 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) => callback());
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet" />
+	public IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet
+		=> this;
 
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action{T1, T2, T3, T4})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4> callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, p1, p2, p3, p4, _) => callback(p1, p2, p3, p4));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action{T1, T2, T3, T4, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, p1, p2, p3, p4, v) => callback(p1, p2, p3, p4, v));
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet(Action{int, T1, T2, T3, T4, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<int, T1, T2, T3, T4, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_getterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action)" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) => callback());
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action{TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, v) => callback(v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action{T1, T2, T3, T4, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<T1, T2, T3, T4, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback =
-			new((_, p1, p2, p3, p4, v) => callback(p1, p2, p3, p4, v));
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
-
-	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet(Action{int, T1, T2, T3, T4, TValue})" />
-	public IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<int, T1, T2, T3, T4, TValue> callback)
-	{
-		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
-		return this;
-	}
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet" />
+	public IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet
+		=> this;
 
 	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Returns(TValue)" />
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue)

--- a/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
@@ -34,10 +34,90 @@ public interface IInteractiveIndexerSetup : ISetup
 }
 
 /// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer getter for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerGetterSetup<TValue, out T1>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameter of the indexer.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<T1> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameter of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
+}
+
+/// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer setter for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerSetterSetup<TValue, out T1>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameter of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
+}
+
+/// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
 /// </summary>
 public interface IIndexerSetup<TValue, out T1>
 {
+	/// <summary>
+	///     Sets up callbacks on the getter.
+	/// </summary>
+	IIndexerGetterSetup<TValue, T1> OnGet { get; }
+
+	/// <summary>
+	///     Sets up callbacks on the setter.
+	/// </summary>
+	IIndexerSetterSetup<TValue, T1> OnSet { get; }
+
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
 	/// </summary>
@@ -55,64 +135,6 @@ public interface IIndexerSetup<TValue, out T1>
 	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
 	/// </summary>
 	IIndexerSetup<TValue, T1> InitializeWith(Func<T1, TValue> valueGenerator);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameter of the indexer.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameter of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<T1, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnGet(Action<int, T1, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the value the indexer is set to as single parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameter of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<T1, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> OnSet(Action<int, T1, TValue> callback);
 
 	/// <summary>
 	///     Registers the <paramref name="returnValue" /> for this indexer.
@@ -261,10 +283,91 @@ public interface IIndexerSetupReturnWhenBuilder<TValue, out T1>
 }
 
 /// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer getter for <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerGetterSetup<TValue, out T1, out T2>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
+
+}
+
+/// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer setter for <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerSetterSetup<TValue, out T1, out T2>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
+}
+
+/// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and <typeparamref name="T2" />.
 /// </summary>
 public interface IIndexerSetup<TValue, out T1, out T2>
 {
+	/// <summary>
+	///     Sets up callbacks on the getter.
+	/// </summary>
+	IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
+
+	/// <summary>
+	///     Sets up callbacks on the setter.
+	/// </summary>
+	IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
+
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
 	/// </summary>
@@ -282,64 +385,6 @@ public interface IIndexerSetup<TValue, out T1, out T2>
 	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
 	/// </summary>
 	IIndexerSetup<TValue, T1, T2> InitializeWith(Func<T1, T2, TValue> valueGenerator);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<T1, T2, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(Action<int, T1, T2, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the value the indexer is set to as single parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<T1, T2, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(Action<int, T1, T2, TValue> callback);
 
 	/// <summary>
 	///     Registers the <paramref name="returnValue" /> for this indexer.
@@ -495,11 +540,93 @@ public interface IIndexerSetupReturnWhenBuilder<TValue, out T1, out T2>
 }
 
 /// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer getter for <typeparamref name="T1" />, <typeparamref name="T2" /> and
+///     <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
+}
+
+/// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer setter for <typeparamref name="T1" />, <typeparamref name="T2" /> and
+///     <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
+}
+
+/// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />, <typeparamref name="T2" /> and
 ///     <typeparamref name="T3" />.
 /// </summary>
 public interface IIndexerSetup<TValue, out T1, out T2, out T3>
 {
+	/// <summary>
+	///     Sets up callbacks on the getter.
+	/// </summary>
+	IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+
+	/// <summary>
+	///     Sets up callbacks on the setter.
+	/// </summary>
+	IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
+
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
 	/// </summary>
@@ -517,64 +644,6 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3>
 	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
 	/// </summary>
 	IIndexerSetup<TValue, T1, T2, T3> InitializeWith(Func<T1, T2, T3, TValue> valueGenerator);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<T1, T2, T3, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(Action<int, T1, T2, T3, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the value the indexer is set to as single parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<T1, T2, T3, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(Action<int, T1, T2, T3, TValue> callback);
 
 	/// <summary>
 	///     Registers the <paramref name="returnValue" /> for this indexer.
@@ -732,11 +801,93 @@ public interface IIndexerSetupReturnWhenBuilder<TValue, out T1, out T2, out T3>
 
 #pragma warning disable S2436 // Types and methods should not have too many generic parameters
 /// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer getter for <typeparamref name="T1" />, <typeparamref name="T2" />,
+///     <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
+}
+
+/// <summary>
+///     Sets up a <typeparamref name="TValue" /> indexer setter for <typeparamref name="T1" />, <typeparamref name="T2" />,
+///     <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the indexer is set to as single parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
+	/// </remarks>
+	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
+}
+
+/// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />,
 ///     <typeparamref name="T3" /> and <typeparamref name="T4" />.
 /// </summary>
 public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
 {
+	/// <summary>
+	///     Sets up callbacks on the getter.
+	/// </summary>
+	IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+
+	/// <summary>
+	///     Sets up callbacks on the setter.
+	/// </summary>
+	IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
 	/// </summary>
@@ -754,64 +905,6 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
 	///     Initializes the indexer according to the given <paramref name="valueGenerator" />.
 	/// </summary>
 	IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(Func<T1, T2, T3, T4, TValue> valueGenerator);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<T1, T2, T3, T4, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(Action<int, T1, T2, T3, T4, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the value the indexer is set to as single parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<T1, T2, T3, T4, TValue> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.
-	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(Action<int, T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
 	///     Registers the <paramref name="returnValue" /> for this indexer.

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -40,10 +40,76 @@ public interface IInteractivePropertySetup : ISetup
 }
 
 /// <summary>
+///     Interface for setting up a property getter with fluent syntax.
+/// </summary>
+public interface IPropertyGetterSetup<T>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the property's getter is accessed.
+	/// </summary>
+	IPropertySetupCallbackBuilder<T> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the property's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the value of the property as single parameter.
+	/// </remarks>
+	IPropertySetupCallbackBuilder<T> Do(Action<T> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the property's getter is accessed.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter and the value of the property as second
+	///     parameter.
+	/// </remarks>
+	IPropertySetupCallbackBuilder<T> Do(Action<int, T> callback);
+}
+
+/// <summary>
+///     Interface for setting up a property setter with fluent syntax.
+/// </summary>
+public interface IPropertySetterSetup<T>
+{
+	/// <summary>
+	///     Registers a callback to be invoked whenever the property's value is set.
+	/// </summary>
+	IPropertySetupCallbackBuilder<T> Do(Action callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the property's value is set.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives the value the property is set to as single parameter.
+	/// </remarks>
+	IPropertySetupCallbackBuilder<T> Do(Action<T> callback);
+
+	/// <summary>
+	///     Registers a callback to be invoked whenever the property's value is set.
+	/// </summary>
+	/// <remarks>
+	///     The callback receives an incrementing access counter as first parameter and the value the property is set to as
+	///     second parameter.
+	/// </remarks>
+	IPropertySetupCallbackBuilder<T> Do(Action<int, T> callback);
+}
+
+/// <summary>
 ///     Interface for setting up a property with fluent syntax.
 /// </summary>
 public interface IPropertySetup<T>
 {
+	/// <summary>
+	///     Sets up callbacks on the getter.
+	/// </summary>
+	IPropertyGetterSetup<T> OnGet { get; }
+
+	/// <summary>
+	///     Sets up callbacks on the setter.
+	/// </summary>
+	IPropertySetterSetup<T> OnSet { get; }
+
 	/// <summary>
 	///     Flag indicating if the base class implementation should be called, and its return values used as default values.
 	/// </summary>
@@ -56,48 +122,6 @@ public interface IPropertySetup<T>
 	///     Initializes the property with the given <paramref name="value" />.
 	/// </summary>
 	IPropertySetup<T> InitializeWith(T value);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the property's getter is accessed.
-	/// </summary>
-	IPropertySetupCallbackBuilder<T> OnGet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the property's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the value of the property as single parameter.
-	/// </remarks>
-	IPropertySetupCallbackBuilder<T> OnGet(Action<T> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the property's getter is accessed.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter and the value of the property as second parameter.
-	/// </remarks>
-	IPropertySetupCallbackBuilder<T> OnGet(Action<int, T> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set.
-	/// </summary>
-	IPropertySetupCallbackBuilder<T> OnSet(Action callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives the value the property is set to as single parameter.
-	/// </remarks>
-	IPropertySetupCallbackBuilder<T> OnSet(Action<T> callback);
-
-	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set.
-	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter and the value the property is set to as second parameter.
-	/// </remarks>
-	IPropertySetupCallbackBuilder<T> OnSet(Action<int, T> callback);
 
 	/// <summary>
 	///     Registers the <paramref name="returnValue" /> for this property.

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -120,8 +120,9 @@ public abstract class PropertySetup : IInteractivePropertySetup
 /// <summary>
 ///     Sets up a property.
 /// </summary>
-public class PropertySetup<T>(string name)
-	: PropertySetup, IPropertySetupCallbackBuilder<T>, IPropertySetupReturnBuilder<T>
+public class PropertySetup<T>(string name) : PropertySetup,
+	IPropertySetupCallbackBuilder<T>, IPropertySetupReturnBuilder<T>,
+	IPropertyGetterSetup<T>, IPropertySetterSetup<T>
 {
 	private readonly List<Callback<Action<int, T>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T, T>>> _returnCallbacks = [];
@@ -326,8 +327,12 @@ public class PropertySetup<T>(string name)
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetup{T}.OnGet(Action)" />
-	public IPropertySetupCallbackBuilder<T> OnGet(Action callback)
+	/// <inheritdoc cref="IPropertySetup{T}.OnGet" />
+	public IPropertyGetterSetup<T> OnGet
+		=> this;
+
+	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action)" />
+	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action callback)
 	{
 		Callback<Action<int, T>> item = new((_, _) => callback());
 		_currentCallback = item;
@@ -335,8 +340,8 @@ public class PropertySetup<T>(string name)
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetup{T}.OnGet(Action{T})" />
-	public IPropertySetupCallbackBuilder<T> OnGet(Action<T> callback)
+	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action{T})" />
+	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<T> callback)
 	{
 		Callback<Action<int, T>> item = new((_, v) => callback(v));
 		_currentCallback = item;
@@ -344,8 +349,8 @@ public class PropertySetup<T>(string name)
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetup{T}.OnGet(Action{int, T})" />
-	public IPropertySetupCallbackBuilder<T> OnGet(Action<int, T> callback)
+	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action{int, T})" />
+	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<int, T> callback)
 	{
 		Callback<Action<int, T>> item = new(callback);
 		_currentCallback = item;
@@ -353,8 +358,12 @@ public class PropertySetup<T>(string name)
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetup{T}.OnSet(Action)" />
-	public IPropertySetupCallbackBuilder<T> OnSet(Action callback)
+	/// <inheritdoc cref="IPropertySetup{T}.OnSet" />
+	public IPropertySetterSetup<T> OnSet
+		=> this;
+
+	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action)" />
+	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action callback)
 	{
 		Callback<Action<int, T>> item = new((_, _) => callback());
 		_currentCallback = item;
@@ -362,8 +371,8 @@ public class PropertySetup<T>(string name)
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetup{T}.OnSet(Action{T})" />
-	public IPropertySetupCallbackBuilder<T> OnSet(Action<T> callback)
+	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action{T})" />
+	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<T> callback)
 	{
 		Callback<Action<int, T>> item = new((_, newValue) => callback(newValue));
 		_currentCallback = item;
@@ -371,8 +380,8 @@ public class PropertySetup<T>(string name)
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetup{T}.OnSet(Action{int, T})" />
-	public IPropertySetupCallbackBuilder<T> OnSet(Action<int, T> callback)
+	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action{int, T})" />
+	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<int, T> callback)
 	{
 		Callback<Action<int, T>> item = new(callback);
 		_currentCallback = item;

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -589,6 +589,62 @@ namespace Mockolate.Setup
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, out TReturn? returnValue) { }
     }
+    public interface IIndexerGetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+    }
     public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> InParallel();
@@ -667,17 +723,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
@@ -691,17 +741,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
@@ -715,17 +759,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2, out T3>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
@@ -739,17 +777,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
@@ -809,6 +841,18 @@ namespace Mockolate.Setup
     {
         T Subject { get; }
     }
+    public interface IPropertyGetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+    }
+    public interface IPropertySetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+    }
     public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         Mockolate.Setup.IPropertySetupWhenBuilder<T> InParallel();
@@ -830,14 +874,10 @@ namespace Mockolate.Setup
     }
     public interface IPropertySetup<T>
     {
+        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
         Mockolate.Setup.IPropertySetup<T> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IPropertySetup<T> InitializeWith(T value);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
@@ -1199,9 +1239,11 @@ namespace Mockolate.Setup
         public TResult GetResult(System.Func<TResult> defaultValueGenerator) { }
         public TResult GetResult(TResult baseValue, System.Func<TResult> defaultValueGenerator) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1210,14 +1252,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback) { }
@@ -1230,9 +1264,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1241,14 +1277,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback) { }
@@ -1261,9 +1289,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2, Mockolate.Parameters.IParameter match3) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1272,14 +1302,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback) { }
@@ -1292,9 +1314,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2, Mockolate.Parameters.IParameter match3, Mockolate.Parameters.IParameter match4) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1303,14 +1327,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback) { }
@@ -1366,10 +1382,12 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(string name) { }
         public override string Name { get; }
+        public Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        public Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
         public Mockolate.Setup.IPropertySetup<T> CallingBaseClass(bool callBaseClass = true) { }
         protected override bool? GetCallBaseClass() { }
         protected override void InitializeValue(object? value) { }
@@ -1377,12 +1395,6 @@ namespace Mockolate.Setup
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator) { }
         protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
         protected override bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -588,6 +588,62 @@ namespace Mockolate.Setup
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, out TReturn? returnValue) { }
     }
+    public interface IIndexerGetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+    }
     public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> InParallel();
@@ -666,17 +722,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
@@ -690,17 +740,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
@@ -714,17 +758,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2, out T3>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
@@ -738,17 +776,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
@@ -808,6 +840,18 @@ namespace Mockolate.Setup
     {
         T Subject { get; }
     }
+    public interface IPropertyGetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+    }
+    public interface IPropertySetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+    }
     public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         Mockolate.Setup.IPropertySetupWhenBuilder<T> InParallel();
@@ -829,14 +873,10 @@ namespace Mockolate.Setup
     }
     public interface IPropertySetup<T>
     {
+        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
         Mockolate.Setup.IPropertySetup<T> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IPropertySetup<T> InitializeWith(T value);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
@@ -1198,9 +1238,11 @@ namespace Mockolate.Setup
         public TResult GetResult(System.Func<TResult> defaultValueGenerator) { }
         public TResult GetResult(TResult baseValue, System.Func<TResult> defaultValueGenerator) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1209,14 +1251,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback) { }
@@ -1229,9 +1263,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1240,14 +1276,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback) { }
@@ -1260,9 +1288,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2, Mockolate.Parameters.IParameter match3) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1271,14 +1301,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback) { }
@@ -1291,9 +1313,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2, Mockolate.Parameters.IParameter match3, Mockolate.Parameters.IParameter match4) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1302,14 +1326,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback) { }
@@ -1365,10 +1381,12 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(string name) { }
         public override string Name { get; }
+        public Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        public Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
         public Mockolate.Setup.IPropertySetup<T> CallingBaseClass(bool callBaseClass = true) { }
         protected override bool? GetCallBaseClass() { }
         protected override void InitializeValue(object? value) { }
@@ -1376,12 +1394,6 @@ namespace Mockolate.Setup
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator) { }
         protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
         protected override bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -565,6 +565,62 @@ namespace Mockolate.Setup
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, out TReturn? returnValue) { }
     }
+    public interface IIndexerGetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+    }
+    public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+    }
+    public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+    }
     public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> InParallel();
@@ -643,17 +699,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
@@ -667,17 +717,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
@@ -691,17 +735,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2, out T3>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
@@ -715,17 +753,11 @@ namespace Mockolate.Setup
     }
     public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
     {
+        Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator);
         Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
         Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
@@ -785,6 +817,18 @@ namespace Mockolate.Setup
     {
         T Subject { get; }
     }
+    public interface IPropertyGetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+    }
+    public interface IPropertySetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+    }
     public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         Mockolate.Setup.IPropertySetupWhenBuilder<T> InParallel();
@@ -806,14 +850,10 @@ namespace Mockolate.Setup
     }
     public interface IPropertySetup<T>
     {
+        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
         Mockolate.Setup.IPropertySetup<T> CallingBaseClass(bool callBaseClass = true);
         Mockolate.Setup.IPropertySetup<T> InitializeWith(T value);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
         Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
@@ -1175,9 +1215,11 @@ namespace Mockolate.Setup
         public TResult GetResult(System.Func<TResult> defaultValueGenerator) { }
         public TResult GetResult(TResult baseValue, System.Func<TResult> defaultValueGenerator) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1186,14 +1228,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnGet(System.Action<int, T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<T1, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> OnSet(System.Action<int, T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback) { }
@@ -1206,9 +1240,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1217,14 +1253,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnGet(System.Action<int, T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<T1, T2, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> OnSet(System.Action<int, T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback) { }
@@ -1237,9 +1265,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2, Mockolate.Parameters.IParameter match3) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1248,14 +1278,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnGet(System.Action<int, T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<T1, T2, T3, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> OnSet(System.Action<int, T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback) { }
@@ -1268,9 +1290,11 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         protected override bool TryGetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, object?[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.Parameters.IParameter match1, Mockolate.Parameters.IParameter match2, Mockolate.Parameters.IParameter match3, Mockolate.Parameters.IParameter match4) { }
+        public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> CallingBaseClass(bool callBaseClass = true) { }
         protected override T ExecuteGetterCallback<T>(Mockolate.Interactions.IndexerGetterAccess indexerGetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
@@ -1279,14 +1303,6 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(object?[] parameters) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnGet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<T1, T2, T3, T4, TValue> callback) { }
-        public Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> OnSet(System.Action<int, T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback) { }
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback) { }
@@ -1342,10 +1358,12 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetupWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(string name) { }
         public override string Name { get; }
+        public Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        public Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
         public Mockolate.Setup.IPropertySetup<T> CallingBaseClass(bool callBaseClass = true) { }
         protected override bool? GetCallBaseClass() { }
         protected override void InitializeValue(object? value) { }
@@ -1353,12 +1371,6 @@ namespace Mockolate.Setup
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult>? defaultValueGenerator) { }
         protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
         protected override bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnGet(System.Action<int, T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<T> callback) { }
-        public Mockolate.Setup.IPropertySetupCallbackBuilder<T> OnSet(System.Action<int, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback) { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue) { }

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnGetTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnGetTests.cs
@@ -12,7 +12,7 @@ public sealed partial class SetupIndexerTests
 			List<int> invocations = [];
 			IIndexerService sut = Mock.Create<IIndexerService>();
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet((i, _) => { invocations.Add(i); })
+				.OnGet.Do((i, _) => { invocations.Add(i); })
 				.For(4);
 
 			for (int i = 0; i < 20; i++)
@@ -29,7 +29,7 @@ public sealed partial class SetupIndexerTests
 			List<int> invocations = [];
 			IIndexerService sut = Mock.Create<IIndexerService>();
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet((i, _) => { invocations.Add(i); })
+				.OnGet.Do((i, _) => { invocations.Add(i); })
 				.When(x => x > 2)
 				.For(4);
 
@@ -50,9 +50,9 @@ public sealed partial class SetupIndexerTests
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet(() => { callCount1++; })
-				.OnGet(v => { callCount2 += v; }).InParallel()
-				.OnGet(v => { callCount3 += v; });
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2 += v; }).InParallel()
+				.OnGet.Do(v => { callCount3 += v; });
 
 			_ = sut[1];
 			_ = sut[2];
@@ -74,7 +74,7 @@ public sealed partial class SetupIndexerTests
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet(v => { sum += v; }).Only(times);
+				.OnGet.Do(v => { sum += v; }).Only(times);
 
 			_ = sut[1];
 			_ = sut[2];
@@ -92,8 +92,8 @@ public sealed partial class SetupIndexerTests
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet(() => { callCount1++; })
-				.OnGet(v => { callCount2 += v; }).OnlyOnce();
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2 += v; }).OnlyOnce();
 
 			_ = sut[1];
 			_ = sut[2];
@@ -110,7 +110,7 @@ public sealed partial class SetupIndexerTests
 			int callCount = 0;
 			IIndexerService mock = Mock.Create<IIndexerService>();
 			mock.SetupMock.Indexer(It.Is<int>(i => i < 4))
-				.OnGet(() => { callCount++; });
+				.OnGet.Do(() => { callCount++; });
 
 			_ = mock[1];
 			_ = mock[2];
@@ -128,7 +128,7 @@ public sealed partial class SetupIndexerTests
 			int callCount = 0;
 			IIndexerService mock = Mock.Create<IIndexerService>();
 			mock.SetupMock.Indexer(It.Is<int>(i => i < 4))
-				.OnGet(v => { callCount += v; });
+				.OnGet.Do(v => { callCount += v; });
 
 			_ = mock[1];
 			_ = mock[2];
@@ -147,8 +147,8 @@ public sealed partial class SetupIndexerTests
 			IIndexerService sut = Mock.Create<IIndexerService>();
 
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet(() => { callCount1++; })
-				.OnGet(v => { callCount2 += v; });
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2 += v; });
 
 			_ = sut[1];
 			_ = sut[2];
@@ -165,7 +165,7 @@ public sealed partial class SetupIndexerTests
 			List<int> invocations = [];
 			IIndexerService sut = Mock.Create<IIndexerService>();
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet((i, _) => { invocations.Add(i); })
+				.OnGet.Do((i, _) => { invocations.Add(i); })
 				.When(x => x is > 3 and < 9);
 
 			for (int i = 0; i < 20; i++)
@@ -182,7 +182,7 @@ public sealed partial class SetupIndexerTests
 			int callCount = 0;
 			IIndexerService mock = Mock.Create<IIndexerService>();
 			mock.SetupMock.Indexer(It.IsAny<int>())
-				.OnGet(() => { callCount++; });
+				.OnGet.Do(() => { callCount++; });
 
 			_ = mock[1];
 			_ = mock[2, 2];
@@ -199,7 +199,7 @@ public sealed partial class SetupIndexerTests
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[1];
 				_ = mock[2, 2];
@@ -214,7 +214,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -231,7 +231,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -252,9 +252,9 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _) => { callCount2 += p1; }).InParallel()
-					.OnGet((p1, _) => { callCount3 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _) => { callCount2 += p1; }).InParallel()
+					.OnGet.Do((p1, _) => { callCount3 += p1; });
 
 				_ = sut[1, 2];
 				_ = sut[2, 2];
@@ -276,7 +276,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((p1, _) => { sum += p1; }).Only(times);
+					.OnGet.Do((p1, _) => { sum += p1; }).Only(times);
 
 				_ = sut[1, 2];
 				_ = sut[2, 2];
@@ -294,8 +294,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _) => { callCount2 += p1; }).OnlyOnce();
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _) => { callCount2 += p1; }).OnlyOnce();
 
 				_ = sut[1, 2];
 				_ = sut[2, 2];
@@ -312,7 +312,7 @@ public sealed partial class SetupIndexerTests
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4))
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[5, 1]; // no
 				_ = mock[3, 2]; // yes
@@ -330,7 +330,7 @@ public sealed partial class SetupIndexerTests
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4))
-					.OnGet((v1, v2) => { callCount += v1 * v2; });
+					.OnGet.Do((v1, v2) => { callCount += v1 * v2; });
 
 				_ = mock[5, 1]; // no
 				_ = mock[3, 2]; // yes (6)
@@ -350,8 +350,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _) => { callCount2 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _) => { callCount2 += p1; });
 
 				_ = sut[1, 2];
 				_ = sut[2, 2];
@@ -368,7 +368,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)
@@ -388,7 +388,7 @@ public sealed partial class SetupIndexerTests
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[1];
 				_ = mock[2, 2];
@@ -404,7 +404,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -421,7 +421,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -442,9 +442,9 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _) => { callCount2 += p1; }).InParallel()
-					.OnGet((p1, _, _) => { callCount3 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _) => { callCount2 += p1; }).InParallel()
+					.OnGet.Do((p1, _, _) => { callCount3 += p1; });
 
 				_ = sut[1, 2, 3];
 				_ = sut[2, 2, 3];
@@ -466,7 +466,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((p1, _, _) => { sum += p1; }).Only(times);
+					.OnGet.Do((p1, _, _) => { sum += p1; }).Only(times);
 
 				_ = sut[1, 2, 3];
 				_ = sut[2, 2, 3];
@@ -484,8 +484,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _) => { callCount2 += p1; }).OnlyOnce();
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _) => { callCount2 += p1; }).OnlyOnce();
 
 				_ = sut[1, 2, 3];
 				_ = sut[2, 2, 3];
@@ -503,7 +503,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4),
 						It.Is<int>(i => i < 4))
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[1, 5, 1]; // no
 				_ = mock[3, 1, 2]; // yes
@@ -523,7 +523,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4),
 						It.Is<int>(i => i < 4))
-					.OnGet((v1, v2, v3) => { callCount += v1 * v2 * v3; });
+					.OnGet.Do((v1, v2, v3) => { callCount += v1 * v2 * v3; });
 
 				_ = mock[1, 5, 1]; // no
 				_ = mock[3, 1, 2]; // yes (6)
@@ -544,8 +544,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _) => { callCount2 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _) => { callCount2 += p1; });
 
 				_ = sut[1, 2, 3];
 				_ = sut[2, 2, 3];
@@ -562,7 +562,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)
@@ -582,7 +582,7 @@ public sealed partial class SetupIndexerTests
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[1];
 				_ = mock[2, 2];
@@ -598,7 +598,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -615,7 +615,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -636,9 +636,9 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _, _) => { callCount2 += p1; }).InParallel()
-					.OnGet((p1, _, _, _) => { callCount3 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnGet.Do((p1, _, _, _) => { callCount3 += p1; });
 
 				_ = sut[1, 2, 3, 4];
 				_ = sut[2, 2, 3, 4];
@@ -660,7 +660,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((p1, _, _, _) => { sum += p1; }).Only(times);
+					.OnGet.Do((p1, _, _, _) => { sum += p1; }).Only(times);
 
 				_ = sut[1, 2, 3, 4];
 				_ = sut[2, 2, 3, 4];
@@ -678,8 +678,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _, _) => { callCount2 += p1; }).OnlyOnce();
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _, _) => { callCount2 += p1; }).OnlyOnce();
 
 				_ = sut[1, 2, 3, 4];
 				_ = sut[2, 2, 3, 4];
@@ -697,7 +697,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 5), It.Is<int>(i => i < 5),
 						It.Is<int>(i => i < 5), It.Is<int>(i => i < 5))
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[1, 1, 5, 1]; // no
 				_ = mock[3, 1, 2, 4]; // yes
@@ -718,7 +718,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 5), It.Is<int>(i => i < 5),
 						It.Is<int>(i => i < 5), It.Is<int>(i => i < 5))
-					.OnGet((v1, v2, v3, v4) => { callCount += v1 * v2 * v3 * v4; });
+					.OnGet.Do((v1, v2, v3, v4) => { callCount += v1 * v2 * v3 * v4; });
 
 				_ = mock[1, 5, 1, 3]; // no
 				_ = mock[3, 1, 2, 4]; // yes (24)
@@ -739,8 +739,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _, _) => { callCount2 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _, _) => { callCount2 += p1; });
 
 				_ = sut[1, 2, 3, 4];
 				_ = sut[2, 2, 3, 4];
@@ -757,7 +757,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnGet((i, _, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)
@@ -778,7 +778,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[1];
 				_ = mock[2, 2];
@@ -796,7 +796,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet((i, _, _, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -814,7 +814,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet((i, _, _, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -836,9 +836,9 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _, _, _) => { callCount2 += p1; }).InParallel()
-					.OnGet((p1, _, _, _, _) => { callCount3 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnGet.Do((p1, _, _, _, _) => { callCount3 += p1; });
 
 				_ = sut[1, 2, 3, 4, 5];
 				_ = sut[2, 2, 3, 4, 5];
@@ -861,7 +861,7 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet((p1, _, _, _, _) => { sum += p1; }).Only(times);
+					.OnGet.Do((p1, _, _, _, _) => { sum += p1; }).Only(times);
 
 				_ = sut[1, 2, 3, 4, 5];
 				_ = sut[2, 2, 3, 4, 5];
@@ -880,8 +880,8 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _, _, _) => { callCount2 += p1; }).OnlyOnce();
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _, _, _) => { callCount2 += p1; }).OnlyOnce();
 
 				_ = sut[1, 2, 3, 4, 5];
 				_ = sut[2, 2, 3, 4, 5];
@@ -899,7 +899,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 6), It.Is<int>(i => i < 6),
 						It.Is<int>(i => i < 6), It.Is<int>(i => i < 6), It.Is<int>(i => i < 6))
-					.OnGet(() => { callCount++; });
+					.OnGet.Do(() => { callCount++; });
 
 				_ = mock[1, 1, 1, 6, 1]; // no
 				_ = mock[1, 3, 1, 2, 4]; // yes
@@ -920,7 +920,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 6), It.Is<int>(i => i < 6),
 						It.Is<int>(i => i < 6), It.Is<int>(i => i < 6), It.Is<int>(i => i < 6))
-					.OnGet((v1, v2, v3, v4, v5) => { callCount += v1 * v2 * v3 * v4 * v5; });
+					.OnGet.Do((v1, v2, v3, v4, v5) => { callCount += v1 * v2 * v3 * v4 * v5; });
 
 				_ = mock[1, 1, 1, 7, 1]; // no
 				_ = mock[1, 3, 1, 2, 4]; // yes (24)
@@ -943,8 +943,8 @@ public sealed partial class SetupIndexerTests
 
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet(() => { callCount1++; })
-					.OnGet((p1, _, _, _, _) => { callCount2 += p1; });
+					.OnGet.Do(() => { callCount1++; })
+					.OnGet.Do((p1, _, _, _, _) => { callCount2 += p1; });
 
 				_ = sut[1, 2, 3, 4, 5];
 				_ = sut[2, 2, 3, 4, 5];
@@ -962,7 +962,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnGet((i, _, _, _, _, _) => { invocations.Add(i); })
+					.OnGet.Do((i, _, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnSetTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnSetTests.cs
@@ -12,7 +12,7 @@ public sealed partial class SetupIndexerTests
 			List<int> invocations = [];
 			IIndexerService sut = Mock.Create<IIndexerService>();
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet((i, _, _) => { invocations.Add(i); })
+				.OnSet.Do((i, _, _) => { invocations.Add(i); })
 				.For(4);
 
 			for (int i = 0; i < 20; i++)
@@ -29,7 +29,7 @@ public sealed partial class SetupIndexerTests
 			List<int> invocations = [];
 			IIndexerService sut = Mock.Create<IIndexerService>();
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet((i, _, _) => { invocations.Add(i); })
+				.OnSet.Do((i, _, _) => { invocations.Add(i); })
 				.When(x => x > 2)
 				.For(4);
 
@@ -50,9 +50,9 @@ public sealed partial class SetupIndexerTests
 			IIndexerService mock = Mock.Create<IIndexerService>();
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet(() => { callCount1++; })
-				.OnSet((p1, _) => { callCount2 += p1; }).InParallel()
-				.OnSet((p1, _) => { callCount3 += p1; });
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((p1, _) => { callCount2 += p1; }).InParallel()
+				.OnSet.Do((p1, _) => { callCount3 += p1; });
 
 			mock[4] = "foo";
 			mock[6] = "foo";
@@ -75,7 +75,7 @@ public sealed partial class SetupIndexerTests
 			IIndexerService mock = Mock.Create<IIndexerService>();
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet((p1, _) => { sum += p1; }).Only(times);
+				.OnSet.Do((p1, _) => { sum += p1; }).Only(times);
 
 			mock[1] = "foo";
 			mock[2] = "foo";
@@ -94,8 +94,8 @@ public sealed partial class SetupIndexerTests
 			IIndexerService mock = Mock.Create<IIndexerService>();
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet(() => { callCount++; })
-				.OnSet((p1, _) => { sum += p1; }).OnlyOnce();
+				.OnSet.Do(() => { callCount++; })
+				.OnSet.Do((p1, _) => { sum += p1; }).OnlyOnce();
 
 			mock[1] = "foo";
 			mock[2] = "foo";
@@ -112,7 +112,7 @@ public sealed partial class SetupIndexerTests
 			int callCount = 0;
 			IIndexerService mock = Mock.Create<IIndexerService>();
 			mock.SetupMock.Indexer(It.Is<int>(i => i < 4))
-				.OnSet(_ => { callCount++; });
+				.OnSet.Do(_ => { callCount++; });
 
 			mock[1] = "";
 			mock[2] = "";
@@ -130,7 +130,7 @@ public sealed partial class SetupIndexerTests
 			int callCount = 0;
 			IIndexerService mock = Mock.Create<IIndexerService>();
 			mock.SetupMock.Indexer(It.Is<int>(i => i < 4))
-				.OnSet(() => { callCount++; });
+				.OnSet.Do(() => { callCount++; });
 
 			mock[1] = "";
 			mock[2] = "";
@@ -149,8 +149,8 @@ public sealed partial class SetupIndexerTests
 			IIndexerService mock = Mock.Create<IIndexerService>();
 
 			mock.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet(() => { callCount1++; })
-				.OnSet((p1, _) => { callCount2 += p1; });
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((p1, _) => { callCount2 += p1; });
 
 			mock[4] = "foo";
 			mock[6] = "foo";
@@ -167,7 +167,7 @@ public sealed partial class SetupIndexerTests
 			List<int> invocations = [];
 			IIndexerService sut = Mock.Create<IIndexerService>();
 			sut.SetupMock.Indexer(It.IsAny<int>())
-				.OnSet((i, _, _) => { invocations.Add(i); })
+				.OnSet.Do((i, _, _) => { invocations.Add(i); })
 				.When(x => x is > 3 and < 9);
 
 			for (int i = 0; i < 20; i++)
@@ -186,7 +186,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -203,7 +203,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -224,9 +224,9 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((p1, _, _) => { callCount3 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet.Do((p1, _, _) => { callCount3 += p1; });
 
 				mock[4, 2] = "foo";
 				mock[6, 2] = "foo";
@@ -249,7 +249,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((p1, _, _) => { sum += p1; }).Only(times);
+					.OnSet.Do((p1, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2] = "foo";
 				mock[2, 2] = "foo";
@@ -268,8 +268,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount++; })
-					.OnSet((p1, _, _) => { sum += p1; }).OnlyOnce();
+					.OnSet.Do(() => { callCount++; })
+					.OnSet.Do((p1, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2] = "foo";
 				mock[2, 2] = "foo";
@@ -286,7 +286,7 @@ public sealed partial class SetupIndexerTests
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4))
-					.OnSet(v => { callCount += v.Length; });
+					.OnSet.Do(v => { callCount += v.Length; });
 
 				mock[1, 1] = "a"; // yes (1)
 				mock[1, 2] = "bb"; // yes (2)
@@ -307,7 +307,7 @@ public sealed partial class SetupIndexerTests
 				int callCount = 0;
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4))
-					.OnSet(() => { callCount++; });
+					.OnSet.Do(() => { callCount++; });
 
 				mock[1, 1] = ""; // yes
 				mock[1, 2] = ""; // yes
@@ -327,8 +327,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _) => { callCount2 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _) => { callCount2 += p1; });
 
 				mock[4, 2] = "foo";
 				mock[6, 2] = "foo";
@@ -345,7 +345,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)
@@ -365,7 +365,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -382,7 +382,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -403,9 +403,9 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((p1, _, _, _) => { callCount3 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet.Do((p1, _, _, _) => { callCount3 += p1; });
 
 				mock[4, 2, 3] = "foo";
 				mock[6, 2, 3] = "foo";
@@ -428,7 +428,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((p1, _, _, _) => { sum += p1; }).Only(times);
+					.OnSet.Do((p1, _, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2, 3] = "foo";
 				mock[2, 2, 3] = "foo";
@@ -447,8 +447,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount++; })
-					.OnSet((p1, _, _, _) => { sum += p1; }).OnlyOnce();
+					.OnSet.Do(() => { callCount++; })
+					.OnSet.Do((p1, _, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2, 3] = "foo";
 				mock[2, 2, 3] = "foo";
@@ -466,7 +466,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4),
 						It.Is<int>(i => i < 4))
-					.OnSet(v => { callCount += v.Length; });
+					.OnSet.Do(v => { callCount += v.Length; });
 
 				mock[1, 1, 1] = "a"; // yes (1)
 				mock[1, 2, 1] = "bb"; // yes (2)
@@ -488,7 +488,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 4), It.Is<int>(i => i < 4),
 						It.Is<int>(i => i < 4))
-					.OnSet(() => { callCount++; });
+					.OnSet.Do(() => { callCount++; });
 
 				mock[1, 1, 1] = ""; // yes
 				mock[1, 1, 2] = ""; // yes
@@ -509,8 +509,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _, _) => { callCount2 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _, _) => { callCount2 += p1; });
 
 				mock[4, 2, 3] = "foo";
 				mock[6, 2, 3] = "foo";
@@ -527,7 +527,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)
@@ -547,7 +547,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -564,7 +564,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -585,9 +585,9 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _, _, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((p1, _, _, _, _) => { callCount3 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet.Do((p1, _, _, _, _) => { callCount3 += p1; });
 
 				mock[4, 2, 3, 4] = "foo";
 				mock[6, 2, 3, 4] = "foo";
@@ -610,7 +610,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((p1, _, _, _, _) => { sum += p1; }).Only(times);
+					.OnSet.Do((p1, _, _, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2, 3, 4] = "foo";
 				mock[2, 2, 3, 4] = "foo";
@@ -629,8 +629,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount++; })
-					.OnSet((p1, _, _, _, _) => { sum += p1; }).OnlyOnce();
+					.OnSet.Do(() => { callCount++; })
+					.OnSet.Do((p1, _, _, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2, 3, 4] = "foo";
 				mock[2, 2, 3, 4] = "foo";
@@ -648,7 +648,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 5), It.Is<int>(i => i < 5),
 						It.Is<int>(i => i < 5), It.Is<int>(i => i < 5))
-					.OnSet(v => { callCount += v.Length; });
+					.OnSet.Do(v => { callCount += v.Length; });
 
 				mock[1, 1, 1, 1] = "a"; // yes (1)
 				mock[1, 2, 1, 3] = "bb"; // yes (2)
@@ -670,7 +670,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 5), It.Is<int>(i => i < 5),
 						It.Is<int>(i => i < 5), It.Is<int>(i => i < 5))
-					.OnSet(() => { callCount++; });
+					.OnSet.Do(() => { callCount++; });
 
 				mock[1, 1, 1, 1] = ""; // yes
 				mock[1, 1, 2, 2] = ""; // yes
@@ -691,8 +691,8 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _, _, _) => { callCount2 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _, _, _) => { callCount2 += p1; });
 
 				mock[4, 2, 3, 4] = "foo";
 				mock[6, 2, 3, 4] = "foo";
@@ -709,7 +709,7 @@ public sealed partial class SetupIndexerTests
 				List<int> invocations = [];
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
-					.OnSet((i, _, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)
@@ -730,7 +730,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet((i, _, _, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _, _, _) => { invocations.Add(i); })
 					.For(4);
 
 				for (int i = 0; i < 20; i++)
@@ -748,7 +748,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet((i, _, _, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x > 2)
 					.For(4);
 
@@ -770,9 +770,9 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _, _, _, _) => { callCount2 += p1; }).InParallel()
-					.OnSet((p1, _, _, _, _, _) => { callCount3 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _, _, _, _) => { callCount2 += p1; }).InParallel()
+					.OnSet.Do((p1, _, _, _, _, _) => { callCount3 += p1; });
 
 				mock[4, 2, 3, 4, 5] = "foo";
 				mock[6, 2, 3, 4, 5] = "foo";
@@ -796,7 +796,7 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet((p1, _, _, _, _, _) => { sum += p1; }).Only(times);
+					.OnSet.Do((p1, _, _, _, _, _) => { sum += p1; }).Only(times);
 
 				mock[1, 2, 3, 4, 5] = "foo";
 				mock[2, 2, 3, 4, 5] = "foo";
@@ -816,8 +816,8 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet(() => { callCount++; })
-					.OnSet((p1, _, _, _, _, _) => { sum += p1; }).OnlyOnce();
+					.OnSet.Do(() => { callCount++; })
+					.OnSet.Do((p1, _, _, _, _, _) => { sum += p1; }).OnlyOnce();
 
 				mock[1, 2, 3, 4, 5] = "foo";
 				mock[2, 2, 3, 4, 5] = "foo";
@@ -835,7 +835,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 6), It.Is<int>(i => i < 6),
 						It.Is<int>(i => i < 6), It.Is<int>(i => i < 6), It.Is<int>(i => i < 6))
-					.OnSet(v => { callCount += v.Length; });
+					.OnSet.Do(v => { callCount += v.Length; });
 
 				mock[1, 1, 1, 1, 1] = "a"; // yes (1)
 				mock[4, 1, 2, 1, 3] = "bb"; // yes (2)
@@ -857,7 +857,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService mock = Mock.Create<IIndexerService>();
 				mock.SetupMock.Indexer(It.Is<int>(i => i < 6), It.Is<int>(i => i < 6),
 						It.Is<int>(i => i < 6), It.Is<int>(i => i < 6), It.Is<int>(i => i < 6))
-					.OnSet(() => { callCount++; });
+					.OnSet.Do(() => { callCount++; });
 
 				mock[1, 1, 1, 1, 1] = ""; // yes
 				mock[1, 1, 1, 2, 2] = ""; // yes
@@ -879,8 +879,8 @@ public sealed partial class SetupIndexerTests
 
 				mock.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet(() => { callCount1++; })
-					.OnSet((p1, _, _, _, _, _) => { callCount2 += p1; });
+					.OnSet.Do(() => { callCount1++; })
+					.OnSet.Do((p1, _, _, _, _, _) => { callCount2 += p1; });
 
 				mock[4, 2, 3, 4, 5] = "foo";
 				mock[6, 2, 3, 4, 5] = "foo";
@@ -898,7 +898,7 @@ public sealed partial class SetupIndexerTests
 				IIndexerService sut = Mock.Create<IIndexerService>();
 				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
 						It.IsAny<int>())
-					.OnSet((i, _, _, _, _, _, _) => { invocations.Add(i); })
+					.OnSet.Do((i, _, _, _, _, _, _) => { invocations.Add(i); })
 					.When(x => x is > 3 and < 9);
 
 				for (int i = 0; i < 20; i++)

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnGetTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnGetTests.cs
@@ -12,7 +12,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnGet((i, _) => { invocations.Add(i); })
+				.OnGet.Do((i, _) => { invocations.Add(i); })
 				.For(4);
 
 			for (int i = 0; i < 20; i++)
@@ -29,7 +29,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnGet((i, _) => { invocations.Add(i); })
+				.OnGet.Do((i, _) => { invocations.Add(i); })
 				.When(x => x > 2)
 				.For(4);
 
@@ -50,9 +50,9 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnGet(() => { callCount1++; })
-				.OnGet(v => { callCount2 += v; }).InParallel()
-				.OnGet(v => { callCount3 += v; });
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2 += v; }).InParallel()
+				.OnGet.Do(v => { callCount3 += v; });
 
 			sut.MyProperty = 1;
 			_ = sut.MyProperty;
@@ -79,7 +79,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnGet(v => { sum += v; }).Only(times);
+				.OnGet.Do(v => { sum += v; }).Only(times);
 
 			sut.MyProperty = 1;
 			_ = sut.MyProperty;
@@ -103,8 +103,8 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnGet(() => { callCount1++; })
-				.OnGet(v => { callCount2 += v; }).OnlyOnce();
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2 += v; }).OnlyOnce();
 
 			sut.MyProperty = 1;
 			_ = sut.MyProperty;
@@ -127,8 +127,8 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnGet(() => { callCount1++; })
-				.OnGet(v => { callCount2 += v; });
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2 += v; });
 
 			sut.MyProperty = 1;
 			_ = sut.MyProperty;
@@ -150,7 +150,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnGet(() => { callCount++; });
+				.OnGet.Do(() => { callCount++; });
 
 			_ = sut.MyProperty;
 
@@ -164,7 +164,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnGet(() => { callCount++; });
+				.OnGet.Do(() => { callCount++; });
 
 			_ = sut.MyOtherProperty;
 			sut.MyProperty = 1;
@@ -178,7 +178,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnGet((i, _) => { invocations.Add(i); })
+				.OnGet.Do((i, _) => { invocations.Add(i); })
 				.When(x => x is > 3 and < 9);
 
 			for (int i = 0; i < 20; i++)
@@ -198,7 +198,7 @@ public sealed partial class SetupPropertyTests
 
 			sut.SetupMock.Property.MyProperty
 				.InitializeWith(4)
-				.OnGet(v =>
+				.OnGet.Do(v =>
 				{
 					callCount++;
 					receivedValue = v;
@@ -217,7 +217,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnGet(_ => { callCount++; });
+				.OnGet.Do(_ => { callCount++; });
 
 			_ = sut.MyOtherProperty;
 			sut.MyProperty = 1;

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnSetTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnSetTests.cs
@@ -12,7 +12,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnSet((i, _) => { invocations.Add(i); })
+				.OnSet.Do((i, _) => { invocations.Add(i); })
 				.For(4);
 
 			for (int i = 0; i < 20; i++)
@@ -29,7 +29,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnSet((i, _) => { invocations.Add(i); })
+				.OnSet.Do((i, _) => { invocations.Add(i); })
 				.When(x => x > 2)
 				.For(4);
 
@@ -51,9 +51,9 @@ public sealed partial class SetupPropertyTests
 
 			sut.SetupMock.Property.MyProperty
 				.InitializeWith(2)
-				.OnSet(() => { callCount1++; })
-				.OnSet((_, v) => { callCount2 += v; }).InParallel()
-				.OnSet((_, v) => { callCount3 += v; });
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((_, v) => { callCount2 += v; }).InParallel()
+				.OnSet.Do((_, v) => { callCount3 += v; });
 
 			sut.MyProperty = 4;
 			sut.MyProperty = 6;
@@ -76,7 +76,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnSet((_, v) => { sum += v; }).Only(times);
+				.OnSet.Do((_, v) => { sum += v; }).Only(times);
 
 			sut.MyProperty = 1;
 			sut.MyProperty = 2;
@@ -95,8 +95,8 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnSet(() => { callCount1++; })
-				.OnSet((_, v) => { callCount2 += v; }).OnlyOnce();
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((_, v) => { callCount2 += v; }).OnlyOnce();
 
 			sut.MyProperty = 1;
 			sut.MyProperty = 2;
@@ -116,8 +116,8 @@ public sealed partial class SetupPropertyTests
 
 			sut.SetupMock.Property.MyProperty
 				.InitializeWith(2)
-				.OnSet(() => { callCount1++; })
-				.OnSet((_, v) => { callCount2 += v; });
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((_, v) => { callCount2 += v; });
 
 			sut.MyProperty = 4;
 			sut.MyProperty = 6;
@@ -135,7 +135,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnSet(() => { callCount++; });
+				.OnSet.Do(() => { callCount++; });
 
 			sut.MyProperty = 5;
 
@@ -149,7 +149,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnSet(() => { callCount++; });
+				.OnSet.Do(() => { callCount++; });
 
 			sut.MyOtherProperty = 1;
 			_ = sut.MyProperty;
@@ -163,7 +163,7 @@ public sealed partial class SetupPropertyTests
 			List<int> invocations = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 			sut.SetupMock.Property.MyProperty
-				.OnSet((i, _) => { invocations.Add(i); })
+				.OnSet.Do((i, _) => { invocations.Add(i); })
 				.When(x => x is > 3 and < 9);
 
 			for (int i = 0; i < 20; i++)
@@ -183,7 +183,7 @@ public sealed partial class SetupPropertyTests
 
 			sut.SetupMock.Property.MyProperty
 				.InitializeWith(4)
-				.OnSet((_, v) =>
+				.OnSet.Do((_, v) =>
 				{
 					callCount++;
 					receivedNewValue = v;
@@ -202,7 +202,7 @@ public sealed partial class SetupPropertyTests
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.OnSet((_, _) => { callCount++; });
+				.OnSet.Do((_, _) => { callCount++; });
 
 			sut.MyOtherProperty = 1;
 			_ = sut.MyProperty;

--- a/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
+++ b/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
@@ -52,7 +52,7 @@ public sealed class ProtectedMockTests
 		int callCount = 0;
 		MyProtectedClass mock = Mock.Create<MyProtectedClass>();
 
-		mock.SetupMock.Protected.Indexer(It.IsAny<int>()).InitializeWith(42).OnGet(() => callCount++);
+		mock.SetupMock.Protected.Indexer(It.IsAny<int>()).InitializeWith(42).OnGet.Do(() => callCount++);
 
 		int result = mock.GetMyProtectedIndexer(3);
 
@@ -67,7 +67,7 @@ public sealed class ProtectedMockTests
 		int callCount = 0;
 		MyProtectedClass mock = Mock.Create<MyProtectedClass>();
 
-		mock.SetupMock.Protected.Indexer(It.IsAny<int>()).OnSet(() => callCount++);
+		mock.SetupMock.Protected.Indexer(It.IsAny<int>()).OnSet.Do(() => callCount++);
 
 		mock.SetMyProtectedIndexer(3, 4);
 


### PR DESCRIPTION
This PR refactors the callback API for properties and indexers by introducing a mandatory `Do` method, replacing the previous pattern where `OnGet` and `OnSet` directly accepted callbacks. This is a breaking change that improves API clarity and consistency.

### Key Changes:
- Changed `OnGet` and `OnSet` from methods accepting callbacks to properties returning setup interfaces
- Introduced `IPropertyGetterSetup`/`IPropertySetterSetup` and `IIndexerGetterSetup`/`IIndexerSetterSetup` interfaces with `Do` methods
- Updated all test files to use the new `OnGet.Do(...)` and `OnSet.Do(...)` syntax

---

- *Fixes #284*