### PR TITLE
fix: persist indexer values when return setup is conditional

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -774,11 +774,6 @@ internal static partial class Sources
 		sb.Append("\t\t\t=> _skipBaseClass;").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IndexerSetup.HasReturnCalls()\" />").AppendLine();
-		sb.Append("\t\tprotected override bool HasReturnCalls()").AppendLine();
-		sb.Append("\t\t\t=> _returnCallbacks.Count > 0;").AppendLine();
-		sb.AppendLine();
-
 		sb.Append(
 				"\t\t/// <inheritdoc cref=\"ExecuteSetterCallback{TValue}(IndexerSetterAccess, TValue, MockBehavior)\" />")
 			.AppendLine();

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -12,10 +12,6 @@ namespace Mockolate.Setup;
 /// </summary>
 public abstract class IndexerSetup : IInteractiveIndexerSetup
 {
-	/// <inheritdoc cref="IInteractiveIndexerSetup.HasReturnCalls()" />
-	bool IInteractiveIndexerSetup.HasReturnCalls()
-		=> HasReturnCalls();
-
 	/// <inheritdoc cref="IInteractiveIndexerSetup.Matches(IndexerAccess)" />
 	bool IInteractiveIndexerSetup.Matches(IndexerAccess indexerAccess)
 		=> IsMatch(indexerAccess.Parameters);
@@ -110,11 +106,6 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 	///     Gets the flag indicating if the base class implementation should be skipped.
 	/// </summary>
 	protected abstract bool? GetSkipBaseClass();
-
-	/// <summary>
-	///     Gets a value indicating whether this setup has return calls configured.
-	/// </summary>
-	protected abstract bool HasReturnCalls();
 
 	/// <summary>
 	///     Attempts to retrieve the initial <paramref name="value" /> for the <paramref name="parameters" />, if an
@@ -389,10 +380,6 @@ public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
 	/// <inheritdoc cref="IndexerSetup.GetSkipBaseClass()" />
 	protected override bool? GetSkipBaseClass()
 		=> _skipBaseClass;
-
-	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
-	protected override bool HasReturnCalls()
-		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="ExecuteGetterCallback{TValue}(IndexerGetterAccess, TValue, MockBehavior)" />
 	protected override T ExecuteGetterCallback<T>(IndexerGetterAccess indexerGetterAccess, T value,
@@ -745,10 +732,6 @@ public class IndexerSetup<TValue, T1, T2>(NamedParameter match1, NamedParameter 
 	/// <inheritdoc cref="IndexerSetup.GetSkipBaseClass()" />
 	protected override bool? GetSkipBaseClass()
 		=> _skipBaseClass;
-
-	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
-	protected override bool HasReturnCalls()
-		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="ExecuteGetterCallback{TValue}(IndexerGetterAccess, TValue, MockBehavior)" />
 	protected override T ExecuteGetterCallback<T>(IndexerGetterAccess indexerGetterAccess, T value,
@@ -1116,10 +1099,6 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	/// <inheritdoc cref="IndexerSetup.GetSkipBaseClass()" />
 	protected override bool? GetSkipBaseClass()
 		=> _skipBaseClass;
-
-	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
-	protected override bool HasReturnCalls()
-		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="ExecuteGetterCallback{TValue}(IndexerGetterAccess, TValue, MockBehavior)" />
 	protected override T ExecuteGetterCallback<T>(IndexerGetterAccess indexerGetterAccess, T value,
@@ -1502,10 +1481,6 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	/// <inheritdoc cref="IndexerSetup.GetSkipBaseClass()" />
 	protected override bool? GetSkipBaseClass()
 		=> _skipBaseClass;
-
-	/// <inheritdoc cref="IndexerSetup.HasReturnCalls()" />
-	protected override bool HasReturnCalls()
-		=> _returnCallbacks.Count > 0;
 
 	/// <inheritdoc cref="ExecuteGetterCallback{TValue}(IndexerGetterAccess, TValue, MockBehavior)" />
 	protected override T ExecuteGetterCallback<T>(IndexerGetterAccess indexerGetterAccess, T value,

--- a/Source/Mockolate/Setup/IndexerSetupResult.cs
+++ b/Source/Mockolate/Setup/IndexerSetupResult.cs
@@ -59,14 +59,16 @@ public class IndexerSetupResult<TResult>(
 		TResult value;
 		if (_setup is IndexerSetup indexerSetup)
 		{
-			_setup.GetInitialValue(_behavior, defaultValueGenerator, indexerAccess.Parameters, out value);
+			value = getIndexerValue(_setup,
+				() =>
+				{
+					_setup.GetInitialValue(_behavior, defaultValueGenerator, indexerAccess.Parameters,
+						out var v);
+					return v;
+				}, indexerAccess.Parameters);
 			value = indexerSetup.InvokeGetter(indexerAccess, value, _behavior);
-
-			if (_setup.HasReturnCalls())
-			{
-				setIndexerValue(indexerAccess.Parameters, value);
-				return value;
-			}
+			setIndexerValue(indexerAccess.Parameters, value);
+			return value;
 		}
 		else if (_behavior.ThrowWhenNotSetup)
 		{

--- a/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
@@ -16,11 +16,6 @@ public interface IInteractiveIndexerSetup : ISetup
 	bool? SkipBaseClass();
 
 	/// <summary>
-	///     Gets a value indicating whether this setup has return calls configured.
-	/// </summary>
-	bool HasReturnCalls();
-
-	/// <summary>
 	///     Checks if the <paramref name="indexerAccess" /> matches the setup.
 	/// </summary>
 	bool Matches(IndexerAccess indexerAccess);

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -858,7 +858,6 @@ namespace Mockolate.Setup
     public interface IInteractiveIndexerSetup : Mockolate.Setup.ISetup
     {
         void GetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
-        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
         bool? SkipBaseClass();
     }
@@ -1286,7 +1285,6 @@ namespace Mockolate.Setup
         protected abstract void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value);
         protected abstract bool? GetSkipBaseClass();
-        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters);
         protected static bool Matches(Mockolate.Parameters.NamedParameter[] namedParameters, Mockolate.Parameters.NamedParameterValue[] values) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
@@ -1311,7 +1309,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1336,7 +1333,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1361,7 +1357,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1386,7 +1381,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -857,7 +857,6 @@ namespace Mockolate.Setup
     public interface IInteractiveIndexerSetup : Mockolate.Setup.ISetup
     {
         void GetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
-        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
         bool? SkipBaseClass();
     }
@@ -1285,7 +1284,6 @@ namespace Mockolate.Setup
         protected abstract void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value);
         protected abstract bool? GetSkipBaseClass();
-        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters);
         protected static bool Matches(Mockolate.Parameters.NamedParameter[] namedParameters, Mockolate.Parameters.NamedParameterValue[] values) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
@@ -1310,7 +1308,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1335,7 +1332,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1360,7 +1356,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1385,7 +1380,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -820,7 +820,6 @@ namespace Mockolate.Setup
     public interface IInteractiveIndexerSetup : Mockolate.Setup.ISetup
     {
         void GetInitialValue<TValue>(Mockolate.MockBehavior behavior, System.Func<TValue> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue value);
-        bool HasReturnCalls();
         bool Matches(Mockolate.Interactions.IndexerAccess indexerAccess);
         bool? SkipBaseClass();
     }
@@ -1248,7 +1247,6 @@ namespace Mockolate.Setup
         protected abstract void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior);
         protected abstract void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value);
         protected abstract bool? GetSkipBaseClass();
-        protected abstract bool HasReturnCalls();
         protected abstract bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters);
         protected static bool Matches(Mockolate.Parameters.NamedParameter[] namedParameters, Mockolate.Parameters.NamedParameterValue[] values) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
@@ -1273,7 +1271,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1298,7 +1295,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1323,7 +1319,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }
@@ -1348,7 +1343,6 @@ namespace Mockolate.Setup
         protected override void ExecuteSetterCallback<T>(Mockolate.Interactions.IndexerSetterAccess indexerSetterAccess, T value, Mockolate.MockBehavior behavior) { }
         protected override void GetInitialValue<T>(Mockolate.MockBehavior behavior, System.Func<T> defaultValueGenerator, Mockolate.Parameters.NamedParameterValue[] parameters, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T value) { }
         protected override bool? GetSkipBaseClass() { }
