### PR TITLE
fix: clear collections of validated running monitors

### DIFF
--- a/Source/Mockolate/Monitor/MockMonitor.cs
+++ b/Source/Mockolate/Monitor/MockMonitor.cs
@@ -70,7 +70,7 @@ public abstract class MockMonitor
 	private void OnClearing(object? sender, EventArgs e)
 	{
 		_monitoringStart = 0;
-		UpdateInteractions();
+		Interactions.Clear();
 	}
 
 	/// <summary>

--- a/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
@@ -6,6 +6,21 @@ namespace Mockolate.Tests.Monitor;
 public sealed class MockMonitorTests
 {
 	[Fact]
+	public async Task ClearAllInteractions_WhenMonitorIsRunning_ShouldClearInternalCollection()
+	{
+		IMyService sut = Mock.Create<IMyService>();
+		Mock<IMyService> mock = ((IMockSubject<IMyService>)sut).Mock;
+		MockMonitor<IMyService> monitor = new(mock);
+
+		sut.IsValid(1);
+		using IDisposable disposable = monitor.Run();
+		sut.IsValid(1);
+		await That(monitor.Verify.Invoked.IsValid(It.Is(1))).Once();
+		sut.SetupMock.ClearAllInteractions();
+		await That(monitor.Verify.Invoked.IsValid(It.Is(1))).Never();
+	}
+
+	[Fact]
 	public async Task DisposeTwice_ShouldNotIncludeMoreInvocations()
 	{
 		IMyService sut = Mock.Create<IMyService>();


### PR DESCRIPTION
This PR fixes an issue where clearing interactions on a running monitor would not properly clear the monitor's internal collection. The fix changes `OnClearing` to directly clear the `Interactions` collection instead of calling `UpdateInteractions()`.

### Key Changes:
- Modified `OnClearing` method to directly clear the `Interactions` collection
- Added test coverage for clearing interactions on a running monitor