### PR TITLE
coverage: improve coverage of `MockRegistration`

### DIFF
--- a/Source/Mockolate/MockRegistration.Setup.cs
+++ b/Source/Mockolate/MockRegistration.Setup.cs
@@ -52,7 +52,8 @@ public partial class MockRegistration
 		else
 		{
 			((IInteractivePropertySetup)matchingSetup).InitializeWith(
-				defaultValueGenerator(((IInteractivePropertySetup)matchingSetup).CallBaseClass() ?? Behavior.CallBaseClass));
+				defaultValueGenerator(((IInteractivePropertySetup)matchingSetup).CallBaseClass() ??
+				                      Behavior.CallBaseClass));
 		}
 
 		return matchingSetup;
@@ -119,9 +120,8 @@ public partial class MockRegistration
 				return [];
 			}
 
-			return _storage.Where(methodSetup => interactions.Interactions.All(interaction
-				=> interaction is not MethodInvocation methodInvocation
-				   || !((IInteractiveMethodSetup)methodSetup).Matches(methodInvocation)));
+			return _storage.Where(methodSetup => interactions.Interactions.OfType<MethodInvocation>()
+				.All(methodInvocation => !((IInteractiveMethodSetup)methodSetup).Matches(methodInvocation)));
 		}
 
 		/// <inheritdoc cref="object.ToString()" />
@@ -135,7 +135,7 @@ public partial class MockRegistration
 
 			StringBuilder sb = new();
 			sb.Append(_storage.Count).Append(_storage.Count == 1 ? " method:" : " methods:").AppendLine();
-			foreach (IInteractiveMethodSetup methodSetup in _storage)
+			foreach (MethodSetup methodSetup in _storage)
 			{
 				sb.Append(methodSetup).AppendLine();
 			}
@@ -172,9 +172,8 @@ public partial class MockRegistration
 				return [];
 			}
 
-			return _storage.Values.Where(propertySetup => interactions.Interactions.All(interaction
-				=> interaction is not PropertyAccess propertyAccess
-				   || !((IInteractivePropertySetup)propertySetup).Matches(propertyAccess)));
+			return _storage.Values.Where(propertySetup => interactions.Interactions.OfType<PropertyAccess>()
+				.All(propertyAccess => !((IInteractivePropertySetup)propertySetup).Matches(propertyAccess)));
 		}
 
 		/// <inheritdoc cref="object.ToString()" />
@@ -289,15 +288,14 @@ public partial class MockRegistration
 				return [];
 			}
 
-			return _storage.Where(indexerSetup => interactions.Interactions.All(interaction
-				=> interaction is not IndexerAccess indexerAccess
-				   || !((IInteractiveIndexerSetup)indexerSetup).Matches(indexerAccess)));
+			return _storage.Where(indexerSetup => interactions.Interactions.OfType<IndexerAccess>()
+				.All(indexerAccess => !((IInteractiveIndexerSetup)indexerSetup).Matches(indexerAccess)));
 		}
 
 		private sealed class ValueStorage
 		{
 			private ValueStorage? _nullStorage;
-			private ConcurrentDictionary<object, ValueStorage>? _storage = [];
+			private ConcurrentDictionary<object, ValueStorage>? _storage;
 
 			public object? Value { get; set; }
 

--- a/Source/Mockolate/MockRegistration.Verify.cs
+++ b/Source/Mockolate/MockRegistration.Verify.cs
@@ -20,10 +20,11 @@ public partial class MockRegistration
 			Interactions,
 			Interactions.Interactions
 				.OfType<MethodInvocation>()
-				.Where(method =>
-					method.Name.Equals(methodName) &&
-					method.Parameters.Length == parameters.Length &&
-					!parameters.Where((parameter, i) => !parameter.Parameter.Matches(method.Parameters[i])).Any())
+				.Where(method => method.Name.Equals(methodName) &&
+				                 method.Parameters.Length == parameters.Length &&
+				                 !parameters
+					                 .Where((parameter, i) => !parameter.Parameter.Matches(method.Parameters[i]))
+					                 .Any())
 				.Cast<IInteraction>()
 				.ToArray(),
 			$"invoked method {methodName.SubstringAfterLast('.')}({string.Join(", ", parameters.Select(x => x.Parameter.ToString()))})");