-        protected override bool HasReturnCalls() { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value) { }
         protected override bool IsMatch(Mockolate.Parameters.NamedParameterValue[] parameters) { }

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.ReturnsThrowsTests.cs
@@ -7,326 +7,353 @@ public sealed partial class SetupIndexerTests
 {
 	public sealed class ReturnsThrowsTests
 	{
-		[Fact]
-		public async Task IndexerReturns_WithSpecificParameter_ShouldIterateThroughValues()
+		public sealed class With1Level
 		{
-			IIndexerService mock = Mock.Create<IIndexerService>();
-			mock.SetupMock.Indexer(It.Is(1))
-				.Returns("a")
-				.Returns("b");
-
-			string result11 = mock[1];
-			string result2 = mock[2];
-			string result12 = mock[1];
-			string result13 = mock[1];
-			string result14 = mock[1];
-			string result15 = mock[1];
-
-			await That(result11).IsEqualTo("a");
-			await That(result2).IsEqualTo("");
-			await That(result12).IsEqualTo("b");
-			await That(result13).IsEqualTo("a");
-			await That(result14).IsEqualTo("b");
-			await That(result15).IsEqualTo("a");
-		}
-
-		[Fact]
-		public async Task MixReturnsAndThrows_ShouldIterateThroughBoth()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns("a")
-				.Throws(new Exception("foo"))
-				.Returns(() => "b");
-
-			string result1 = sut[1];
-			Exception? result2 = Record.Exception(() => _ = sut[2]);
-			string result3 = sut[3];
-
-			await That(result1).IsEqualTo("a");
-			await That(result2).HasMessage("foo");
-			await That(result3).IsEqualTo("b");
-		}
-
-		[Fact]
-		public async Task MultipleReturns_ShouldIterateThroughAllRegisteredValues()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns("a")
-				.Returns(() => "b")
-				.Returns(p1 => $"foo-{p1}");
-
-			string[] result = new string[10];
-			for (int i = 0; i < 10; i++)
+			[Fact]
+			public async Task IndexerReturns_WithSpecificParameter_ShouldIterateThroughValues()
 			{
-				result[i] = sut[i];
+				IIndexerService mock = Mock.Create<IIndexerService>();
+				mock.SetupMock.Indexer(It.Is(1))
+					.Returns("a")
+					.Returns("b");
+
+				string result11 = mock[1];
+				string result2 = mock[2];
+				string result12 = mock[1];
+				string result13 = mock[1];
+				string result14 = mock[1];
+				string result15 = mock[1];
+
+				await That(result11).IsEqualTo("a");
+				await That(result2).IsEqualTo("");
+				await That(result12).IsEqualTo("b");
+				await That(result13).IsEqualTo("a");
+				await That(result14).IsEqualTo("b");
+				await That(result15).IsEqualTo("a");
 			}
 
-			await That(result).IsEqualTo(["a", "b", "foo-2", "a", "b", "foo-5", "a", "b", "foo-8", "a",]);
-		}
-
-		[Fact]
-		public async Task Returns_Callback_ShouldReturnExpectedValue()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns(() => "foo");
-
-			string result = sut[1];
-
-			await That(result).IsEqualTo("foo");
-		}
-
-		[Fact]
-		public async Task Returns_CallbackWithParameters_ShouldReturnExpectedValue()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.InitializeWith("a")
-				.Returns(p1 => $"foo-{p1}");
-
-			string result = sut[3];
-
-			await That(result).IsEqualTo("foo-3");
-		}
-
-		[Fact]
-		public async Task Returns_CallbackWithParametersAndValue_ShouldReturnExpectedValue()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.InitializeWith("init")
-				.Returns((p1, v) => $"foo-{v}-{p1}");
-
-			string result = sut[3];
-
-			await That(result).IsEqualTo("foo-init-3");
-		}
-
-		[Fact]
-		public async Task Returns_For_ShouldLimitUsage_ToSpecifiedNumber()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns("foo").For(2)
-				.Returns("bar").For(3);
-
-			List<string> values = [];
-			for (int i = 0; i < 10; i++)
+			[Fact]
+			public async Task MixReturnsAndThrows_ShouldIterateThroughBoth()
 			{
-				values.Add(sut[i]);
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("a")
+					.Throws(new Exception("foo"))
+					.Returns(() => "b");
+
+				string result1 = sut[1];
+				Exception? result2 = Record.Exception(() => _ = sut[2]);
+				string result3 = sut[3];
+
+				await That(result1).IsEqualTo("a");
+				await That(result2).HasMessage("foo");
+				await That(result3).IsEqualTo("b");
 			}
 
