### PR TITLE
docs: document new features

### DIFF
--- a/Docs/pages/04-verify-interactions.md
+++ b/Docs/pages/04-verify-interactions.md
@@ -29,7 +29,7 @@ sut.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(5))
 ```
 
 You can also use `WithCancellation(CancellationToken)` to wait for the expected interactions until the cancellation
-token is canceled. If you combine this with the `Within` method, both cancellations are respected.
+token is canceled. If you combine this with the `Within` method, both the timeout and the cancellation token are respected.
 
 In both cases, it will block the test execution until the expected interaction occurs or the timeout is reached.
 If the interaction does not occur within the specified time, a `MockVerificationException` will be thrown.

--- a/Docs/pages/special-types/01-httpclient.md
+++ b/Docs/pages/special-types/01-httpclient.md
@@ -261,7 +261,7 @@ httpClient.SetupMock.Method.GetAsync(It.IsAny<Uri>())
     // Returns a response with status code 200 OK and a JSON content {"foo":"bar"}
     .ReturnsAsync(HttpStatusCode.OK, "{\"foo\":\"bar\"}", "application/json");
 
-byte[] bytes = //... some byte array content
+byte[] bytes = new byte[] { /* ... */ };
 
 httpClient.SetupMock.Method.GetAsync(It.IsAny<Uri>())
     // Returns a response with status code 200 OK and a binary content with the provided bytes

--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ sut.VerifyMock.Invoked.Dispense(It.Is("Dark"), It.Is(5))
 ```
 
 You can also use `WithCancellation(CancellationToken)` to wait for the expected interactions until the cancellation
-token is canceled. If you combine this with the `Within` method, both cancellations are respected.
+token is canceled. If you combine this with the `Within` method, both the timeout and the cancellation token are respected.
 
 In both cases, it will block the test execution until the expected interaction occurs or the timeout is reached.
 If the interaction does not occur within the specified time, a `MockVerificationException` will be thrown.
@@ -1266,7 +1266,7 @@ httpClient.SetupMock.Method.GetAsync(It.IsAny<Uri>())
     // Returns a response with status code 200 OK and a JSON content {"foo":"bar"}
     .ReturnsAsync(HttpStatusCode.OK, "{\"foo\":\"bar\"}", "application/json");
 
-byte[] bytes = //... some byte array content
+byte[] bytes = new byte[] { /* ... */ };
 
 httpClient.SetupMock.Method.GetAsync(It.IsAny<Uri>())
     // Returns a response with status code 200 OK and a binary content with the provided bytes


### PR DESCRIPTION
Updates Mockolate’s user-facing documentation to cover newly added verification waiting options, setup-specific verification, and `HttpClient` convenience return helpers, aligning README and Docs pages with the latest API surface.

### Changes:
- Document `Within(TimeSpan)` and `WithCancellation(CancellationToken)` for waiting on verifications
  #496
- Add documentation for verifying invocations of a specific method setup via `InvokedSetup(setup)`
  #493
- Document `HttpClient` `.ReturnsAsync(HttpStatusCode, ...)` overloads for simplified response setup
  #497