### PR TITLE
refactor: remove dead code in delegate source generation

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -33,13 +33,4 @@ internal record MockClass : Class
 
 	public IEnumerable<Class> DistinctAdditionalImplementations()
 		=> AdditionalImplementations.Distinct().Where(x => x.ClassFullName != ClassFullName);
-
-	internal IEnumerable<Class> GetAllClasses()
-	{
-		yield return this;
-		foreach (Class implementation in DistinctAdditionalImplementations())
-		{
-			yield return implementation;
-		}
-	}
 }

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -54,7 +54,7 @@ public class MockGenerator : IIncrementalGenerator
 			{
 				context.AddSource($"MockFor{mockToGenerate.Name}Extensions.g.cs",
 					SourceText.From(
-						Sources.Sources.ForMockCombinationExtensions(mockToGenerate.Name, mockToGenerate.MockClass),
+						Sources.Sources.ForMockCombinationExtensions(mockToGenerate.Name, mockToGenerate.MockClass, mockToGenerate.MockClass.DistinctAdditionalImplementations()),
 						Encoding.UTF8));
 			}
 		}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.CombinationExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.CombinationExtensions.cs
@@ -1,14 +1,13 @@
 using System.Text;
-using Microsoft.CodeAnalysis;
 using Mockolate.SourceGenerators.Entities;