-			await That(values).IsEqualTo(["foo", "foo", "bar", "bar", "bar", "", "", "", "", "",]);
-		}
-
-		[Fact]
-		public async Task Returns_Forever_ShouldUseTheLastValueForever()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns("a")
-				.Returns("b")
-				.Returns("c").Forever();
-
-			string[] result = new string[10];
-			for (int i = 0; i < 10; i++)
+			[Fact]
+			public async Task MultipleReturns_ShouldIterateThroughAllRegisteredValues()
 			{
-				result[i] = sut[i];
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("a")
+					.Returns(() => "b")
+					.Returns(p1 => $"foo-{p1}");
+
+				string[] result = new string[10];
+				for (int i = 0; i < 10; i++)
+				{
+					result[i] = sut[i];
+				}
+
+				await That(result).IsEqualTo(["a", "b", "foo-2", "a", "b", "foo-5", "a", "b", "foo-8", "a",]);
 			}
 
-			await That(result).IsEqualTo(["a", "b", "c", "c", "c", "c", "c", "c", "c", "c",]);
-		}
-
-		[Fact]
-		public async Task Returns_ShouldReturnExpectedValue()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns("foo");
-
-			string result = sut[3];
-
-			await That(result).IsEqualTo("foo");
-		}
-
-		[Fact]
-		public async Task Returns_When_ShouldOnlyUseValueWhenPredicateIsTrue()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns("foo").When(i => i > 0);
-
-			string result1 = sut[3];
-			string result2 = sut[4];
-			string result3 = sut[5];
-
-			await That(result1).IsEqualTo("");
-			await That(result2).IsEqualTo("foo");
-			await That(result3).IsEqualTo("foo");
-		}
-
-		[Fact]
-		public async Task Returns_WhenFor_ShouldLimitUsage_ToSpecifiedNumber()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Returns("foo").When(i => i > 0).For(2)
-				.Returns("baz")
-				.Returns("bar").For(3);
-
-			List<string> values = [];
-			for (int i = 0; i < 10; i++)
+			[Fact]
+			public async Task Returns_Callback_ShouldReturnExpectedValue()
 			{
-				values.Add(sut[i]);
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns(() => "foo");
+
+				string result = sut[1];
+
+				await That(result).IsEqualTo("foo");
 			}
 
