### PR TITLE
refactor: re-order `ReturnsThrowsAsyncExtensions`

### DIFF
--- a/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
+++ b/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
@@ -110,6 +110,111 @@ public static class ReturnsThrowsAsyncExtensions
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup, Func<T1, T2, T3, T4, TReturn> callback)
 		=> setup.Returns((v1, v2, v3, v4) => Task.FromResult(callback(v1, v2, v3, v4)));
 
+#if NET8_0_OR_GREATER
+#pragma warning disable CA2012 // Use ValueTasks correctly
+	/// <summary>
+	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
+		this IReturnMethodSetup<ValueTask<TReturn>> setup, TReturn returnValue)
+		=> setup.Returns(ValueTask.FromResult(returnValue));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
+		this IReturnMethodSetup<ValueTask<TReturn>> setup, Func<TReturn> callback)
+		=> setup.Returns(() => ValueTask.FromResult(callback()));
+
+	/// <summary>
+	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, TReturn returnValue)
+		=> setup.Returns(ValueTask.FromResult(returnValue));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, Func<TReturn> callback)
+		=> setup.Returns(() => ValueTask.FromResult(callback()));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, Func<T1, TReturn> callback)
+		=> setup.Returns(v1 => ValueTask.FromResult(callback(v1)));
+
+	/// <summary>
+	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, TReturn returnValue)
+		=> setup.Returns(ValueTask.FromResult(returnValue));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, Func<TReturn> callback)
+		=> setup.Returns(() => ValueTask.FromResult(callback()));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, Func<T1, T2, TReturn> callback)
+		=> setup.Returns((v1, v2) => ValueTask.FromResult(callback(v1, v2)));
+
+	/// <summary>
+	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, TReturn returnValue)
+		=> setup.Returns(ValueTask.FromResult(returnValue));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, Func<TReturn> callback)
+		=> setup.Returns(() => ValueTask.FromResult(callback()));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, Func<T1, T2, T3, TReturn> callback)
+		=> setup.Returns((v1, v2, v3) => ValueTask.FromResult(callback(v1, v2, v3)));
+
+	/// <summary>
+	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
+		T4>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, TReturn returnValue)
+		=> setup.Returns(ValueTask.FromResult(returnValue));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
+		T4>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<TReturn> callback)
+		=> setup.Returns(() => ValueTask.FromResult(callback()));
+
+	/// <summary>
+	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	/// </summary>
+	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
+		T4>(
+		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<T1, T2, T3, T4, TReturn> callback)
+		=> setup.Returns((v1, v2, v3, v4) => ValueTask.FromResult(callback(v1, v2, v3, v4)));
+#pragma warning restore CA2012 // Use ValueTasks correctly
+#endif
+
 	/// <summary>
 	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
 	/// </summary>
@@ -233,107 +338,6 @@ public static class ReturnsThrowsAsyncExtensions
 
 #if NET8_0_OR_GREATER
 #pragma warning disable CA2012 // Use ValueTasks correctly
-	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
-		this IReturnMethodSetup<ValueTask<TReturn>> setup, TReturn returnValue)
-		=> setup.Returns(ValueTask.FromResult(returnValue));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
-		this IReturnMethodSetup<ValueTask<TReturn>> setup, Func<TReturn> callback)
-		=> setup.Returns(() => ValueTask.FromResult(callback()));
-
-	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, TReturn returnValue)
-		=> setup.Returns(ValueTask.FromResult(returnValue));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, Func<TReturn> callback)
-		=> setup.Returns(() => ValueTask.FromResult(callback()));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, Func<T1, TReturn> callback)
-		=> setup.Returns(v1 => ValueTask.FromResult(callback(v1)));
-
-	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, TReturn returnValue)
-		=> setup.Returns(ValueTask.FromResult(returnValue));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, Func<TReturn> callback)
-		=> setup.Returns(() => ValueTask.FromResult(callback()));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, Func<T1, T2, TReturn> callback)
-		=> setup.Returns((v1, v2) => ValueTask.FromResult(callback(v1, v2)));
-
-	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, TReturn returnValue)
-		=> setup.Returns(ValueTask.FromResult(returnValue));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, Func<TReturn> callback)
-		=> setup.Returns(() => ValueTask.FromResult(callback()));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, Func<T1, T2, T3, TReturn> callback)
-		=> setup.Returns((v1, v2, v3) => ValueTask.FromResult(callback(v1, v2, v3)));
-
-	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
-		T4>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, TReturn returnValue)
-		=> setup.Returns(ValueTask.FromResult(returnValue));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
-		T4>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<TReturn> callback)
-		=> setup.Returns(() => ValueTask.FromResult(callback()));
-
-	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
-	/// </summary>
-	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
-		T4>(
-		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<T1, T2, T3, T4, TReturn> callback)
-		=> setup.Returns((v1, v2, v3, v4) => ValueTask.FromResult(callback(v1, v2, v3, v4)));
-
 	/// <summary>
 	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
 	/// </summary>


### PR DESCRIPTION
This PR refactors the `ReturnsThrowsAsyncExtensions` class by reordering method overloads to comply with SonarQube rule [S4136](https://sonarsource.atlassian.net/browse/RSPEC-4136), which requires method overloads to be grouped together. The change moves all `ValueTask<T>` overloads of `ReturnsAsync` methods to appear immediately after the `Task<T>` overloads, before the `ThrowsAsync` methods.

### Key Changes:
- Relocated `ValueTask<T>` overloads of `ReturnsAsync` methods from after `ThrowsAsync` methods to immediately after `Task<T>` overloads