### PR TITLE
coverage: add missing tests for source generator project

### DIFF
--- a/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
+++ b/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -70,35 +69,7 @@ internal static class MockGeneratorHelpers
 				}
 				else if (IsMockable(methodSymbol.ReturnType))
 				{
-					ImmutableArray<ITypeParameterSymbol> genericParameters = methodSymbol.TypeParameters;
-					// If the method has generic parameters, and the return type does not match the first generic type parameter, use return type as main type and all generic types as additional implementations
-					if (genericParameters.Length > 0)
-					{
-						ITypeSymbol[] genericTypeSymbols = genericParameters
-							.Select(tp => methodSymbol.TypeArguments.Length > tp.Ordinal ? methodSymbol.TypeArguments[tp.Ordinal] : null)
-							.Where(t => t != null)
-							.Cast<ITypeSymbol>()
-							.ToArray();
-						if (SymbolEqualityComparer.Default.Equals(methodSymbol.ReturnType, genericTypeSymbols[0]))
-						{
-							if (genericTypeSymbols.Length == 1)
-							{
-								yield return new MockClass([methodSymbol.ReturnType,], sourceAssembly);
-							}
-							else
-							{
-								yield return new MockClass(genericTypeSymbols, sourceAssembly);
-							}
-						}
-						else
-						{
-							yield return new MockClass([methodSymbol.ReturnType, ..genericTypeSymbols,], sourceAssembly);
-						}
-					}
-					else
-					{
-						yield return new MockClass([methodSymbol.ReturnType,], sourceAssembly);
-					}
+					yield return new MockClass([methodSymbol.ReturnType,], sourceAssembly);
 
 					foreach (MockClass? additionalMockClass in DiscoverMockableTypes([methodSymbol.ReturnType,], sourceAssembly))
 					{

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -565,6 +565,101 @@ public class GeneralTests
 	}
 
 	[Fact]
+	public async Task WhenInterfaceHasMockAndMockolate_MockProperties_ShouldUseMockolate_Mock__1ForMockAccessProperty()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IMyInterface.CreateMock();
+			         }
+			     }
+
+			     public interface IMyInterface
+			     {
+			         int Mock { get; }
+			         bool Mockolate_Mock { get; }
+			     }
+			     """);
+
+		await That(result.Sources)
+			.ContainsKey("Mock.IMyInterface.g.cs").WhoseValue
+			.Contains("Mockolate_Mock__1")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenInterfaceHasMockMockolate_MockAndMockolate_Mock__1Properties_ShouldUseMockolate_Mock__2()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IMyInterface.CreateMock();
+			         }
+			     }
+
+			     public interface IMyInterface
+			     {
+			         int Mock { get; }
+			         bool Mockolate_Mock { get; }
+			         string Mockolate_Mock__1 { get; }
+			     }
+			     """);
+
+		await That(result.Sources)
+			.ContainsKey("Mock.IMyInterface.g.cs").WhoseValue
+			.Contains("Mockolate_Mock__2")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenInterfaceMembersOccupyAllMockRegistryNameCandidates_ShouldUseMockRegistry_2()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IMyInterface.CreateMock();
+			         }
+			     }
+
+			     public interface IMyInterface
+			     {
+			         string MockRegistry_1 { get; }
+			         event EventHandler MockRegistry;
+			         int MockolateMockRegistry(bool value);
+			     }
+			     """, typeof(EventHandler));
+
+		await That(result.Sources)
+			.ContainsKey("Mock.IMyInterface.g.cs").WhoseValue
+			.Contains("MockRegistry_2")
+			.IgnoringNewlineStyle().And
+			.DoesNotContain("private global::Mockolate.MockRegistry MockRegistry_1 { get; }")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
 	public async Task WithAttributes_ShouldAddAttributesToGeneratedCode()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -11,6 +11,7 @@ public class MockGeneratorTests
 			.Run("""
 			     using Mockolate;
 
+			     #nullable enable
 			     namespace MyCode;
 
 			     public class Program