-			await That(values).IsEqualTo(["baz", "bar", "bar", "bar", "foo", "foo", "baz", "baz", "baz", "baz",]);
-		}
-
-		[Fact]
-		public async Task Returns_WithoutSetup_ShouldReturnDefault()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			string result = sut[2];
-
-			await That(result).IsEmpty();
-		}
-
-		[Fact]
-		public async Task Throws_Callback_ShouldThrowException()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Throws(() => new Exception("foo"));
-
-			void Act()
+			[Fact]
+			public async Task Returns_CallbackWithParameters_ShouldReturnExpectedValue()
 			{
-				_ = sut[3];
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.InitializeWith("a")
+					.Returns(p1 => $"foo-{p1}");
+
+				string result = sut[3];
+
+				await That(result).IsEqualTo("foo-3");
 			}
 
-			await That(Act).ThrowsException().WithMessage("foo");
-		}
-
-		[Fact]
-		public async Task Throws_CallbackWithParameters_ShouldThrowException()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.InitializeWith("init")
-				.Throws(p1 => new Exception($"foo-{p1}"));
-
-			void Act()
+			[Fact]
+			public async Task Returns_CallbackWithParametersAndValue_ShouldReturnExpectedValue()
 			{
-				_ = sut[3];
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.InitializeWith("init")
+					.Returns((p1, v) => $"foo-{v}-{p1}");
+
+				string result = sut[3];
+
+				await That(result).IsEqualTo("foo-init-3");
 			}
 
-			await That(Act).ThrowsException().WithMessage("foo-3");
-		}
-
-		[Fact]
-		public async Task Throws_CallbackWithParametersAndValue_ShouldThrowException()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.InitializeWith("init")
-				.Throws((p1, v) => new Exception($"foo-{v}-{p1}"));
-
-			void Act()
+			[Fact]
+			public async Task Returns_For_ShouldLimitUsage_ToSpecifiedNumber()
 			{
-				_ = sut[3];
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("foo").For(2)
+					.Returns("bar").For(3);
+
+				List<string> values = [];
+				for (int i = 0; i < 10; i++)
+				{
+					values.Add(sut[i]);
+				}
+
+				await That(values).IsEqualTo(["foo", "foo", "bar", "bar", "bar", "", "", "", "", "",]);
 			}
 
-			await That(Act).ThrowsException().WithMessage("foo-init-3");
-		}
-
-		[Fact]
-		public async Task Throws_Generic_ShouldThrowException()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Throws<ArgumentNullException>();
-
-			void Act()
+			[Fact]
+			public async Task Returns_Forever_ShouldUseTheLastValueForever()
 			{
-				_ = sut[3];
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("a")
+					.Returns("b")
+					.Returns("c").Forever();
+
+				string[] result = new string[10];
+				for (int i = 0; i < 10; i++)
+				{
+					result[i] = sut[i];
+				}
+
+				await That(result).IsEqualTo(["a", "b", "c", "c", "c", "c", "c", "c", "c", "c",]);
 			}
 
