### PR TITLE
fix: consider char-set header when decoding string content

### DIFF
--- a/Source/Mockolate/Web/ItExtensions.HttpContent.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.cs
@@ -279,10 +279,25 @@ public static partial class ItExtensions
 
 		private static string GetStringFromHttpContent(HttpContent content)
 		{
+			static Encoding GetEncodingFromCharset(string? charset)
+			{
+				if (!string.IsNullOrEmpty(charset))
+				{
+					try
+					{
+						return Encoding.GetEncoding(charset);
+					}
+					catch (ArgumentException)
+					{
+						// If the charset is invalid or not supported, we fall back to the default encoding (UTF-8).
+					}
+				}
+
+				return Encoding.UTF8;
+			}
+
 			string? charset = content.Headers.ContentType?.CharSet;
-			Encoding encoding = !string.IsNullOrEmpty(charset)
-				? Encoding.GetEncoding(charset)
-				: Encoding.UTF8;
+			Encoding encoding = GetEncodingFromCharset(charset);
 #if NET8_0_OR_GREATER
 			Stream stream = content.ReadAsStream();
 			using StreamReader reader = new(stream, encoding, leaveOpen: true);


### PR DESCRIPTION
Updates `It.IsHttpContent().WithString(...)` matching to decode `HttpContent` using the `charset` specified in the `Content-Type` header, with added tests to validate charset-aware behavior.

### Key Changes:
- Decode `HttpContent` using `ContentType.CharSet` when present, otherwise fall back to UTF-8.
- Add/adjust unit tests for case sensitivity and charset-handling scenarios.

---

- *Fixes #467*