### PR TITLE
fix: execution order of `OnlyOnce` callbacks

### DIFF
--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -137,7 +137,6 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 		}
 
 		_invocationCount++;
-		Interlocked.Increment(ref index);
 		return false;
 	}
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -72,6 +72,28 @@ public sealed partial class SetupMethodTests
 	}
 
 	[Fact]
+	public async Task MultipleOnlyOnceCallbacks_ShouldExecuteInOrder()
+	{
+		List<int> receivedCalls = [];
+		IMethodService sut = Mock.Create<IMethodService>();
+
+		sut.SetupMock.Method.MyVoidMethodWithoutParameters()
+			.Do(() => receivedCalls.Add(1)).OnlyOnce()
+			.Do(() => receivedCalls.Add(2)).OnlyOnce()
+			.Do(() => receivedCalls.Add(3)).OnlyOnce()
+			.Do(() => receivedCalls.Add(4)).OnlyOnce()
+			.Do(() => receivedCalls.Add(5)).OnlyOnce();
+
+		sut.MyVoidMethodWithoutParameters();
+		sut.MyVoidMethodWithoutParameters();
+		sut.MyVoidMethodWithoutParameters();
+		sut.MyVoidMethodWithoutParameters();
+		sut.MyVoidMethodWithoutParameters();
+
+		await That(receivedCalls).IsEqualTo([1, 2, 3, 4, 5,]);
+	}
+
+	[Fact]
 	public async Task OverlappingSetups_ShouldUseLatestMatchingSetup()
 	{
 		IMethodService mock = Mock.Create<IMethodService>();


### PR DESCRIPTION
This PR fixes the execution order of `OnlyOnce` callbacks in the Mockolate mocking library. The issue was that callbacks configured with `OnlyOnce()` were being executed in reverse order due to an incorrect index increment operation.

### Key changes
- Removed premature index increment in `Callback.Invoke` method that was causing callbacks to execute in reverse order
- Added comprehensive test to verify sequential execution of multiple `OnlyOnce` callbacks