### PR TITLE
feat: support `in` and `ref readonly` parameters

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Helpers.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Helpers.cs
@@ -153,6 +153,7 @@ internal static class Helpers
 		{
 			(RefKind.Ref, _) => $"IRefParameter<{GetType(parameter)}>",
 			(RefKind.Out, _) => $"IOutParameter<{GetType(parameter)}>",
+			(RefKind.RefReadOnlyParameter, _) => $"IRefParameter<{GetType(parameter)}>",
 			(_, SpecialGenericType.Span) => $"ISpanParameter<{GetType(parameter)}>",
 			(_, SpecialGenericType.ReadOnlySpan) => $"IReadOnlySpanParameter<{GetType(parameter)}>",
 			(_, _) => $"IParameter<{GetType(parameter)}>",
@@ -170,7 +171,7 @@ internal static class Helpers
 	}
 
 	public static bool IsNullable(this MethodParameter parameter)
-		=> parameter.RefKind is not RefKind.Ref and not RefKind.Out &&
+		=> parameter.RefKind is not RefKind.Ref and not RefKind.Out and not RefKind.RefReadOnlyParameter &&
 		   parameter.Type.SpecialGenericType is not (SpecialGenericType.Span or SpecialGenericType.ReadOnlySpan);
 
 

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -50,7 +50,7 @@ public class MockGenerator : IIncrementalGenerator
 
 			context.AddSource($"MockFor{mockToGenerate.Name}.g.cs",
 				SourceText.From(Sources.Sources.ForMock(mockToGenerate.Name, mockToGenerate.MockClass), Encoding.UTF8));
