### PR TITLE
fix: support `InvokedSetup` also for `HttpClient`

### DIFF
--- a/Source/Mockolate/MockExtensions.cs
+++ b/Source/Mockolate/MockExtensions.cs
@@ -9,33 +9,40 @@ namespace Mockolate;
 /// </summary>
 public static class MockExtensions
 {
-	/// <summary>
-	///     Clears all interactions recorded by the mock object.
-	/// </summary>
-	public static void ClearAllInteractions<T>(this IMockSetup<T> mock)
-		where T : class
+	/// <inheritdoc cref="MockExtensions" />
+	extension<T>(IMockSetup<T> mock) where T : class
 	{
-		if (mock is IHasMockRegistration hasMockRegistration)
+		/// <summary>
+		///     Clears all interactions recorded by the mock object.
+		/// </summary>
+		public void ClearAllInteractions()
 		{
-			hasMockRegistration.Registrations.ClearAllInteractions();
+			if (mock is IHasMockRegistration hasMockRegistration)
+			{
+				hasMockRegistration.Registrations.ClearAllInteractions();
+			}
 		}
 	}
 
-	/// <summary>
-	///     Verifies the method invocations for the <paramref name="setup" /> on the mock.
-	/// </summary>
-	public static VerificationResult<T> InvokedSetup<T>(this IMockVerify<T> verify, IMethodSetup setup)
+	/// <inheritdoc cref="MockExtensions" />
+	extension<T>(IMockVerify<T> verify)
 	{
-		if (verify is not Mock<T> mock)
+		/// <summary>
+		///     Verifies the method invocations for the <paramref name="setup" /> on the mock.
+		/// </summary>
+		public VerificationResult<T> InvokedSetup(IMethodSetup setup)
 		{
-			throw new MockException("The subject is no mock subject.");
-		}
+			if (verify is not Mock<T> mock)
+			{
+				throw new MockException("The subject is no mock subject.");
+			}
 
-		if (setup is not IVerifiableMethodSetup verifiableMethodSetup)
-		{
-			throw new MockException("The setup is not verifiable.");
-		}
+			if (setup is not IVerifiableMethodSetup verifiableMethodSetup)
+			{
+				throw new MockException("The setup is not verifiable.");
+			}
 
-		return mock.Registrations.Method(mock.Subject, verifiableMethodSetup.GetMatch());
+			return mock.Registrations.Method(mock.Subject, verifiableMethodSetup.GetMatch());
+		}
 	}
 }

--- a/Source/Mockolate/Web/HttpClientExtensions.ReturnsAsync.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.ReturnsAsync.cs
@@ -6,7 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Mockolate.Setup;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 public static partial class HttpClientExtensions
 {

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
@@ -6,7 +6,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
@@ -6,7 +6,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
@@ -7,7 +7,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
@@ -6,7 +6,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
@@ -6,7 +6,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
@@ -5,7 +5,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Verify;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
@@ -5,7 +5,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Verify;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
@@ -6,7 +6,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Verify;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
@@ -5,7 +5,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Verify;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
@@ -5,7 +5,8 @@ using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Verify;
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 #pragma warning disable S2325 // Methods and properties that don't access instance data should be static
 public static partial class HttpClientExtensions

--- a/Source/Mockolate/Web/HttpClientExtensions.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.cs
@@ -6,11 +6,14 @@ using System.Threading.Tasks;
 using Mockolate.Exceptions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
+using Mockolate.Verify;
+using Mockolate.Web;
 #if NETSTANDARD2_0
 using Mockolate.Internals.Polyfills;
 #endif
 
-namespace Mockolate.Web;
+// ReSharper disable once CheckNamespace
+namespace Mockolate;
 
 /// <summary>
 ///     Extensions for mocking <see cref="HttpClient" />.
@@ -42,6 +45,30 @@ public static partial class HttpClientExtensions
 
 			throw new MockException(
 				"Cannot setup HttpClient when it is not mocked with a mockable HttpMessageHandler.");
+		}
+	}
+
+	/// <inheritdoc cref="HttpClientExtensions" />
+	extension(IMockVerify<HttpClient> verify)
+	{
+		/// <summary>
+		///     Verifies the method invocations for the <paramref name="setup" /> on the mock.
+		/// </summary>
+		public VerificationResult<HttpClient> InvokedSetup(IMethodSetup setup)
+		{
+			if (verify is not Mock<HttpClient> { ConstructorParameters.Length: > 0, } httpClientMock ||
+			    httpClientMock.ConstructorParameters[0] is not IMockSubject<HttpMessageHandler> httpMessageHandlerMock)
+			{
+				throw new MockException("Cannot verify HttpClient when it is not mocked with a mockable HttpMessageHandler.");
+			}
+
+			if (setup is not IVerifiableMethodSetup verifiableMethodSetup)
+			{
+				throw new MockException("The setup is not verifiable.");
+			}
+
+			return httpMessageHandlerMock.Registrations.Method(httpClientMock.Subject,
+				verifiableMethodSetup.GetMatch());
 		}
 	}
 

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -21,6 +21,69 @@ namespace Mockolate
         public virtual bool CanGenerateValue(System.Type type) { }
         public virtual object? GenerateValue(System.Type type, params object?[] parameters) { }
     }
