### PR TITLE
refactor!: introduce `IMockBehaviorAccess` to simplify public API surface

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockRegistration.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockRegistration.cs
@@ -41,7 +41,8 @@ internal static partial class Sources
 			sb.AppendLine(
 				"\t\tpartial void Generate<T>(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior, Action<IMockSetup<T>>[] setups, params Type[] types)");
 			sb.Append("\t\t{").AppendLine();
-			sb.Append("\t\t\tif (mockBehavior.TryInitialize<T>(out Action<IMockSetup<T>>[]? additionalSetups))")
+			sb.Append("\t\t\tIMockBehaviorAccess mockBehaviorAccess = (IMockBehaviorAccess)mockBehavior;").AppendLine();
+			sb.Append("\t\t\tif (mockBehaviorAccess.TryInitialize<T>(out Action<IMockSetup<T>>[]? additionalSetups))")
 				.AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tif (setups.Length > 0)").AppendLine();
@@ -59,7 +60,8 @@ internal static partial class Sources
 			sb.Append("\t\t\t\t}").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
 			sb.AppendLine();
-			sb.Append("\t\t\tif (constructorParameters is null && mockBehavior.TryGetConstructorParameters<T>(out object?[]? parameters))")
+			sb.Append(
+					"\t\t\tif (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<T>(out object?[]? parameters))")
 				.AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tconstructorParameters = new BaseClass.ConstructorParameters(parameters);").AppendLine();
@@ -247,13 +249,14 @@ internal static partial class Sources
 			}
 
 			sb.AppendLine("\t\t}");
-			
+
 			sb.AppendLine();
 			sb.AppendLine(
 				"\t\tpartial void GenerateWrapped<T>(T instance, MockBehavior mockBehavior, Action<IMockSetup<T>>[] setups)");
 			sb.Append("\t\t{").AppendLine();
 			index = 0;
-			foreach ((string Name, MockClass MockClass) mock in mocks.Where(m => m.MockClass.AdditionalImplementations.Count == 0))
+			foreach ((string Name, MockClass MockClass) mock in mocks.Where(m
+				         => m.MockClass.AdditionalImplementations.Count == 0))
 			{
 				if (index++ > 0)
 				{
@@ -266,13 +269,14 @@ internal static partial class Sources
 
 				sb.Append("if (typeof(T) == typeof(").Append(mock.MockClass.ClassFullName).Append("))").AppendLine();
 				sb.Append("\t\t\t{").AppendLine();
-				
+
 				sb.Append("\t\t\t\tMockRegistration mockRegistration = new MockRegistration(mockBehavior, \"")
 					.Append(mock.MockClass.DisplayString).Append("\");").AppendLine();
 
 				if (mock.MockClass.IsInterface)
 				{
-					sb.Append("\t\t\t\t_value = new MockFor").Append(mock.Name).Append("(mockBehavior, instance as ").Append(mock.MockClass.ClassFullName).Append(");").AppendLine();
+					sb.Append("\t\t\t\t_value = new MockFor").Append(mock.Name).Append("(mockBehavior, instance as ")
+						.Append(mock.MockClass.ClassFullName).Append(");").AppendLine();
 					sb.Append("\t\t\t\tif (setups.Length > 0)").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t\tIMockSetup<").Append(mock.MockClass.ClassFullName)
@@ -285,11 +289,12 @@ internal static partial class Sources
 					sb.Append("\t\t\t\t\t}").AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
 				}
-				
+
 				sb.Append("\t\t\t}").AppendLine();
 			}
+
 			sb.AppendLine("\t\t}");
-			
+
 			sb.AppendLine("\t}");
 			sb.AppendLine();
 		}

