### PR TITLE
fix: consider `ClearAllInteractions` in running monitor

### DIFF
--- a/Source/Mockolate/Interactions/MockInteractions.cs
+++ b/Source/Mockolate/Interactions/MockInteractions.cs
@@ -62,8 +62,8 @@ public class MockInteractions : IMockInteractions
 
 	internal void Clear()
 	{
-		OnClearing?.Invoke(this, EventArgs.Empty);
 		_interactions.Clear();
+		OnClearing?.Invoke(this, EventArgs.Empty);
 		_index = -1;
 	}
 }

--- a/Source/Mockolate/Monitor/MockMonitor.cs
+++ b/Source/Mockolate/Monitor/MockMonitor.cs
@@ -50,10 +50,10 @@ public abstract class MockMonitor
 
 		_monitoringStart = _monitoredInvocations.Count;
 		_monitoredInvocations.OnClearing += OnClearing;
-		return new MonitorScope(() => Stop());
+		return new MonitorScope(Stop);
 	}
 
-	internal void Stop()
+	private void Stop()
 	{
 		if (_monitoringStart >= 0)
 		{
@@ -69,8 +69,8 @@ public abstract class MockMonitor
 
 	private void OnClearing(object? sender, EventArgs e)
 	{
-		UpdateInteractions();
 		_monitoringStart = 0;
+		UpdateInteractions();
 	}
 
 	/// <summary>

--- a/Tests/Mockolate.Tests/MockExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/MockExtensionsTests.cs
@@ -8,7 +8,34 @@ public sealed class MockExtensionsTests
 	public sealed class ClearAllInteractionsTests
 	{
 		[Fact]
-		public async Task Monitor_ShouldWorkAcrossClearAllInteractions()
+		public async Task Monitor_WhenRunning_ShouldClearAllInteractions()
+		{
+			IChocolateDispenser mock = Mock.Create<IChocolateDispenser>();
+
+			mock.Dispense("Dark", 1);
+			MockMonitor<IChocolateDispenser> monitor;
+			using (_ = mock.MonitorMock(out monitor))
+			{
+				mock.Dispense("Light", 2);
+				mock.Dispense("Dark", 3);
+				mock.SetupMock.ClearAllInteractions();
+			}
+
+			mock.Dispense("Light", 4);
+
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(1))).Never();
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Light"), It.Is(2))).Never();
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(3))).Never();
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Light"), It.Is(4))).Once();
+
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Dark"), It.Is(1))).Never();
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Light"), It.Is(2))).Never();
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Dark"), It.Is(3))).Never();
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Light"), It.Is(4))).Never();
+		}
+
+		[Fact]
+		public async Task Monitor_WhenRunning_ShouldContinueAfterClearAllInteractions()
 		{
 			IChocolateDispenser mock = Mock.Create<IChocolateDispenser>();
 
@@ -26,6 +53,33 @@ public sealed class MockExtensionsTests
 			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(1))).Never();
 			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Light"), It.Is(2))).Never();
 			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(3))).Once();
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Light"), It.Is(4))).Once();
+
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Dark"), It.Is(1))).Never();
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Light"), It.Is(2))).Never();
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Dark"), It.Is(3))).Once();
+			await That(monitor.Verify.Invoked.Dispense(It.Is("Light"), It.Is(4))).Never();
+		}
+
+		[Fact]
+		public async Task Monitor_WhenStopped_ShouldIgnoreClearAllInteractions()
+		{
+			IChocolateDispenser mock = Mock.Create<IChocolateDispenser>();
+
+			mock.Dispense("Dark", 1);
+			MockMonitor<IChocolateDispenser> monitor;
+			using (_ = mock.MonitorMock(out monitor))
+			{
+				mock.Dispense("Light", 2);
+				mock.Dispense("Dark", 3);
+			}
+
+			mock.SetupMock.ClearAllInteractions();
+			mock.Dispense("Light", 4);
+
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(1))).Never();
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Light"), It.Is(2))).Never();
+			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(3))).Never();
 			await That(mock.VerifyMock.Invoked.Dispense(It.Is("Light"), It.Is(4))).Once();
 
 			await That(monitor.Verify.Invoked.Dispense(It.Is("Dark"), It.Is(1))).Never();


### PR DESCRIPTION
This PR fixes a bug where `ClearAllInteractions` was not properly handled when called during an active monitoring session. The fix ensures that the monitor correctly updates its state when interactions are cleared, maintaining accurate tracking of monitored invocations.

### Key Changes:
- Modified the event handler order in `MockInteractions.Clear()` to invoke `OnClearing` after clearing interactions
- Updated `MockMonitor.OnClearing` to reset `_monitoringStart` before calling `UpdateInteractions`
- Changed `Stop()` from `internal` to `private` visibility
- Added comprehensive test coverage for various `ClearAllInteractions` scenarios during monitoring