### PR TITLE
fix: correctly escape generic types in generated XML-Doc

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
@@ -120,7 +120,7 @@ internal static partial class Sources
 					.Append(@class.ClassFullName.EscapeForXmlDoc())
 					.Append(".").Append(@delegate.Name.EscapeForXmlDoc()).Append("(")
 					.Append(string.Join(", ",
-						@delegate.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname)))
+						@delegate.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname.EscapeForXmlDoc())))
 					.Append(")\"/> with the given <paramref name=\"parameters\"/>..")
 					.AppendLine();
 				sb.Append("\t\t/// </summary>").AppendLine();
@@ -311,7 +311,7 @@ internal static partial class Sources
 				.Append(@class.ClassFullName.EscapeForXmlDoc()).Append(".")
 				.Append(method.Name.EscapeForXmlDoc()).Append("(")
 				.Append(string.Join(", ",
-					method.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname)))
+					method.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname.EscapeForXmlDoc())))
 				.Append(")\"/>");
 		}
 		else
@@ -889,7 +889,7 @@ internal static partial class Sources
 				.Append(@class.ClassFullName.EscapeForXmlDoc())
 				.Append(".").Append(method.Name.EscapeForXmlDoc()).Append("(")
 				.Append(string.Join(", ",
-					method.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname)))
+					method.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname.EscapeForXmlDoc())))
 				.Append(")\"/>").Append(method.Parameters.Count > 0 ? " with the given " : "")
 				.Append(string.Join(", ", method.Parameters.Select(p => $"<paramref name=\"{p.Name}\"/>"))).Append(".")
 				.AppendLine();
@@ -952,7 +952,7 @@ internal static partial class Sources
 				.Append(@class.ClassFullName.EscapeForXmlDoc())
 				.Append(".").Append(method.Name.EscapeForXmlDoc()).Append("(")
 				.Append(string.Join(", ",
-					method.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname)))
+					method.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname.EscapeForXmlDoc())))
 				.Append(")\"/> with the given <paramref name=\"parameters\"/>..")
 				.AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();

--- a/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
+++ b/Tests/Mockolate.Tests/Protected/ProtectedMockTests.cs
@@ -76,6 +76,30 @@ public sealed class ProtectedMockTests
 		await That(callCount).IsEqualTo(1);
 	}
 
+	[Fact]
+	public async Task OnlyProtectedVirtualMembers()
+	{
+		OnlyProtectedVirtualMembersService mock = Mock.Create<OnlyProtectedVirtualMembersService>();
+
+		bool result1 = mock.DoValidate(-1);
+
+		mock.SetupMock.Protected.Method.Validate(It.IsAny<int>()).Returns(true);
+
+		bool result2 = mock.DoValidate(-1);
+
+		await That(result1).IsFalse();
+		await That(result2).IsTrue();
+	}
+
+	public abstract class OnlyProtectedVirtualMembersService
+	{
+		public bool DoValidate(int value)
+			=> Validate(value);
+
+		protected virtual bool Validate(int value)
+			=> value > 0;
+	}
+
 #pragma warning disable CS0067 // Event is never used
 #pragma warning disable CA1070 // Do not declare event fields as virtual
 	public abstract class MyProtectedClass


### PR DESCRIPTION
This PR fixes XML documentation generation for generic types by ensuring proper XML escaping of type parameters in generated documentation comments.

### Key Changes:
- Added `.EscapeForXmlDoc()` calls to generic type parameters in method/delegate signatures within XML documentation
- Added test case to verify mocking of protected virtual members