### PR TITLE
fix: make events only nullable when source is nullable

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1044,8 +1044,7 @@ internal static partial class Sources
 		sb.Append(@event.Attributes, "\t\t");
 		if (explicitInterfaceImplementation)
 		{
-			sb.Append(@event.IsStatic ? "\t\tstatic event " : "\t\tevent ").Append(@event.Type.Fullname.TrimEnd('?'))
-				.Append("? ").Append(className).Append('.').Append(@event.Name).AppendLine();
+			sb.Append(@event.IsStatic ? "\t\tstatic event " : "\t\tevent ").Append(@event.Type.Fullname).Append(' ').Append(className).Append('.').Append(@event.Name).AppendLine();
 		}
 		else
 		{
@@ -1062,11 +1061,11 @@ internal static partial class Sources
 					sb.Append("override ");
 				}
 
-				sb.Append("event ").Append(@event.Type.Fullname.TrimEnd('?')).Append("? ");
+				sb.Append("event ").Append(@event.Type.Fullname).Append(' ');
 			}
 			else
 			{
-				sb.Append(@event.IsStatic ? "\t\tstatic event " : "\t\tevent ").Append(@event.Type.Fullname.TrimEnd('?')).Append("? ")
+				sb.Append(@event.IsStatic ? "\t\tstatic event " : "\t\tevent ").Append(@event.Type.Fullname).Append(' ')
 					.Append(@event.ExplicitImplementation).Append('.');
 			}
 

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -471,7 +471,7 @@ public class GeneralTests
 			          """).IgnoringNewlineStyle().And
 			.Contains("""
 			          		[global::System.Obsolete("This event is obsolete")]
-			          		public override event global::System.EventHandler<int>? SomeEvent
+			          		public override event global::System.EventHandler<int> SomeEvent
 			          """).IgnoringNewlineStyle().And
 			.Contains("""
 			          		[global::System.Obsolete("This property is obsolete")]
@@ -722,7 +722,7 @@ public class GeneralTests
 			             ArrayParam = new string[] { "a", "b" },
 			             OptionalIntParam = null
 			         )]
-			         event EventHandler<int> MyEvent;
+			         event EventHandler<int>? MyEvent;
 			     }
 
 			     public enum MyEnum

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
@@ -25,17 +25,17 @@ public sealed partial class MockTests
 
 					     public interface IMyService : IMyServiceBase1
 					     {
-					         new event EventHandler<string> SomeEvent;
+					         new event EventHandler<string>? SomeEvent;
 					     }
 
 					     public interface IMyServiceBase1 : IMyServiceBase2
 					     {
-					         new event EventHandler<int> SomeEvent;
+					         new event EventHandler<int>? SomeEvent;
 					     }
 
 					     public interface IMyServiceBase2
 					     {
-					         event EventHandler<long> SomeEvent;
+					         event EventHandler<long>? SomeEvent;
 					     }
 					     """);
 
@@ -118,7 +118,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		private global::System.EventHandler? _mockolateEvent_global__MyCode_IMyService_SomeEvent;
 					          		/// <inheritdoc cref="global::MyCode.IMyService.SomeEvent" />
-					          		public event global::System.EventHandler? SomeEvent
+					          		public event global::System.EventHandler SomeEvent
 					          		{
 					          			add
 					          			{
@@ -209,7 +209,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		private global::System.EventHandler? _mockolateEvent_global__MyCode_IMyService_MyDirectEvent;
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyDirectEvent" />
-					          		public event global::System.EventHandler? MyDirectEvent
+					          		public event global::System.EventHandler MyDirectEvent
 					          		{
 					          			add
 					          			{
@@ -234,7 +234,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		private global::System.EventHandler? _mockolateEvent_global__MyCode_IMyServiceBase1_MyBaseEvent1;
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase1.MyBaseEvent1" />
-					          		public event global::System.EventHandler? MyBaseEvent1
+					          		public event global::System.EventHandler MyBaseEvent1
 					          		{
 					          			add
 					          			{
@@ -259,7 +259,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		private global::System.EventHandler? _mockolateEvent_global__MyCode_IMyServiceBase2_MyBaseEvent2;
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase2.MyBaseEvent2" />
-					          		public event global::System.EventHandler? MyBaseEvent2
+					          		public event global::System.EventHandler MyBaseEvent2
 					          		{
 					          			add
 					          			{
@@ -284,7 +284,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		private global::System.EventHandler? _mockolateEvent_global__MyCode_IMyServiceBase3_MyBaseEvent3;
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase3.MyBaseEvent3" />
-					          		public event global::System.EventHandler? MyBaseEvent3
+					          		public event global::System.EventHandler MyBaseEvent3
 					          		{
 					          			add
 					          			{
@@ -328,7 +328,7 @@ public sealed partial class MockTests
 
 					     public class MyService
 					     {
-					         public virtual event EventHandler SomeEvent;
+					         public virtual event EventHandler? SomeEvent;
 					         public event EventHandler? SomeOtherEvent;
 					         protected virtual event EventHandler SomeProtectedEvent;
 					     }
@@ -374,7 +374,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		private global::System.EventHandler? _mockolateEvent_global__MyCode_IMyOtherService_SomeThirdEvent;
 					          		/// <inheritdoc cref="global::MyCode.IMyOtherService.SomeThirdEvent" />
-					          		event global::System.EventHandler? global::MyCode.IMyOtherService.SomeThirdEvent
+					          		event global::System.EventHandler global::MyCode.IMyOtherService.SomeThirdEvent
 					          		{
 					          			add
 					          			{


### PR DESCRIPTION
Updates the source generator’s event emission so the generated mock’s event nullability matches the source declaration, reducing incorrect `?` annotations in generated mocks.

### Key Changes:
- Adjusted mock event generation to use the event type as-is (preserving `?` only when present on the source event).
- Updated source generator tests to assert the new nullability behavior for interface/class events and overrides.