### PR TITLE
fix: allow duplicate request content access

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ForMock.Extensions.cs
@@ -403,34 +403,7 @@ internal static partial class Sources
 
 		sb.AppendLine();
 		sb.AppendLine("\t\t{");
-
-		if (@class is { ClassName: "HttpClient", ClassFullName: "System.Net.Http.HttpClient", } &&
-		    method.Name.StartsWith("Send"))
-		{
-			sb.Append("\t\t\tif (setup is Mock<System.Net.Http.HttpClient> httpClientMock &&").AppendLine();
-			sb.Append(
-					"\t\t\t    httpClientMock.ConstructorParameters[0] is IMockSubject<System.Net.Http.HttpMessageHandler> httpMessageHandlerMock &&")
-				.AppendLine();
-			sb.Append(
-					"\t\t\t    httpMessageHandlerMock.Mock is IMockMethodSetup<System.Net.Http.HttpMessageHandler> httpMessageHandlerSetup)")
-				.AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			AppendMethodSetupBody(sb, method, useParameters,
-				"\t\t\t\t",
-				method.GetUniqueNameString().Replace("System.Net.Http.HttpMessageInvoker",
-					"System.Net.Http.HttpMessageHandler"),
-				"httpMessageHandlerSetup");
-			sb.Append("\t\t\t}").AppendLine();
-			sb.Append("\t\t\telse").AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			AppendMethodSetupBody(sb, method, useParameters, "\t\t\t\t");
-			sb.Append("\t\t\t}").AppendLine();
-		}
-		else
-		{
-			AppendMethodSetupBody(sb, method, useParameters);
-		}
-
+		AppendMethodSetupBody(sb, method, useParameters);
 		sb.AppendLine("\t\t}");
 	}
 

--- a/Source/Mockolate/Web/HttpClientExtensions.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.cs
@@ -73,7 +73,6 @@ public static partial class HttpClientExtensions
 		}
 	}
 