@@ -23,20 +24,20 @@ public class MockGeneratorTests
 
 			     public interface IInterface1
 			     {
-			         void Method(int? value);
+			         void Method(string? value);
 			     }
 
 			     public interface IInterface2
 			     {
-			         void Method(int value);
+			         void Method(string value);
 			     }
 			     """);
 
 		await That(result.Diagnostics).IsEmpty();
 
 		await That(result.Sources).ContainsKey("Mock.IInterface1__IInterface2.g.cs").WhoseValue
-			.Contains("void Method(")
-			.IgnoringNewlineStyle();
+			.Contains("public void Method(string? value)").And
+			.Contains("void global::MyCode.IInterface2.Method(string value)");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -5,6 +5,41 @@ namespace Mockolate.SourceGenerators.Tests;
 public class MockGeneratorTests
 {
 	[Fact]
+	public async Task SameMethodDifferingOnlyByNullability_ShouldUseExplicitImplementationForConflictingInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IInterface1.CreateMock().Implementing<IInterface2>();
+			         }
+			     }
+
+			     public interface IInterface1
+			     {
+			         void Method(int? value);
+			     }
+
+			     public interface IInterface2
+			     {
+			         void Method(int value);
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+
+		await That(result.Sources).ContainsKey("Mock.IInterface1__IInterface2.g.cs").WhoseValue
+			.Contains("void Method(")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
 	public async Task SealedClass_ShouldNotBeIncluded()
 	{
 		GeneratorResult result = Generator
@@ -71,6 +106,84 @@ public class MockGeneratorTests
 			"Mock.MyService__IMyInterface1.g.cs",
 			"Mock.MyService__IMyInterface1__IMyInterface2.g.cs",
 		]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task WhenImplementingAdditionalInterface_WithBaseClassHavingOptionalConstructorParameter_ShouldGenerateTryCastWithDefaultValue()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock().Implementing<IMyInterface>();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(int value = 0) { }
+			     }
+
+			     public interface IMyInterface
+			     {
+			         void DoWork();
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+
+		await That(result.Sources).ContainsKey("Mock.MyService__IMyInterface.g.cs").WhoseValue
+			.Contains("static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)")
+			.IgnoringNewlineStyle().And
+			.Contains("mock.MockRegistry.ConstructorParameters.Length >= 0 && mock.MockRegistry.ConstructorParameters.Length <= 1")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenImplementingAdditionalInterface_WithBaseClassHavingRequiredConstructorParameter_ShouldGenerateTryCast()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock([42]).Implementing<IMyInterface>();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(int value) { }
+			     }
+
+			     public interface IMyInterface
+			     {
+			         void DoWork();
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+
+		await That(result.Sources).ContainsKey("Mock.MyService__IMyInterface.g.cs").WhoseValue
+			.Contains("static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)")
+			.IgnoringNewlineStyle().And
+			.Contains("No parameterless constructor found for 'MyCode.MyService'")
+			.IgnoringNewlineStyle().And
+			.Contains("mock.MockRegistry.ConstructorParameters.Length == 1")
+			.IgnoringNewlineStyle().And
+			.DoesNotContain("TryCastWithDefaultValue")
+			.IgnoringNewlineStyle();
 	}
 
 	[Fact]
@@ -287,6 +400,47 @@ public class MockGeneratorTests
 	}
 
 	[Fact]
+	public async Task WhenUsingCreateMockFromNonMockolateNamespace_ShouldNotBeIncluded()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using MockolateExtensions;
+
+			     namespace MyCode
+			     {
+			         public class Program
+			         {
+			             public static void Main(string[] args)
+			             {
+			                 _ = new MyService().CreateMock();
+			             }
+			         }
+
+			         public class MyService { }
+			     }
+
+			     namespace MockolateExtensions
+			     {
+			         public static class MockExtensions
+			         {
+			             public static T CreateMock<T>(this T value)
+			                 where T : class
+			                 => value;
+			         }
+			     }
+			     """);
+
+		await ThatAll(
+			That(result.Sources.Keys).IsEqualTo([
+				"Mock.g.cs",
+				"MockBehaviorExtensions.g.cs",
+			]).InAnyOrder().IgnoringCase(),
+			That(result.Diagnostics).IsEmpty()
+		);
+	}
+
+	[Fact]
 	public async Task WhenUsingSetups_ShouldGenerateMocksAndExtensions()
 	{
 		GeneratorResult result = Generator
@@ -377,46 +531,5 @@ public class MockGeneratorTests
 
 		await That(result.Sources).ContainsKey("Mock.HttpMessageHandler.g.cs").And
 			.ContainsKey("Mock.HttpClient.g.cs");
-	}
-
-	[Fact]
-	public async Task WhenUsingCreateMockFromNonMockolateNamespace_ShouldNotBeIncluded()
-	{
-		GeneratorResult result = Generator
-			.Run("""
-			     using System;
-			     using MockolateExtensions;
-
-			     namespace MyCode
-			     {
-			         public class Program
-			         {
-			             public static void Main(string[] args)
-			             {
-			                 _ = new MyService().CreateMock();
-			             }
-			         }
-
-			         public class MyService { }
-			     }
-
-			     namespace MockolateExtensions
-			     {
-			         public static class MockExtensions
-			         {
-			             public static T CreateMock<T>(this T value)
-			                 where T : class
-			                 => value;
-			         }
-			     }
-			     """);
-
-		await ThatAll(
-			That(result.Sources.Keys).IsEqualTo([
-				"Mock.g.cs",
-				"MockBehaviorExtensions.g.cs",
-			]).InAnyOrder().IgnoringCase(),
-			That(result.Diagnostics).IsEmpty()
-		);
 	}
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -207,6 +207,67 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task MethodWithEnumDefaultValue_ShouldGenerateCastExpression()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IService.CreateMock();
+					         }
+					     }
+
+					     public enum Status { Active = 0, Inactive = 1 }
+
+					     public interface IService
+					     {
+					         void Process(Status status = Status.Inactive);
+					     }
+					     """);
+
+				await That(result.Sources)
+					.ContainsKey("Mock.IService.g.cs").WhoseValue
+					.Contains("(global::MyCode.Status)1")
+					.IgnoringNewlineStyle();
+			}
+
+			[Fact]
+			public async Task MethodWithStructDefaultValue_ShouldGenerateDefaultKeyword()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using System;
+					     using Mockolate;
+
+					     namespace MyCode;
+
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IService.CreateMock();
+					         }
+					     }
+
+					     public interface IService
+					     {
+					         void Process(DateTime time = default);
+					     }
+					     """, typeof(DateTime));
+
+				await That(result.Sources)
+					.ContainsKey("Mock.IService.g.cs").WhoseValue
+					.Contains("DateTime time = default")
+					.IgnoringNewlineStyle();
+			}
+
+			[Fact]
 			public async Task MultipleImplementations_ShouldOnlyHaveOneExplicitImplementation()
 			{
 				GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -200,7 +200,7 @@ public sealed partial class MockTests
 				.IgnoringNewlineStyle().And
 				.Contains("Verify(int a, int b, int c, int d, int e)")
 				.IgnoringNewlineStyle().And
-				.DoesNotContain("Setup(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<int>? c, global::Mockolate.Parameters.IParameter<int>? d, global::Mockolate.Parameters.IParameter<int>? e, global::Mockolate.Parameters.IParameter<int>?")
+				.Contains("Setup(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<int>? c, global::Mockolate.Parameters.IParameter<int>? d, global::Mockolate.Parameters.IParameter<int>? e)")
 				.IgnoringNewlineStyle();
 		}
 
