### PR TITLE
coverage: reduce exclusion of tests for .NET Framework

### DIFF
--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringTests.cs
@@ -96,7 +96,6 @@ public sealed partial class ItExtensionsTests
 				await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
 			}
 
-#if !NETFRAMEWORK
 			[Fact]
 			public async Task ShouldSupportMonitoring()
 			{
@@ -119,12 +118,13 @@ public sealed partial class ItExtensionsTests
 					await httpClient.PostAsync("https://www.aweXpect.com", response, CancellationToken.None);
 				}
 
+#if !NETFRAMEWORK
 				await That(
 						await Task.WhenAll(monitor.Values.Select(c => c!.ReadAsStringAsync())))
 					.IsEqualTo(["foo", "foobar", "foo-baz",]);
+#endif
 				await That(callbackCount).IsEqualTo(3);
 			}
-#endif
 
 			[Theory]
 			[InlineData("image/png", false)]

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.cs
@@ -13,7 +13,6 @@ public sealed partial class ItExtensionsTests
 {
 	public sealed partial class IsHttpContentTests
 	{
-#if !NETFRAMEWORK
 		[Fact]
 		public async Task ShouldSupportMonitoring()
 		{
@@ -35,13 +34,14 @@ public sealed partial class ItExtensionsTests
 				await httpClient.PostAsync("https://www.aweXpect.com", response, CancellationToken.None);
 			}
 
+#if !NETFRAMEWORK
 			await That(
 					(await Task.WhenAll(monitor.Values.Select(c => c!.ReadAsByteArrayAsync())))
 					.Select(x => x.Length))
 				.IsEqualTo([0, 1, 3,]);
+#endif
 			await That(callbackCount).IsEqualTo(3);
 		}
-#endif
 
 		[Fact]
 		public async Task ShouldSupportMultipleCombinations()

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.cs
@@ -12,7 +12,6 @@ public sealed partial class ItExtensionsTests
 {
 	public sealed partial class IsHttpRequestMessageTests
 	{
-#if !NETFRAMEWORK
 		[Fact]
 		public async Task ShouldSupportMonitoring()
 		{
@@ -33,13 +32,14 @@ public sealed partial class ItExtensionsTests
 				await httpClient.PostAsync("https://www.aweXpect.com", response, CancellationToken.None);
 			}
 
+#if !NETFRAMEWORK
 			await That(
 					(await Task.WhenAll(monitor.Values.Select(c => c!.Content!.ReadAsByteArrayAsync())))
 					.Select(x => x.Length))
 				.IsEqualTo([0, 1, 3,]);
+#endif
 			await That(callbackCount).IsEqualTo(3);
 		}
-#endif
 
 		[Theory]
 		[InlineData(nameof(HttpMethod.Get), true)]


### PR DESCRIPTION
Reduces conditional compilation exclusions so more of the HTTP monitoring tests run under .NET Framework, while still skipping the specific body-content assertions that aren’t supported there.

### Key Changes:
- Removed `#if !NETFRAMEWORK` guards around entire monitoring tests so the tests execute on .NET Framework.
- Re-scoped `#if !NETFRAMEWORK` to only wrap assertions that read/validate request/response content payloads.