-			await That(Act).ThrowsExactly<ArgumentNullException>();
-		}
-
-		[Fact]
-		public async Task Throws_ShouldThrowException()
-		{
-			IIndexerService sut = Mock.Create<IIndexerService>();
-
-			sut.SetupMock.Indexer(It.IsAny<int>())
-				.Throws(new Exception("foo"));
-
-			void Act()
+			[Fact]
+			public async Task Returns_ShouldReturnExpectedValue()
 			{
-				_ = sut[3];
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("foo");
+
+				string result = sut[3];
+
+				await That(result).IsEqualTo("foo");
 			}
 
-			await That(Act).ThrowsException().WithMessage("foo");
-		}
-
-		[Fact]
-		public async Task WithoutCallback_IIndexerSetupReturnBuilder_ShouldNotThrow()
-		{
-			IIndexerService mock = Mock.Create<IIndexerService>();
-			IIndexerSetupReturnBuilder<string, int> setup =
-				(IIndexerSetupReturnBuilder<string, int>)mock.SetupMock.Indexer(It.IsAny<int>());
-
-			void ActWhen()
+			[Fact]
+			public async Task Returns_When_ShouldOnlyUseValueWhenPredicateIsTrue()
 			{
-				setup.When(_ => true);
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("foo").When(i => i > 0);
+
+				string result1 = sut[3];
+				string result2 = sut[4];
+				string result3 = sut[5];
+
+				await That(result1).IsEqualTo("");
+				await That(result2).IsEqualTo("foo");
+				await That(result3).IsEqualTo("foo");
 			}
 
-			void ActFor()
+			[Fact]
+			public async Task Returns_WhenFor_ShouldLimitUsage_ToSpecifiedNumber()
 			{
-				setup.For(2);
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("foo").When(i => i > 0).For(2)
+					.Returns("baz")
+					.Returns("bar").For(3);
+
+				List<string> values = [];
+				for (int i = 0; i < 10; i++)
+				{
+					values.Add(sut[i]);
+				}
+
+				await That(values).IsEqualTo(["baz", "bar", "bar", "bar", "foo", "foo", "baz", "baz", "baz", "baz",]);
 			}
 
-			await That(ActWhen).DoesNotThrow();
-			await That(ActFor).DoesNotThrow();
-		}
-
-		[Fact]
-		public async Task WithoutCallback_IIndexerSetupReturnWhenBuilder_ShouldNotThrow()
-		{
-			IIndexerService mock = Mock.Create<IIndexerService>();
-			IIndexerSetupReturnWhenBuilder<string, int> setup =
-				(IIndexerSetupReturnWhenBuilder<string, int>)mock.SetupMock.Indexer(It.IsAny<int>());
-
-			void ActFor()
+			[Fact]
+			public async Task Returns_WithoutSetup_ShouldReturnDefault()
 			{
-				setup.For(2);
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				string result = sut[2];
+
+				await That(result).IsEmpty();
 			}
 
-			void ActOnly()
+			[Fact]
+			public async Task SetupWithoutReturn_ShouldUseBaseValue()
 			{
-				setup.Only(2);
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.OnGet.Do(() => { });
+
+				string result = sut[1];
+
+				await That(result).IsEqualTo("foo-1");
 			}
 
-			await That(ActFor).DoesNotThrow();
-			await That(ActOnly).DoesNotThrow();
+			[Fact]
+			public async Task SetupWithReturn_ShouldIgnoreBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns("bar");
+
+				string result = sut[1];
+
+				await That(result).IsEqualTo("bar");
+			}
+
+			[Fact]
+			public async Task Throws_Callback_ShouldThrowException()
+			{
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Throws(() => new Exception("foo"));
+
+				void Act()
+				{
+					_ = sut[3];
+				}
+
+				await That(Act).ThrowsException().WithMessage("foo");
+			}
+
+			[Fact]
+			public async Task Throws_CallbackWithParameters_ShouldThrowException()
+			{
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.InitializeWith("init")
+					.Throws(p1 => new Exception($"foo-{p1}"));
+
+				void Act()
+				{
+					_ = sut[3];
+				}
+
+				await That(Act).ThrowsException().WithMessage("foo-3");
+			}
+
+			[Fact]
+			public async Task Throws_CallbackWithParametersAndValue_ShouldThrowException()
+			{
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.InitializeWith("init")
+					.Throws((p1, v) => new Exception($"foo-{v}-{p1}"));
+
+				void Act()
+				{
+					_ = sut[3];
+				}
+
+				await That(Act).ThrowsException().WithMessage("foo-init-3");
+			}
+
+			[Fact]
+			public async Task Throws_Generic_ShouldThrowException()
+			{
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Throws<ArgumentNullException>();
+
+				void Act()
+				{
+					_ = sut[3];
+				}
+
+				await That(Act).ThrowsExactly<ArgumentNullException>();
+			}
+
+			[Fact]
+			public async Task Throws_ShouldThrowException()
+			{
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Throws(new Exception("foo"));
+
+				void Act()
+				{
+					_ = sut[3];
+				}
+
+				await That(Act).ThrowsException().WithMessage("foo");
+			}
+
+			[Fact]
+			public async Task WithoutCallback_IIndexerSetupReturnBuilder_ShouldNotThrow()
+			{
+				IIndexerService mock = Mock.Create<IIndexerService>();
+				IIndexerSetupReturnBuilder<string, int> setup =
+					(IIndexerSetupReturnBuilder<string, int>)mock.SetupMock.Indexer(It.IsAny<int>());
+
+				void ActWhen()
+				{
+					setup.When(_ => true);
+				}
+
+				void ActFor()
+				{
+					setup.For(2);
+				}
+
+				await That(ActWhen).DoesNotThrow();
+				await That(ActFor).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithoutCallback_IIndexerSetupReturnWhenBuilder_ShouldNotThrow()
+			{
+				IIndexerService mock = Mock.Create<IIndexerService>();
+				IIndexerSetupReturnWhenBuilder<string, int> setup =
+					(IIndexerSetupReturnWhenBuilder<string, int>)mock.SetupMock.Indexer(It.IsAny<int>());
+
+				void ActFor()
+				{
+					setup.For(2);
+				}
+
+				void ActOnly()
+				{
+					setup.Only(2);
+				}
+
+				await That(ActFor).DoesNotThrow();
+				await That(ActOnly).DoesNotThrow();
+			}
 		}
 
 		public sealed class With2Levels
