### PR TITLE
feat: simplify constructor usage for `MockMonitor<T>`

### DIFF
--- a/Docs/pages/advanced-features/03-monitor-interactions.md
+++ b/Docs/pages/advanced-features/03-monitor-interactions.md
@@ -27,7 +27,7 @@ var sut = Mock.Create<IChocolateDispenser>();
 sut.Dispense("Dark", 1); // Not monitored
 using var scope = sut.MonitorMock(out var monitor);
 sut.Dispense("Dark", 2); // Monitored
-sut.Dispense("Dark", 3); // Not monitored
+sut.Dispense("Dark", 3); // Monitored
 
 // Verifications on the monitor only count interactions during the lifetime scope of the `IDisposable`
 monitor.Verify.Invoked.Dispense(It.Is("Dark"), It.IsAny<int>()).Twice();

--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ var sut = Mock.Create<IChocolateDispenser>();
 sut.Dispense("Dark", 1); // Not monitored
 using var scope = sut.MonitorMock(out var monitor);
 sut.Dispense("Dark", 2); // Monitored
-sut.Dispense("Dark", 3); // Not monitored
+sut.Dispense("Dark", 3); // Monitored
 
 // Verifications on the monitor only count interactions during the lifetime scope of the `IDisposable`
 monitor.Verify.Invoked.Dispense(It.Is("Dark"), It.IsAny<int>()).Twice();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
@@ -51,10 +51,10 @@ internal static partial class Sources
 				.Append(@class.ClassFullName.EscapeForXmlDoc()).Append("\" />.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
 			sb.Append("\t\tpublic System.IDisposable MonitorMock(out MockMonitor<").Append(@class.ClassFullName)
-				.AppendLine("> monitor)").AppendLine();
+				.Append("> monitor)").AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tmonitor = new MockMonitor<").Append(@class.ClassFullName)
-				.AppendLine(">(GetMockOrThrow(subject));").AppendLine();
+				.AppendLine(">(subject);").AppendLine();
 			sb.Append("\t\t\treturn monitor.Run();").AppendLine();
 			sb.Append("\t\t}").AppendLine();
 			sb.AppendLine("\t}");
@@ -203,10 +203,10 @@ internal static partial class Sources
 				.Append(@class.ClassFullName.EscapeForXmlDoc()).Append("\" />.").AppendLine();
 			sb.Append("\t\t/// </summary>").AppendLine();
 			sb.Append("\t\tpublic System.IDisposable MonitorMock(out MockMonitor<").Append(@class.ClassFullName)
-				.AppendLine("> monitor)").AppendLine();
+				.Append("> monitor)").AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tmonitor = new MockMonitor<").Append(@class.ClassFullName)
-				.AppendLine(">(GetMockOrThrow(subject));").AppendLine();
+				.AppendLine(">(subject);").AppendLine();
 			sb.Append("\t\t\treturn monitor.Run();").AppendLine();
 			sb.Append("\t\t}").AppendLine();
 			sb.AppendLine("\t}");

--- a/Source/Mockolate/Monitor/MockMonitor.cs
+++ b/Source/Mockolate/Monitor/MockMonitor.cs
@@ -101,26 +101,22 @@ public abstract class MockMonitor
 /// </summary>
 /// <remarks>
 ///     Use this class to track and analyze interactions with a mock, such as which members were accessed or
-///     which events were subscribed to, during a test session. Monitoring is session-based; begin a session with the Run
-///     method and dispose the returned scope to finalize monitoring.
+///     which events were subscribed to, during a test session.<br />
+///     Monitoring is session-based: begin a session with the <see cref="MockMonitor.Run()" /> method and
+///     dispose the returned scope to finalize monitoring.
 /// </remarks>
 public sealed class MockMonitor<T> : MockMonitor
 {
-	/// <inheritdoc cref="MockMonitor{T}" />
-	public MockMonitor(Mock<T> mock) : base(mock.Interactions)
-	{
-		Verify = new Mock<T>(mock.Subject,
-			new MockRegistration(mock.Registrations.Behavior, mock.Registrations.Prefix, Interactions));
-	}
-
 	/// <inheritdoc cref="MockMonitor{T}" />
 	public MockMonitor(T mock) : this(mock as IMockSubject<T>)
 	{
 	}
 
 	private MockMonitor(IMockSubject<T>? mockSubject)
-		: this(mockSubject?.Mock ?? throw new MockException("The subject is no mock."))
+		: base(mockSubject?.Mock.Interactions ?? throw new MockException("The subject is no mock."))
 	{
+		Verify = new Mock<T>(mockSubject.Mock.Subject,
+			new MockRegistration(mockSubject.Registrations.Behavior, mockSubject.Registrations.Prefix, Interactions));
 	}
 
 	/// <summary>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -568,7 +568,6 @@ namespace Mockolate.Monitor
     }
     public sealed class MockMonitor<T> : Mockolate.Monitor.MockMonitor
     {
-        public MockMonitor(Mockolate.Mock<T> mock) { }
         public MockMonitor(T mock) { }
         public Mockolate.Verify.IMockVerify<T> Verify { get; }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -567,7 +567,6 @@ namespace Mockolate.Monitor
     }
     public sealed class MockMonitor<T> : Mockolate.Monitor.MockMonitor
     {
-        public MockMonitor(Mockolate.Mock<T> mock) { }
         public MockMonitor(T mock) { }
         public Mockolate.Verify.IMockVerify<T> Verify { get; }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -534,7 +534,6 @@ namespace Mockolate.Monitor
     }
     public sealed class MockMonitor<T> : Mockolate.Monitor.MockMonitor
     {
-        public MockMonitor(Mockolate.Mock<T> mock) { }
         public MockMonitor(T mock) { }
         public Mockolate.Verify.IMockVerify<T> Verify { get; }
     }

--- a/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
@@ -1,3 +1,4 @@
+using Mockolate.Exceptions;
 using Mockolate.Monitor;
 using Mockolate.Tests.TestHelpers;
 
@@ -17,6 +18,20 @@ public sealed class MockMonitorTests
 		await That(monitor.Verify.Invoked.IsValid(It.Is(1))).Once();
 		sut.SetupMock.ClearAllInteractions();
 		await That(monitor.Verify.Invoked.IsValid(It.Is(1))).Never();
+	}
+
+	[Fact]
+	public async Task Constructor_WithoutMock_ShouldThrowMockException()
+	{
+		MyServiceBase sut = new();
+
+		void Act()
+		{
+			_ = new MockMonitor<MyServiceBase>(sut);
+		}
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("The subject is no mock.");
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR replaces the constructor to `MockMonitor<T>` with a simpler one that accepts the mock instance directly (type `T`) instead of requiring users to cast to `IMockSubject<T>` and access the `Mock` property. This change streamlines the API and improves usability.

### Key Changes:
- Added a new public constructor `MockMonitor(T mock)` that internally handles the cast to `IMockSubject<T>`
- Updated all test cases to use the simplified constructor syntax
- Updated documentation examples to demonstrate the new simplified approach