### PR TITLE
fix: `HttpClient` shares the registry with its handler

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -159,6 +159,10 @@ internal static partial class Sources
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tconstructorParameters = [new global::Mockolate.Mock.HttpMessageHandler(mockRegistry),];").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
+			sb.Append("\t\t\telse if (constructorParameters.Length > 0 && constructorParameters[0] is global::Mockolate.IMock httpMessageHandlerMock)").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\tmockRegistry = httpMessageHandlerMock.MockRegistry;").AppendLine();
+			sb.Append("\t\t\t}").AppendLine();
 		}
 
 		sb.AppendLine();

--- a/Tests/Mockolate.Tests/Web/HttpClientTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using Mockolate.Setup;
 using Mockolate.Web;
 
 namespace Mockolate.Tests.Web;
@@ -13,11 +14,14 @@ public class HttpClientTests
 		HttpMessageHandler handler = HttpMessageHandler.CreateMock();
 		HttpClient client1 = HttpClient.CreateMock([handler,]);
 		HttpClient client2 = HttpClient.CreateMock([handler,]);
-
-		client1.Mock.Setup.GetAsync(It.IsUri("aweXpect.com")).ReturnsAsync(HttpStatusCode.Accepted);
+		IMethodSetup setup = client1.Mock.Setup
+			.GetAsync(It.IsUri("aweXpect.com"))
+			.ReturnsAsync(HttpStatusCode.Accepted);
 
 		HttpResponseMessage response = await client2.GetAsync("https://aweXpect.com", CancellationToken.None);
 
 		await That(response.StatusCode).IsEqualTo(HttpStatusCode.Accepted);
+		await That(client1.Mock.VerifySetup(setup)).Once();
+		await That(client2.Mock.VerifySetup(setup)).Once();
 	}
 }


### PR DESCRIPTION
This PR fixes `HttpClient` mock creation so that when an `HttpMessageHandler` mock is supplied via constructor parameters, the resulting `HttpClient` mock shares the same `MockRegistry` as the handler—making setups/verifications consistent across multiple clients using the same handler.

### Key Changes:
- Updated the source generator’s `HttpClient` special-case to reuse the handler mock’s `MockRegistry` when provided as the first constructor parameter.
- Strengthened the existing `HttpClient` shared-handler test to also verify that the same setup can be verified via both `HttpClient` mocks.

---

- *Part of #560*