@@ -527,6 +554,30 @@ public sealed partial class SetupIndexerTests
 				string result = sut[1, 2];
 
 				await That(result).IsEmpty();
+			}
+
+			[Fact]
+			public async Task SetupWithoutReturn_ShouldUseBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
+					.OnGet.Do(() => { });
+
+				string result = sut[1, 2];
+
+				await That(result).IsEqualTo("foo-1-2");
+			}
+
+			[Fact]
+			public async Task SetupWithReturn_ShouldIgnoreBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>())
+					.Returns("bar");
+
+				string result = sut[1, 2];
+
+				await That(result).IsEqualTo("bar");
 			}
 
 			[Fact]
@@ -858,6 +909,51 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
+			public async Task SetupWithoutReturn_ShouldUseBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+					.OnGet.Do(() => { });
+
+				string result = sut[1, 2, 3];
+
+				await That(result).IsEqualTo("foo-1-2-3");
+			}
+
+			[Fact]
+			public async Task Returns_WithPredicate_ShouldApplyReturnWhenPredicateMatches()
+			{
+				List<string> results = [];
+				IIndexerService sut = Mock.Create<IIndexerService>();
+
+				sut.SetupMock.Indexer(It.IsAny<int>())
+					.Returns(() => "foo").When(i => i is > 3 and < 6);
+
+				results.Add(sut[1]);
+				results.Add(sut[1]);
+				sut[1] = "bar";
+				results.Add(sut[1]);
+				results.Add(sut[1]);
+				results.Add(sut[1]);
+				results.Add(sut[1]);
+				results.Add(sut[1]);
+
+				await That(results).IsEqualTo(["", "", "bar", "bar", "foo", "foo", "foo",]);
+			}
+
+			[Fact]
+			public async Task SetupWithReturn_ShouldIgnoreBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+					.Returns("bar");
+
+				string result = sut[1, 2, 3];
+
+				await That(result).IsEqualTo("bar");
+			}
+
+			[Fact]
 			public async Task Throws_Callback_ShouldThrowException()
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
@@ -1184,6 +1280,30 @@ public sealed partial class SetupIndexerTests
 				string result = sut[1, 2, 3, 4];
 
 				await That(result).IsEmpty();
+			}
+
+			[Fact]
+			public async Task SetupWithoutReturn_ShouldUseBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+					.OnGet.Do(() => { });
+
+				string result = sut[1, 2, 3, 4];
+
+				await That(result).IsEqualTo("foo-1-2-3-4");
+			}
+
+			[Fact]
+			public async Task SetupWithReturn_ShouldIgnoreBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+					.Returns("bar");
+
+				string result = sut[1, 2, 3, 4];
+
+				await That(result).IsEqualTo("bar");
 			}
 
 			[Fact]