-using Type = Mockolate.SourceGenerators.Entities.Type;
 
 namespace Mockolate.SourceGenerators.Sources;
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
-	public static string ForMockCombinationExtensions(string name, MockClass mockClass)
+	public static string ForMockCombinationExtensions(string name, MockClass mockClass,
+		IEnumerable<Class> distinctAdditionalImplementations)
 	{
 		StringBuilder sb = InitializeBuilder([
 			"Mockolate.Exceptions",
@@ -56,282 +55,69 @@ internal static partial class Sources
 		              """);
 		sb.AppendLine();
 
-		if (mockClass.Delegate is not null)
-		{
-			AppendDelegateExtensions(sb, mockClass, mockClass.Delegate);
-		}
-		else
-		{
-			if (mockClass.AdditionalImplementations.Any())
-			{
-				AppendMockExtensions(sb, mockClass);
-			}
+		sb.Append("\textension(").Append(mockClass.ClassFullName).AppendLine(" subject)");
+		sb.AppendLine("\t{");
 
-			sb.AppendLine();
+		HashSet<string> usedNames = [];
+		foreach (Class @class in distinctAdditionalImplementations)
+		{
+			AppendAdditionalMockExtensions(sb, @class, usedNames);
 		}
+
+		sb.AppendLine("\t}");
 
 		sb.AppendLine("}");
 		sb.AppendLine("#nullable disable");
 		return sb.ToString();
 	}
 
-	private static void AppendDelegateExtensions(StringBuilder sb, MockClass mockClass, Method method)
+	private static void AppendAdditionalMockExtensions(StringBuilder sb, Class @class, HashSet<string> usedNames)
 	{
-		#region Setup
-
-		sb.Append("\textension(IMockSetup<").Append(mockClass.ClassFullName).AppendLine("> setup)");
-		sb.AppendLine("\t{");
-		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Sets up the delegate <see cref=\"").Append(mockClass.ClassFullName.EscapeForXmlDoc())
-			.Append("\" /> on the mock.").AppendLine();
-		sb.Append("\t\t/// </summary>").AppendLine();
-		if (method.ReturnType != Type.Void)
-		{
-			sb.Append("\t\tpublic ReturnMethodSetup<")
-				.Append(method.ReturnType.Fullname);
-			foreach (MethodParameter parameter in method.Parameters)
-			{
-				sb.Append(", ").Append(parameter.Type.Fullname);
-			}
-
-			sb.Append("> Delegate(");
-		}
-		else
-		{
-			sb.Append("\t\tpublic VoidMethodSetup");
-			if (method.Parameters.Count > 0)
-			{
-				sb.Append('<');
-				int index = 0;
-				foreach (MethodParameter parameter in method.Parameters)
-				{
-					if (index++ > 0)
-					{
-						sb.Append(", ");
-					}
-
-					sb.Append(parameter.Type.Fullname);
-				}
-
-				sb.Append('>');
-			}
-
-			sb.Append(" Delegate(");
-		}
-
-		int i = 0;
-		foreach (MethodParameter parameter in method.Parameters)
-		{
-			if (i++ > 0)
-			{
-				sb.Append(", ");
-			}
-
-			sb.Append(parameter.RefKind switch
-				{
-					RefKind.Ref => "IRefParameter<",
-					RefKind.Out => "IOutParameter<",
-					_ => "IParameter<",
-				}).Append(parameter.Type.Fullname)
-				.Append('>');
-			if (parameter.RefKind is not RefKind.Ref and not RefKind.Out)
-			{
-				sb.Append('?');
-			}
-
-			sb.Append(' ').Append(parameter.Name);
-		}
-
-		sb.Append(")");
-		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
-		{
-			foreach (GenericParameter gp in method.GenericParameters.Value)
-			{
-				gp.AppendWhereConstraint(sb, "\t\t\t");
-			}
-		}
-
 		sb.AppendLine();
-
-		sb.AppendLine("\t\t{");
-
-		if (method.ReturnType != Type.Void)
+		int nameSuffix = 1;
+		string name = @class.ClassName.Replace('.', '_');
+		while (!usedNames.Add(name))
 		{
-			sb.Append("\t\t\tvar methodSetup = new ReturnMethodSetup<")
-				.Append(method.ReturnType.Fullname);
-			foreach (MethodParameter parameter in method.Parameters)
-			{
-				sb.Append(", ").Append(parameter.Type.Fullname);
-			}
-
-			sb.Append(">");
-		}
-		else
-		{
-			sb.Append("\t\t\tvar methodSetup = new VoidMethodSetup");
-
-			if (method.Parameters.Count > 0)
-			{
-				sb.Append('<');
-				int index = 0;
-				foreach (MethodParameter parameter in method.Parameters)
-				{
-					if (index++ > 0)
-					{
-						sb.Append(", ");
-					}
-
-					sb.Append(parameter.Type.Fullname);
-				}
-
-				sb.Append('>');
-			}
+			name = $"{@class.ClassName.Replace('.', '_')}__{++nameSuffix}";
 		}
 
-		sb.Append("(\"").Append(mockClass.ClassFullName).Append('.').Append(method.Name).Append("\"");
-		foreach (MethodParameter parameter in method.Parameters)
-		{
-			sb.Append(", new NamedParameter(\"").Append(parameter.Name).Append("\", ").Append(parameter.Name);
-			if (parameter.RefKind is not RefKind.Ref and not RefKind.Out)
-			{
-				sb.Append(" ?? It.IsNull<").Append(parameter.Type.Fullname)
-					.Append(">()");
-			}
-
-			sb.Append(")");
-		}
-
-		sb.Append(");").AppendLine();
-		sb.AppendLine("\t\t\tif (setup is IMockSetup mockSetup)");
-		sb.AppendLine("\t\t\t{");
-		sb.AppendLine("\t\t\t\tmockSetup.RegisterMethod(methodSetup);");
-		sb.AppendLine("\t\t\t}");
-		sb.AppendLine("\t\t\treturn methodSetup;");
-		sb.AppendLine("\t\t}");
-		sb.AppendLine("\t}");
-
-		#endregion
-
-		sb.AppendLine();
-
-		#region Verify
-
-		sb.Append("\textension(IMockVerify<").Append(mockClass.ClassFullName).Append(", Mock<")
-			.Append(mockClass.ClassFullName).Append(">>").Append(" verify)").AppendLine();
-		sb.AppendLine("\t{");
 		sb.Append("\t\t/// <summary>").AppendLine();
-		sb.Append("\t\t///     Verifies the delegate invocations for <see cref=\"")
-			.Append(mockClass.ClassFullName.EscapeForXmlDoc()).Append("\"/> on the mock.").AppendLine();
+		sb.Append("\t\t///     Sets up the mock for <see cref=\"").Append(@class.ClassFullName.EscapeForXmlDoc())
+			.Append("\" />")
+			.AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
-		sb.Append("\t\tpublic VerificationResult<").Append(mockClass.ClassFullName).Append("> Invoked(");
-		i = 0;
-		foreach (MethodParameter parameter in method.Parameters)
-		{
-			if (i++ > 0)
-			{
-				sb.Append(", ");
-			}
-
-			sb.Append(parameter.RefKind switch
-				{
-					RefKind.Ref => "IVerifyRefParameter<",
-					RefKind.Out => "IVerifyOutParameter<",
-					_ => "IParameter<",
-				}).Append(parameter.Type.Fullname)
-				.Append('>');
-			if (parameter.RefKind is not RefKind.Ref and not RefKind.Out)
-			{
-				sb.Append('?');
-			}
-
-			sb.Append(' ').Append(parameter.Name);
-		}
-
-		sb.Append(")").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tIMockInvoked<IMockVerify<").Append(mockClass.ClassFullName).Append(", Mock<")
-			.Append(mockClass.ClassFullName).Append(">>> invoked = (IMockInvoked<IMockVerify<")
-			.Append(mockClass.ClassFullName).Append(", Mock<")
-			.Append(mockClass.ClassFullName).Append(">>>)verify;").AppendLine();
-		sb.Append("\t\t\treturn invoked.Method(\"")
-			.Append(mockClass.ClassFullName).Append('.').Append(method.Name)
-			.Append("\"");
-
-		foreach (MethodParameter parameter in method.Parameters)
-		{
-			sb.Append(", ");
-			sb.Append(parameter.Name);
-			if (parameter.RefKind is not RefKind.Ref and not RefKind.Out)
-			{
-				sb.Append(" ?? It.IsNull<").Append(parameter.Type.Fullname)
-					.Append(">()");
-			}
-		}
-
-		sb.AppendLine(");");
-		sb.Append("\t\t}").AppendLine();
-
-		sb.AppendLine("\t}");
-
-		#endregion
-	}
-
-	private static void AppendMockExtensions(StringBuilder sb, MockClass mockClass)
-	{
-		sb.Append("\textension(").Append(mockClass.ClassFullName).AppendLine(" subject)");
-		sb.AppendLine("\t{");
-
-		HashSet<string> usedNames = [];
-		foreach (Class? @class in mockClass.DistinctAdditionalImplementations())
+		sb.Append("\t\tpublic IMockSetup<").Append(@class.ClassFullName).Append("> Setup").Append(name)
+			.Append("Mock")
+			.AppendLine();
+		sb.Append("\t\t\t=> new Mock<").Append(@class.ClassFullName).Append(">((").Append(@class.ClassFullName)
+			.Append(")subject, GetMockOrThrow(subject).Registrations);")
+			.AppendLine();
+		if (@class.AllEvents().Any())
 		{
 			sb.AppendLine();
-			int nameSuffix = 1;
-			string name = @class.ClassName.Replace('.', '_');
-			while (!usedNames.Add(name))
-			{
-				name = $"{@class.ClassName.Replace('.', '_')}__{++nameSuffix}";
-			}
-
 			sb.Append("\t\t/// <summary>").AppendLine();
-			sb.Append("\t\t///     Sets up the mock for <see cref=\"").Append(@class.ClassFullName.EscapeForXmlDoc())
-				.Append("\" />")
-				.AppendLine();
+			sb.Append("\t\t///     Raise events on the mock for <see cref=\"")
+				.Append(@class.ClassFullName.EscapeForXmlDoc())
+				.Append("\" />").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic IMockSetup<").Append(@class.ClassFullName).Append("> Setup").Append(name)
-				.Append("Mock")
-				.AppendLine();
-			sb.Append("\t\t\t=> new Mock<").Append(@class.ClassFullName).Append(">((").Append(@class.ClassFullName)
-				.Append(")subject, GetMockOrThrow(subject).Registrations);")
-				.AppendLine();
-			if (@class.AllEvents().Any())
-			{
-				sb.AppendLine();
-				sb.Append("\t\t/// <summary>").AppendLine();
-				sb.Append("\t\t///     Raise events on the mock for <see cref=\"")
-					.Append(@class.ClassFullName.EscapeForXmlDoc())
-					.Append("\" />").AppendLine();
-				sb.Append("\t\t/// </summary>").AppendLine();
-				sb.Append("\t\tpublic IMockRaises<").Append(@class.ClassFullName).Append("> RaiseOn")
-					.Append(name).Append("Mock").AppendLine();
-				sb.Append("\t\t\t=> new Mock<").Append(@class.ClassFullName).Append(">((").Append(@class.ClassFullName)
-					.Append(")subject, GetMockOrThrow(subject).Registrations);")
-					.AppendLine();
-			}
-
-			sb.AppendLine();
-			sb.Append("\t\t/// <summary>").AppendLine();
-			sb.Append("\t\t///     Verifies the interactions with the mocked subject of <see cref=\"")
-				.Append(@class.ClassFullName.EscapeForXmlDoc()).Append("\" /> on the mock.").AppendLine();
-			sb.Append("\t\t/// </summary>").AppendLine();
-			sb.Append("\t\tpublic IMockVerify<").Append(@class.ClassFullName).Append("> VerifyOn").Append(name)
-				.Append("Mock")
-				.AppendLine();
+			sb.Append("\t\tpublic IMockRaises<").Append(@class.ClassFullName).Append("> RaiseOn")
+				.Append(name).Append("Mock").AppendLine();
 			sb.Append("\t\t\t=> new Mock<").Append(@class.ClassFullName).Append(">((").Append(@class.ClassFullName)
 				.Append(")subject, GetMockOrThrow(subject).Registrations);")
 				.AppendLine();
 		}
 
-		sb.AppendLine("\t}");
+		sb.AppendLine();
+		sb.Append("\t\t/// <summary>").AppendLine();
+		sb.Append("\t\t///     Verifies the interactions with the mocked subject of <see cref=\"")
+			.Append(@class.ClassFullName.EscapeForXmlDoc()).Append("\" /> on the mock.").AppendLine();
+		sb.Append("\t\t/// </summary>").AppendLine();
+		sb.Append("\t\tpublic IMockVerify<").Append(@class.ClassFullName).Append("> VerifyOn").Append(name)
+			.Append("Mock")
+			.AppendLine();
+		sb.Append("\t\t\t=> new Mock<").Append(@class.ClassFullName).Append(">((").Append(@class.ClassFullName)
+			.Append(")subject, GetMockOrThrow(subject).Registrations);")
+			.AppendLine();
 	}
 }
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -26,13 +26,7 @@ internal static partial class Sources
 			sb.Append("/// <summary>").AppendLine();
 			sb.Append("///     A mock implementing <see cref=\"")
 				.Append(mockClass.ClassFullName.EscapeForXmlDoc())
-				.Append("\" />");
-			foreach (Class? additional in mockClass.DistinctAdditionalImplementations())
-			{
-				sb.Append(" and <see cref=\"").Append(additional.ClassFullName.EscapeForXmlDoc()).Append("\" />");
-			}
-
-			sb.AppendLine(".");
+				.Append("\" />.");
 			sb.Append("/// </summary>").AppendLine();
 			sb.Append("internal class MockFor").Append(name).Append(" : IMockSubject<").Append(mockClass.ClassFullName)
 				.Append(">").AppendLine();

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/MockClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/MockClassTests.cs
@@ -38,4 +38,41 @@ public sealed class MockClassTests
 					$"public static T Create<T, {types}>(BaseClass.ConstructorParameters constructorParameters, MockBehavior mockBehavior, params Action<IMockSetup<T>>[] setups)");
 		}
 	}
+
+	[Fact]
+	public async Task ShouldSupportSpecialTypes()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using Mockolate;
+
+			     namespace MyCode;
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = Mock.Create<IMyService>();
+			         }
+			     }
+
+			     public interface IMyService
+			     {
+			         void MyMethod(object v1, bool v2, string v3, char v4, byte v5, sbyte v6, short v7, ushort v8, int v9, uint v10, long v11, ulong v12, float v13, double v14, decimal v15);
+			     }
+			     """);
+
+		await That(result.Sources).ContainsKey("MockForIMyService.g.cs").WhoseValue
+			.Contains("""
+			          	public void MyMethod(object v1, bool v2, string v3, char v4, byte v5, sbyte v6, short v7, ushort v8, int v9, uint v10, long v11, ulong v12, float v13, double v14, decimal v15)
+			          	{
+			          		MethodSetupResult methodExecution = MockRegistrations.InvokeMethod("MyCode.IMyService.MyMethod", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+			          		if (this._wrapped is not null)
+			          		{
+			          			this._wrapped.MyMethod(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+			          		}
+			          		methodExecution.TriggerCallbacks(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+			          	}
+			          """).IgnoringNewlineStyle();
+	}
 }


### PR DESCRIPTION
This PR removes dead code related to delegate source generation and consolidates some test methods. The main focus is on cleaning up unused methods in the source generator and reorganizing test cases for better structure.

### Key Changes
- Removed unused delegate-related source generation methods (`AppendDelegateExtensions`, `AppendMockExtensions`)
- Add missing source generation tests
- Eliminated unused helper method `GetAllClasses()` from `MockClass`
- Reorganized test methods by moving several tests to earlier positions in the test file