### PR TITLE
fix: build warning about conflicting `DoesNotReturnAttribute`

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Mockolate.Internal.Tests.csproj
+++ b/Tests/Mockolate.Internal.Tests/Mockolate.Internal.Tests.csproj
@@ -7,4 +7,8 @@
 		<ProjectReference Include="..\..\Source\Mockolate.Analyzers.CodeFixers\Mockolate.Analyzers.CodeFixers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0"/>
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Remove="Nullable" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR addresses a build warning caused by a conflicting `DoesNotReturnAttribute` by excluding the `Nullable` NuGet package from the internal test project. The types are already generated in the main project and available due to the `InternalsVisibleTo` attribute.