@@ -1526,6 +1646,32 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
+			public async Task SetupWithoutReturn_ShouldUseBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(
+						It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+					.OnGet.Do(() => { });
+
+				string result = sut[1, 2, 3, 4, 5];
+
+				await That(result).IsEqualTo("foo-1-2-3-4-5");
+			}
+
+			[Fact]
+			public async Task SetupWithReturn_ShouldIgnoreBaseValue()
+			{
+				IndexerMethodSetupTest sut = Mock.Create<IndexerMethodSetupTest>();
+				sut.SetupMock.Indexer(
+						It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+					.Returns("bar");
+
+				string result = sut[1, 2, 3, 4, 5];
+
+				await That(result).IsEqualTo("bar");
+			}
+
+			[Fact]
 			public async Task Throws_Callback_ShouldThrowException()
 			{
 				IIndexerService sut = Mock.Create<IIndexerService>();
@@ -1654,6 +1800,45 @@ public sealed partial class SetupIndexerTests
 
 				await That(ActFor).DoesNotThrow();
 				await That(ActOnly).DoesNotThrow();
+			}
+		}
+
+		public class IndexerMethodSetupTest
+		{
+			private string? _data1;
+			private string? _data2;
+			private string? _data3;
+			private string? _data4;
+			private string? _data5;
+			
+			public virtual string this[int index]
+			{
+				get => _data1 ?? $"foo-{index}";
+				set => _data1 = value;
+			}
+
+			public virtual string this[int index1, int index2]
+			{
+				get => _data2 ?? $"foo-{index1}-{index2}";
+				set => _data2 = value;
+			}
+
+			public virtual string this[int index1, int index2, int index3]
+			{
+				get => _data3 ?? $"foo-{index1}-{index2}-{index3}";
+				set => _data3 = value;
+			}
+
+			public virtual string this[int index1, int index2, int index3, int index4]
+			{
+				get => _data4 ?? $"foo-{index1}-{index2}-{index3}-{index4}";
+				set => _data4 = value;
+			}
+
+			public virtual string this[int index1, int index2, int index3, int index4, int index5]
+			{
+				get => _data5 ?? $"foo-{index1}-{index2}-{index3}-{index4}-{index5}";
+				set => _data5 = value;
 			}
 		}
 	}

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -305,9 +305,6 @@ public sealed partial class SetupIndexerTests
 		protected override bool? GetSkipBaseClass()
 			=> throw new NotSupportedException();
 
-		protected override bool HasReturnCalls()
-			=> throw new NotSupportedException();
-
 		protected override void GetInitialValue<T>(MockBehavior behavior, Func<T> defaultValueGenerator,
 			NamedParameterValue[] parameters,
 			[NotNullWhen(true)] out T value)

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.ReturnsThrowsTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.ReturnsThrowsTests.cs
@@ -126,13 +126,48 @@ public sealed partial class SetupPropertyTests
 		}
 
 		[Fact]
+		public async Task Returns_OnlyOnce_ShouldKeepLastUsedValue()
+		{
+			IPropertyService sut = Mock.Create<IPropertyService>();
+			sut.SetupMock.Property.MyProperty.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				values[i] = sut.MyProperty;
+				if (i == 4)
+				{
+					sut.MyProperty = 10;
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 1, 1, 10, 10, 10, 10, 10,]);
+		}
+
+		[Fact]
+		public async Task Returns_OnlyOnce_ShouldUseReturnValueOnlyOnce()
+		{
+			IPropertyService sut = Mock.Create<IPropertyService>();
+			sut.SetupMock.Property.MyProperty.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyProperty = 0;
+				values[i] = sut.MyProperty;
+			}
+
+			await That(values).IsEqualTo([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,]);
+		}
+
+		[Fact]
 		public async Task Returns_PredicateIsFalse_ShouldUseInitializedDefaultValue()
 		{
 			List<int> results = [];
 			IPropertyService sut = Mock.Create<IPropertyService>();
 
 			sut.SetupMock.Property.MyProperty
-				.Returns(() => 4).When(i => i > 3);
+				.Returns(() => 4).When(i => i is > 3 and < 6);
 
 			results.Add(sut.MyProperty);
 			results.Add(sut.MyProperty);

--- a/Tests/Mockolate.Tests/SetupExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/SetupExtensionsTests.cs
@@ -262,7 +262,7 @@ public sealed class SetupExtensionsTests
 		}
 
 		[Fact]
-		public async Task OnlyOnce_With1Parameter_ShouldApplySetupOnlyOnce()
+		public async Task OnlyOnce_With1Parameter_ShouldKeepLastUsedValue()
 		{
 			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
 			sut.SetupMock.Indexer(It.IsAny<int>()).Returns(1).OnlyOnce();
@@ -270,6 +270,26 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				values[i] = sut[10];
+				if (i == 4)
+				{
+					sut[10] = 10;
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 1, 1, 10, 10, 10, 10, 10,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With1Parameter_ShouldUseReturnValueOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10] = 0;
 				values[i] = sut[10];
 			}
 
@@ -285,6 +305,7 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				sut[10] = 0;
 				values[i] = sut[10];
 			}
 