+    public static class HttpClientExtensions
+    {
+        extension(Mockolate.Setup.IMockMethodSetup<System.Net.Http.HttpClient> setup)
+        {
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> SendAsync(Mockolate.Parameters.IParameter<System.Net.Http.HttpRequestMessage> request) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+        }
+        extension(Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> setup)
+        {
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content, string mediaType) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes, string mediaType) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
+        }
+        extension(Mockolate.Verify.IMockVerify<System.Net.Http.HttpClient> verify)
+        {
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> InvokedSetup(Mockolate.Setup.IMethodSetup setup) { }
+        }
+        extension(Mockolate.Verify.IMockVerifyInvokedWithToStringWithEqualsWithGetHashCode<System.Net.Http.HttpClient> verifyInvoked)
+        {
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+        }
+    }
     public interface IDefaultValueGenerator
     {
         object? GenerateValue(System.Type type, params object?[] parameters);
@@ -111,9 +174,16 @@ namespace Mockolate
     }
     public static class MockExtensions
     {
-        public static void ClearAllInteractions<T>(this Mockolate.Setup.IMockSetup<T> mock)
-            where T :  class { }
-        public static Mockolate.Verify.VerificationResult<T> InvokedSetup<T>(this Mockolate.Verify.IMockVerify<T> verify, Mockolate.Setup.IMethodSetup setup) { }
+        extension<T>(Mockolate.Setup.IMockSetup<T> mock)
+            where T :  class
+        {
+            public void ClearAllInteractions() { }
+        }
+        extension<T>(Mockolate.Verify.IMockVerify<T> verify)
+            where T :  notnull
+        {
+            public Mockolate.Verify.VerificationResult<T> InvokedSetup(Mockolate.Setup.IMethodSetup setup) { }
+        }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MockRegistration
@@ -1806,65 +1876,6 @@ namespace Mockolate.Verify
 }
 namespace Mockolate.Web
 {
-    public static class HttpClientExtensions
-    {
-        extension(Mockolate.Setup.IMockMethodSetup<System.Net.Http.HttpClient> setup)
-        {
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> SendAsync(Mockolate.Parameters.IParameter<System.Net.Http.HttpRequestMessage> request) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-        }
-        extension(Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> setup)
-        {
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content, string mediaType) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes, string mediaType) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
-        }
-        extension(Mockolate.Verify.IMockVerifyInvokedWithToStringWithEqualsWithGetHashCode<System.Net.Http.HttpClient> verifyInvoked)
-        {
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-        }
-    }
     public class HttpFormDataValue
     {
         public HttpFormDataValue(string value) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -20,6 +20,69 @@ namespace Mockolate
         public virtual bool CanGenerateValue(System.Type type) { }
         public virtual object? GenerateValue(System.Type type, params object?[] parameters) { }
     }