@@ -226,9 +226,9 @@ public sealed partial class MockTests
 
 			await That(result.Sources)
 				.ContainsKey("Mock.Program_ProcessAll.g.cs").WhoseValue
-				.Contains("global::Mockolate.Parameters.IOutParameter<int> a, global::Mockolate.Parameters.IOutParameter<int> b, global::Mockolate.Parameters.IOutParameter<int> c, global::Mockolate.Parameters.IOutParameter<int> d, global::Mockolate.Parameters.IOutParameter<int> e")
+				.Contains("Setup(global::Mockolate.Parameters.IOutParameter<int> a, global::Mockolate.Parameters.IOutParameter<int> b, global::Mockolate.Parameters.IOutParameter<int> c, global::Mockolate.Parameters.IOutParameter<int> d, global::Mockolate.Parameters.IOutParameter<int> e)")
 				.IgnoringNewlineStyle().And
-				.DoesNotContain("int? a")
+				.DoesNotContain("Setup(int")
 				.IgnoringNewlineStyle();
 		}
 

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -175,6 +175,64 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task DelegateWithMoreThanMaxParameters_ShouldGenerateSingleAllValueFlagsOverload()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = ProcessAll.CreateMock();
+				         }
+
+				         public delegate int ProcessAll(int a, int b, int c, int d, int e);
+				     }
+				     """);
+
+			await That(result.Sources)
+				.ContainsKey("Mock.Program_ProcessAll.g.cs").WhoseValue
+				.Contains("Setup(int a, int b, int c, int d, int e)")
+				.IgnoringNewlineStyle().And
+				.Contains("Verify(int a, int b, int c, int d, int e)")
+				.IgnoringNewlineStyle().And
+				.DoesNotContain("Setup(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<int>? c, global::Mockolate.Parameters.IParameter<int>? d, global::Mockolate.Parameters.IParameter<int>? e, global::Mockolate.Parameters.IParameter<int>?")
+				.IgnoringNewlineStyle();
+		}
+
+		[Fact]
+		public async Task DelegateWithMoreThanMaxParametersAllOut_ShouldNotGenerateValueFlagsOverload()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = ProcessAll.CreateMock();
+				         }
+
+				         public delegate void ProcessAll(out int a, out int b, out int c, out int d, out int e);
+				     }
+				     """);
+
+			await That(result.Sources)
+				.ContainsKey("Mock.Program_ProcessAll.g.cs").WhoseValue
+				.Contains("global::Mockolate.Parameters.IOutParameter<int> a, global::Mockolate.Parameters.IOutParameter<int> b, global::Mockolate.Parameters.IOutParameter<int> c, global::Mockolate.Parameters.IOutParameter<int> d, global::Mockolate.Parameters.IOutParameter<int> e")
+				.IgnoringNewlineStyle().And
+				.DoesNotContain("int? a")
+				.IgnoringNewlineStyle();
+		}
+
+		[Fact]
 		public async Task DelegateWithParameterNamedResult_ShouldGenerateUniqueLocalVariableName()
 		{
 			GeneratorResult result = Generator


### PR DESCRIPTION
Adds targeted unit tests to improve coverage for the Mockolate source generator, and simplifies one helper path in the generator’s mock-discovery logic.

### Key Changes:
- Added new source-generator tests covering delegate overload generation edge-cases and default-parameter literal emission.
- Added new tests for name-collision handling in generated members and some additional interface/constructor scenarios.
- Simplified `MockGeneratorHelpers.ExtractMockOrMockFactoryCreateSyntaxOrDefault` by removing unused generic-parameter handling.