### PR TITLE
refactor: eliminate duplicated code in source generators

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -39,7 +39,7 @@ internal static partial class Sources
 		          """).AppendLine();
 		foreach (int item in indexerSetups)
 		{
-			string types = string.Join(", ", Enumerable.Range(1, item).Select(i => $"T{i}"));
+			string types = GetGenericTypeParameters(item);
 			sb.Append($$"""
 			            		/// <summary>
 			            		///     Extensions for indexer callback setups with {{item}} parameters.
@@ -87,447 +87,211 @@ internal static partial class Sources
 
 	private static void AppendIndexerSetup(StringBuilder sb, int numberOfParameters)
 	{
-		string typeParams = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i}"));
-		string outTypeParams = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"out T{i}"));
+		string typeParams = GetGenericTypeParameters(numberOfParameters);
+		string outTypeParams = GetOutGenericTypeParameters(numberOfParameters);
 		string parameters = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"p{i}"));
 		string discards = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(_ => "_"));
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a <typeparamref name=\"TValue\"/> indexer getter for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a <typeparamref name=\"TValue\"/> indexer getter for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerGetterSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action callback);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
+		sb.AppendXmlRemarks("The callback receives the parameters of the indexer.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<")
 			.Append(typeParams)
 			.Append("> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
+		sb.AppendXmlRemarks("The callback receives the parameters of the indexer and the value of the indexer as last parameter.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<")
 			.Append(typeParams)
 			.Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
+		sb.AppendXmlRemarks("The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<int, ")
 			.Append(typeParams)
 			.Append(", TValue> callback);").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a <typeparamref name=\"TValue\"/> indexer setter for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a <typeparamref name=\"TValue\"/> indexer setter for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerSetterSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action callback);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the value the indexer is set to as single parameter.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
+		sb.AppendXmlRemarks("The callback receives the value the indexer is set to as single parameter.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> Do(Action<TValue> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
+		sb.AppendXmlRemarks("The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<")
 			.Append(typeParams).Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
+		sb.AppendXmlRemarks("The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(Action<int, ")
 			.Append(typeParams).Append(", TValue> callback);").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a <typeparamref name=\"TValue\"/> indexer for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Sets up callbacks on the getter.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Sets up callbacks on the getter.");
 		sb.Append("\t\tIIndexerGetterSetup<TValue, ").Append(typeParams)
 			.Append("> OnGet { get; }").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Sets up callbacks on the setter.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Sets up callbacks on the setter.");
 		sb.Append("\t\tIIndexerSetterSetup<TValue, ").Append(typeParams)
 			.Append("> OnSet { get; }").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Flag indicating if the base class implementation should be called, and its return values used as default values.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Flag indicating if the base class implementation should be called, and its return values used as default values.");
+		sb.AppendXmlRemarks("If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.");
 		sb.Append("\t\tIIndexerSetup<TValue, ").Append(typeParams)
 			.Append("> CallingBaseClass(bool callBaseClass = true);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Initializes the indexer with the given <paramref name=\"value\" />.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Initializes the indexer with the given <paramref name=\"value\" />.");
 		sb.Append("\t\tIIndexerSetup<TValue, ").Append(typeParams).Append("> InitializeWith(TValue value);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Initializes the according to the given <paramref name=\"valueGenerator\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Initializes the indexer according to the given <paramref name=\"valueGenerator\" />.");
 		sb.Append("\t\tIIndexerSetup<TValue, ").Append(typeParams).Append("> InitializeWith(Func<")
 			.Append(typeParams).Append(", TValue> valueGenerator);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers the <paramref name=\"returnValue\" /> for this indexer.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers the <paramref name=\"returnValue\" /> for this indexer.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(TValue returnValue);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
 			.Append("> Returns(Func<TValue> callback);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.");
+		sb.AppendXmlRemarks("The callback receives the parameters of the indexer.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
 			.Append(typeParams)
 			.Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to setup the return value for this indexer.");
+		sb.AppendXmlRemarks("The callback receives the parameters of the indexer and the value of the indexer as last parameter.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Returns(Func<")
 			.Append(typeParams).Append(", TValue, TValue> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <typeparamref name=\"TException\" /> to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <typeparamref name=\"TException\" /> to throw when the indexer is read.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws<TException>()")
 			.AppendLine();
 		sb.Append("\t\t\twhere TException : Exception, new();").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <paramref name=\"exception\" /> to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <paramref name=\"exception\" /> to throw when the indexer is read.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Exception exception);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
 			.Append("> Throws(Func<Exception> callback);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     The callback receives the parameters of the indexer.").AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.");
+		sb.AppendXmlRemarks("The callback receives the parameters of the indexer.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams)
 			.Append(", Exception> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the indexer is read.");
+		sb.AppendXmlRemarks("The callback receives the parameters of the indexer and the value of the indexer as last parameter.");
 		sb.Append("\t\tIIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams).Append(", TValue, Exception> callback);").AppendLine();
 
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a callback for a <typeparamref name=\"TValue\"/> indexer for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerSetupCallbackBuilder<TValue, ").Append(outTypeParams)
 			.Append("> : IIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Runs the callback in parallel to the other callbacks.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Runs the callback in parallel to the other callbacks.");
 		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> InParallel();")
 			.AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the callback to only execute for indexer accesses where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Limits the callback to only execute for indexer accesses where the predicate returns true.");
+		sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the indexer has been accessed so far.");
 		sb.Append("\t\tIIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams)
 			.Append("> When(Func<int, bool> predicate);").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a when callback for a <typeparamref name=\"TValue\"/> indexer for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a when callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerSetupCallbackWhenBuilder<TValue, ").Append(outTypeParams)
 			.Append("> : IIndexerSetup<TValue, ").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Repeats the callback for the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IIndexerSetupCallbackBuilder{TValue, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		
+		sb.AppendXmlSummary("Repeats the callback for the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexerSetupCallbackBuilder{{TValue, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams).Append("> For(int times);")
 			.AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Deactivates the callback after the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IIndexerSetupCallbackBuilder{TValue, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Deactivates the callback after the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexerSetupCallbackBuilder{{TValue, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIIndexerSetup<TValue, ").Append(typeParams).Append("> Only(int times);").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a callback for a <typeparamref name=\"TValue\"/> indexer for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a return/throw callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerSetupReturnBuilder<TValue, ").Append(outTypeParams)
 			.Append("> : IIndexerSetupReturnWhenBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the callback to only execute for indexer accesses where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Limits the return/throw callback to only execute for indexer accesses where the predicate returns true.");
+		sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the indexer has been accessed so far.");
 		sb.Append("\t\tIIndexerSetupReturnWhenBuilder<TValue, ").Append(typeParams)
 			.Append("> When(Func<int, bool> predicate);").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a when callback for a <typeparamref name=\"TValue\"/> indexer for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a when return/throw callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerSetupReturnWhenBuilder<TValue, ").Append(outTypeParams)
 			.Append("> : IIndexerSetup<TValue, ").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Repeats the callback for the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IIndexerSetupReturnBuilder{TValue, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Repeats the return/throw callback for the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexerSetupReturnBuilder{{TValue, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIIndexerSetupReturnWhenBuilder<TValue, ").Append(typeParams).Append("> For(int times);")
 			.AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Deactivates the return/throw after the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IIndexerSetupReturnBuilder{TValue, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Deactivates the return/throw after the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexerSetupReturnBuilder{{TValue, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIIndexerSetup<TValue, ").Append(typeParams).Append("> Only(int times);").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a <typeparamref name=\"TValue\"/> indexer for ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal class IndexerSetup<TValue, ").Append(typeParams).Append(">(")
 			.Append(
 				string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"IParameter match{i}")))

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -44,7 +44,7 @@ internal static partial class Sources
 		          """).AppendLine();
 		foreach ((int, bool) item in methodSetups)
 		{
-			string genericParameters = string.Join(", ", Enumerable.Range(1, item.Item1).Select(i => $"T{i}"));
+			string genericParameters = GetGenericTypeParameters(item.Item1);
 			if (!item.Item2)
 			{
 				genericParameters = "TReturn, " + genericParameters;
@@ -106,161 +106,80 @@ internal static partial class Sources
 
 	private static void AppendVoidMethodSetup(StringBuilder sb, int numberOfParameters)
 	{
-		string typeParams = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i}"));
+		string typeParams = GetGenericTypeParameters(numberOfParameters);
 		string parameters = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"p{i}"));
 		string discards = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(_ => "_"));
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <see langword=\"void\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.", "\t");
 		sb.Append("\tinternal interface IVoidMethodSetup<").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Flag indicating if the base class implementation should be called, and its return values used as default values.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Flag indicating if the base class implementation should be called, and its return values used as default values.");
+		sb.AppendXmlRemarks("If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.");
 		sb.Append("\t\tIVoidMethodSetup<").Append(typeParams).Append("> CallingBaseClass(bool callBaseClass = true);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tIVoidMethodSetupCallbackBuilder<").Append(typeParams).Append("> Do(Action callback);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tIVoidMethodSetupCallbackBuilder<").Append(typeParams).Append("> Do(Action<").Append(typeParams)
 			.Append("> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tIVoidMethodSetupCallbackBuilder<").Append(typeParams).Append("> Do(Action<int, ")
 			.Append(typeParams)
 			.Append("> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an iteration in the sequence of method invocations, that does not throw.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an iteration in the sequence of method invocations, that does not throw.");
 		sb.Append("\t\tIVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> DoesNotThrow();").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.");
 		sb.Append("\t\tIVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> Throws<TException>()")
 			.AppendLine();
 		sb.Append("\t\t\twhere TException : Exception, new();").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <paramref name=\"exception\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <paramref name=\"exception\" /> to throw when the method is invoked.");
 		sb.Append("\t\tIVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> Throws(Exception exception);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tIVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams).Append(", Exception> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tIVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> Throws(Func<Exception> callback);")
 			.AppendLine();
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a callback for a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <see langword=\"void\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.", "");
 		sb.Append("internal interface IVoidMethodSetupCallbackBuilder<").Append(typeParams)
 			.Append("> : IVoidMethodSetupCallbackWhenBuilder<").Append(typeParams).Append(">").AppendLine();
 		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Runs the callback in parallel to the other callbacks.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Runs the callback in parallel to the other callbacks.");
 		sb.Append("\t\tIVoidMethodSetupCallbackBuilder<").Append(typeParams).Append("> InParallel();").AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the callback to only execute for indexer accesses where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the callback to only execute for method invocations where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     Provides a zero-based counter indicating how many times the method has been invoked so far.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Limits the callback to only execute for method invocations where the predicate returns true.");
+		sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the method has been invoked so far.");
 		sb.Append("\t\tIVoidMethodSetupCallbackWhenBuilder<").Append(typeParams)
 			.Append("> When(Func<int, bool> predicate);").AppendLine();
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a when callback for a method with ").Append(numberOfParameters)
-			.Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <see langword=\"void\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a when callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.", "");
 		sb.Append("internal interface IVoidMethodSetupCallbackWhenBuilder<").Append(typeParams)
 			.Append("> : IVoidMethodSetup<").Append(typeParams).Append(">").AppendLine();
 		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Repeats the callback for the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Repeats the callback for the given number of <paramref name=\"times\" />.");
 		sb.Append("\t\t/// <remarks>").AppendLine();
 		sb.Append(
 				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IVoidMethodSetupCallbackBuilder{")
@@ -270,11 +189,7 @@ internal static partial class Sources
 		sb.Append("\t\tIVoidMethodSetupCallbackWhenBuilder<").Append(typeParams).Append("> For(int times);")
 			.AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Deactivates the callback after the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Deactivates the callback after the given number of <paramref name=\"times\" />.");
 		sb.Append("\t\t/// <remarks>").AppendLine();
 		sb.Append(
 				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IVoidMethodSetupCallbackBuilder{")
@@ -286,54 +201,22 @@ internal static partial class Sources
 		sb.AppendLine();
 
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a return callback for a method with ").Append(numberOfParameters)
-			.Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <see langword=\"void\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a return callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.", "");
 		sb.Append("internal interface IVoidMethodSetupReturnBuilder<").Append(typeParams)
 			.Append("> : IVoidMethodSetupReturnWhenBuilder<").Append(typeParams).Append(">").AppendLine();
 		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the throw to only execute for method invocations where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     Provides a zero-based counter indicating how many times the method has been invoked so far.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Limits the throw to only execute for method invocations where the predicate returns true.");
+		sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the method has been invoked so far.");
 		sb.Append("\t\tIVoidMethodSetupReturnWhenBuilder<").Append(typeParams)
 			.Append("> When(Func<int, bool> predicate);").AppendLine();
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a when callback for a method with ").Append(numberOfParameters)
-			.Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <see langword=\"void\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a when return callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.", "");
 		sb.Append("internal interface IVoidMethodSetupReturnWhenBuilder<").Append(typeParams)
 			.Append("> : IVoidMethodSetup<").Append(typeParams).Append(">").AppendLine();
 		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Repeats the throw for the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Repeats the throw for the given number of <paramref name=\"times\" />.");
 		sb.Append("\t\t/// <remarks>").AppendLine();
 		sb.Append(
 				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IVoidMethodSetupReturnBuilder{")
@@ -342,11 +225,7 @@ internal static partial class Sources
 		sb.Append("\t\t/// </remarks>").AppendLine();
 		sb.Append("\t\tIVoidMethodSetupReturnWhenBuilder<").Append(typeParams).Append("> For(int times);").AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Deactivates the throw after the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Deactivates the throw after the given number of <paramref name=\"times\" />.");
 		sb.Append("\t\t/// <remarks>").AppendLine();
 		sb.Append(
 				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IVoidMethodSetupReturnBuilder{")
@@ -357,16 +236,7 @@ internal static partial class Sources
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <see langword=\"void\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.", "");
 		sb.Append("internal class VoidMethodSetup<").Append(typeParams)
 			.Append("> : MethodSetup,").AppendLine();
 		sb.Append("\t\tIVoidMethodSetupCallbackBuilder<").Append(typeParams).Append(">,").AppendLine();
@@ -421,16 +291,9 @@ internal static partial class Sources
 		sb.Append("\t\t\t_matches = matches;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Flag indicating if the base class implementation should be called, and its return values used as default values.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		
+		sb.AppendXmlSummary("Flag indicating if the base class implementation should be called, and its return values used as default values.");
+		sb.AppendXmlRemarks("If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.");
 		sb.Append("\t\tpublic IVoidMethodSetup<").Append(typeParams)
 			.Append("> CallingBaseClass(bool callBaseClass = true)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -439,10 +302,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tpublic IVoidMethodSetupCallbackBuilder<").Append(typeParams).Append("> Do(Action callback)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -454,10 +314,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tpublic IVoidMethodSetupCallbackBuilder<").Append(typeParams).Append("> Do(Action<")
 			.Append(typeParams)
 			.Append("> callback)").AppendLine();
@@ -470,10 +327,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tpublic IVoidMethodSetupCallbackBuilder<").Append(typeParams).Append("> Do(Action<int, ")
 			.Append(typeParams)
 			.Append("> callback)").AppendLine();
@@ -486,10 +340,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an iteration in the sequence of method invocations, that does not throw.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an iteration in the sequence of method invocations, that does not throw.");
 		sb.Append("\t\tpublic IVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> DoesNotThrow()")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -502,10 +353,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.");
 		sb.Append("\t\tpublic IVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> Throws<TException>()")
 			.AppendLine();
 		sb.Append("\t\t\twhere TException : Exception, new()").AppendLine();
@@ -519,10 +367,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <paramref name=\"exception\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <paramref name=\"exception\" /> to throw when the method is invoked.");
 		sb.Append("\t\tpublic IVoidMethodSetupReturnBuilder<").Append(typeParams)
 			.Append("> Throws(Exception exception)")
 			.AppendLine();
@@ -536,11 +381,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tpublic IVoidMethodSetupReturnBuilder<").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams).Append(", Exception> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -552,11 +393,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tpublic IVoidMethodSetupReturnBuilder<").Append(typeParams)
 			.Append("> Throws(Func<Exception> callback)")
 			.AppendLine();
@@ -798,290 +635,142 @@ internal static partial class Sources
 		string parameters = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"p{i}"));
 		string discards = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(_ => "_"));
 
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <typeparamref name=\"TReturn\" />.").AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary($"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.", "\t");
 		sb.Append("\tinternal interface IReturnMethodSetup<TReturn, ").Append(typeParams).Append(">")
 			.AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Flag indicating if the base class implementation should be called, and its return values used as default values.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Flag indicating if the base class implementation should be called, and its return values used as default values.");
+		sb.AppendXmlRemarks("If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.");
 		sb.Append("\t\tIReturnMethodSetup<TReturn, ").Append(typeParams)
 			.Append("> CallingBaseClass(bool callBaseClass = true);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tIReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams).Append("> Do(Action callback);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tIReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams).Append("> Do(Action<")
 			.Append(typeParams).Append("> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tIReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams).Append("> Do(Action<int, ")
 			.Append(typeParams).Append("> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this method.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to setup the return value for this method.");
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams).Append("> Returns(Func<")
 			.Append(typeParams).Append(", TReturn> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this method.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to setup the return value for this method.");
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Returns(Func<TReturn> callback);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers the <paramref name=\"returnValue\" /> for this method.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers the <paramref name=\"returnValue\" /> for this method.");
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Returns(TReturn returnValue);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.");
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams).Append("> Throws<TException>()")
 			.AppendLine();
 		sb.Append("\t\t\twhere TException : Exception, new();").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <paramref name=\"exception\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <paramref name=\"exception\" /> to throw when the method is invoked.");
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Throws(Exception exception);")
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams).Append(", Exception> callback);").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Throws(Func<Exception> callback);").AppendLine();
-		sb.Append("}").AppendLine();
+		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <typeparamref name=\"TReturn\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
-		sb.Append("internal interface IReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams)
+		sb.AppendXmlSummary($"Sets up a callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.", "\t");
+		sb.Append("\tinternal interface IReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams)
 			.Append("> : IReturnMethodSetupCallbackWhenBuilder<TReturn, ").Append(typeParams).Append(">")
 			.AppendLine();
-		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Runs the callback in parallel to the other callbacks.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t{").AppendLine();
+		sb.AppendXmlSummary("Runs the callback in parallel to the other callbacks.");
 		sb.Append("\t\tIReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams).Append("> InParallel();")
 			.AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the callback to only execute for indexer accesses where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the callback to only execute for method invocations where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     Provides a zero-based counter indicating how many times the method has been invoked so far.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		
+		sb.AppendXmlSummary("Limits the callback to only execute for method invocations where the predicate returns true.");
+		sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the method has been invoked so far.");
 		sb.Append("\t\tIReturnMethodSetupCallbackWhenBuilder<TReturn, ").Append(typeParams)
 			.Append("> When(Func<int, bool> predicate);").AppendLine();
-		sb.Append("}").AppendLine();
+		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
-
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <typeparamref name=\"TReturn\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
-		sb.Append("internal interface IReturnMethodSetupCallbackWhenBuilder<TReturn, ").Append(typeParams)
+		
+		sb.AppendXmlSummary($"Sets up a when callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.", "\t");
+		sb.Append("\tinternal interface IReturnMethodSetupCallbackWhenBuilder<TReturn, ").Append(typeParams)
 			.Append("> : IReturnMethodSetup<TReturn, ").Append(typeParams).Append(">")
 			.AppendLine();
-		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Repeats the callback for the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupCallbackBuilder{TReturn, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t{").AppendLine();
+		
+		sb.AppendXmlSummary("Repeats the callback for the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupCallbackBuilder{{TReturn, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIReturnMethodSetupCallbackWhenBuilder<TReturn, ").Append(typeParams).Append("> For(int times);")
 			.AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Deactivates the callback after the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupCallbackBuilder{TReturn, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		
+		sb.AppendXmlSummary("Deactivates the callback after the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupCallbackBuilder{{TReturn, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIReturnMethodSetup<TReturn, ").Append(typeParams).Append("> Only(int times);").AppendLine();
-		sb.Append("}").AppendLine();
+		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <typeparamref name=\"TReturn\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
-		sb.Append("internal interface IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
+		sb.AppendXmlSummary($"Sets up a return callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.", "\t");
+		sb.Append("\tinternal interface IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> : IReturnMethodSetupReturnWhenBuilder<TReturn, ").Append(typeParams).Append(">")
 			.AppendLine();
-		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Limits the return/throw to only execute for method invocations where the predicate returns true.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     Provides a zero-based counter indicating how many times the method has been invoked so far.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t{").AppendLine();
+		
+		sb.AppendXmlSummary("Limits the return/throw to only execute for method invocations where the predicate returns true.");
+		sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the method has been invoked so far.");
 		sb.Append("\t\tIReturnMethodSetupReturnWhenBuilder<TReturn, ").Append(typeParams)
 			.Append("> When(Func<int, bool> predicate);").AppendLine();
-		sb.Append("}").AppendLine();
+		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <typeparamref name=\"TReturn\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
-		sb.Append("internal interface IReturnMethodSetupReturnWhenBuilder<TReturn, ").Append(typeParams)
+		sb.AppendXmlSummary($"Sets up a when return callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.", "\t");
+		sb.Append("\tinternal interface IReturnMethodSetupReturnWhenBuilder<TReturn, ").Append(typeParams)
 			.Append("> : IReturnMethodSetup<TReturn, ").Append(typeParams).Append(">")
 			.AppendLine();
-		sb.Append("{").AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Repeats the callback for the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupReturnBuilder{TReturn, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.Append("\t{").AppendLine();
+		
+		sb.AppendXmlSummary("Repeats the callback for the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupReturnBuilder{{TReturn, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIReturnMethodSetupReturnWhenBuilder<TReturn, ").Append(typeParams).Append("> For(int times);")
 			.AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Deactivates the return/throw after the given number of <paramref name=\"times\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append(
-				"\t\t///     The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupReturnBuilder{TReturn, ")
-			.Append(typeParams).Append("}.When(Func{int, bool})\" /> evaluates to <see langword=\"true\" />).")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Deactivates the return/throw after the given number of <paramref name=\"times\" />.");
+		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IReturnMethodSetupReturnBuilder{{TReturn, {typeParams}}}.When(Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
 		sb.Append("\t\tIReturnMethodSetup<TReturn, ").Append(typeParams).Append("> Only(int times);").AppendLine();
-		sb.Append("}").AppendLine();
+		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
-
-
-		sb.Append("/// <summary>").AppendLine();
-		sb.Append("///     Sets up a method with ").Append(numberOfParameters).Append(" parameters ");
-		for (int i = 1; i < numberOfParameters - 1; i++)
-		{
-			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />, ");
-		}
-
-		sb.Append("<typeparamref name=\"T").Append(numberOfParameters - 1).Append("\" /> and <typeparamref name=\"T")
-			.Append(numberOfParameters).Append("\" /> returning <typeparamref name=\"TReturn\" />.").AppendLine();
-		sb.Append("/// </summary>").AppendLine();
-		sb.Append("internal class ReturnMethodSetup<TReturn, ").Append(typeParams)
+		
+		sb.AppendXmlSummary($"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.", "\t");
+		sb.Append("\tinternal class ReturnMethodSetup<TReturn, ").Append(typeParams)
 			.Append("> : MethodSetup,").AppendLine();
 		sb.Append("\t\tIReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams).Append(">,").AppendLine();
 		sb.Append("\t\tIReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams).Append(">").AppendLine();
-		sb.Append("{").AppendLine();
+		sb.Append("\t{").AppendLine();
 		sb.Append("\t\tprivate readonly List<Callback<Action<int, ").Append(typeParams).Append(">>> _callbacks = [];")
 			.AppendLine();
 		sb.Append("\t\tprivate readonly List<Callback<Func<int, ").Append(typeParams)
@@ -1132,15 +821,8 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Flag indicating if the base class implementation should be called, and its return values used as default values.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\t/// <remarks>").AppendLine();
-		sb.Append("\t\t///     If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.")
-			.AppendLine();
-		sb.Append("\t\t/// </remarks>").AppendLine();
+		sb.AppendXmlSummary("Flag indicating if the base class implementation should be called, and its return values used as default values.");
+		sb.AppendXmlRemarks("If not specified, use <see cref=\"MockBehavior.CallBaseClass\" />.");
 		sb.Append("\t\tpublic IReturnMethodSetup<TReturn, ").Append(typeParams)
 			.Append("> CallingBaseClass(bool callBaseClass = true)")
 			.AppendLine();
@@ -1150,10 +832,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tpublic IReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams)
 			.Append("> Do(Action callback)")
 			.AppendLine();
@@ -1166,10 +845,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tpublic IReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams).Append("> Do(Action<")
 			.Append(typeParams).Append("> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -1181,10 +857,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to execute when the method is called.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to execute when the method is called.");
 		sb.Append("\t\tpublic IReturnMethodSetupCallbackBuilder<TReturn, ").Append(typeParams)
 			.Append("> Do(Action<int, ")
 			.Append(typeParams).Append("> callback)").AppendLine();
@@ -1197,10 +870,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this method.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to setup the return value for this method.");
 		sb.Append("\t\tpublic IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams).Append("> Returns(Func<")
 			.Append(typeParams).Append(", TReturn> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -1213,10 +883,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers a <paramref name=\"callback\" /> to setup the return value for this method.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> to setup the return value for this method.");
 		sb.Append("\t\tpublic IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Returns(Func<TReturn> callback)")
 			.AppendLine();
@@ -1230,9 +897,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers the <paramref name=\"returnValue\" /> for this method.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers the <paramref name=\"returnValue\" /> for this method.");
 		sb.Append("\t\tpublic IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Returns(TReturn returnValue)")
 			.AppendLine();
@@ -1246,10 +911,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <typeparamref name=\"TException\" /> to throw when the method is invoked.");
 		sb.Append("\t\tpublic IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Throws<TException>()")
 			.AppendLine();
@@ -1264,10 +926,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Registers an <paramref name=\"exception\" /> to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers an <paramref name=\"exception\" /> to throw when the method is invoked.");
 		sb.Append("\t\tpublic IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Throws(Exception exception)")
 			.AppendLine();
@@ -1280,12 +939,8 @@ internal static partial class Sources
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
-
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tpublic IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams).Append("> Throws(Func<")
 			.Append(typeParams).Append(", Exception> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -1299,11 +954,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append(
-				"\t\t///     Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.")
-			.AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.AppendXmlSummary("Registers a <paramref name=\"callback\" /> that will calculate the exception to throw when the method is invoked.");
 		sb.Append("\t\tpublic IReturnMethodSetupReturnBuilder<TReturn, ").Append(typeParams)
 			.Append("> Throws(Func<Exception> callback)")
 			.AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -138,23 +138,11 @@ internal static partial class Sources
 		sb.AppendLine();
 		for (int numberOfArguments = 1; numberOfArguments < maxNumberOfArguments; numberOfArguments++)
 		{
-			string types = string.Join(", ", Enumerable.Range(2, numberOfArguments).Select(n => $"T{n}"));
-			sb.AppendLine("\t/// <summary>");
-			sb.Append("\t///     Create a new mock for <typeparamref name=\"T\" /> that also implements ")
-				.Append(numberOfArguments > 1 ? "interfaces " : "interface ")
-				.Append(string.Join(", ",
-					Enumerable.Range(2, numberOfArguments - 1).Select(n => $"<typeparamref name=\"T{n}\" />")))
-				.Append(numberOfArguments > 1 ? " and " : "")
-				.Append("<typeparamref name=\"T").Append(numberOfArguments + 1).Append("\" />")
-				.Append(" with the default <see cref=\"MockBehavior\" />.").AppendLine();
-			sb.AppendLine("\t/// </summary>");
+			string types = GetGenericTypeParameters(numberOfArguments, 2);
+			sb.AppendXmlSummary($"Create a new mock for <typeparamref name=\"T\" /> that also implements {GetAdditionalInterfacesDescription(numberOfArguments)} with the default <see cref=\"MockBehavior\" />.");
 			sb.AppendLine(
 				"\t/// <typeparam name=\"T\">Type to mock, which can be an interface or a class.</typeparam>");
-			for (int i = 2; i <= numberOfArguments + 1; i++)
-			{
-				sb.Append("\t/// <typeparam name=\"T").Append(i)
-					.Append("\">Additional interface that is implemented by the mock.</typeparam>").AppendLine();
-			}
+			sb.AppendTypeParamDocs(numberOfArguments, "Additional interface that is implemented by the mock.", startIndex: 2);
 
 			sb.AppendLine($$"""
 			                	/// <remarks>
@@ -172,22 +160,10 @@ internal static partial class Sources
 			                """);
 			sb.AppendLine();
 
-			sb.AppendLine("\t/// <summary>");
-			sb.Append("\t///     Create a new mock for <typeparamref name=\"T\" /> that also implements ")
-				.Append(numberOfArguments > 1 ? "interfaces " : "interface ")
-				.Append(string.Join(", ",
-					Enumerable.Range(2, numberOfArguments - 1).Select(n => $"<typeparamref name=\"T{n}\" />")))
-				.Append(numberOfArguments > 1 ? " and " : "")
-				.Append("<typeparamref name=\"T").Append(numberOfArguments + 1).Append("\" />")
-				.Append(" with the default <see cref=\"MockBehavior\" />.").AppendLine();
-			sb.AppendLine("\t/// </summary>");
+			sb.AppendXmlSummary($"Create a new mock for <typeparamref name=\"T\" /> that also implements {GetAdditionalInterfacesDescription(numberOfArguments)} with the default <see cref=\"MockBehavior\" />.");
 			sb.AppendLine(
 				"\t/// <typeparam name=\"T\">Type to mock, which can be an interface or a class.</typeparam>");
-			for (int i = 2; i <= numberOfArguments + 1; i++)
-			{
-				sb.Append("\t/// <typeparam name=\"T").Append(i)
-					.Append("\">Additional interface that is implemented by the mock.</typeparam>").AppendLine();
-			}
+			sb.AppendTypeParamDocs(numberOfArguments, "Additional interface that is implemented by the mock.", startIndex: 2);
 
 			sb.AppendLine($$"""
 			                	/// <remarks>
@@ -238,22 +214,10 @@ internal static partial class Sources
 			                """);
 			sb.AppendLine();
 
-			sb.Append("\t/// <summary>").AppendLine();
-			sb.Append("\t///     Create a new mock for <typeparamref name=\"T\" /> that also implements ")
-				.Append(numberOfArguments > 1 ? "interfaces " : "interface ")
-				.Append(string.Join(", ",
-					Enumerable.Range(2, numberOfArguments - 1).Select(n => $"<typeparamref name=\"T{n}\" />")))
-				.Append(numberOfArguments > 1 ? " and " : "")
-				.Append("<typeparamref name=\"T").Append(numberOfArguments + 1).Append("\" />")
-				.Append(" with the given <paramref name=\"mockBehavior\" />.").AppendLine();
-			sb.Append("\t/// </summary>").AppendLine();
-			sb.Append("\t/// <typeparam name=\"T\">Type to mock, which can be an interface or a class.</typeparam>")
-				.AppendLine();
-			for (int i = 2; i <= numberOfArguments + 1; i++)
-			{
-				sb.Append("\t/// <typeparam name=\"T").Append(i)
-					.Append("\">Additional interface that is implemented by the mock.</typeparam>").AppendLine();
-			}
+			sb.AppendXmlSummary($"Create a new mock for <typeparamref name=\"T\" /> that also implements {GetAdditionalInterfacesDescription(numberOfArguments)} with the given <paramref name=\"mockBehavior\" />.");
+			sb.AppendLine(
+				"\t/// <typeparam name=\"T\">Type to mock, which can be an interface or a class.</typeparam>");
+			sb.AppendTypeParamDocs(numberOfArguments, "Additional interface that is implemented by the mock.", startIndex: 2);
 
 			sb.AppendLine($$"""
 			                	/// <remarks>
@@ -326,23 +290,12 @@ internal static partial class Sources
 		              """);
 		for (int numberOfArguments = 1; numberOfArguments < maxNumberOfArguments; numberOfArguments++)
 		{
-			string types = string.Join(", ", Enumerable.Range(2, numberOfArguments).Select(n => $"T{n}"));
+			string types = GetGenericTypeParameters(numberOfArguments, 2);
 			sb.AppendLine();
-			sb.AppendLine("\t\t/// <summary>");
-			sb.Append("\t\t///     Create a new mock for <typeparamref name=\"T\" /> that also implements ")
-				.Append(numberOfArguments > 1 ? "interfaces " : "interface ")
-				.Append(string.Join(", ",
-					Enumerable.Range(2, numberOfArguments - 1).Select(n => $"<typeparamref name=\"T{n}\" />")))
-				.Append(numberOfArguments > 1 ? " and " : "")
-				.Append("<typeparamref name=\"T").Append(numberOfArguments + 1).Append("\" />.").AppendLine();
-			sb.AppendLine("\t\t/// </summary>");
+			sb.AppendXmlSummary($"Create a new mock for <typeparamref name=\"T\" /> that also implements {GetAdditionalInterfacesDescription(numberOfArguments)}.");
 			sb.AppendLine(
 				"\t\t/// <typeparam name=\"T\">Type to mock, which can be an interface or a class.</typeparam>");
-			for (int i = 2; i <= numberOfArguments + 1; i++)
-			{
-				sb.Append("\t\t/// <typeparam name=\"T").Append(i)
-					.Append("\">Additional interface that is implemented by the mock.</typeparam>").AppendLine();
-			}
+			sb.AppendTypeParamDocs(numberOfArguments, "Additional interface that is implemented by the mock.", "\t\t", 2);
 
 			sb.AppendLine($$"""
 			                		/// <remarks>
@@ -360,21 +313,10 @@ internal static partial class Sources
 			                """);
 
 			sb.AppendLine();
-			sb.AppendLine("\t\t/// <summary>");
-			sb.Append("\t\t///     Create a new mock for <typeparamref name=\"T\" /> that also implements ")
-				.Append(numberOfArguments > 1 ? "interfaces " : "interface ")
-				.Append(string.Join(", ",
-					Enumerable.Range(2, numberOfArguments - 1).Select(n => $"<typeparamref name=\"T{n}\" />")))
-				.Append(numberOfArguments > 1 ? " and " : "")
-				.Append("<typeparamref name=\"T").Append(numberOfArguments + 1).Append("\" />.").AppendLine();
-			sb.AppendLine("\t\t/// </summary>");
+			sb.AppendXmlSummary($"Create a new mock for <typeparamref name=\"T\" /> that also implements {GetAdditionalInterfacesDescription(numberOfArguments)}.");
 			sb.AppendLine(
 				"\t\t/// <typeparam name=\"T\">Type to mock, which can be an interface or a class.</typeparam>");
-			for (int i = 2; i <= numberOfArguments + 1; i++)
-			{
-				sb.Append("\t\t/// <typeparam name=\"T").Append(i)
-					.Append("\">Additional interface that is implemented by the mock.</typeparam>").AppendLine();
-			}
+			sb.AppendTypeParamDocs(numberOfArguments, "Additional interface that is implemented by the mock.", "\t\t", 2);
 
 			sb.AppendLine($$"""
 			                		/// <remarks>
@@ -574,7 +516,99 @@ internal static partial class Sources
 			_ => "",
 		};
 
-	internal static string EscapeForXmlDoc(this string value)
+	private static string EscapeForXmlDoc(this string value)
 		=> value.Replace('<', '{').Replace('>', '}');
+
+	/// <summary>
+	///     Generates a comma-separated list of generic type parameters (e.g., "T1, T2, T3").
+	/// </summary>
+	private static string GetGenericTypeParameters(int count, int startIndex = 1)
+		=> string.Join(", ", Enumerable.Range(startIndex, count).Select(i => $"T{i}"));
+
+	/// <summary>
+	///     Generates a comma-separated list of generic type parameters with 'out' variance (e.g., "out T1, out T2").
+	/// </summary>
+	private static string GetOutGenericTypeParameters(int count, int startIndex = 1)
+		=> string.Join(", ", Enumerable.Range(startIndex, count).Select(i => $"out T{i}"));
+
+	/// <summary>
+	///     Appends XML documentation summary tags with the given text.
+	/// </summary>
+	private static StringBuilder AppendXmlSummary(this StringBuilder sb, string summaryText, string indent = "\t\t")
+	{
+		sb.Append(indent).Append("/// <summary>").AppendLine();
+		sb.Append(indent).Append("///     ").Append(summaryText).AppendLine();
+		sb.Append(indent).Append("/// </summary>").AppendLine();
+		return sb;
+	}
+
+	/// <summary>
+	///     Appends XML documentation remarks tags with the given text.
+	/// </summary>
+	private static StringBuilder AppendXmlRemarks(this StringBuilder sb, string remarksText, string indent = "\t\t")
+	{
+		sb.Append(indent).Append("/// <remarks>").AppendLine();
+		sb.Append(indent).Append("///     ").Append(remarksText).AppendLine();
+		sb.Append(indent).Append("/// </remarks>").AppendLine();
+		return sb;
+	}
+
+	/// <summary>
+	///     Generates a descriptive text listing type parameters (e.g., "T1, T2 and T3" or just "T1").
+	/// </summary>
+	private static string GetTypeParametersDescription(int numberOfParameters, int startIndex = 1)
+	{
+		if (numberOfParameters == 1)
+		{
+			return $"<typeparamref name=\"T{startIndex}\" />";
+		}
+
+		StringBuilder sb = new();
+		for (int i = startIndex; i < startIndex + numberOfParameters - 1; i++)
+		{
+			if (i > startIndex)
+			{
+				sb.Append(", ");
+			}
+			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />");
+		}
+		sb.Append(" and <typeparamref name=\"T").Append(startIndex + numberOfParameters - 1).Append("\" />");
+		return sb.ToString();
+	}
+
+	/// <summary>
+	///     Appends type parameter XML documentation for generic parameters.
+	/// </summary>
+	private static StringBuilder AppendTypeParamDocs(this StringBuilder sb, int count, string description, string indent = "\t", int startIndex = 1)
+	{
+		for (int i = startIndex; i < startIndex + count; i++)
+		{
+			sb.Append(indent).Append("/// <typeparam name=\"T").Append(i).Append("\">").Append(description).AppendLine("</typeparam>");
+		}
+		return sb;
+	}
+
+	/// <summary>
+	///     Generates description text for additional interfaces (e.g., "interface T2" or "interfaces T2, T3 and T4").
+	/// </summary>
+	private static string GetAdditionalInterfacesDescription(int numberOfArguments, int startIndex = 2)
+	{
+		if (numberOfArguments == 1)
+		{
+			return $"interface <typeparamref name=\"T{startIndex}\" />";
+		}
+
+		StringBuilder sb = new("interfaces ");
+		for (int i = startIndex; i < startIndex + numberOfArguments - 1; i++)
+		{
+			if (i > startIndex)
+			{
+				sb.Append(", ");
+			}
+			sb.Append("<typeparamref name=\"T").Append(i).Append("\" />");
+		}
+		sb.Append(" and <typeparamref name=\"T").Append(startIndex + numberOfArguments - 1).Append("\" />");
+		return sb.ToString();
+	}
 }
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high


### PR DESCRIPTION
This PR refactors source generator code to eliminate duplication by extracting common XML documentation generation patterns into reusable helper methods. The changes consolidate repetitive string-building logic for generic type parameters and XML documentation tags.

### Key changes:
- Introduced helper methods (`GetGenericTypeParameters`, `GetOutGenericTypeParameters`, `AppendXmlSummary`, `AppendXmlRemarks`, `GetTypeParametersDescription`, `AppendTypeParamDocs`, `GetAdditionalInterfacesDescription`) to replace duplicated code patterns
- Replaced inline XML documentation generation with calls to these helper methods across multiple source generator files
- Changed `EscapeForXmlDoc` visibility from `internal` to `private` as it's no longer needed outside its containing class