--- a/Source/Mockolate/IMockBehaviorAccess.cs
+++ b/Source/Mockolate/IMockBehaviorAccess.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mockolate.Setup;
+
+namespace Mockolate;
+
+/// <summary>
+///     Gives access to the initializations and constructor parameters of a <see cref="MockBehavior" />.
+/// </summary>
+public interface IMockBehaviorAccess
+{
+	/// <summary>
+	///     Tries to get the initialization setups for a mock of type <typeparamref name="T" />.
+	/// </summary>
+	/// <remarks>
+	///     Returns <see langword="false" />, when no matching initialization is found.
+	/// </remarks>
+	bool TryInitialize<T>([NotNullWhen(true)] out Action<IMockSetup<T>>[]? setups);
+
+	/// <summary>
+	///     Tries to get the constructor parameters for a mock of type <typeparamref name="T" />.
+	/// </summary>
+	/// <remarks>
+	///     Returns <see langword="false" />, when no matching constructor parameters are found.
+	/// </remarks>
+	bool TryGetConstructorParameters<T>([NotNullWhen(true)] out object?[]? parameters);
+}

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -22,6 +22,11 @@ namespace Mockolate
         Mockolate.MockRegistration Registrations { get; }
     }
     public interface IInteractiveMock<out T> { }
