### PR TITLE
refactor: wildcards support multiline strings

### DIFF
--- a/Source/Mockolate/Internals/Wildcard.cs
+++ b/Source/Mockolate/Internals/Wildcard.cs
@@ -17,8 +17,8 @@ internal readonly struct Wildcard
 				new Regex(
 					item.RegexPattern,
 					item.IgnoreCase
-						? RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled
-						: RegexOptions.Multiline | RegexOptions.Compiled,
+						? RegexOptions.IgnoreCase | RegexOptions.Compiled
+						: RegexOptions.Compiled,
 					Regex.InfiniteMatchTimeout)));
 		return wildcard;
 	}

--- a/Tests/Mockolate.Internal.Tests/WildcardTests.cs
+++ b/Tests/Mockolate.Internal.Tests/WildcardTests.cs
@@ -1,0 +1,19 @@
+using Mockolate.Internals;
+
+namespace Mockolate.Internal.Tests;
+
+public class WildcardTests
+{
+	[Theory]
+	[InlineData("\r\n")]
+	[InlineData("\r")]
+	[InlineData("\n")]
+	public async Task ShouldSupportMultilineStrings(string newlineSeparator)
+	{
+		Wildcard wildcard = Wildcard.Pattern("fo*az", false);
+
+		bool result = wildcard.Matches($"foo{newlineSeparator}bar{newlineSeparator}baz");
+
+		await That(result).IsTrue();
+	}
+}


### PR DESCRIPTION
This PR fixes wildcard pattern matching to correctly support multiline strings by removing the redundant `RegexOptions.Multiline` flag.

### Key Changes:
- Removed `RegexOptions.Multiline` from wildcard regex compilation
- Added test case to verify wildcard pattern matching works correctly with strings containing line breaks