### PR TITLE
refactor: remove duplicate code in `VerificationResult`

### DIFF
--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -8,6 +8,7 @@ namespace Mockolate.Verify;
 /// </summary>
 public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerificationResult
 {
+	private readonly string _expectation;
 	private readonly MockInteractions _interactions;
 	private readonly IInteraction[] _matchingInteractions;
 	private readonly TVerify _verify;
@@ -19,11 +20,8 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 		_verify = verify;
 		_interactions = interactions;
 		_matchingInteractions = matchingInteractions;
-		Expectation = expectation;
+		_expectation = expectation;
 	}
-
-	/// <inheritdoc cref="IVerificationResult.Expectation" />
-	public string Expectation { get; }
 
 	#region IVerificationResult<TVerify>
 
@@ -33,18 +31,11 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 
 	#endregion
 
-	/// <inheritdoc cref="IVerificationResult.Verify(Func{IInteraction[], Boolean})" />
-	public bool Verify(Func<IInteraction[], bool> predicate)
-	{
-		_interactions.Verified(_matchingInteractions);
-		return predicate(_matchingInteractions);
-	}
-
 	#region IVerificationResult
 
 	/// <inheritdoc cref="IVerificationResult.Expectation" />
 	string IVerificationResult.Expectation
-		=> Expectation;
+		=> _expectation;
 
 	/// <inheritdoc cref="IVerificationResult.MockInteractions" />
 	MockInteractions IVerificationResult.MockInteractions

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -1743,7 +1743,5 @@ namespace Mockolate.Verify
     public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult, Mockolate.Verify.IVerificationResult<TVerify>
     {
         public VerificationResult(TVerify verify, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
-        public string Expectation { get; }
-        public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -1742,7 +1742,5 @@ namespace Mockolate.Verify
     public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult, Mockolate.Verify.IVerificationResult<TVerify>
     {
         public VerificationResult(TVerify verify, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
-        public string Expectation { get; }
-        public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -1705,7 +1705,5 @@ namespace Mockolate.Verify
     public class VerificationResult<TVerify> : Mockolate.Verify.IVerificationResult, Mockolate.Verify.IVerificationResult<TVerify>
     {
         public VerificationResult(TVerify verify, Mockolate.Interactions.MockInteractions interactions, Mockolate.Interactions.IInteraction[] matchingInteractions, string expectation) { }
-        public string Expectation { get; }
-        public bool Verify(System.Func<Mockolate.Interactions.IInteraction[], bool> predicate) { }
     }
 }

--- a/Tests/Mockolate.Tests/ItTests.IsInRangeTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsInRangeTests.cs
@@ -33,6 +33,27 @@ public sealed partial class ItTests
 		[InlineData(5, 6, true)]
 		[InlineData(4, 6, true)]
 		[InlineData(6, 7, false)]
+		public async Task ExecuteWith5_Inclusive_ShouldMatchWhenRangeContains5(int minimum, int maximum,
+			bool expectFound)
+		{
+			IMyServiceWithNullable mock = Mock.Create<IMyServiceWithNullable>();
+			It.IInRangeParameter<int> range = It.IsInRange(minimum, maximum);
+			range.Exclusive();
+
+			mock.DoSomethingWithInt(5);
+
+			await That(mock.VerifyMock.Invoked.DoSomethingWithInt(range.Inclusive()))
+				.Exactly(expectFound ? 1 : 0);
+		}
+
+		[Theory]
+		[InlineData(3, 5, true)]
+		[InlineData(3, 6, true)]
+		[InlineData(2, 4, false)]
+		[InlineData(5, 5, true)]
+		[InlineData(5, 6, true)]
+		[InlineData(4, 6, true)]
+		[InlineData(6, 7, false)]
 		public async Task ExecuteWith5_ShouldMatchWhenRangeContains5(int minimum, int maximum, bool expectFound)
 		{
 			IMyServiceWithNullable mock = Mock.Create<IMyServiceWithNullable>();

--- a/Tests/Mockolate.Tests/ItTests.IsOneOfTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsOneOfTests.cs
@@ -6,28 +6,6 @@ public sealed partial class ItTests
 {
 	public sealed class IsOneOfTests
 	{
-		[Fact]
-		public async Task ToString_WithNullableIntValues_ShouldReturnExpectedValue()
-		{
-			IParameter<int?> sut = It.IsOneOf<int?>(3, null, 5);
-			string expectedValue = "It.IsOneOf(3, null, 5)";
-
-			string? result = sut.ToString();
-
-			await That(result).IsEqualTo(expectedValue);
-		}
-
-		[Fact]
-		public async Task ToString_WithStringValues_ShouldReturnExpectedValue()
-		{
-			IParameter<string> sut = It.IsOneOf("foo", "bar");
-			string expectedValue = "It.IsOneOf(\"foo\", \"bar\")";
-
-			string? result = sut.ToString();
-
-			await That(result).IsEqualTo(expectedValue);
-		}
-
 		[Theory]
 		[InlineData(1, false)]
 		[InlineData(4, false)]
@@ -81,6 +59,39 @@ public sealed partial class ItTests
 			await That(value1.Progress).IsEqualTo(1);
 			await That(result1).IsEqualTo(3);
 			await That(mock.VerifyMock.Invoked.DoSomething(It.IsOneOf(other1, other2))).Never();
+		}
+
+		[Fact]
+		public async Task ToString_Using_ShouldReturnExpectedValue()
+		{
+			IParameter<int> sut = It.IsOneOf(3, 5).Using(new AllEqualComparer());
+			string expectedValue = "It.IsOneOf(3, 5).Using(new AllEqualComparer())";
+
+			string? result = sut.ToString();
+
+			await That(result).IsEqualTo(expectedValue);
+		}
+
+		[Fact]
+		public async Task ToString_WithNullableIntValues_ShouldReturnExpectedValue()
+		{
+			IParameter<int?> sut = It.IsOneOf<int?>(3, null, 5);
+			string expectedValue = "It.IsOneOf(3, null, 5)";
+
+			string? result = sut.ToString();
+
+			await That(result).IsEqualTo(expectedValue);
+		}
+
+		[Fact]
+		public async Task ToString_WithStringValues_ShouldReturnExpectedValue()
+		{
+			IParameter<string> sut = It.IsOneOf("foo", "bar");
+			string expectedValue = "It.IsOneOf(\"foo\", \"bar\")";
+
+			string? result = sut.ToString();
+
+			await That(result).IsEqualTo(expectedValue);
 		}
 
 		[Theory]

--- a/Tests/Mockolate.Tests/MockEvents/RaiseTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/RaiseTests.cs
@@ -113,6 +113,19 @@ public sealed partial class RaiseTests
 		await That(callCount).IsEqualTo(2);
 	}
 
+	[Fact]
+	public async Task WhenUsingRaise_WithoutRegistration_ShouldNotThrow()
+	{
+		IRaiseEvent mock = Mock.Create<IRaiseEvent>();
+
+		void Act()
+		{
+			mock.RaiseOnMock.SomeEvent(this, EventArgs.Empty);
+		}
+
+		await That(Act).DoesNotThrow();
+	}
+
 	public interface IMyEventService : IMyEventServiceBase1
 	{
 		new event EventHandler<string> SomeEvent;

--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
@@ -40,6 +40,23 @@ public class VerificationResultTests
 	}
 
 	[Fact]
+	public async Task VerificationResult_MockInteractions_HasAllInteractions()
+	{
+		IChocolateDispenser sut = Mock.Create<IChocolateDispenser>();
+
+		sut.Dispense("Dark", 2);
+		_ = sut.TotalDispensed;
+		sut["Dark"] = 5;
+		sut.TotalDispensed = 10;
+		_ = sut["Milk"];
+
+		VerificationResult<IChocolateDispenser> result
+			= sut.VerifyMock.Got.TotalDispensed();
+
+		await That(((IVerificationResult)result).MockInteractions.Count).IsEqualTo(5);
+	}
+
+	[Fact]
 	public async Task VerificationResult_Set_ShouldHaveExpectedValue()
 	{
 		IChocolateDispenser sut = Mock.Create<IChocolateDispenser>();


### PR DESCRIPTION
This PR refactors the `VerificationResult<TVerify>` class by removing duplicate code and simplifying its implementation. The key change is making properties explicitly implemented via the `IVerificationResult` interface rather than maintaining both explicit and implicit implementations.

### Key changes:
- Converted `Expectation` property from public to explicit interface implementation backed by a private field
- Removed duplicate `Verify` method that was identical to the interface implementation
- Added test coverage for `MockInteractions` and various edge cases in related components