### PR TITLE
docs: add documentation for HTTP form data

### DIFF
--- a/Docs/pages/special-types/01-httpclient.md
+++ b/Docs/pages/special-types/01-httpclient.md
@@ -195,7 +195,6 @@ httpClient.SetupMock.Method
 ### Form data content
 
 To verify against the URL-encoded form data content, use the following methods:
-To verify against the binary content, use the following methods:
 
 - `.WithFormData(string, string)`: checks that the form-data content contains the provided key-value pair
 - `.WithFormData(IEnumerable<(string, string)>)`: checks that the form-data content contains the provided key-value
@@ -206,7 +205,7 @@ To verify against the binary content, use the following methods:
 httpClient.SetupMock.Method
     .PostAsync(
         It.IsAny<string>(),
-        It.IsHttpContent("application/octet-stream").WithFormData("my-key", "my-value"))
+        It.IsHttpContent("application/x-www-form-urlencoded").WithFormData("my-key", "my-value"))
     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 ```
 

--- a/README.md
+++ b/README.md
@@ -1176,7 +1176,6 @@ httpClient.SetupMock.Method
 **Form data content**
 
 To verify against the URL-encoded form data content, use the following methods:
-To verify against the binary content, use the following methods:
 
 - `.WithFormData(string, string)`: checks that the form-data content contains the provided key-value pair
 - `.WithFormData(IEnumerable<(string, string)>)`: checks that the form-data content contains the provided key-value
@@ -1187,7 +1186,7 @@ To verify against the binary content, use the following methods:
 httpClient.SetupMock.Method
     .PostAsync(
         It.IsAny<string>(),
-        It.IsHttpContent("application/octet-stream").WithFormData("my-key", "my-value"))
+        It.IsHttpContent("application/x-www-form-urlencoded").WithFormData("my-key", "my-value"))
     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 ```
 


### PR DESCRIPTION
Updates HttpClient matching documentation to cover generic content matching, richer query matching, and adds form-data (URL-encoded) content matching guidance.

### Key Changes:
- Replaced `It.IsStringContent(...)` examples with `It.IsHttpContent(...)` and new `WithString...` matchers.
- Expanded `.WithQuery(...)` docs to include key/value pair matching and raw query string matching.
- Added docs for URL-encoded form-data matching (`WithFormData(...)`) in HttpClient examples.