-
 	private interface IHttpRequestMessageParameter
 	{
 		bool Matches(HttpRequestMessage value);
@@ -87,7 +86,14 @@ public static partial class HttpClientExtensions
 		: IHttpRequestMessageParameter
 	{
 		public bool Matches(HttpRequestMessage value)
-			=> ((IParameter)parameter).Matches(valueSelector(value));
+		{
+			if (parameter is IHttpRequestMessagePropertyParameter<T> httpRequestMessageParameter)
+			{
+				return httpRequestMessageParameter.Matches(valueSelector(value), value);
+			}
+
+			return ((IParameter)parameter).Matches(valueSelector(value));
+		}
 
 		public void InvokeCallbacks(HttpRequestMessage value)
 		{

--- a/Source/Mockolate/Web/IHttpRequestMessagePropertyParameter.cs
+++ b/Source/Mockolate/Web/IHttpRequestMessagePropertyParameter.cs
@@ -1,0 +1,16 @@
+using System.Net.Http;
+using Mockolate.Parameters;
+
+namespace Mockolate.Web;
+
+/// <summary>
+///     A parameter of type <typeparamref name="T" /> that also gets a <see cref="HttpRequestMessage" />.
+/// </summary>
+internal interface IHttpRequestMessagePropertyParameter<T> : IParameter<T>
+{
+	/// <summary>
+	///     Matches the property of type <typeparamref name="T" /> while also considering the
+	///     <paramref name="requestMessage" />.
+	/// </summary>
+	bool Matches(T value, HttpRequestMessage? requestMessage);
+}

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PatchTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PatchTests.cs
@@ -23,12 +23,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = Mock.Create<HttpClient>();
 
 				await httpClient.PatchAsync("https://www.aweXpect.com",
-					new StringContent("", Encoding.UTF8, mediaType),
+					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.VerifyMock.Invoked.PatchAsync(
 						It.IsAny<string?>(),
-						It.IsHttpContent("application/json")))
+						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
 
@@ -111,12 +111,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = Mock.Create<HttpClient>();
 
 				await httpClient.PatchAsync("https://www.aweXpect.com",
-					new StringContent("", Encoding.UTF8, mediaType),
+					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.VerifyMock.Invoked.PatchAsync(
 						It.IsUri("*aweXpect.com*"),
-						It.IsHttpContent("application/json")))
+						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
 

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PostTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PostTests.cs
@@ -22,12 +22,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = Mock.Create<HttpClient>();
 
 				await httpClient.PostAsync("https://www.aweXpect.com",
-					new StringContent("", Encoding.UTF8, mediaType),
+					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.VerifyMock.Invoked.PostAsync(
 						It.IsAny<string?>(),
-						It.IsHttpContent("application/json")))
+						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
 
@@ -109,12 +109,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = Mock.Create<HttpClient>();
 
 				await httpClient.PostAsync("https://www.aweXpect.com",
-					new StringContent("", Encoding.UTF8, mediaType),
+					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.VerifyMock.Invoked.PostAsync(
 						It.IsUri("*aweXpect.com*"),
-						It.IsHttpContent("application/json")))
+						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
 

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PutTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PutTests.cs
@@ -22,12 +22,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = Mock.Create<HttpClient>();
 
 				await httpClient.PutAsync("https://www.aweXpect.com",
-					new StringContent("", Encoding.UTF8, mediaType),
+					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.VerifyMock.Invoked.PutAsync(
 						It.IsAny<string?>(),
-						It.IsHttpContent("application/json")))
+						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
 
@@ -109,12 +109,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = Mock.Create<HttpClient>();
 
 				await httpClient.PutAsync("https://www.aweXpect.com",
-					new StringContent("", Encoding.UTF8, mediaType),
+					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.VerifyMock.Invoked.PutAsync(
 						It.IsUri("*aweXpect.com*"),
-						It.IsHttpContent("application/json")))
+						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithBytesTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithBytesTests.cs
@@ -53,6 +53,24 @@ public sealed partial class ItExtensionsTests
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
 			}
+
+			[Fact]
+			public async Task WhenValidatedAndSetup_ShouldResetStreamPosition()
+			{
+				byte[] body = [0x66, 0x67,];
+				HttpClient httpClient = Mock.Create<HttpClient>();
+				httpClient.SetupMock.Method
+					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithBytes(body))
+					.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+				HttpResponseMessage result = await httpClient
+					.PostAsync("https://www.aweXpect.com", new ByteArrayContent(body), CancellationToken.None);
+
+				await That(httpClient.VerifyMock.Invoked
+						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithBytes(body)))
+					.Once();
+				await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
+			}
 		}
 	}
 }

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringTests.cs
@@ -139,6 +139,23 @@ public sealed partial class ItExtensionsTests
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
 			}
 
+			[Fact]
+			public async Task WhenValidatedAndSetup_ShouldResetStreamPosition()
+			{
+				HttpClient httpClient = Mock.Create<HttpClient>();
+				httpClient.SetupMock.Method
+					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString("foo"))
+					.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+				HttpResponseMessage result = await httpClient
+					.PostAsync("https://www.aweXpect.com", new StringContent("foo"), CancellationToken.None);
+
+				await That(httpClient.VerifyMock.Invoked
+						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString("foo")))
+					.Once();
+				await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
+			}
+
 			[Theory]
 			[InlineData("foo")]
 			public async Task WithInvalidCharsetHeader_ShouldFallbackToUtf8(string charsetHeader)


### PR DESCRIPTION
Enables matching/verifying `HttpContent` multiple times (setup + verify) without consuming the underlying content stream, including additional support for .NET Framework where `HttpContent` can be disposed automatically.

### Key Changes:
- Added tests to ensure setups and verifications can both read the same request content.
- Updated `HttpContent` parameter matching to be `HttpRequestMessage`-aware and to restore stream position after reading.
- Updated source generator output for `HttpClient.Send*` on .NET Framework to persist request content bytes for later matching.

---

- *Fixes #468*