+    public static class HttpClientExtensions
+    {
+        extension(Mockolate.Setup.IMockMethodSetup<System.Net.Http.HttpClient> setup)
+        {
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> SendAsync(Mockolate.Parameters.IParameter<System.Net.Http.HttpRequestMessage> request) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+        }
+        extension(Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> setup)
+        {
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content, string mediaType) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes, string mediaType) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
+        }
+        extension(Mockolate.Verify.IMockVerify<System.Net.Http.HttpClient> verify)
+        {
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> InvokedSetup(Mockolate.Setup.IMethodSetup setup) { }
+        }
+        extension(Mockolate.Verify.IMockVerifyInvokedWithToStringWithEqualsWithGetHashCode<System.Net.Http.HttpClient> verifyInvoked)
+        {
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+        }
+    }
     public interface IDefaultValueGenerator
     {
         object? GenerateValue(System.Type type, params object?[] parameters);
@@ -110,9 +173,16 @@ namespace Mockolate
     }
     public static class MockExtensions
     {
-        public static void ClearAllInteractions<T>(this Mockolate.Setup.IMockSetup<T> mock)
-            where T :  class { }
-        public static Mockolate.Verify.VerificationResult<T> InvokedSetup<T>(this Mockolate.Verify.IMockVerify<T> verify, Mockolate.Setup.IMethodSetup setup) { }
+        extension<T>(Mockolate.Setup.IMockSetup<T> mock)
+            where T :  class
+        {
+            public void ClearAllInteractions() { }
+        }
+        extension<T>(Mockolate.Verify.IMockVerify<T> verify)
+            where T :  notnull
+        {
+            public Mockolate.Verify.VerificationResult<T> InvokedSetup(Mockolate.Setup.IMethodSetup setup) { }
+        }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MockRegistration
@@ -1805,65 +1875,6 @@ namespace Mockolate.Verify
 }
 namespace Mockolate.Web
 {
-    public static class HttpClientExtensions
-    {
-        extension(Mockolate.Setup.IMockMethodSetup<System.Net.Http.HttpClient> setup)
-        {
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> SendAsync(Mockolate.Parameters.IParameter<System.Net.Http.HttpRequestMessage> request) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-        }
-        extension(Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> setup)
-        {
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content, string mediaType) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes, string mediaType) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
-        }
-        extension(Mockolate.Verify.IMockVerifyInvokedWithToStringWithEqualsWithGetHashCode<System.Net.Http.HttpClient> verifyInvoked)
-        {
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PatchAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-        }
-    }
     public class HttpFormDataValue
     {
         public HttpFormDataValue(string value) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -19,6 +19,61 @@ namespace Mockolate
         public virtual bool CanGenerateValue(System.Type type) { }
         public virtual object? GenerateValue(System.Type type, params object?[] parameters) { }
     }
+    public static class HttpClientExtensions
+    {
+        extension(Mockolate.Setup.IMockMethodSetup<System.Net.Http.HttpClient> setup)
+        {
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> SendAsync(Mockolate.Parameters.IParameter<System.Net.Http.HttpRequestMessage> request) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+        }
+        extension(Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> setup)
+        {
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content, string mediaType) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes, string mediaType) { }
+            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
+        }
+        extension(Mockolate.Verify.IMockVerify<System.Net.Http.HttpClient> verify)
+        {
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> InvokedSetup(Mockolate.Setup.IMethodSetup setup) { }
+        }
+        extension(Mockolate.Verify.IMockVerifyInvokedWithToStringWithEqualsWithGetHashCode<System.Net.Http.HttpClient> verifyInvoked)
+        {
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
+        }
+    }
     public interface IDefaultValueGenerator
     {
         object? GenerateValue(System.Type type, params object?[] parameters);
@@ -105,9 +160,16 @@ namespace Mockolate
     }
     public static class MockExtensions
     {
-        public static void ClearAllInteractions<T>(this Mockolate.Setup.IMockSetup<T> mock)
-            where T :  class { }
-        public static Mockolate.Verify.VerificationResult<T> InvokedSetup<T>(this Mockolate.Verify.IMockVerify<T> verify, Mockolate.Setup.IMethodSetup setup) { }
+        extension<T>(Mockolate.Setup.IMockSetup<T> mock)
+            where T :  class
+        {
+            public void ClearAllInteractions() { }
+        }
+        extension<T>(Mockolate.Verify.IMockVerify<T> verify)
+            where T :  notnull
+        {
+            public Mockolate.Verify.VerificationResult<T> InvokedSetup(Mockolate.Setup.IMethodSetup setup) { }
+        }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MockRegistration
@@ -1754,57 +1816,6 @@ namespace Mockolate.Verify
 }
 namespace Mockolate.Web
 {
-    public static class HttpClientExtensions
-    {
-        extension(Mockolate.Setup.IMockMethodSetup<System.Net.Http.HttpClient> setup)
-        {
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> SendAsync(Mockolate.Parameters.IParameter<System.Net.Http.HttpRequestMessage> request) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-        }
-        extension(Mockolate.Setup.IReturnMethodSetup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> setup)
-        {
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, string content, string mediaType) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, byte[] bytes, string mediaType) { }
-            public Mockolate.Setup.IReturnMethodSetupReturnBuilder<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>, System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken> ReturnsAsync(System.Net.HttpStatusCode statusCode, System.Net.Http.HttpContent content) { }
-        }
-        extension(Mockolate.Verify.IMockVerifyInvokedWithToStringWithEqualsWithGetHashCode<System.Net.Http.HttpClient> verifyInvoked)
-        {
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> DeleteAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> GetAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PostAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?>? content = null) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<string?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-            public Mockolate.Verify.VerificationResult<System.Net.Http.HttpClient> PutAsync(Mockolate.Parameters.IParameter<System.Uri?> requestUri, Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> content, Mockolate.Parameters.IParameter<System.Threading.CancellationToken> cancellationToken) { }
-        }
-    }
     public class HttpFormDataValue
     {
         public HttpFormDataValue(string value) { }

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
@@ -5,6 +5,7 @@ using Mockolate.Exceptions;
 using Mockolate.Interactions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
+using Mockolate.Verify;
 using Mockolate.Web;
 
 namespace Mockolate.Tests.Web;
@@ -28,6 +29,69 @@ public sealed partial class HttpClientExtensionsTests
 		]));
 
 		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task InvokedSetup_ShouldWorkForHttpClient()
