### PR TITLE
fix: compilation error with explicit interface members

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -20,7 +20,6 @@ internal record Class
 		List<Event>? exceptEvents = null)
 	{
 		_sourceAssembly = sourceAssembly;
-		Namespace = type.ContainingNamespace.ToString();
 		ClassFullName = type.ToDisplayString(Helpers.TypeDisplayFormat);
 		ClassName = GetTypeName(type);
 		DisplayString = GetTypeFullName(type);
@@ -38,26 +37,26 @@ internal record Class
 		IsInterface = type.TypeKind == TypeKind.Interface;
 		List<Method> methods = ToListExcept(type.GetMembers().OfType<IMethodSymbol>()
 			// Exclude getter/setter methods
-			.Where(x => x.MethodKind is MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation)
+			.Where(x => x.MethodKind is MethodKind.Ordinary)
 			.Where(x => !x.IsSealed)
-			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract || x.ExplicitInterfaceImplementations.Length > 0)
-			.Where(x => ShouldIncludeMember(x, x.ExplicitInterfaceImplementations.Length))
+			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
+			.Where(ShouldIncludeMember)
 			.Select(x => new Method(x, alreadyDefinedMethods))
 			.Distinct(), exceptMethods, Method.ContainingTypeIndependentEqualityComparer);
 		Methods = new EquatableArray<Method>(methods.ToArray());
 
 		List<Property> properties = ToListExcept(type.GetMembers().OfType<IPropertySymbol>()
 			.Where(x => !x.IsSealed)
-			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract || x.ExplicitInterfaceImplementations.Length > 0)
-			.Where(x => ShouldIncludeMember(x, x.ExplicitInterfaceImplementations.Length))
+			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
+			.Where(ShouldIncludeMember)
 			.Select(x => new Property(x, alreadyDefinedProperties))
 			.Distinct(), exceptProperties, Property.ContainingTypeIndependentEqualityComparer);
 		Properties = new EquatableArray<Property>(properties.ToArray());
 
 		List<Event> events = ToListExcept(type.GetMembers().OfType<IEventSymbol>()
 			.Where(x => !x.IsSealed)
-			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract || x.ExplicitInterfaceImplementations.Length > 0)
-			.Where(x => ShouldIncludeMember(x, x.ExplicitInterfaceImplementations.Length))
+			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
+			.Where(ShouldIncludeMember)
 			.Select(x => (x, x.Type as INamedTypeSymbol))
 			.Where(x => x.Item2?.DelegateInvokeMethod is not null)
 			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, alreadyDefinedEvents))
@@ -90,15 +89,14 @@ internal record Class
 						exceptEvents))
 				.ToArray());
 