-			if (mockToGenerate.MockClass.AdditionalImplementations.Any())
+			if (mockToGenerate.MockClass.AdditionalImplementations.Any() && mockToGenerate.MockClass.Delegate is null)
 			{
 				context.AddSource($"MockFor{mockToGenerate.Name}Extensions.g.cs",
 					SourceText.From(

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.cs
@@ -396,7 +396,7 @@ internal static partial class Sources
 		}
 
 		sb.AppendLine("\t{");
-		if (property.Getter != null && property.Getter.Accessibility != Accessibility.Private)
+		if (property.Getter != null)
 		{
 			sb.Append("\t\t");
 			if (property.Getter.Accessibility != property.Accessibility)
@@ -505,7 +505,7 @@ internal static partial class Sources
 			sb.AppendLine("\t\t}");
 		}
 
-		if (property.Setter != null && property.Setter.Accessibility != Accessibility.Private)
+		if (property.Setter != null)
 		{
 			sb.Append("\t\t");
 			if (property.Setter.Accessibility != property.Accessibility)
@@ -891,7 +891,7 @@ internal static partial class Sources
 	///     Formats method parameters with ref/out keywords and names for method invocations.
 	/// </summary>
 	private static string FormatMethodParametersWithRefKind(IEnumerable<MethodParameter> parameters)
-		=> string.Join(", ", parameters.Select(p => $"{p.RefKind.GetString()}{p.Name}"));
+		=> string.Join(", ", parameters.Select(p => $"{p.RefKind.GetString(true)}{p.Name}"));
 
 	/// <summary>
 	///     Formats indexer parameters as comma-separated names or wrappers.

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -496,23 +496,21 @@ internal static partial class Sources
 	internal static string ToVisibilityString(this Accessibility accessibility)
 		=> accessibility switch
 		{
-			Accessibility.Private => "private",
 			Accessibility.Protected => "protected",
 			Accessibility.Internal => "internal",
 			Accessibility.ProtectedOrInternal => "protected",
 			Accessibility.Public => "public",
 			Accessibility.ProtectedAndInternal => "private protected",
-			_ => throw new ArgumentOutOfRangeException(nameof(accessibility), accessibility, null),
+			_ => "private",
 		};
 
-	internal static string GetString(this RefKind refKind)
+	internal static string GetString(this RefKind refKind, bool replaceRefReadonlyWithIn = false)
 		=> refKind switch
 		{
-			RefKind.None => "",
 			RefKind.In => "in ",
 			RefKind.Out => "out ",
 			RefKind.Ref => "ref ",
-			RefKind.RefReadOnlyParameter => "ref readonly ",
+			RefKind.RefReadOnlyParameter => replaceRefReadonlyWithIn ? "in " : "ref readonly ",
 			_ => "",
 		};
 
@@ -558,11 +556,6 @@ internal static partial class Sources
 	/// </summary>
 	private static string GetTypeParametersDescription(int numberOfParameters, int startIndex = 1)
 	{
-		if (numberOfParameters == 1)
-		{
-			return $"<typeparamref name=\"T{startIndex}\" />";
-		}
-
 		StringBuilder sb = new();
 		for (int i = startIndex; i < startIndex + numberOfParameters - 1; i++)
 		{

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/ForMockTests.ImplementClassTests.cs
@@ -1019,7 +1019,7 @@ public sealed partial class ForMockTests
 		}
 
 		[Fact]
-		public async Task Methods_ShouldSupportRefAndOutParameters()
+		public async Task Methods_ShouldSupportRefInAndOutParameters()
 		{
 			GeneratorResult result = Generator
 				.Run("""
@@ -1039,6 +1039,8 @@ public sealed partial class ForMockTests
 				     {
 				         void MyMethod1(ref int index);
 				         bool MyMethod2(int index, out bool isReadOnly);
+				         void MyMethod3(in MyReadonlyStruct p1);
+				         void MyMethod4(ref readonly MyReadonlyStruct p1);
 				     }
 				     """);
 
@@ -1083,6 +1085,30 @@ public sealed partial class ForMockTests
 				          		isReadOnly = methodExecution.SetOutParameter<bool>("isReadOnly", () => MockRegistrations.Behavior.DefaultValue.Generate(default(bool)!));
 				          		methodExecution.TriggerCallbacks(index, isReadOnly);
 				          		return methodExecution.Result;
+				          	}
+				          """).IgnoringNewlineStyle().And
+				.Contains("""
+				          	/// <inheritdoc cref="MyCode.IMyService.MyMethod3(in MyReadonlyStruct)" />
+				          	public void MyMethod3(in MyReadonlyStruct p1)
+				          	{
+				          		MethodSetupResult methodExecution = MockRegistrations.InvokeMethod("MyCode.IMyService.MyMethod3", p1);
+				          		if (this._wrapped is not null)
+				          		{
+				          			this._wrapped.MyMethod3(in p1);
+				          		}
+				          		methodExecution.TriggerCallbacks(p1);
+				          	}
+				          """).IgnoringNewlineStyle().And
+				.Contains("""
+				          	/// <inheritdoc cref="MyCode.IMyService.MyMethod4(ref readonly MyReadonlyStruct)" />
+				          	public void MyMethod4(ref readonly MyReadonlyStruct p1)
+				          	{
+				          		MethodSetupResult methodExecution = MockRegistrations.InvokeMethod("MyCode.IMyService.MyMethod4", p1);
+				          		if (this._wrapped is not null)
+				          		{
+				          			this._wrapped.MyMethod4(in p1);
+				          		}
+				          		methodExecution.TriggerCallbacks(p1);
 				          	}
 				          """).IgnoringNewlineStyle();
 		}
@@ -1199,6 +1225,9 @@ public sealed partial class ForMockTests
 				         int SomeProperty { get; set; }
 				         bool? SomeReadOnlyProperty { get; }
 				         bool? SomeWriteOnlyProperty { set; }
+				         internal int SomeInternalProperty { get; set; }
+				         private int SomePrivateProperty { get; set; }
+				         private protected int SomePrivateProtectedProperty { get; set; }
 				     }
 				     """);
 
@@ -1241,6 +1270,60 @@ public sealed partial class ForMockTests
 				          			if (this._wrapped is not null)
 				          			{
 				          				this._wrapped.SomeWriteOnlyProperty = value;
+				          			}
+				          		}
+				          	}
+				          """).IgnoringNewlineStyle().And
+				.Contains("""
+				          	/// <inheritdoc cref="MyCode.IMyService.SomeInternalProperty" />
+				          	internal int SomeInternalProperty
+				          	{
+				          		get
+				          		{
+				          			return MockRegistrations.GetProperty<int>("MyCode.IMyService.SomeInternalProperty", () => MockRegistrations.Behavior.DefaultValue.Generate(default(int)!), this._wrapped is null ? null : () => this._wrapped.SomeInternalProperty);
+				          		}
+				          		set
+				          		{
+				          			MockRegistrations.SetProperty("MyCode.IMyService.SomeInternalProperty", value);
+				          			if (this._wrapped is not null)
+				          			{
+				          				this._wrapped.SomeInternalProperty = value;
+				          			}
+				          		}
+				          	}
+				          """).IgnoringNewlineStyle().And
+				.Contains("""
+				          	/// <inheritdoc cref="MyCode.IMyService.SomePrivateProperty" />
+				          	private int SomePrivateProperty
+				          	{
+				          		get
+				          		{
+				          			return MockRegistrations.GetProperty<int>("MyCode.IMyService.SomePrivateProperty", () => MockRegistrations.Behavior.DefaultValue.Generate(default(int)!), this._wrapped is null ? null : () => this._wrapped.SomePrivateProperty);
+				          		}
+				          		set
+				          		{
+				          			MockRegistrations.SetProperty("MyCode.IMyService.SomePrivateProperty", value);
+				          			if (this._wrapped is not null)
+				          			{
+				          				this._wrapped.SomePrivateProperty = value;
+				          			}
+				          		}
+				          	}
+				          """).IgnoringNewlineStyle().And
+				.Contains("""
+				          	/// <inheritdoc cref="MyCode.IMyService.SomePrivateProtectedProperty" />
+				          	private protected int SomePrivateProtectedProperty
+				          	{
+				          		get
+				          		{
+				          			return MockRegistrations.GetProperty<int>("MyCode.IMyService.SomePrivateProtectedProperty", () => MockRegistrations.Behavior.DefaultValue.Generate(default(int)!), this._wrapped is null ? null : () => this._wrapped.SomePrivateProtectedProperty);
+				          		}
+				          		set
+				          		{
+				          			MockRegistrations.SetProperty("MyCode.IMyService.SomePrivateProtectedProperty", value);
+				          			if (this._wrapped is not null)
+				          			{
+				          				this._wrapped.SomePrivateProtectedProperty = value;
 				          			}
 				          		}
 				          	}

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -564,6 +564,32 @@ public sealed partial class SetupMethodTests
 				"The method 'Mockolate.Tests.MockMethods.SetupMethodTests.IMethodService.MyIntMethodWithoutParameters()' was invoked without prior setup.");
 	}
 