+    public interface IMockBehaviorAccess
+    {
+        bool TryGetConstructorParameters<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object?[]? parameters);
+        bool TryInitialize<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Action<Mockolate.Setup.IMockSetup<T>>[]? setups);
+    }
     public interface IMockSubject<T> : Mockolate.IHasMockRegistration
     {
         Mockolate.Mock<T> Mock { get; }
@@ -75,7 +80,7 @@ namespace Mockolate
         public static Mockolate.Parameters.IParameters Parameters(System.Func<Mockolate.Parameters.NamedParameterValue[], bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Parameters.IDefaultEventParameters WithDefaultParameters() { }
     }
-    public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>
+    public class MockBehavior : Mockolate.IMockBehaviorAccess, System.IEquatable<Mockolate.MockBehavior>
     {
         public MockBehavior(Mockolate.IDefaultValueGenerator defaultValue) { }
         public Mockolate.IDefaultValueGenerator DefaultValue { get; init; }
@@ -83,8 +88,6 @@ namespace Mockolate
         public bool ThrowWhenNotSetup { get; init; }
         public Mockolate.MockBehavior Initialize<T>(params System.Action<Mockolate.Setup.IMockSetup<T>>[] setups) { }
         public Mockolate.MockBehavior Initialize<T>(params System.Action<int, Mockolate.Setup.IMockSetup<T>>[] setups) { }
-        public bool TryGetConstructorParameters<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object?[]? parameters) { }
-        public bool TryInitialize<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Action<Mockolate.Setup.IMockSetup<T>>[]? setups) { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(System.Func<object?[]> parameters) { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(params object?[] parameters) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -21,6 +21,11 @@ namespace Mockolate
         Mockolate.MockRegistration Registrations { get; }
     }
     public interface IInteractiveMock<out T> { }
+    public interface IMockBehaviorAccess
+    {
+        bool TryGetConstructorParameters<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object?[]? parameters);
+        bool TryInitialize<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Action<Mockolate.Setup.IMockSetup<T>>[]? setups);
+    }
     public interface IMockSubject<T> : Mockolate.IHasMockRegistration
     {
         Mockolate.Mock<T> Mock { get; }
@@ -74,7 +79,7 @@ namespace Mockolate
         public static Mockolate.Parameters.IParameters Parameters(System.Func<Mockolate.Parameters.NamedParameterValue[], bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Parameters.IDefaultEventParameters WithDefaultParameters() { }
     }
-    public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>
+    public class MockBehavior : Mockolate.IMockBehaviorAccess, System.IEquatable<Mockolate.MockBehavior>
     {
         public MockBehavior(Mockolate.IDefaultValueGenerator defaultValue) { }
         public Mockolate.IDefaultValueGenerator DefaultValue { get; init; }
@@ -82,8 +87,6 @@ namespace Mockolate
         public bool ThrowWhenNotSetup { get; init; }
         public Mockolate.MockBehavior Initialize<T>(params System.Action<Mockolate.Setup.IMockSetup<T>>[] setups) { }
         public Mockolate.MockBehavior Initialize<T>(params System.Action<int, Mockolate.Setup.IMockSetup<T>>[] setups) { }
-        public bool TryGetConstructorParameters<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object?[]? parameters) { }
-        public bool TryInitialize<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Action<Mockolate.Setup.IMockSetup<T>>[]? setups) { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(System.Func<object?[]> parameters) { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(params object?[] parameters) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -20,6 +20,11 @@ namespace Mockolate
         Mockolate.MockRegistration Registrations { get; }
     }
     public interface IInteractiveMock<out T> { }
+    public interface IMockBehaviorAccess
+    {
+        bool TryGetConstructorParameters<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object?[]? parameters);
+        bool TryInitialize<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Action<Mockolate.Setup.IMockSetup<T>>[]? setups);
+    }
     public interface IMockSubject<T> : Mockolate.IHasMockRegistration
     {
         Mockolate.Mock<T> Mock { get; }
@@ -69,7 +74,7 @@ namespace Mockolate
         public static Mockolate.Parameters.IParameters Parameters(System.Func<Mockolate.Parameters.NamedParameterValue[], bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static Mockolate.Parameters.IDefaultEventParameters WithDefaultParameters() { }
     }
-    public class MockBehavior : System.IEquatable<Mockolate.MockBehavior>
+    public class MockBehavior : Mockolate.IMockBehaviorAccess, System.IEquatable<Mockolate.MockBehavior>
     {
         public MockBehavior(Mockolate.IDefaultValueGenerator defaultValue) { }
         public Mockolate.IDefaultValueGenerator DefaultValue { get; init; }
@@ -77,8 +82,6 @@ namespace Mockolate
         public bool ThrowWhenNotSetup { get; init; }
         public Mockolate.MockBehavior Initialize<T>(params System.Action<Mockolate.Setup.IMockSetup<T>>[] setups) { }
         public Mockolate.MockBehavior Initialize<T>(params System.Action<int, Mockolate.Setup.IMockSetup<T>>[] setups) { }
-        public bool TryGetConstructorParameters<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object?[]? parameters) { }
-        public bool TryInitialize<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Action<Mockolate.Setup.IMockSetup<T>>[]? setups) { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(System.Func<object?[]> parameters) { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(params object?[] parameters) { }
     }

--- a/Tests/Mockolate.SourceGenerators.Tests/Sources/MockRegistrationTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Sources/MockRegistrationTests.cs
@@ -335,7 +335,8 @@ public sealed class MockRegistrationTests
 			.Contains("""
 			          		partial void Generate<T>(BaseClass.ConstructorParameters? constructorParameters, MockBehavior mockBehavior, Action<IMockSetup<T>>[] setups, params Type[] types)
 			          		{
-			          			if (mockBehavior.TryInitialize<T>(out Action<IMockSetup<T>>[]? additionalSetups))
+			          			IMockBehaviorAccess mockBehaviorAccess = (IMockBehaviorAccess)mockBehavior;
+			          			if (mockBehaviorAccess.TryInitialize<T>(out Action<IMockSetup<T>>[]? additionalSetups))
 			          			{
 			          				if (setups.Length > 0)
 			          				{
@@ -350,7 +351,7 @@ public sealed class MockRegistrationTests
 			          				}
 			          			}
 			          
-			          			if (constructorParameters is null && mockBehavior.TryGetConstructorParameters<T>(out object?[]? parameters))
+			          			if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<T>(out object?[]? parameters))
 			          			{
 			          				constructorParameters = new BaseClass.ConstructorParameters(parameters);
 			          			}


### PR DESCRIPTION
This pull request introduces `IMockBehaviorAccess` as a new interface to simplify the public API surface of `MockBehavior`. The refactoring moves `TryInitialize` and `TryGetConstructorParameters` methods from being public methods on `MockBehavior` to explicit interface implementations on the new `IMockBehaviorAccess` interface.

### Key Changes:
- Introduced `IMockBehaviorAccess` interface with `TryInitialize` and `TryGetConstructorParameters` methods
- Made `MockBehavior` implement `IMockBehaviorAccess` with explicit interface implementation
- Updated generated code to cast `MockBehavior` to `IMockBehaviorAccess` before accessing these methods