-		bool ShouldIncludeMember(ISymbol member, int explicitInterfaceImplementations)
+		bool ShouldIncludeMember(ISymbol member)
 		{
-			if (IsInterface || member.IsAbstract || explicitInterfaceImplementations > 0)
+			if (IsInterface || member.IsAbstract)
 			{
 				return true;
 			}
 
-			if ((member.DeclaredAccessibility == Accessibility.Internal ||
-			     member.DeclaredAccessibility == Accessibility.ProtectedOrInternal) &&
+			if (member.DeclaredAccessibility is Accessibility.Internal or Accessibility.ProtectedOrInternal &&
 			    !SymbolEqualityComparer.Default.Equals(member.ContainingAssembly, _sourceAssembly))
 			{
 				return false;
@@ -114,7 +112,6 @@ internal record Class
 	public EquatableArray<Event> Events { get; }
 
 	public bool IsInterface { get; }
-	public string? Namespace { get; }
 	public string ClassFullName { get; }
 	public string ClassName { get; }
 	public string DisplayString { get; }

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -1,9 +1,12 @@
-﻿namespace Mockolate.SourceGenerators.Tests;
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Mockolate.SourceGenerators.Tests;
 
 public sealed partial class MockTests
 {
 	[Fact]
-	public async Task DeeplyNestedClass_ShouldSetupAndVerifyForAllInheritedTypes()
+	public async Task DeeplyNestedClass_ShouldSetupAndVerifyForAllInheritedTypesExceptExplicitInterfaceMembers()
 	{
 		GeneratorResult result = Generator
 			.Run("""
@@ -65,35 +68,74 @@ public sealed partial class MockTests
 		await That(result.Sources).ContainsKey("Mock.OuterClass.g.cs").WhoseValue
 			.Contains("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.OuterValue").And
 			.Contains("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.BaseClassValue").And
-			.Contains("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.DirectValue").And
-			.Contains("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.ParentValue").And
-			.Contains("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.NestedValue").And
+			.DoesNotContain("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.DirectValue").And
+			.DoesNotContain("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.ParentValue").And
+			.DoesNotContain("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.NestedValue").And
 			.Contains("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.OuterMethod()").And
 			.Contains("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.BaseClassMethod()").And
-			.Contains("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.DirectMethod()").And
-			.Contains("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.ParentMethod()").And
-			.Contains("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.NestedMethod()").And
+			.DoesNotContain("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.DirectMethod()").And
+			.DoesNotContain("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.ParentMethod()").And
+			.DoesNotContain("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.NestedMethod()").And
 			.Contains("void IMockRaiseOnOuterClass.OuterEvent(object? sender, global::System.EventArgs e)").And
 			.Contains("void IMockRaiseOnOuterClass.BaseClassEvent(object? sender, global::System.EventArgs e)").And
-			.Contains("void IMockRaiseOnOuterClass.DirectEvent(object? sender, global::System.EventArgs e)").And
-			.Contains("void IMockRaiseOnOuterClass.ParentEvent(object? sender, global::System.EventArgs e)").And
-			.Contains("void IMockRaiseOnOuterClass.NestedEvent(object? sender, global::System.EventArgs e)").And
+			.DoesNotContain("void IMockRaiseOnOuterClass.DirectEvent(object? sender, global::System.EventArgs e)").And
+			.DoesNotContain("void IMockRaiseOnOuterClass.ParentEvent(object? sender, global::System.EventArgs e)").And
+			.DoesNotContain("void IMockRaiseOnOuterClass.NestedEvent(object? sender, global::System.EventArgs e)").And
 			.Contains("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.OuterValue").And
 			.Contains("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.BaseClassValue").And
-			.Contains("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.DirectValue").And
-			.Contains("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.ParentValue").And
-			.Contains("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.NestedValue").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.DirectValue").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.ParentValue").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.NestedValue").And
 			.Contains("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.OuterMethod()").And
 			.Contains("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.BaseClassMethod()").And
-			.Contains("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.DirectMethod()").And
-			.Contains("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.ParentMethod()").And
-			.Contains("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.NestedMethod()").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.DirectMethod()").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.ParentMethod()").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.NestedMethod()").And
 			.Contains("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.OuterEvent").And
 			.Contains("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.BaseClassEvent").And
-			.Contains("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.DirectEvent").And
-			.Contains("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.ParentEvent").And
-			.Contains("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.NestedEvent");
+			.DoesNotContain("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.DirectEvent").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.ParentEvent").And
+			.DoesNotContain("global::Mockolate.Verify.VerificationEventResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.NestedEvent");
 	}
+	
+	[Fact]
+	public async Task ExplicitInterfaceImplementation_ShouldNotAddAccessibility()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using System.Collections;
+			     using System.Collections.Generic;
+			     using System.Threading.Tasks;
+			     using Mockolate;
+			     
+			     namespace MyCode;
+			     
+			     public abstract class MyService : IEnumerable<int>
+			     {
+			     	public IEnumerator<int> GetEnumerator()
+			     	{
+			     		return new List<int>().GetEnumerator();
+			     	}
+			     
+			     	IEnumerator IEnumerable.GetEnumerator()
+			     	{
+			     		return GetEnumerator();
+			     	}
+			     }
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+			     """, typeof(IEnumerator), typeof(IEnumerable<int>));
+
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.DoesNotContain("private global::System.Collections.IEnumerator GetEnumerator()");
+	}
+	
 	[Fact]
 	public async Task ForTypesWithAdditionalConstructorsWithParameters_ShouldWorkForAllNonPrivateConstructors()
 	{


### PR DESCRIPTION
Fixes a source-generator compilation error triggered by explicit interface implementations by preventing the generator from treating explicit interface members as mockable members on classes.

### Key Changes:
- Update member discovery in `Class` entity to exclude explicit interface implementations from generated mock member lists.
- Adjust existing generator test expectations to ensure explicit interface members are not exposed for setup/verify/raise APIs.
- Add a focused regression test ensuring explicit interface implementations are not emitted with an accessibility modifier.