### PR TITLE
fix: do not check type of `HttpContent`

### DIFF
--- a/Source/Mockolate/Web/ItExtensions.HttpContent.IsBinaryContent.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.IsBinaryContent.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net.Http;
 #if !NET8_0_OR_GREATER
 using System.Linq;
@@ -77,7 +78,14 @@ public static partial class ItExtensions
 
 			if (_body is not null)
 			{
-				byte[] content = value.ReadAsByteArrayAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+#if NET8_0_OR_GREATER
+				Stream stream = value.ReadAsStream();
+#else
+				Stream stream = value.ReadAsStreamAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+#endif
+				using MemoryStream ms = new();
+				stream.CopyTo(ms);
+				byte[] content = ms.ToArray();
 				switch (_bodyMatchType)
 				{
 					case BodyMatchType.Exact when

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.IsStringContent.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.IsStringContent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using Mockolate.Internals;
@@ -120,14 +121,15 @@ public static partial class ItExtensions
 				return false;
 			}
 
-			if (value is not StringContent)
-			{
-				return false;
-			}
-
 			if (_body is not null)
 			{
-				string content = value.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+#if NET8_0_OR_GREATER
+				Stream stream = value.ReadAsStream();
+#else
+				Stream stream = value.ReadAsStreamAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+#endif
+				using StreamReader reader = new(stream);
+				string content = reader.ReadToEnd();
 				switch (_bodyMatchType)
 				{
 					case BodyMatchType.Exact when

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsStringContentTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsStringContentTests.cs
@@ -14,6 +14,22 @@ public sealed partial class ItExtensionsTests
 {
 	public sealed class IsStringContentTests
 	{
+		[Fact]
+		public async Task ShouldNotCheckHttpContentType()
+		{
+			string expectedValue = "foo";
+			byte[] bytes = Encoding.UTF8.GetBytes(expectedValue);
+			HttpClient httpClient = Mock.Create<HttpClient>();
+			httpClient.SetupMock.Method
+				.PostAsync(It.IsAny<Uri>(), It.IsStringContent().WithBody("foo"))
+				.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+			HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				new ByteArrayContent(bytes),
+				CancellationToken.None);
+
+			await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
+		}
 #if !NETFRAMEWORK
 		[Fact]
 		public async Task ShouldSupportMonitoring()

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.UriTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.UriTests.cs
@@ -121,6 +121,20 @@ public sealed partial class ItExtensionsTests
 		}
 
 		[Theory]
+		[InlineData("https://www.aweXpect.com")]
+		[InlineData(443)]
+		[InlineData(null)]
+		public async Task WhenTypeDoesNotMatch_ShouldReturnFalse(object? value)
+		{
+			ItExtensions.IUriParameter sut = It.IsUri();
+			IParameter parameter = (IParameter)sut;
+
+			bool result = parameter.Matches(value);
+
+			await That(result).IsFalse();
+		}
+
+		[Theory]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "www.awexpect.com", true)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "*awexpect*", true)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "*aweXpect*", true)]


### PR DESCRIPTION
This pull request fixes an issue where `HttpContent` parameter matching was overly strict by removing type checking for `HttpContent` instances. The change allows matching based on content rather than concrete type.

### Key Changes:
- Removed `StringContent` type check in `IsStringContent` matcher
- Replaced direct content reading methods with stream-based reading to support any `HttpContent` type
- Added test coverage for non-matching types and type-agnostic content matching