### PR TITLE
fix: use correct type for `SetupExtensions`

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -44,7 +44,7 @@ internal static partial class Sources
 			            		/// <summary>
 			            		///     Extensions for indexer callback setups with {{item}} parameters.
 			            		/// </summary>
-			            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, {{types}}> setup)
+			            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, {{types}}> setup)
 			            		{
 			            			/// <summary>
 			            			///     Executes the callback only once.
@@ -56,7 +56,7 @@ internal static partial class Sources
 			            		/// <summary>
 			            		///     Extensions for indexer setups with {{item}} parameters.
 			            		/// </summary>
-			            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, {{types}}> setup)
+			            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, {{types}}> setup)
 			            		{
 			            			/// <summary>
 			            			///     Returns/throws forever.

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -52,14 +52,14 @@ internal static partial class Sources
 
 			string xmlDocSummary = item.Item2 ? "returning void" : "returning <typeparamref name=\"TReturn\"/>";
 			string typePrefix = item.Item2
-				? "Mockolate.Setup.IVoidMethodSetupReturnBuilder"
-				: "Mockolate.Setup.IReturnMethodSetupReturnBuilder";
+				? "Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder"
+				: "Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder";
 			string setupTypePrefix = item.Item2
 				? "Mockolate.Setup.IVoidMethodSetup"
 				: "Mockolate.Setup.IReturnMethodSetup";
 			string setupCallbackPrefix = item.Item2
-				? "Mockolate.Setup.IVoidMethodSetupCallbackBuilder"
-				: "Mockolate.Setup.IReturnMethodSetupCallbackBuilder";
+				? "Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder"
+				: "Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder";
 			sb.Append($$"""
 			            		/// <summary>
 			            		///     Extensions for method callback setup {{xmlDocSummary}} with {{item.Item1}} parameters.

--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -27,12 +27,12 @@ public class Callback
 	/// </summary>
 	protected bool IsActive(int matchingCount)
 	{
-		if (_onlyTimes > 0 && matchingCount >= _onlyTimes)
+		if (_forTimes is not null)
 		{
-			return false;
+			matchingCount -= _forTimes.Value;
 		}
 
-		return true;
+		return _onlyTimes == 0 || matchingCount < _onlyTimes;
 	}
 
 	/// <summary>

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -40,7 +40,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer setups with one parameter.
 	/// </summary>
-	extension<TValue, T1>(IIndexerSetupReturnBuilder<TValue, T1> setup)
+	extension<TValue, T1>(IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -58,7 +58,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer callback setups with one parameter.
 	/// </summary>
-	extension<TValue, T1>(IIndexerSetupCallbackBuilder<TValue, T1> setup)
+	extension<TValue, T1>(IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -70,7 +70,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer setups with two parameters.
 	/// </summary>
-	extension<TValue, T1, T2>(IIndexerSetupReturnBuilder<TValue, T1, T2> setup)
+	extension<TValue, T1, T2>(IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -88,7 +88,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer callback setups with two parameters.
 	/// </summary>
-	extension<TValue, T1, T2>(IIndexerSetupCallbackBuilder<TValue, T1, T2> setup)
+	extension<TValue, T1, T2>(IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -100,7 +100,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer setups with three parameters.
 	/// </summary>
-	extension<TValue, T1, T2, T3>(IIndexerSetupReturnBuilder<TValue, T1, T2, T3> setup)
+	extension<TValue, T1, T2, T3>(IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -118,7 +118,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer callback setups with three parameters.
 	/// </summary>
-	extension<TValue, T1, T2, T3>(IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> setup)
+	extension<TValue, T1, T2, T3>(IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -130,7 +130,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer setups with four parameters.
 	/// </summary>
-	extension<TValue, T1, T2, T3, T4>(IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> setup)
+	extension<TValue, T1, T2, T3, T4>(IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -148,7 +148,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for indexer callback setups with four parameters.
 	/// </summary>
-	extension<TValue, T1, T2, T3, T4>(IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> setup)
+	extension<TValue, T1, T2, T3, T4>(IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -160,7 +160,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning <typeparamref name="TReturn" /> without parameters.
 	/// </summary>
-	extension<TReturn>(IReturnMethodSetupReturnBuilder<TReturn> setup)
+	extension<TReturn>(IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -178,7 +178,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning <typeparamref name="TReturn" /> without parameters.
 	/// </summary>
-	extension<TReturn>(IReturnMethodSetupCallbackBuilder<TReturn> setup)
+	extension<TReturn>(IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -190,7 +190,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning <typeparamref name="TReturn" /> with one parameter.
 	/// </summary>
-	extension<TReturn, T1>(IReturnMethodSetupReturnBuilder<TReturn, T1> setup)
+	extension<TReturn, T1>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -208,7 +208,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning <typeparamref name="TReturn" /> with one parameter.
 	/// </summary>
-	extension<TReturn, T1>(IReturnMethodSetupCallbackBuilder<TReturn, T1> setup)
+	extension<TReturn, T1>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -220,7 +220,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning <typeparamref name="TReturn" /> with two parameters.
 	/// </summary>
-	extension<TReturn, T1, T2>(IReturnMethodSetupReturnBuilder<TReturn, T1, T2> setup)
+	extension<TReturn, T1, T2>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -238,7 +238,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning <typeparamref name="TReturn" /> with two parameters.
 	/// </summary>
-	extension<TReturn, T1, T2>(IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> setup)
+	extension<TReturn, T1, T2>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -250,7 +250,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning <typeparamref name="TReturn" /> with three parameters.
 	/// </summary>
-	extension<TReturn, T1, T2, T3>(IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> setup)
+	extension<TReturn, T1, T2, T3>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -268,7 +268,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning <typeparamref name="TReturn" /> with three parameters.
 	/// </summary>
-	extension<TReturn, T1, T2, T3>(IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> setup)
+	extension<TReturn, T1, T2, T3>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -280,7 +280,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning <typeparamref name="TReturn" /> with four parameters.
 	/// </summary>
-	extension<TReturn, T1, T2, T3, T4>(IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> setup)
+	extension<TReturn, T1, T2, T3, T4>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -298,7 +298,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning <typeparamref name="TReturn" /> with four parameters.
 	/// </summary>
-	extension<TReturn, T1, T2, T3, T4>(IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> setup)
+	extension<TReturn, T1, T2, T3, T4>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -311,7 +311,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning void without parameters.
 	/// </summary>
-	extension(IVoidMethodSetupReturnBuilder setup)
+	extension(IVoidMethodSetupReturnWhenBuilder setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -329,7 +329,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning void without parameters.
 	/// </summary>
-	extension(IVoidMethodSetupCallbackBuilder setup)
+	extension(IVoidMethodSetupCallbackWhenBuilder setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -341,7 +341,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning void with one parameter.
 	/// </summary>
-	extension<T1>(IVoidMethodSetupReturnBuilder<T1> setup)
+	extension<T1>(IVoidMethodSetupReturnWhenBuilder<T1> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -359,7 +359,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning void with one parameter.
 	/// </summary>
-	extension<T1>(IVoidMethodSetupCallbackBuilder<T1> setup)
+	extension<T1>(IVoidMethodSetupCallbackWhenBuilder<T1> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -371,7 +371,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning void with two parameters.
 	/// </summary>
-	extension<T1, T2>(IVoidMethodSetupReturnBuilder<T1, T2> setup)
+	extension<T1, T2>(IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -389,7 +389,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning void with two parameters.
 	/// </summary>
-	extension<T1, T2>(IVoidMethodSetupCallbackBuilder<T1, T2> setup)
+	extension<T1, T2>(IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -401,7 +401,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning void with three parameters.
 	/// </summary>
-	extension<T1, T2, T3>(IVoidMethodSetupReturnBuilder<T1, T2, T3> setup)
+	extension<T1, T2, T3>(IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -419,7 +419,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning void with three parameters.
 	/// </summary>
-	extension<T1, T2, T3>(IVoidMethodSetupCallbackBuilder<T1, T2, T3> setup)
+	extension<T1, T2, T3>(IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -431,7 +431,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method setup returning void with four parameters.
 	/// </summary>
-	extension<T1, T2, T3, T4>(IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> setup)
+	extension<T1, T2, T3, T4>(IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
 	{
 		/// <summary>
 		///     Returns/throws forever.
@@ -449,7 +449,7 @@ public static class SetupExtensions
 	/// <summary>
 	///     Extensions for method callback setup returning void with four parameters.
 	/// </summary>
-	extension<T1, T2, T3, T4>(IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> setup)
+	extension<T1, T2, T3, T4>(IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -194,20 +194,20 @@ namespace Mockolate
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -215,14 +215,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -231,7 +231,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -239,7 +239,7 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -249,7 +249,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -258,31 +258,31 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn> setup)
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
             where TReturn :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn> setup)
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
             where TReturn :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1> setup)
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
             where TReturn :  notnull
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1> setup)
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
             where TReturn :  notnull
             where T1 :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2> setup)
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -290,14 +290,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> setup)
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> setup)
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -306,7 +306,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> setup)
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -314,7 +314,7 @@ namespace Mockolate
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> setup)
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -324,7 +324,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> setup)
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -333,40 +333,40 @@ namespace Mockolate
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupReturnBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupCallbackBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder setup)
         {
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1> setup)
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1> setup)
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1> setup)
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1> setup)
             where T1 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2> setup)
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
             where T1 :  notnull
             where T2 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2> setup)
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3> setup)
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
@@ -374,14 +374,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3> setup)
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> setup)
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
@@ -390,7 +390,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> setup)
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -193,20 +193,20 @@ namespace Mockolate
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -214,14 +214,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -230,7 +230,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -238,7 +238,7 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -248,7 +248,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -257,31 +257,31 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn> setup)
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
             where TReturn :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn> setup)
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
             where TReturn :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1> setup)
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
             where TReturn :  notnull
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1> setup)
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
             where TReturn :  notnull
             where T1 :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2> setup)
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -289,14 +289,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> setup)
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> setup)
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -305,7 +305,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> setup)
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -313,7 +313,7 @@ namespace Mockolate
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> setup)
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -323,7 +323,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> setup)
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -332,40 +332,40 @@ namespace Mockolate
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupReturnBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupCallbackBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder setup)
         {
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1> setup)
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1> setup)
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1> setup)
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1> setup)
             where T1 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2> setup)
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
             where T1 :  notnull
             where T2 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2> setup)
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3> setup)
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
@@ -373,14 +373,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3> setup)
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> setup)
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
@@ -389,7 +389,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> setup)
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -174,20 +174,20 @@ namespace Mockolate
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -195,14 +195,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -211,7 +211,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -219,7 +219,7 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -229,7 +229,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -238,31 +238,31 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn> setup)
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
             where TReturn :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn> setup)
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
             where TReturn :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1> setup)
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
             where TReturn :  notnull
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1> setup)
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
             where TReturn :  notnull
             where T1 :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2> setup)
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -270,14 +270,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> setup)
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> setup)
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -286,7 +286,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> setup)
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -294,7 +294,7 @@ namespace Mockolate
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> setup)
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -304,7 +304,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> setup)
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
             where TReturn :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -313,40 +313,40 @@ namespace Mockolate
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupReturnBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupCallbackBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder setup)
         {
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1> setup)
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1> setup)
             where T1 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1> setup)
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1> setup)
             where T1 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2> setup)
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
             where T1 :  notnull
             where T2 :  notnull
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2> setup)
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
             where T1 :  notnull
             where T2 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3> setup)
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
@@ -354,14 +354,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3> setup)
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> setup)
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull
@@ -370,7 +370,7 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> setup)
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
             where T1 :  notnull
             where T2 :  notnull
             where T3 :  notnull

--- a/Tests/Mockolate.Tests/SetupExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/SetupExtensionsTests.cs
@@ -1,0 +1,1927 @@
+using System.Collections.Generic;
+
+namespace Mockolate.Tests;
+
+public sealed class SetupExtensionsTests
+{
+	public sealed class PropertySetupReturnWhenBuilderTests
+	{
+		[Fact]
+		public async Task Forever_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Property.MyProperty.Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyProperty;
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Property.MyProperty.Returns(1).Returns(2).Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyProperty;
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Property.MyProperty.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyProperty;
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Property.MyProperty.Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyProperty;
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+	}
+
+	public sealed class PropertySetupWhenBuilderTests
+	{
+		[Fact]
+		public async Task OnlyOnce_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Property.MyProperty.OnGet.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyProperty;
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Property.MyProperty.OnGet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyProperty;
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+	}
+
+	public sealed class IndexerSetupReturnWhenBuilderTests
+	{
+		[Fact]
+		public async Task Forever_With1Parameter_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>()).Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10];
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With1Parameter_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>()).Returns(1).Returns(2).Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10];
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With2Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20];
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With2Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2).Returns(3).When(i => i >= 2)
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20];
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With3Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2).Returns(3)
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30];
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With3Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2).Returns(3)
+				.When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30];
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With4Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1)
+				.Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40];
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With4Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1)
+				.Returns(2).Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40];
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With5Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40, 50];
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With5Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).Returns(2).Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40, 50];
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10];
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>()).Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20];
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30];
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1)
+				.OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40];
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).For(3)
+				.OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40, 50];
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut[10, 20, 30, 40, 50];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+	}
+
+	public sealed class IndexerSetupWhenBuilderTests
+	{
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>()).OnGet.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10];
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>()).OnGet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).OnGet.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20];
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).OnGet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).OnGet.Do(() => values.Add(1))
+				.OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20, 30];
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).OnGet.Do(() => values.Add(1))
+				.For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20, 30];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).OnGet
+				.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20, 30, 40];
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).OnGet
+				.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20, 30, 40];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.OnGet.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20, 30, 40, 50];
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.OnGet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut[10, 20, 30, 40, 50];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+	}
+
+	public sealed class ReturnMethodSetupReturnWhenBuilderTests
+	{
+		[Fact]
+		public async Task Forever_With0Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod().Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod();
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With0Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod().Returns(1).Returns(2).Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod();
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With1Parameter_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>()).Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10);
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With1Parameter_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>()).Returns(1).Returns(2).Returns(3).When(i => i >= 2)
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10);
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With2Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2).Returns(3)
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With2Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2).Returns(3)
+				.When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With3Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2)
+				.Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With3Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).Returns(2)
+				.Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With4Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With4Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).Returns(2).Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With5Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).Returns(2).Returns(3).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With5Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).Returns(2).Returns(3).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod().Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod();
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod().Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod();
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10);
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>()).Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>()).Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).For(3)
+				.OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyIntMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+	}
+
+	public sealed class ReturnMethodSetupWhenBuilderTests
+	{
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod().Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod();
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod().Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod();
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>()).Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>()).Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1)).For(3)
+				.OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1))
+				.OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1))
+				.For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyIntMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				_ = sut.MyIntMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+	}
+
+	public sealed class VoidMethodSetupReturnWhenBuilderTests
+	{
+		[Fact]
+		public async Task Forever_With0Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod().Throws(new Exception("1")).Throws(new Exception("2"))
+				.Throws(new Exception("3")).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod();
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With0Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod().Throws(new Exception("1")).Throws(new Exception("2"))
+				.Throws(new Exception("3")).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod();
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With1Parameter_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>()).Throws(new Exception("1")).Throws(new Exception("2"))
+				.Throws(new Exception("3")).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With1Parameter_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>()).Throws(new Exception("1")).Throws(new Exception("2"))
+				.Throws(new Exception("3")).When(i => i >= 2)
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With2Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>()).Throws(new Exception("1"))
+				.Throws(new Exception("2")).Throws(new Exception("3"))
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With2Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>()).Throws(new Exception("1"))
+				.Throws(new Exception("2")).Throws(new Exception("3"))
+				.When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With3Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).Throws(new Exception("2"))
+				.Throws(new Exception("3")).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With3Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).Throws(new Exception("2"))
+				.Throws(new Exception("3")).When(i => i >= 2).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With4Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).Throws(new Exception("2")).Throws(new Exception("3")).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With4Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).Throws(new Exception("2")).Throws(new Exception("3")).When(i => i >= 2)
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With5Parameters_ShouldKeepApplyingTheSetup()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).Throws(new Exception("2")).Throws(new Exception("3")).Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40, 50);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 3, 3, 3, 3, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task Forever_With5Parameters_When_ShouldKeepApplyingTheSetupWhenThePredicateMatches()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).Throws(new Exception("2")).Throws(new Exception("3")).When(i => i >= 2)
+				.Forever();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40, 50);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 2, 1, 2, 1, 2, 3, 3, 3, 3,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod().Throws(new Exception("1")).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod();
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod().Throws(new Exception("1")).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod();
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>()).Throws(new Exception("1")).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>()).Throws(new Exception("1")).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>()).Throws(new Exception("1")).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>()).Throws(new Exception("1")).For(3)
+				.OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).For(3)
+				.OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_ShouldApplySetupOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40, 50);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_WithFor_ShouldApplySetupOnlyForTimes()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Throws(new Exception("1")).For(3).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					sut.MyVoidMethod(10, 20, 30, 40, 50);
+				}
+				catch (Exception ex)
+				{
+					values[i] = int.Parse(ex.Message);
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+	}
+
+	public sealed class VoidMethodSetupWhenBuilderTests
+	{
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod().Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod();
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With0Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod().Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod();
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>()).Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>()).Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1)).For(3)
+				.OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1))
+				.OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Do(() => values.Add(1))
+				.For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20, 30);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20, 30, 40);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_ShouldInvokeTheCallbackOnlyOnce()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Method
+				.MyVoidMethod(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyVoidMethod(10, 20, 30, 40, 50);
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+	}
+
+	public interface ISetupExtensionsTestService
+	{
+		int MyProperty { get; set; }
+
+		int this[int index1] { get; set; }
+		int this[int index1, int index2] { get; set; }
+		int this[int index1, int index2, int index3] { get; set; }
+		int this[int index1, int index2, int index3, int index4] { get; set; }
+		int this[int index1, int index2, int index3, int index4, int index5] { get; set; }
+
+		int MyIntMethod();
+		int MyIntMethod(int param1);
+		int MyIntMethod(int param1, int param2);
+		int MyIntMethod(int param1, int param2, int param3);
+		int MyIntMethod(int param1, int param2, int param3, int param4);
+		int MyIntMethod(int param1, int param2, int param3, int param4, int param5);
+
+		void MyVoidMethod();
+		void MyVoidMethod(int param1);
+		void MyVoidMethod(int param1, int param2);
+		void MyVoidMethod(int param1, int param2, int param3);
+		void MyVoidMethod(int param1, int param2, int param3, int param4);
+		void MyVoidMethod(int param1, int param2, int param3, int param4, int param5);
+	}
+}


### PR DESCRIPTION
This PR corrects the interface types used in `SetupExtensions` to reference the `*WhenBuilder` interfaces instead of the `*Builder` interfaces. The change ensures that the extension methods are applied to the correct builder types returned after using `.When()` predicates.

### Key Changes
- Updated extension method declarations to use `*WhenBuilder` interfaces instead of `*Builder` interfaces
- Updated source generators to emit the corrected interface types
- Updated API compatibility test expectations to reflect the corrected types
- Added comprehensive test coverage for the setup extension methods
- Fixed the `Callback.IsActive` logic to properly handle `_forTimes`