### PR TITLE
refactor: simplify `PropertySetup`

### DIFF
--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -194,7 +194,6 @@ public class PropertySetup<T>(string name) : PropertySetup,
 			}
 		}
 
-		bool foundCallback = false;
 		foreach (Callback<Func<int, T, T>> _ in _returnCallbacks)
 		{
 			Callback<Func<int, T, T>> returnCallback =
@@ -202,14 +201,13 @@ public class PropertySetup<T>(string name) : PropertySetup,
 			if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
 				    => @delegate(invocationCount, _value), out T? newValue))
 			{
-				foundCallback = true;
 				_value = newValue;
 				_isInitialized = true;
 				break;
 			}
 		}
 
-		if (!foundCallback && _returnCallbacks.Count > 0 && !_isInitialized)
+		if (!_isInitialized)
 		{
 			_value = defaultValueGenerator() is T value ? value : default!;
 			_isInitialized = true;
@@ -261,10 +259,6 @@ public class PropertySetup<T>(string name) : PropertySetup,
 		if (value is T typedValue)
 		{
 			_value = typedValue;
-		}
-		else
-		{
-			_value = default!;
 		}
 	}
 


### PR DESCRIPTION
This PR simplifies the `PropertySetup` class by removing redundant logic and improving test coverage for callback handling.

### Key Changes:
- Removed unnecessary `foundCallback` tracking variable in `InvokeGetter`
- Simplified conditional logic for value initialization
- Added tests for `MethodSetupResult.TriggerCallbacks` with null parameters
- Improved test coverage for parameter callback invocation scenarios