### PR TITLE
refactor: simplify `InvokeGetter` in `PropertySetup`

### DIFF
--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -207,12 +207,6 @@ public class PropertySetup<T>(string name) : PropertySetup,
 			}
 		}
 
-		if (!_isInitialized)
-		{
-			_value = defaultValueGenerator() is T value ? value : default!;
-			_isInitialized = true;
-		}
-
 		if (!TryCast(_value, out TResult result))
 		{
 			throw new MockException(

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
@@ -6,17 +6,6 @@ namespace Mockolate.Tests.MockProperties;
 public sealed partial class SetupPropertyTests
 {
 	[Fact]
-	public async Task InitializeValue_NotMatchingTypes_ShouldUseDefault()
-	{
-		MyPropertySetup<int> setup = new();
-
-		setup.MyInitializeValue("f");
-
-		int result = setup.InvokeGetter<int>();
-		await That(result).IsEqualTo(0);
-	}
-
-	[Fact]
 	public async Task InvokeGetter_InvalidType_ShouldThrowMockException()
 	{
 		MyPropertySetup<int> setup = new();


### PR DESCRIPTION
The PR simplifies the `InvokeGetter` method in `PropertySetup` by removing redundant initialization logic that was previously handling type mismatches. The code now relies solely on the initialization that occurs in the `if (factory is not null)` block above.

### Key Changes:
- Removed fallback initialization logic from `InvokeGetter` that attempted to use `defaultValueGenerator` when `_isInitialized` was false
- Removed corresponding test `InitializeValue_NotMatchingTypes_ShouldUseDefault` that validated the removed behavior