### PR TITLE
docs: add Github link in documentation overview

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -4,7 +4,8 @@
 
 [![Nuget](https://img.shields.io/nuget/v/Mockolate)](https://www.nuget.org/packages/Mockolate)
 
-**Mockolate** is a modern, strongly-typed, AOT-compatible mocking library for .NET, powered by source generators.
+[**Mockolate**](https://github.com/aweXpect/Mockolate) is a modern, strongly-typed, AOT-compatible mocking library
+for .NET, powered by source generators.
 It enables fast, compile-time validated mocking with .NET Standard 2.0, .NET 8, .NET 10 and .NET Framework 4.8.
 
 - **Source generator-based**: No runtime proxy generation.


### PR DESCRIPTION
This PR adds a GitHub repository link to the documentation overview page by making the "Mockolate" name a clickable hyperlink.