### PR TITLE
refactor: document reason for `It` and `Match` not being static.

### DIFF
--- a/Source/Mockolate/It.cs
+++ b/Source/Mockolate/It.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Mockolate.Parameters;
 
 namespace Mockolate;
@@ -11,6 +12,10 @@ namespace Mockolate;
 /// </summary>
 public partial class It
 {
+	/// <summary>
+	///     This class is intentionally not static to allow adding static extension methods on <see cref="It" />.
+	/// </summary>
+	[ExcludeFromCodeCoverage]
 	private It()
 	{
 		// Prevent instantiation.

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Mockolate;
 
 #pragma warning disable S3453 // This class can't be instantiated; make its constructor 'public'.
@@ -6,6 +8,10 @@ namespace Mockolate;
 /// </summary>
 public partial class Match
 {
+	/// <summary>
+	///     This class is intentionally not static to allow adding static extension methods on <see cref="Match" />.
+	/// </summary>
+	[ExcludeFromCodeCoverage]
 	private Match()
 	{
 		// Prevent instantiation.


### PR DESCRIPTION
This PR adds XML documentation to explain the design decision behind `It` and `Match` classes not being static. The documentation clarifies that these classes must remain non-static to support static extension methods, which is a C# language limitation.

### Key changes:
- Added XML documentation comments to private constructors explaining why the classes aren't static
- Added `[ExcludeFromCodeCoverage]` attributes to the private constructors