### PR TITLE
fix: remove CS0460 build error in generated code

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1850,14 +1850,6 @@ internal static partial class Sources
 			sb.Append(")");
 		}
 
-		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
-		{
-			foreach (GenericParameter gp in method.GenericParameters.Value)
-			{
-				gp.AppendWhereConstraint(sb, "\t\t\t");
-			}
-		}
-
 		sb.AppendLine();
 		sb.AppendLine("\t\t{");
 		if (method.ReturnType != Type.Void)
@@ -2252,14 +2244,6 @@ internal static partial class Sources
 		}
 
 		sb.Append(")");
-		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
-		{
-			foreach (GenericParameter gp in method.GenericParameters.Value)
-			{
-				gp.AppendWhereConstraint(sb, "\t\t\t");
-			}
-		}
-
 		sb.AppendLine();
 
 		sb.Append("\t\t\t=> this.Registrations.Method<").Append(verifyName).Append(">(this, ");

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -230,6 +230,19 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task GenericMethodWithWhereClause_ShouldWork()
+	{
+		IMyServiceWithGenericMethodsWithWhereClause sut = IMyServiceWithGenericMethodsWithWhereClause.CreateMock();
+
+		sut.Mock.Setup.MyMethod<IChocolateDispenser>(It.IsTrue()).Returns(3);
+
+		int result = sut.MyMethod<IChocolateDispenser>(true);
+
+		await That(result).IsEqualTo(3);
+		await That(sut.Mock.Verify.MyMethod<IChocolateDispenser>(It.IsTrue())).Once();
+	}
+
+	[Fact]
 	public async Task ToString_ShouldReturnImplementedType()
 	{
 		IChocolateDispenser sut = IChocolateDispenser.CreateMock();
@@ -370,6 +383,11 @@ public sealed partial class MockTests
 
 		// ReSharper disable once UnassignedGetOnlyAutoProperty
 		public int Number { get; }
+	}
+
+	public interface IMyServiceWithGenericMethodsWithWhereClause
+	{
+		int MyMethod<T>(bool flag) where T : IChocolateDispenser;
 	}
 
 	public sealed class Nested


### PR DESCRIPTION
This PR updates the Mockolate source generator to avoid emitting generic `where` constraints on explicit interface implementation methods, preventing [CS0460](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/interface-implementation-errors#generic-type-constraints) build errors when mocked members include constrained generic methods:

> Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.

### Key Changes:
- Stop emitting `where` constraints in generated *setup* explicit interface implementations.
- Stop emitting `where` constraints in generated *verify* explicit interface implementations.
- Add a regression test covering a mocked constrained generic method (`where T : ...`) to ensure generation compiles and runtime behavior works.