### PR TITLE
feat: Make `CreateMock` with constructor parameters private for interfaces

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -80,7 +80,7 @@ internal static partial class Sources
 		sb.AppendXmlSummary($"Create a new mock for <see cref=\"{escapedClassName}\" /> using the <paramref name=\"constructorParameters\" /> with the given <paramref name=\"mockBehavior\" />.");
 		sb.AppendXmlRemarks("All provided <paramref name=\"setups\" /> are immediately applied to the mock.");
 		sb.Append("\t\t[global::Mockolate.MockGenerator]").AppendLine();
-		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(object?[]? constructorParameters, global::Mockolate.MockBehavior? mockBehavior = null, params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(name).Append(">[] setups)").AppendLine();
+		sb.Append("\t\t").Append(@class.IsInterface ? "private" : "public").Append(" static ").Append(@class.ClassFullName).Append(" CreateMock(object?[]? constructorParameters, global::Mockolate.MockBehavior? mockBehavior = null, params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(name).Append(">[] setups)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tmockBehavior ??= global::Mockolate.MockBehavior.Default;").AppendLine();
 		sb.Append("\t\t\tIMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;").AppendLine();

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -190,7 +190,7 @@ public sealed partial class MockTests
 	[Fact]
 	public async Task Create_WithSetups_ShouldApplySetups()
 	{
-		IMyService mock = IMyService.CreateMock([], null,
+		IMyService mock = IMyService.CreateMock(
 			setup => setup.Multiply(It.Is(1), It.IsAny<int?>()).Returns(2),
 			setup => setup.Multiply(It.Is(2), It.IsAny<int?>()).Returns(4),
 			setup => setup.Multiply(It.Is(3), It.IsAny<int?>()).Returns(8)


### PR DESCRIPTION
Updates the source generator so that the `CreateMock` overload accepting constructor parameters is not publicly exposed for interface mocks, and adjusts a unit test to use the remaining public overloads.

### Key Changes:
- Generate `CreateMock(object?[]? constructorParameters, ...)` as `private` when the mocked type is an interface.
- Update `MockTests` to call the public `CreateMock(params setups)` overload for an interface mock.

---

- *Fixes #538*