### PR TITLE
chore: increase test timeout

### DIFF
--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.AsyncTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.AsyncTests.cs
@@ -47,7 +47,7 @@ public sealed partial class VerificationResultTests
 			IChocolateDispenser sut = Mock.Create<IChocolateDispenser>();
 
 			VerificationResult<IChocolateDispenser> result = sut.VerifyMock.Invoked.Dispense(Match.AnyParameters())
-				.Within(TimeSpan.FromSeconds(10));
+				.Within(TimeSpan.FromSeconds(30));
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
 
@@ -55,7 +55,7 @@ public sealed partial class VerificationResultTests
 			{
 				for (int i = 0; i < 1000; i++)
 				{
-					await Task.Delay(10, CancellationToken.None);
+					await Task.Delay(10, CancellationToken.None).ConfigureAwait(false);
 					sut.Dispense("Dark", i);
 					if (token.IsCancellationRequested)
 					{


### PR DESCRIPTION
Adjusts an async verification test to be less flaky under slower CI environments.

### Key Changes:
- Increased the verification window from 10s to 30s.
- Added `ConfigureAwait(false)` to an awaited `Task.Delay` in the background loop.