### PR TITLE
coverage: Add missing test case for `TypeFormatter`

### DIFF
--- a/Source/Mockolate/Internals/TypeFormatter.cs
+++ b/Source/Mockolate/Internals/TypeFormatter.cs
@@ -86,7 +86,8 @@ internal static class TypeFormatter
 		}
 		else if (!AppendedPrimitiveAlias(value, stringBuilder))
 		{
-			if (value.IsNested && value.DeclaringType is not null)
+			// Handle nested types
+			if (value.DeclaringType is not null)
 			{
 				FormatType(value.DeclaringType, stringBuilder);
 				stringBuilder.Append('.');

--- a/Tests/Mockolate.Internal.Tests/TypeFormatterTests.cs
+++ b/Tests/Mockolate.Internal.Tests/TypeFormatterTests.cs
@@ -27,6 +27,17 @@ public sealed class TypeFormatterTests
 		await That(result).IsEqualTo("TypeFormatterTests.MyType");
 	}
 
+	[Fact]
+	public async Task ShouldFormatVoid()
+	{
+		MethodInfo methodInfo = GetType().GetMethod(nameof(MyMethod), BindingFlags.NonPublic | BindingFlags.Static)!;
+		Type type = methodInfo.ReturnType;
+
+		string result = type.FormatType();
+
+		await That(result).IsEqualTo("void");
+	}
+
 	private class MyType;
 
 	// ReSharper disable once UnusedTypeParameter


### PR DESCRIPTION
This PR adds a missing test case for the `TypeFormatter` class to verify proper formatting of the `void` type, improving test coverage for this internal utility.

### Key Changes:
- Added a new test method `ShouldFormatVoid()` to verify that the `TypeFormatter` correctly formats void return types
- Simplified the nested type check in `TypeFormatter.cs` by removing the redundant `value.IsNested` condition