@@ -292,7 +313,7 @@ public sealed class SetupExtensionsTests
 		}
 
 		[Fact]
-		public async Task OnlyOnce_With2Parameters_ShouldApplySetupOnlyOnce()
+		public async Task OnlyOnce_With2Parameters_ShouldKeepLastUsedValue()
 		{
 			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
 			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
@@ -300,6 +321,26 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				values[i] = sut[10, 20];
+				if (i == 4)
+				{
+					sut[10, 20] = 10;
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 1, 1, 10, 10, 10, 10, 10,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With2Parameters_ShouldUseReturnValueOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20] = 0;
 				values[i] = sut[10, 20];
 			}
 
@@ -315,6 +356,7 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				sut[10, 20] = 0;
 				values[i] = sut[10, 20];
 			}
 
@@ -322,7 +364,7 @@ public sealed class SetupExtensionsTests
 		}
 
 		[Fact]
-		public async Task OnlyOnce_With3Parameters_ShouldApplySetupOnlyOnce()
+		public async Task OnlyOnce_With3Parameters_ShouldKeepLastUsedValue()
 		{
 			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
 			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
@@ -330,6 +372,26 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				values[i] = sut[10, 20, 30];
+				if (i == 4)
+				{
+					sut[10, 20, 30] = 10;
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 1, 1, 10, 10, 10, 10, 10,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With3Parameters_ShouldUseReturnValueOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20, 30] = 0;
 				values[i] = sut[10, 20, 30];
 			}
 
@@ -345,6 +407,7 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				sut[10, 20, 30] = 0;
 				values[i] = sut[10, 20, 30];
 			}
 
@@ -352,15 +415,36 @@ public sealed class SetupExtensionsTests
 		}
 
 		[Fact]
-		public async Task OnlyOnce_With4Parameters_ShouldApplySetupOnlyOnce()
+		public async Task OnlyOnce_With4Parameters_ShouldKeepLastUsedValue()
 		{
 			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
-			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()).Returns(1)
-				.OnlyOnce();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).OnlyOnce();
 
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				values[i] = sut[10, 20, 30, 40];
+				if (i == 4)
+				{
+					sut[10, 20, 30, 40] = 10;
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 1, 1, 10, 10, 10, 10, 10,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With4Parameters_ShouldUseReturnValueOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20, 30, 40] = 0;
 				values[i] = sut[10, 20, 30, 40];
 			}
 
@@ -377,6 +461,7 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				sut[10, 20, 30, 40] = 0;
 				values[i] = sut[10, 20, 30, 40];
 			}
 
@@ -384,7 +469,7 @@ public sealed class SetupExtensionsTests
 		}
 
 		[Fact]
-		public async Task OnlyOnce_With5Parameters_ShouldApplySetupOnlyOnce()
+		public async Task OnlyOnce_With5Parameters_ShouldKeepLastUsedValue()
 		{
 			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
 			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
@@ -393,6 +478,27 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				values[i] = sut[10, 20, 30, 40, 50];
+				if (i == 4)
+				{
+					sut[10, 20, 30, 40, 50] = 10;
+				}
+			}
+
+			await That(values).IsEqualTo([1, 1, 1, 1, 1, 10, 10, 10, 10, 10,]);
+		}
+
+		[Fact]
+		public async Task OnlyOnce_With5Parameters_ShouldUseReturnValueOnlyOnce()
+		{
+			ISetupExtensionsTestService sut = Mock.Create<ISetupExtensionsTestService>();
+			sut.SetupMock.Indexer(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+				.Returns(1).OnlyOnce();
+
+			int[] values = new int[10];
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20, 30, 40, 50] = 0;
 				values[i] = sut[10, 20, 30, 40, 50];
 			}
 
@@ -409,6 +515,7 @@ public sealed class SetupExtensionsTests
 			int[] values = new int[10];
 			for (int i = 0; i < 10; i++)
 			{
+				sut[10, 20, 30, 40, 50] = 0;
 				values[i] = sut[10, 20, 30, 40, 50];
 			}
 


### PR DESCRIPTION
This PR fixes a bug in the indexer setup mechanism to ensure that indexer values persist correctly when return setups are conditional (using modifiers like `OnlyOnce()`, `For()`, or `When()`). Previously, when conditional setups expired or didn't match, the mock would incorrectly return default values instead of preserving the last value that was set.

### Key changes:
- Refactored indexer value retrieval logic to always consult the backing storage before applying conditional return setups
- Removed the now-obsolete `HasReturnCalls()` method from the indexer setup infrastructure
- Added comprehensive test coverage to verify that indexer values persist correctly across various scenarios with conditional setups