+	[Fact]
+	public async Task WithInParameter_ShouldUseSetup()
+	{
+		IMethodSetupWithInAndRefReadonlyParameter sut = Mock.Create<IMethodSetupWithInAndRefReadonlyParameter>();
+		MyReadonlyStruct value = new(3);
+		sut.SetupMock.Method.MethodWithInParameter(It.IsAny<MyReadonlyStruct>())
+			.Returns(p1 => p1.Value);
+
+		int result = sut.MethodWithInParameter(in value);
+
+		await That(result).IsEqualTo(3);
+	}
+
+	[Fact]
+	public async Task WithRefReadonlyParameter_ShouldUseSetup()
+	{
+		IMethodSetupWithInAndRefReadonlyParameter sut = Mock.Create<IMethodSetupWithInAndRefReadonlyParameter>();
+		MyReadonlyStruct value = new(3);
+		sut.SetupMock.Method.MethodWithRefReadonlyParameter(It.IsAnyRef<MyReadonlyStruct>())
+			.Returns(p1 => p1.Value);
+
+		int result = sut.MethodWithRefReadonlyParameter(in value);
+
+		await That(result).IsEqualTo(3);
+	}
+
 	public class ReturnMethodWith0Parameters
 	{
 		[Fact]
@@ -994,6 +1020,17 @@ public sealed partial class SetupMethodTests
 		void MethodWithRefParameter(int p1, ref int p2);
 		void MethodWithoutOtherOverloads(int p1, int p2, int p3);
 		void MethodWithSingleParameter(int p1);
+	}
+
+	public interface IMethodSetupWithInAndRefReadonlyParameter
+	{
+		int MethodWithInParameter(in MyReadonlyStruct p1);
+		int MethodWithRefReadonlyParameter(ref readonly MyReadonlyStruct p1);
+	}
+
+	public readonly struct MyReadonlyStruct(int value)
+	{
+		public int Value { get; } = value;
 	}
 
 	public interface IReturnMethodSetupWithParametersTest


### PR DESCRIPTION
This PR adds support for `in` and `ref readonly` parameter modifiers to the Mockolate mocking library. These parameter modifiers allow passing readonly struct values by reference, enabling performance optimizations while maintaining immutability guarantees.

### Key changes:
- Added support for generating mock implementations with `in` and `ref readonly` parameters
- Extended property mocking to support non-public accessibility levels (internal, private, private protected)
- Updated parameter conversion logic to handle `RefReadOnlyParameter` kind