### PR TITLE
fix: string representation of `It.Matches` as regex

### DIFF
--- a/Source/Mockolate/It.IsFalse.cs
+++ b/Source/Mockolate/It.IsFalse.cs
@@ -14,6 +14,7 @@ public partial class It
 
 	private sealed class FalseParameterMatch : TypedMatch<bool>
 	{
+		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />
 		protected override bool Matches(bool value) => !value;
 
 		/// <inheritdoc cref="object.ToString()" />

--- a/Source/Mockolate/It.IsNull.cs
+++ b/Source/Mockolate/It.IsNull.cs
@@ -15,6 +15,7 @@ public partial class It
 
 	private sealed class NullParameterMatch<T> : TypedMatch<T>
 	{
+		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />
 		protected override bool Matches(T value) => value is null;
 
 		/// <inheritdoc cref="object.ToString()" />

--- a/Source/Mockolate/It.IsTrue.cs
+++ b/Source/Mockolate/It.IsTrue.cs
@@ -14,6 +14,7 @@ public partial class It
 
 	private sealed class TrueParameterMatch : TypedMatch<bool>
 	{
+		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />
 		protected override bool Matches(bool value) => value;
 
 		/// <inheritdoc cref="object.ToString()" />

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -65,7 +65,7 @@ namespace Mockolate
         }
         public interface IParameterMatches : Mockolate.Parameters.IParameter<string>
         {
-            Mockolate.It.IParameterMatches AsRegex(System.Text.RegularExpressions.RegexOptions options = 0, System.TimeSpan? timeout = default);
+            Mockolate.It.IParameterMatches AsRegex(System.Text.RegularExpressions.RegexOptions options = 0, System.TimeSpan? timeout = default, [System.Runtime.CompilerServices.CallerArgumentExpression("options")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("timeout")] string doNotPopulateThisValue2 = "");
             Mockolate.It.IParameterMatches IgnoringCase(bool ignoreCase = true);
         }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -64,7 +64,7 @@ namespace Mockolate
         }
         public interface IParameterMatches : Mockolate.Parameters.IParameter<string>
         {
-            Mockolate.It.IParameterMatches AsRegex(System.Text.RegularExpressions.RegexOptions options = 0, System.TimeSpan? timeout = default);
+            Mockolate.It.IParameterMatches AsRegex(System.Text.RegularExpressions.RegexOptions options = 0, System.TimeSpan? timeout = default, [System.Runtime.CompilerServices.CallerArgumentExpression("options")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("timeout")] string doNotPopulateThisValue2 = "");
             Mockolate.It.IParameterMatches IgnoringCase(bool ignoreCase = true);
         }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -59,7 +59,7 @@ namespace Mockolate
         }
         public interface IParameterMatches : Mockolate.Parameters.IParameter<string>
         {
-            Mockolate.It.IParameterMatches AsRegex(System.Text.RegularExpressions.RegexOptions options = 0, System.TimeSpan? timeout = default);
+            Mockolate.It.IParameterMatches AsRegex(System.Text.RegularExpressions.RegexOptions options = 0, System.TimeSpan? timeout = default, [System.Runtime.CompilerServices.CallerArgumentExpression("options")] string doNotPopulateThisValue1 = "", [System.Runtime.CompilerServices.CallerArgumentExpression("timeout")] string doNotPopulateThisValue2 = "");
             Mockolate.It.IParameterMatches IgnoringCase(bool ignoreCase = true);
         }
     }


### PR DESCRIPTION
This PR fixes the string representation of `It.Matches` when used with the `AsRegex` method. The changes ensure that when `AsRegex()` is called with parameters, the `ToString()` method accurately reflects those parameters using `CallerArgumentExpression` attributes to capture the original parameter expressions.

### Key Changes:
- Enhanced `AsRegex` method to capture caller argument expressions for options and timeout parameters
- Updated `ToString()` implementation to include regex-specific parameters in the output
- Added comprehensive test coverage for the new `ToString()` behavior