### PR TITLE
coverage: add missing tests for `Callback`

### DIFF
--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -195,7 +195,6 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 				_invocationCount++;
 				_matchingCount++;
 				returnValue = callback(_invocationCount - 1, @delegate)!;
-
 				return true;
 			}
 

--- a/Tests/Mockolate.Internal.Tests/CallbackTests.cs
+++ b/Tests/Mockolate.Internal.Tests/CallbackTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Mockolate.Setup;
+
+namespace Mockolate.Internal.Tests;
+
+public class CallbackTests
+{
+	[Fact]
+	public async Task Invoke_ShouldIncludeIndexWhenMatching()
+	{
+		List<int> values = [];
+		Callback<Action> sut = new(() => { });
+		sut.For(2);
+		sut.When(v => v > 1);
+
+		int index = 0;
+		for (int i = 0; i < 5; i++)
+		{
+			sut.Invoke(ref index, (v, _) => values.Add(v));
+		}
+
+		await That(values).IsEqualTo([2, 3,]);
+	}
+
+	[Theory]
+	[InlineData(1, false)]
+	[InlineData(2, false)]
+	[InlineData(3, true)]
+	[InlineData(4, true)]
+	[InlineData(5, false)]
+	public async Task Invoke_WithForAndWhen_ShouldMatchInExpectedIterations(int invocationCount, bool expectResult)
+	{
+		Callback<Action> sut = new(() => { });
+		sut.For(2);
+		sut.When(v => v > 1);
+
+		int index = 0;
+		bool result = false;
+		for (int iteration = 1; iteration <= invocationCount; iteration++)
+		{
+			result = sut.Invoke(ref index, (_, _) => { });
+		}
+
+		await That(result).IsEqualTo(expectResult);
+	}
+
+	[Fact]
+	public async Task Invoke_WithReturnValue_ShouldIncludeIndexWhenMatching()
+	{
+		List<int> values = [];
+		Callback<Action> sut = new(() => { });
+		sut.For(2);
+		sut.When(v => v > 1);
+
+		int index = 0;
+		for (int i = 0; i < 5; i++)
+		{
+			sut.Invoke<string>(ref index, (v, _) =>
+			{
+				values.Add(v);
+				return $"foo-{v}";
+			}, out string? _);
+		}
+
+		await That(values).IsEqualTo([2, 3,]);
+	}
+
+	[Theory]
+	[InlineData(1, false)]
+	[InlineData(2, false)]
+	[InlineData(3, true)]
+	[InlineData(4, true)]
+	[InlineData(5, false)]
+	public async Task Invoke_WithReturnValue_WithForAndWhen_ShouldMatchInExpectedIterations(int invocationCount,
+		bool expectResult)
+	{
+		Callback<Action> sut = new(() => { });
+		sut.For(2);
+		sut.When(v => v > 1);
+
+		int index = 0;
+		bool result = false;
+		for (int iteration = 1; iteration <= invocationCount; iteration++)
+		{
+			result = sut.Invoke(ref index, (_, _) => "foo", out string? _);
+		}
+
+		await That(result).IsEqualTo(expectResult);
+	}
+}

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallbackTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallbackTests.cs
@@ -40,6 +40,44 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
+			public async Task For_InParallel_ShouldLimitMatches()
+			{
+				List<int> callIndices = [];
+				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
+
+				sut.SetupMock.Method.Method0()
+					.Do(v => { callIndices.Add(v); }).InParallel().When(v => v > 1).For(2)
+					.Returns("a");
+
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+
+				await That(callIndices).IsEqualTo([2, 3,]);
+			}
+
+			[Fact]
+			public async Task For_ShouldLimitMatches()
+			{
+				List<int> callIndices = [];
+				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
+
+				sut.SetupMock.Method.Method0()
+					.Do(v => { callIndices.Add(v); }).When(v => v > 1).For(2)
+					.Returns("a");
+
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+
+				await That(callIndices).IsEqualTo([2, 3,]);
+			}
+
+			[Fact]
 			public async Task For_ShouldStopExecutingCallbackAfterTheGivenTimes()
 			{
 				List<int> invocations = [];
@@ -1896,6 +1934,42 @@ public sealed partial class SetupMethodTests
 				sut.Method0(false);
 
 				await That(callCount).IsEqualTo(0);
+			}
+
+			[Fact]
+			public async Task For_InParallel_ShouldLimitMatches()
+			{
+				List<int> callIndices = [];
+				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
+
+				sut.SetupMock.Method.Method0()
+					.Do(v => { callIndices.Add(v); }).InParallel().When(v => v > 1).For(2);
+
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+
+				await That(callIndices).IsEqualTo([2, 3,]);
+			}
+
+			[Fact]
+			public async Task For_ShouldLimitMatches()
+			{
+				List<int> callIndices = [];
+				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
+
+				sut.SetupMock.Method.Method0()
+					.Do(v => { callIndices.Add(v); }).When(v => v > 1).For(2);
+
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+				sut.Method0();
+
+				await That(callIndices).IsEqualTo([2, 3,]);
 			}
 
 			[Fact]

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.ReturnsThrowsTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.ReturnsThrowsTests.cs
@@ -27,6 +27,24 @@ public sealed partial class SetupMethodTests
 			}
 
 			[Fact]
+			public async Task For_ShouldLimitMatches()
+			{
+				List<string> results = [];
+				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
+
+				sut.SetupMock.Method.Method0()
+					.Returns("a").When(v => v > 1).For(2);
+
+				results.Add(sut.Method0());
+				results.Add(sut.Method0());
+				results.Add(sut.Method0());
+				results.Add(sut.Method0());
+				results.Add(sut.Method0());
+
+				await That(results).IsEqualTo(["", "", "a", "a", "",]);
+			}
+
+			[Fact]
 			public async Task MixReturnsAndThrows_ShouldIterateThroughBoth()
 			{
 				IReturnMethodSetupTest sut = Mock.Create<IReturnMethodSetupTest>();
@@ -2054,6 +2072,31 @@ public sealed partial class SetupMethodTests
 
 				await That(Act).Throws<ArgumentOutOfRangeException>()
 					.WithMessage("Times must be greater than zero.").AsPrefix();
+			}
+
+			[Fact]
+			public async Task For_ShouldLimitMatches()
+			{
+				List<string> results = [];
+				IVoidMethodSetupTest sut = Mock.Create<IVoidMethodSetupTest>();
+
+				sut.SetupMock.Method.Method0()
+					.Throws(new Exception("a")).When(v => v > 1).For(2);
+
+				for (int i = 0; i < 5; i++)
+				{
+					try
+					{
+						sut.Method0();
+						results.Add("");
+					}
+					catch (Exception ex)
+					{
+						results.Add(ex.Message);
+					}
+				}
+
+				await That(results).IsEqualTo(["", "", "a", "a", "",]);
 			}
 
 			[Fact]


### PR DESCRIPTION
This PR adds test coverage for the `Callback` class's `For` and `When` methods, particularly testing how they work together to limit the number of matching invocations. The changes include tests for both void and return methods, with and without `InParallel`, and new low-level unit tests for the `Callback` class itself.

### Key Changes:
- Added tests for `For` method behavior when combined with `When` conditions in return method setups
- Added tests for `For` method behavior when combined with `When` conditions in void method setups and callbacks
- Created a new test file with direct unit tests for the `Callback` class