### PR TITLE
feat: simplify specifying wildcard matches for web

### DIFF
--- a/Source/Mockolate/Internals/Wildcard.cs
+++ b/Source/Mockolate/Internals/Wildcard.cs
@@ -10,9 +10,9 @@ internal readonly struct Wildcard
 
 	private static readonly ConcurrentDictionary<(string RegexPattern, bool IgnoreCase), Wildcard> RegexCache = new();
 
-	public static Wildcard Pattern(string pattern, bool ignoreCase)
+	public static Wildcard Pattern(string pattern, bool ignoreCase, bool fullMatch = true)
 	{
-		Wildcard wildcard = RegexCache.GetOrAdd((ToRegularExpression(pattern), ignoreCase),
+		Wildcard wildcard = RegexCache.GetOrAdd((ToRegularExpression(pattern, fullMatch), ignoreCase),
 			item => new Wildcard(
 				new Regex(
 					item.RegexPattern,
@@ -31,7 +31,7 @@ internal readonly struct Wildcard
 	public bool Matches(string value)
 		=> Regex.IsMatch(value);
 
-	public static string ToRegularExpression(string pattern)
+	public static string ToRegularExpression(string pattern, bool fullMatch)
 	{
 		string regex = Regex.Escape(pattern)
 #if NETFRAMEWORK || NETSTANDARD2_0
@@ -41,6 +41,11 @@ internal readonly struct Wildcard
 			.Replace("\\?", ".", StringComparison.Ordinal)
 			.Replace("\\*", "(?:.|\\n)*", StringComparison.Ordinal);
 #endif
-		return $"^{regex}$";
+		if (fullMatch)
+		{
+			return $"^{regex}$";
+		}
+
+		return regex;
 	}
 }

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.WithString.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.WithString.cs
@@ -73,7 +73,7 @@ public static partial class ItExtensions
 						: StringComparison.Ordinal):
 					return false;
 				case BodyMatchType.Wildcard when
-					!Wildcard.Pattern(value, _ignoringCase).Matches(stringContent):
+					!Wildcard.Pattern(value, _ignoringCase, false).Matches(stringContent):
 					return false;
 				case BodyMatchType.Regex:
 					{

--- a/Source/Mockolate/Web/ItExtensions.Uri.cs
+++ b/Source/Mockolate/Web/ItExtensions.Uri.cs
@@ -94,7 +94,7 @@ public static partial class ItExtensions
 			if (pattern is not null)
 			{
 				string requestUri1 = uri.ToString();
-				Wildcard wildcard = Wildcard.Pattern(pattern, true);
+				Wildcard wildcard = Wildcard.Pattern(pattern, true, false);
 				if (!wildcard.Matches(requestUri1) &&
 				    (!requestUri1.EndsWith('/') || !wildcard.Matches(requestUri1.TrimEnd('/'))))
 				{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.DeleteTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.DeleteTests.cs
@@ -110,7 +110,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", true)]
 			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("aweXpect.com*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.GetTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.GetTests.cs
@@ -110,7 +110,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", true)]
 			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("aweXpect.com*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PatchTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PatchTests.cs
@@ -155,7 +155,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", true)]
 			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("aweXpect.com*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PostTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PostTests.cs
@@ -152,7 +152,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", true)]
 			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("aweXpect.com*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PutTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PutTests.cs
@@ -152,7 +152,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", true)]
 			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("aweXpect.com*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.DeleteTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.DeleteTests.cs
@@ -99,7 +99,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", 1)]
 			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("aweXpect.com*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.GetTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.GetTests.cs
@@ -99,7 +99,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", 1)]
 			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("aweXpect.com*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PatchTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PatchTests.cs
@@ -143,7 +143,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", 1)]
 			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("aweXpect.com*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PostTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PostTests.cs
@@ -140,7 +140,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", 1)]
 			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("aweXpect.com*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PutTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PutTests.cs
@@ -140,7 +140,7 @@ public sealed partial class HttpClientExtensionsTests
 			[Theory]
 			[InlineData("*aweXpect.com*", 1)]
 			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("aweXpect.com*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringMatchingTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringMatchingTests.cs
@@ -89,7 +89,7 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("foo", "f?", false)]
+			[InlineData("foo", "f?", true)]
 			[InlineData("foo", "f??", true)]
 			[InlineData("foo", "f*", true)]
 			[InlineData("foo", "*", true)]
@@ -112,10 +112,13 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("foo", "f?", false)]
+			[InlineData("foo", "f?", true)]
 			[InlineData("foo", "f??", true)]
 			[InlineData("foo", "f*", true)]
 			[InlineData("foo", "*", true)]
+			[InlineData("foo", "o?", true)]
+			[InlineData("foo", "?o", true)]
+			[InlineData("foo", "o", true)]
 			[InlineData("foo", "F*", false)]
 			[InlineData("foo", "*a*", false)]
 			public async Task ShouldCheckForMatchingWildcard(string body, string pattern, bool expectSuccess)

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseContentIsTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseContentIsTests.cs
@@ -280,7 +280,7 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("foo", "f?", false)]
+			[InlineData("foo", "f?", true)]
 			[InlineData("foo", "f??", true)]
 			[InlineData("foo", "f*", true)]
 			[InlineData("foo", "*", true)]
@@ -304,7 +304,7 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("foo", "f?", false)]
+			[InlineData("foo", "f?", true)]
 			[InlineData("foo", "f??", true)]
 			[InlineData("foo", "f*", true)]
 			[InlineData("foo", "*", true)]

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
@@ -52,7 +52,7 @@ public sealed partial class ItExtensionsTests
 				false)]
 			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=124&y=4",
 				false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123", false)]
+			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123", true)]
 			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*www.aweXpect.com*", true)]
 			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*/foo/bar*", true)]
 			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*x=123*", true)]

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.cs
@@ -34,11 +34,12 @@ public sealed partial class ItExtensionsTests
 		}
 
 		[Theory]
+		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "aweXpect.com*x=123", true)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123&y=4", true)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "http://www.aweXpect.com/foo/bar?x=123&y=4", false)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/baz?x=123&y=4", false)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=124&y=4", false)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123", false)]
+		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123", true)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*www.aweXpect.com*", true)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*/foo/bar*", true)]
 		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*x=123*", true)]


### PR DESCRIPTION
This PR updates Mockolate’s web wildcard matching to allow simpler patterns (i.e., patterns can match within the target string rather than requiring full-string matches), and adjusts the existing web-related tests to reflect the new behavior.

### Key Changes:
- Add an optional `fullMatch` parameter to `Wildcard.Pattern(...)` / `ToRegularExpression(...)` to control anchoring (`^...$`).
- Switch URI and HTTP content wildcard matching to use non-full (substring) matching.
- Update and expand web matcher tests to validate the new wildcard semantics.

---

- *Fixes #511*