### PR TITLE
refactor: make `HttpContentParameterWrapper` public

### DIFF
--- a/Source/Mockolate/Web/ItExtensions.HttpContent.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.cs
@@ -235,26 +235,35 @@ public static partial class ItExtensions
 		}
 	}
 
-	private class HttpContentParameterWrapper(IHttpContentParameter parameter) : IHttpContentParameter,
+	/// <summary>
+	///     An abstract wrapper base class for <see cref="IHttpContentParameter" />.
+	/// </summary>
+	public abstract class HttpContentParameterWrapper(IHttpContentParameter parameter) : IHttpContentParameter,
 		IHttpRequestMessagePropertyParameter<HttpContent?>, IParameter
 	{
+		/// <inheritdoc cref="IParameter{T}.Do(Action{T})" />
 		public IParameter<HttpContent?> Do(Action<HttpContent?> callback)
 			=> parameter.Do(callback);
 
+		/// <inheritdoc cref="IHttpHeaderParameter{T}.WithHeaders" />
 		public IHttpContentHeaderParameter WithHeaders(
 			params IEnumerable<(string Name, HttpHeaderValue Value)> headers)
 			=> parameter.WithHeaders(headers);
 
+		/// <inheritdoc cref="IHttpContentParameter.WithString(Func{string, bool})" />
 		public IHttpContentParameter WithString(Func<string, bool> predicate)
 			=> parameter.WithString(predicate);
 
+		/// <inheritdoc cref="IHttpContentParameter.WithBytes(Func{byte[], bool})" />
 		public IHttpContentParameter WithBytes(Func<byte[], bool> predicate)
 			=> parameter.WithBytes(predicate);
 
+		/// <inheritdoc cref="IHttpContentParameter.WithMediaType(string)" />
 		public IHttpContentParameter WithMediaType(string? mediaType)
 			=> parameter.WithMediaType(mediaType);
 
-		public bool Matches(HttpContent? value, HttpRequestMessage? requestMessage)
+		bool IHttpRequestMessagePropertyParameter<HttpContent?>.Matches(HttpContent? value,
+			HttpRequestMessage? requestMessage)
 		{
 			if (parameter is IHttpRequestMessagePropertyParameter<HttpContent?> requestMessagePropertyParameter)
 			{
@@ -264,9 +273,11 @@ public static partial class ItExtensions
 			return Matches(value);
 		}
 
+		/// <inheritdoc cref="IParameter.Matches(object?)" />
 		public bool Matches(object? value)
 			=> ((IParameter)parameter).Matches(value);
 
+		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
 		public void InvokeCallbacks(object? value)
 			=> ((IParameter)parameter).InvokeCallbacks(value);
 	}

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -1860,6 +1860,19 @@ namespace Mockolate.Web
     }
     public static class ItExtensions
     {
+        public abstract class HttpContentParameterWrapper : Mockolate.Parameters.IParameter, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>, Mockolate.Web.ItExtensions.IHttpContentParameter, Mockolate.Web.ItExtensions.IHttpHeaderParameter<Mockolate.Web.ItExtensions.IHttpContentHeaderParameter>
+        {
+            protected HttpContentParameterWrapper(Mockolate.Web.ItExtensions.IHttpContentParameter parameter) { }
+            public Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> Do(System.Action<System.Net.Http.HttpContent?> callback) { }
+            public void InvokeCallbacks(object? value) { }
+            public bool Matches(object? value) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithBytes(System.Func<byte[], bool> predicate) { }
+            public Mockolate.Web.ItExtensions.IHttpContentHeaderParameter WithHeaders([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                    "Name",
+                    "Value"})] System.Collections.Generic.IEnumerable<System.ValueTuple<string, Mockolate.Web.HttpHeaderValue>> headers) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithMediaType(string? mediaType) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithString(System.Func<string, bool> predicate) { }
+        }
         public interface IFormDataContentParameter : Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>, Mockolate.Web.ItExtensions.IHttpContentParameter, Mockolate.Web.ItExtensions.IHttpHeaderParameter<Mockolate.Web.ItExtensions.IHttpContentHeaderParameter>
         {
             Mockolate.Web.ItExtensions.IFormDataContentParameter Exactly();

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -1859,6 +1859,19 @@ namespace Mockolate.Web
     }
     public static class ItExtensions
     {
+        public abstract class HttpContentParameterWrapper : Mockolate.Parameters.IParameter, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>, Mockolate.Web.ItExtensions.IHttpContentParameter, Mockolate.Web.ItExtensions.IHttpHeaderParameter<Mockolate.Web.ItExtensions.IHttpContentHeaderParameter>
+        {
+            protected HttpContentParameterWrapper(Mockolate.Web.ItExtensions.IHttpContentParameter parameter) { }
+            public Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> Do(System.Action<System.Net.Http.HttpContent?> callback) { }
+            public void InvokeCallbacks(object? value) { }
+            public bool Matches(object? value) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithBytes(System.Func<byte[], bool> predicate) { }
+            public Mockolate.Web.ItExtensions.IHttpContentHeaderParameter WithHeaders([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                    "Name",
+                    "Value"})] System.Collections.Generic.IEnumerable<System.ValueTuple<string, Mockolate.Web.HttpHeaderValue>> headers) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithMediaType(string? mediaType) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithString(System.Func<string, bool> predicate) { }
+        }
         public interface IFormDataContentParameter : Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>, Mockolate.Web.ItExtensions.IHttpContentParameter, Mockolate.Web.ItExtensions.IHttpHeaderParameter<Mockolate.Web.ItExtensions.IHttpContentHeaderParameter>
         {
             Mockolate.Web.ItExtensions.IFormDataContentParameter Exactly();

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -1800,6 +1800,19 @@ namespace Mockolate.Web
     }
     public static class ItExtensions
     {
+        public abstract class HttpContentParameterWrapper : Mockolate.Parameters.IParameter, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>, Mockolate.Web.ItExtensions.IHttpContentParameter, Mockolate.Web.ItExtensions.IHttpHeaderParameter<Mockolate.Web.ItExtensions.IHttpContentHeaderParameter>
+        {
+            protected HttpContentParameterWrapper(Mockolate.Web.ItExtensions.IHttpContentParameter parameter) { }
+            public Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> Do(System.Action<System.Net.Http.HttpContent?> callback) { }
+            public void InvokeCallbacks(object? value) { }
+            public bool Matches(object? value) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithBytes(System.Func<byte[], bool> predicate) { }
+            public Mockolate.Web.ItExtensions.IHttpContentHeaderParameter WithHeaders([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                    "Name",
+                    "Value"})] System.Collections.Generic.IEnumerable<System.ValueTuple<string, Mockolate.Web.HttpHeaderValue>> headers) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithMediaType(string? mediaType) { }
+            public Mockolate.Web.ItExtensions.IHttpContentParameter WithString(System.Func<string, bool> predicate) { }
+        }
         public interface IFormDataContentParameter : Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>, Mockolate.Web.ItExtensions.IHttpContentParameter, Mockolate.Web.ItExtensions.IHttpHeaderParameter<Mockolate.Web.ItExtensions.IHttpContentHeaderParameter>
         {
             Mockolate.Web.ItExtensions.IFormDataContentParameter Exactly();


### PR DESCRIPTION
Makes `HttpContentParameterWrapper` part of the public API so consumers can build/reuse HTTP content parameter wrappers.

### Key Changes:
- Promotes `HttpContentParameterWrapper` from private to `public abstract` and adds XML documentation.
- Adjusts interface implementation details for matching and callback forwarding.
- Updates API snapshot expectations for netstandard2.0/net8.0/net10.0.

---

- *Fixes #480*