### PR TITLE
chore: bump Microsoft.CodeAnalysis.CSharp.*.Testing to v1.1.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,8 @@
 		<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2"/>
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3"/>
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.3"/>
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
This PR updates Microsoft.CodeAnalysis.CSharp testing packages to version 1.1.3 for consistency across the codebase.

### Changes:
- Bumped `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing` from 1.1.2 to 1.1.3
- Bumped `Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing` from 1.1.2 to 1.1.3