+	{
+		HttpClient httpClient = Mock.Create<HttpClient>();
+		IMethodSetup setup = httpClient
+			.SetupMock.Method.GetAsync(It.IsUri("https://www.aweXpect.com"))
+			.ReturnsAsync(HttpStatusCode.Accepted);
+
+		HttpResponseMessage result =
+			await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+
+		await That(result.StatusCode)
+			.IsEqualTo(HttpStatusCode.Accepted);
+		await That(httpClient.VerifyMock.InvokedSetup(setup)).Once();
+	}
+
+	[Fact]
+	public async Task InvokedSetup_WhenMethodSetupIsNotVerifiable_ShouldThrowMockException()
+	{
+		HttpClient mock = Mock.Create<HttpClient>();
+		IMethodSetup setup = new MyMethodSetup();
+
+		void Act()
+		{
+			mock.VerifyMock.InvokedSetup(setup).Never();
+		}
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("The setup is not verifiable.");
+	}
+
+	[Fact]
+	public async Task InvokedSetup_WhenSubjectIsNoMock_ShouldThrowMockException()
+	{
+		HttpClient mock = Mock.Create<HttpClient>();
+		IMockVerify<HttpClient> verify = new MyMockVerify<HttpClient>();
+		IMethodSetup setup = mock.SetupMock.Method.SendAsync(Match.AnyParameters());
+
+		void Act()
+		{
+			verify.InvokedSetup(setup).Never();
+		}
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("Cannot verify HttpClient when it is not mocked with a mockable HttpMessageHandler.");
+	}
+
+	[Fact]
+	public async Task InvokedSetup_WhenSubjectIsMockedWithoutConstructorParameters_ShouldThrowMockException()
+	{
+		HttpClient mock = Mock.Create<HttpClient>(BaseClass.WithConstructorParameters());
+		IMockVerify<HttpClient> verify = mock.VerifyMock;
+		IMethodSetup setup = mock.SetupMock.Method.SendAsync(Match.AnyParameters());
+
+		void Act()
+		{
+			verify.InvokedSetup(setup).Never();
+		}
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("Cannot verify HttpClient when it is not mocked with a mockable HttpMessageHandler.");
 	}
 
 	[Fact]
@@ -123,6 +187,19 @@ public sealed partial class HttpClientExtensionsTests
 	private sealed class InvalidParameter : IParameter<string?>
 	{
 		public IParameter<string?> Do(Action<string?> callback)
+			=> throw new NotSupportedException();
+	}
+
+	private sealed class MyMethodSetup : IMethodSetup
+	{
+	}
+
+	private sealed class MyMockVerify<T> : IMockVerify<T>
+	{
+		public bool ThatAllInteractionsAreVerified()
+			=> throw new NotSupportedException();
+
+		public bool ThatAllSetupsAreUsed()
 			=> throw new NotSupportedException();
 	}
 }


### PR DESCRIPTION
This PR adds `InvokedSetup` verification support for `HttpClient` mocks, complementing the existing typed verify methods (e.g., `GetAsync`, `PostAsync`, etc.). It also refactors all `HttpClientExtensions` partial class files to use the `Mockolate` namespace (instead of `Mockolate.Web`) and converts `MockExtensions` to use C# extension member blocks. The API surface files are updated accordingly.

### Key Changes:
- Adds a new `InvokedSetup(IMethodSetup setup)` extension method on `IMockVerify<HttpClient>` to allow setup-based verification on `HttpClient` mocks.
- Moves all `HttpClientExtensions` partial files from `namespace Mockolate.Web` to `namespace Mockolate`, repositioning the class in the public API surface.
- Refactors `MockExtensions.ClearAllInteractions` and `MockExtensions.InvokedSetup` to use C# extension member blocks instead of traditional extension methods.

---

- *Fixes #503*