@@ -36,9 +37,8 @@ public partial class MockRegistration
 		Interactions,
 		Interactions.Interactions
 			.OfType<MethodInvocation>()
-			.Where(method =>
-				method.Name.Equals(methodName) &&
-				parameters.Matches(method.Parameters))
+			.Where(method => method.Name.Equals(methodName) &&
+			                 parameters.Matches(method.Parameters))
 			.Cast<IInteraction>()
 			.ToArray(),
 		$"invoked method {methodName.SubstringAfterLast('.')}({parameters})");
@@ -65,7 +65,8 @@ public partial class MockRegistration
 			Interactions,
 			Interactions.Interactions
 				.OfType<PropertySetterAccess>()
-				.Where(property => property.Name.Equals(propertyName) && value.Matches(property.Value))
+				.Where(property => property.Name.Equals(propertyName) &&
+				                   value.Matches(property.Value))
 				.Cast<IInteraction>()
 				.ToArray(),
 			$"set property {propertyName.SubstringAfterLast('.')} to value {value}");
@@ -81,7 +82,9 @@ public partial class MockRegistration
 			Interactions.Interactions
 				.OfType<IndexerGetterAccess>()
 				.Where(indexer => indexer.Parameters.Length == parameters.Length &&
-				                  !parameters.Where((parameter, i) => !parameter.Parameter.Matches(indexer.Parameters[i])).Any())
+				                  !parameters
+					                  .Where((parameter, i) => !parameter.Parameter.Matches(indexer.Parameters[i]))
+					                  .Any())
 				.Cast<IInteraction>()
 				.ToArray(),
 			$"got indexer [{string.Join(", ", parameters.Select(x => x.Parameter.ToString()))}]");
@@ -98,7 +101,9 @@ public partial class MockRegistration
 				.OfType<IndexerSetterAccess>()
 				.Where(indexer => indexer.Parameters.Length == parameters.Length &&
 				                  (value?.Matches(indexer.Value) ?? indexer.Value is null) &&
-				                  !parameters.Where((parameter, i) => !parameter.Parameter.Matches(indexer.Parameters[i])).Any())
+				                  !parameters
+					                  .Where((parameter, i) => !parameter.Parameter.Matches(indexer.Parameters[i]))
+					                  .Any())
 				.Cast<IInteraction>()
 				.ToArray(),
 			$"set indexer [{string.Join(", ", parameters.Select(x => x.Parameter.ToString()))}] to value {value?.ToString() ?? "null"}");

--- a/Tests/Mockolate.Tests/MockMethods/VerifyInvokedTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/VerifyInvokedTests.cs
@@ -26,6 +26,17 @@ public sealed partial class VerifyInvokedTests
 		await That(mock.VerifyMock.Invoked.GetHashCode()).Once();
 	}
 
+	[Fact]
+	public async Task MethodWithDifferentName_ShouldNotMatch()
+	{
+		MockTests.IMyService sut = Mock.Create<MockTests.IMyService>();
+
+		sut.Multiply(1, 4);
+		sut.Multiply(2, 4);
+
+		await That(sut.VerifyMock.Invoked.Subtract(It.IsAny<int>(), It.IsAny<int?>())).Never();
+	}
+
 	[Theory]
 	[InlineData(2)]
 	[InlineData(42)]

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -386,6 +386,8 @@ public sealed partial class MockTests
 
 		int Multiply(int value, int? multiplier);
 
+		int Subtract(int minuend, int? subtrahend);
+
 		void SetIsValid(bool isValid, Func<bool>? predicate);
 	}
 


### PR DESCRIPTION
This PR improves test coverage for `MockRegistration` by adding a new test case that verifies method name matching behavior in verification. The changes also include code formatting improvements to enhance readability of the `MockRegistration` class.

### Key changes:
- Adds test to verify that method calls with different names don't match during verification
- Reformats LINQ query chains for better readability
- Simplifies unused setup enumeration logic by using `OfType<T>()` instead of pattern matching