### PR TITLE
refactor!: avoid casting for properties and callbacks

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -204,7 +204,6 @@ internal static partial class Sources
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-
 		sb.AppendXmlSummary(
 			$"Sets up a return callback for a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.",
 			"");
@@ -591,8 +590,8 @@ internal static partial class Sources
 			.AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"MethodSetup.TriggerParameterCallbacks(object?[])\" />").AppendLine();
-		sb.Append("\t\tprotected override void TriggerParameterCallbacks(object?[] parameters)").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"MethodSetup.TriggerParameterCallbacks(global::Mockolate.Parameters.INamedParameterValue[])\" />").AppendLine();
+		sb.Append("\t\tprotected override void TriggerParameterCallbacks(global::Mockolate.Parameters.INamedParameterValue[] parameters)").AppendLine();
 		sb.Append("\t\t\t=> TriggerCallbacks([")
 			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"_match{x}")))
 			.Append("], parameters);").AppendLine();
@@ -1222,8 +1221,8 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"MethodSetup.TriggerParameterCallbacks(object?[])\" />").AppendLine();
-		sb.Append("\t\tprotected override void TriggerParameterCallbacks(object?[] parameters)").AppendLine();
+		sb.Append("\t\t/// <inheritdoc cref=\"MethodSetup.TriggerParameterCallbacks(global::Mockolate.Parameters.INamedParameterValue[])\" />").AppendLine();
+		sb.Append("\t\tprotected override void TriggerParameterCallbacks(global::Mockolate.Parameters.INamedParameterValue[] parameters)").AppendLine();
 		sb.Append("\t\t\t=> TriggerCallbacks([")
 			.Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"_match{x}")))
 			.Append("], parameters);").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1333,7 +1333,7 @@ internal static partial class Sources
 				}
 				else
 				{
-					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".SetProperty(").Append(property.GetUniqueNameString())
+					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".SetProperty<").AppendTypeOrWrapper(property.Type).Append(">(").Append(property.GetUniqueNameString())
 						.Append(", value);").AppendLine();
 					if (!property.IsStatic)
 					{
@@ -1390,7 +1390,7 @@ internal static partial class Sources
 			{
 				if (!isClassInterface && !property.IsAbstract)
 				{
-					sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".SetProperty(").Append(property.GetUniqueNameString())
+					sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".SetProperty<").AppendTypeOrWrapper(property.Type).Append(">(").Append(property.GetUniqueNameString())
 						.Append(", value))").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					if (property is { IsStatic: false, } && property.Setter?.IsProtected != true)
@@ -1413,7 +1413,7 @@ internal static partial class Sources
 				}
 				else
 				{
-					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".SetProperty(").Append(property.GetUniqueNameString())
+					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".SetProperty<").AppendTypeOrWrapper(property.Type).Append(">(").Append(property.GetUniqueNameString())
 						.AppendLine(", value);");
 				}
 			}
@@ -1511,14 +1511,23 @@ internal static partial class Sources
 		string methodExecutionVarName = Helpers.GetUniqueLocalVariableName("methodExecution", method.Parameters);
 		if (method.ReturnType != Type.Void)
 		{
-			string parameterVarName = Helpers.GetUniqueLocalVariableName("p", method.Parameters);
 			sb.Append("\t\t\tglobal::Mockolate.Setup.MethodSetupResult<")
 				.AppendTypeOrWrapper(method.ReturnType).Append("> ").Append(methodExecutionVarName)
 				.Append(" = ").Append(mockRegistry).Append(".InvokeMethod<")
 				.AppendTypeOrWrapper(method.ReturnType).Append(">(").Append(method.GetUniqueNameString())
-				.Append(", ").Append(parameterVarName).Append(" => ")
-				.AppendDefaultValueGeneratorFor(method.ReturnType, $"{mockRegistry}.Behavior.DefaultValue",
-					parameterVarName);
+				.Append(", ");
+			if (method.Parameters.Count == 0)
+			{
+				sb.Append("() => ")
+					.AppendDefaultValueGeneratorFor(method.ReturnType, $"{mockRegistry}.Behavior.DefaultValue");
+			}
+			else
+			{
+				string parameterVarName = Helpers.GetUniqueLocalVariableName("p", method.Parameters);
+				sb.Append(parameterVarName).Append(" => ")
+					.AppendDefaultValueGeneratorFor(method.ReturnType, $"{mockRegistry}.Behavior.DefaultValue",
+						parameterVarName);
+			}
 		}
 		else
 		{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -131,13 +131,23 @@ internal static partial class Sources
 		string resultVarName = Helpers.GetUniqueLocalVariableName("result", delegateMethod.Parameters);
 		if (delegateMethod.ReturnType != Type.Void)
 		{
-			string parameterVarName = Helpers.GetUniqueLocalVariableName("p", delegateMethod.Parameters);
 			sb.Append("\t\t\tvar ").Append(resultVarName).Append(" = this.").Append(mockRegistryName).Append(".InvokeMethod<")
 				.Append(delegateMethod.ReturnType.Fullname)
-				.Append(">(").Append(delegateMethod.GetUniqueNameString());
-			sb.Append(", ").Append(parameterVarName).Append(" => ")
-				.AppendDefaultValueGeneratorFor(delegateMethod.ReturnType,
-					$"this.{mockRegistryName}.Behavior.DefaultValue", parameterVarName);
+				.Append(">(").Append(delegateMethod.GetUniqueNameString())
+				.Append(", ");
+			if (delegateMethod.Parameters.Count == 0)
+			{
+				sb.Append("() => ")
+					.AppendDefaultValueGeneratorFor(delegateMethod.ReturnType,
+						$"this.{mockRegistryName}.Behavior.DefaultValue");
+			}
+			else
+			{
+				string parameterVarName = Helpers.GetUniqueLocalVariableName("p", delegateMethod.Parameters);
+				sb.Append(parameterVarName).Append(" => ")
+					.AppendDefaultValueGeneratorFor(delegateMethod.ReturnType,
+						$"this.{mockRegistryName}.Behavior.DefaultValue", parameterVarName);
+			}
 		}
 		else
 		{
@@ -161,7 +171,9 @@ internal static partial class Sources
 			$"this.{mockRegistryName}.Behavior.DefaultValue");
 
 		sb.Append("\t\t\t").Append(resultVarName).Append(".TriggerCallbacks(")
-			.Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.Name))).Append(");").AppendLine();
+			.Append(string.Join(", ", delegateMethod.Parameters.Select(p =>
+				$"new global::Mockolate.Parameters.NamedParameterValue<{p.ToTypeOrWrapper()}>(\"{p.Name}\", {p.ToNameOrWrapper()})")))
+			.Append(");").AppendLine();
 		if (delegateMethod.ReturnType != Type.Void)
 		{
 			sb.Append("\t\t\treturn ").Append(resultVarName).Append(".Result;").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -64,7 +64,8 @@ internal static partial class Sources
 	private static void AppendTriggerCallbacks(StringBuilder sb, string indent, string varName,
 		IEnumerable<MethodParameter> parameters)
 		=> sb.Append(indent).Append(varName).Append(".TriggerCallbacks(")
-			.Append(string.Join(", ", parameters.Select(p => p.ToNameOrNull())))
+			.Append(string.Join(", ", parameters.Select(p =>
+				$"new global::Mockolate.Parameters.NamedParameterValue<{p.ToTypeOrWrapper()}>(\"{p.Name}\", {p.ToNameOrWrapper()})")))
 			.Append(");").AppendLine();
 
 	/// <summary>

--- a/Source/Mockolate/Interactions/IndexerSetterAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerSetterAccess.cs
@@ -9,14 +9,14 @@ namespace Mockolate.Interactions;
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
 [DebuggerNonUserCode]
-public class IndexerSetterAccess(INamedParameterValue[] parameters, object? value) : IndexerAccess(parameters)
+public class IndexerSetterAccess(INamedParameterValue[] parameters, INamedParameterValue value) : IndexerAccess(parameters)
 {
 	/// <summary>
 	///     The value the indexer was being set to.
 	/// </summary>
-	public object? Value { get; } = value;
+	public INamedParameterValue Value { get; } = value;
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
-		=> $"[{Index}] set indexer [{string.Join(", ", Parameters.Select(p => p.ToString()))}] to {Value ?? "null"}";
+		=> $"[{Index}] set indexer [{string.Join(", ", Parameters.Select(p => p.ToString()))}] to {Value}";
 }

--- a/Source/Mockolate/Interactions/PropertySetterAccess.cs
+++ b/Source/Mockolate/Interactions/PropertySetterAccess.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Mockolate.Internals;
+using Mockolate.Parameters;
 
 namespace Mockolate.Interactions;
 
@@ -8,13 +9,13 @@ namespace Mockolate.Interactions;
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
 [DebuggerNonUserCode]
-public class PropertySetterAccess(string propertyName, object? value) : PropertyAccess(propertyName)
+public class PropertySetterAccess(string propertyName, INamedParameterValue value) : PropertyAccess(propertyName)
 {
 	/// <summary>
 	///     The value the property was being set to.
 	/// </summary>
-	public object? Value { get; } = value;
+	public INamedParameterValue Value { get; } = value;
 
 	/// <inheritdoc cref="object.ToString()" />
-	public override string ToString() => $"[{Index}] set property {Name.SubstringAfterLast('.')} to {Value ?? "null"}";
+	public override string ToString() => $"[{Index}] set property {Name.SubstringAfterLast('.')} to {Value}";
 }

--- a/Source/Mockolate/It.IsNot.cs
+++ b/Source/Mockolate/It.IsNot.cs
@@ -63,16 +63,6 @@ public partial class It
 			return !EqualityComparer<T>.Default.Equals(value, _value);
 		}
 
-		public override bool Matches(object? value)
-		{
-			if (value is T typedValue)
-			{
-				return Matches(typedValue);
-			}
-
-			return value is not null || Matches(default(T)!);
-		}
-
 		public override bool Matches(INamedParameterValue value)
 		{
 			if (value.TryGetValue(out T typedValue))

--- a/Source/Mockolate/It.IsOut.cs
+++ b/Source/Mockolate/It.IsOut.cs
@@ -60,18 +60,9 @@ public partial class It
 	[DebuggerNonUserCode]
 	private sealed class InvokedOutParameterMatch<T> : IVerifyOutParameter<T>, IParameter
 	{
-		/// <inheritdoc cref="IParameter.Matches(object?)" />
-		public bool Matches(object? value) => true;
-
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 			=> true;
-
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-		{
-			// Do nothing
-		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)
@@ -110,21 +101,9 @@ public partial class It
 		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter
 		///     of type <typeparamref name="T" />; otherwise <see langword="false" />.
 		/// </returns>
-		public bool Matches(object? value)
-			=> value is T or null;
-
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 			=> value.TryGetValue<T>(out _);
-
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-		{
-			if (TryCast(value, out T typedValue) && _callbacks is not null)
-			{
-				_callbacks.ForEach(a => a.Invoke(typedValue));
-			}
-		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)

--- a/Source/Mockolate/It.IsRef.cs
+++ b/Source/Mockolate/It.IsRef.cs
@@ -107,18 +107,9 @@ public partial class It
 	[DebuggerNonUserCode]
 	private sealed class InvokedRefParameterMatch<T> : IVerifyRefParameter<T>, IParameter
 	{
-		/// <inheritdoc cref="IParameter.Matches(object?)" />
-		public bool Matches(object? value) => true;
-
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 			=> true;
-
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-		{
-			// Do nothing
-		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)
@@ -145,16 +136,6 @@ public partial class It
 		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter
 		///     of type <typeparamref name="T" />; otherwise <see langword="false" />.
 		/// </returns>
-		public bool Matches(object? value)
-		{
-			if (value is T typedValue)
-			{
-				return Matches(typedValue);
-			}
-
-			return value is null && Matches(default(T)!);
-		}
-
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 		{
@@ -162,17 +143,8 @@ public partial class It
 			{
 				return Matches(typedValue);
 			}
-			
-			return false;
-		}
 
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-		{
-			if (TryCast(value, out T typedValue) && _callbacks is not null)
-			{
-				_callbacks.ForEach(a => a.Invoke(typedValue));
-			}
+			return false;
 		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />

--- a/Source/Mockolate/It.cs
+++ b/Source/Mockolate/It.cs
@@ -23,24 +23,6 @@ public partial class It
 		// Prevent instantiation.
 	}
 
-	private static bool TryCast<T>(object? value, out T typedValue)
-	{
-		if (value is T castValue)
-		{
-			typedValue = castValue;
-			return true;
-		}
-
-		if (value is null && default(T) is null)
-		{
-			typedValue = default!;
-			return true;
-		}
-
-		typedValue = default!;
-		return false;
-	}
-
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
@@ -56,16 +38,6 @@ public partial class It
 		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter
 		///     of type <typeparamref name="T" />; otherwise <see langword="false" />.
 		/// </returns>
-		public virtual bool Matches(object? value)
-		{
-			if (value is T typedValue)
-			{
-				return Matches(typedValue);
-			}
-
-			return value is null && Matches(default(T)!);
-		}
-
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public virtual bool Matches(INamedParameterValue value)
 		{
@@ -75,15 +47,6 @@ public partial class It
 			}
 
 			return false;
-		}
-
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-		{
-			if (TryCast(value, out T typedValue) && _callbacks is not null)
-			{
-				_callbacks.ForEach(a => a.Invoke(typedValue));
-			}
 		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -24,6 +24,29 @@ public partial class MockRegistry
 		=> Interactions.Clear();
 
 	/// <summary>
+	///     Executes the method with <paramref name="methodName" /> with no parameters and gets the setup return value.
+	/// </summary>
+	public MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, Func<TResult> defaultValue)
+	{
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, Array.Empty<INamedParameterValue>()));
+
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetup(methodInvocation);
+		if (matchingSetup is null)
+		{
+			if (Behavior.ThrowWhenNotSetup)
+			{
+				throw new MockNotSetupException($"The method '{methodName}()' was invoked without prior setup.");
+			}
+
+			return new MethodSetupResult<TResult>(null, Behavior, defaultValue());
+		}
+
+		return new MethodSetupResult<TResult>(matchingSetup, Behavior,
+			matchingSetup.Invoke(methodInvocation, Behavior, defaultValue));
+	}
+
+	/// <summary>
 	///     Executes the method with <paramref name="methodName" /> and the matching <paramref name="parameters" /> and gets
 	///     the setup return value.
 	/// </summary>
@@ -56,6 +79,24 @@ public partial class MockRegistry
 		{
 			return x.GetValueType().FormatType();
 		}
+	}
+
+	/// <summary>
+	///     Executes the method with <paramref name="methodName" /> with no parameters returning <see langword="void" />.
+	/// </summary>
+	public MethodSetupResult InvokeMethod(string methodName)
+	{
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, Array.Empty<INamedParameterValue>()));
+
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetup(methodInvocation);
+		if (matchingSetup is null && Behavior.ThrowWhenNotSetup)
+		{
+			throw new MockNotSetupException($"The method '{methodName}()' was invoked without prior setup.");
+		}
+
+		matchingSetup?.Invoke(methodInvocation, Behavior);
+		return new MethodSetupResult(matchingSetup, Behavior);
 	}
 
 	/// <summary>
@@ -102,12 +143,12 @@ public partial class MockRegistry
 	/// <remarks>
 	///     Returns a flag, indicating whether the base class implementation should be skipped.
 	/// </remarks>
-	public bool SetProperty(string propertyName, object? value)
+	public bool SetProperty<T>(string propertyName, T value)
 	{
 		IInteraction interaction =
-			((IMockInteractions)Interactions).RegisterInteraction(new PropertySetterAccess(propertyName, value));
+			((IMockInteractions)Interactions).RegisterInteraction(new PropertySetterAccess(propertyName, new NamedParameterValue<T>("value", value)));
 
-		PropertySetup matchingSetup = ResolvePropertySetup<object>(propertyName, null, null, false);
+		PropertySetup matchingSetup = ResolvePropertySetup<T>(propertyName, null, null, false);
 
 		((IInteractivePropertySetup)matchingSetup).InvokeSetter(interaction, value, Behavior);
 		return ((IInteractivePropertySetup)matchingSetup).SkipBaseClass() ?? Behavior.SkipBaseClass;
@@ -127,12 +168,12 @@ public partial class MockRegistry
 					$"The property '{propertyName}' was accessed without prior setup.");
 			}
 
-			object? initialValue = defaultValueGenerator is null
-				? null
+			TResult initialValue = defaultValueGenerator is null
+				? default!
 				: Behavior.SkipBaseClass || baseValueAccessor is null
 					? defaultValueGenerator()
 					: baseValueAccessor.Invoke();
-			PropertySetup setup = new PropertySetup.Default(propertyName, initialValue);
+			PropertySetup setup = new PropertySetup.Default<TResult>(propertyName, initialValue);
 			Setup.Properties.Add(setup);
 			return setup;
 		}
@@ -179,7 +220,7 @@ public partial class MockRegistry
 	/// </remarks>
 	public bool SetIndexer<TResult>(TResult value, params INamedParameterValue[] parameters)
 	{
-		IndexerSetterAccess interaction = new(parameters, value);
+		IndexerSetterAccess interaction = new(parameters, new NamedParameterValue<TResult>("value", value));
 		((IMockInteractions)Interactions).RegisterInteraction(interaction);
 
 		Setup.Indexers.UpdateValue(parameters, value);

--- a/Source/Mockolate/Parameters/IParameter.cs
+++ b/Source/Mockolate/Parameters/IParameter.cs
@@ -10,17 +10,7 @@ public interface IParameter
 	/// <summary>
 	///     Checks if the <paramref name="value" /> matches the expectation.
 	/// </summary>
-	bool Matches(object? value);
-
-	/// <summary>
-	///     Checks if the <paramref name="value" /> matches the expectation.
-	/// </summary>
 	bool Matches(INamedParameterValue value);
-
-	/// <summary>
-	///     Invokes the callbacks registered for this parameter match.
-	/// </summary>
-	void InvokeCallbacks(object? value);
 
 	/// <summary>
 	///     Invokes the callbacks registered for this parameter match.

--- a/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
@@ -1,5 +1,6 @@
 using System;
 using Mockolate.Interactions;
+using Mockolate.Parameters;
 
 namespace Mockolate.Setup;
 
@@ -74,7 +75,7 @@ public interface IInteractiveMethodSetup : ISetup
 	/// <summary>
 	///     Triggers any configured parameter callbacks for the method setup with the specified <paramref name="parameters" />.
 	/// </summary>
-	void TriggerCallbacks(object?[] parameters);
+	void TriggerCallbacks(INamedParameterValue[] parameters);
 }
 
 /// <summary>

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -11,7 +11,7 @@ public interface IInteractivePropertySetup : ISetup
 	/// <summary>
 	///     Invokes the setter logic for the <paramref name="invocation" /> and <paramref name="value" />.
 	/// </summary>
-	void InvokeSetter(IInteraction invocation, object? value, MockBehavior behavior);
+	void InvokeSetter<T>(IInteraction invocation, T value, MockBehavior behavior);
 
 	/// <summary>
 	///     Invokes the getter logic for the <paramref name="invocation" /> and returns the value of type

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -50,8 +50,8 @@ public abstract class MethodSetup(IMethodMatch methodMatch) : IInteractiveMethod
 	void IInteractiveMethodSetup.Invoke(MethodInvocation methodInvocation, MockBehavior behavior)
 		=> ExecuteCallback(methodInvocation, behavior);
 
-	/// <inheritdoc cref="IInteractiveMethodSetup.TriggerCallbacks(object?[])" />
-	public void TriggerCallbacks(object?[] parameters)
+	/// <inheritdoc cref="IInteractiveMethodSetup.TriggerCallbacks(INamedParameterValue[])" />
+	public void TriggerCallbacks(INamedParameterValue[] parameters)
 		=> TriggerParameterCallbacks(parameters);
 
 	/// <inheritdoc cref="IVerifiableMethodSetup.GetMatch()" />
@@ -99,11 +99,10 @@ public abstract class MethodSetup(IMethodMatch methodMatch) : IInteractiveMethod
 	protected abstract TResult GetReturnValue<TResult>(MethodInvocation invocation, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator);
 
-
 	/// <summary>
 	///     Triggers any configured parameter callbacks for the method setup with the specified <paramref name="parameters" />.
 	/// </summary>
-	protected abstract void TriggerParameterCallbacks(object?[] parameters);
+	protected abstract void TriggerParameterCallbacks(INamedParameterValue[] parameters);
 
 	/// <summary>
 	///     Determines whether the specified collection of named parameters contains a reference parameter of the given name
@@ -153,7 +152,7 @@ public abstract class MethodSetup(IMethodMatch methodMatch) : IInteractiveMethod
 	///     Triggers the parameter callbacks for each value in the specified array according to
 	///     the corresponding named parameter.
 	/// </summary>
-	protected static void TriggerCallbacks(NamedParameter?[] namedParameters, object?[] values)
+	protected static void TriggerCallbacks(NamedParameter?[] namedParameters, INamedParameterValue[] values)
 	{
 		if (namedParameters.Length != values.Length)
 		{

--- a/Source/Mockolate/Setup/MethodSetupResult.cs
+++ b/Source/Mockolate/Setup/MethodSetupResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using Mockolate.Parameters;
 
 namespace Mockolate.Setup;
 
@@ -56,8 +57,8 @@ public class MethodSetupResult(IInteractiveMethodSetup? setup, MockBehavior beha
 	/// <summary>
 	///     Triggers any configured parameter callbacks for the method setup with the specified <paramref name="parameters" />.
 	/// </summary>
-	public void TriggerCallbacks(params object?[]? parameters)
-		=> setup?.TriggerCallbacks(parameters ?? [null,]);
+	public void TriggerCallbacks(params INamedParameterValue[]? parameters)
+		=> setup?.TriggerCallbacks(parameters ?? []);
 }
 
 /// <summary>

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
@@ -25,8 +24,8 @@ public abstract class PropertySetup : IInteractivePropertySetup
 	/// </summary>
 	internal abstract bool IsValueInitialized { get; }
 
-	/// <inheritdoc cref="IInteractivePropertySetup.InvokeSetter(IInteraction, object?, MockBehavior)" />
-	void IInteractivePropertySetup.InvokeSetter(IInteraction invocation, object? value, MockBehavior behavior)
+	/// <inheritdoc cref="IInteractivePropertySetup.InvokeSetter{T}(IInteraction, T, MockBehavior)" />
+	void IInteractivePropertySetup.InvokeSetter<T>(IInteraction invocation, T value, MockBehavior behavior)
 		=> InvokeSetter(value, behavior);
 
 	/// <inheritdoc cref="IInteractivePropertySetup.InvokeGetter{TResult}(IInteraction, MockBehavior, Func{TResult}?)" />
@@ -64,7 +63,7 @@ public abstract class PropertySetup : IInteractivePropertySetup
 	/// <summary>
 	///     Invokes the setter logic with the given <paramref name="value" />.
 	/// </summary>
-	protected abstract void InvokeSetter(object? value, MockBehavior behavior);
+	protected abstract void InvokeSetter<TValue>(TValue value, MockBehavior behavior);
 
 	/// <summary>
 	///     Invokes the getter logic and returns the value of type <typeparamref name="TResult" />.
@@ -72,10 +71,8 @@ public abstract class PropertySetup : IInteractivePropertySetup
 	protected abstract TResult InvokeGetter<TResult>(MockBehavior behavior, Func<TResult> defaultValueGenerator);
 
 	[DebuggerNonUserCode]
-	internal class Default(string name, object? initialValue) : PropertySetup
+	internal abstract class Default(string name) : PropertySetup
 	{
-		private object? _value = initialValue;
-
 		/// <inheritdoc cref="PropertySetup.Name" />
 		public override string Name => name;
 
@@ -95,22 +92,45 @@ public abstract class PropertySetup : IInteractivePropertySetup
 		/// <inheritdoc cref="PropertySetup.Matches(PropertyAccess)" />
 		protected override bool Matches(PropertyAccess propertyAccess)
 			=> name.Equals(propertyAccess.Name);
+	}
 
-		/// <inheritdoc cref="PropertySetup.InvokeSetter(object?, MockBehavior)" />
-		protected override void InvokeSetter(object? value, MockBehavior behavior)
-			=> _value = value;
+	[DebuggerNonUserCode]
+	internal sealed class Default<T>(string name, T initialValue) : Default(name)
+	{
+		private T _value = initialValue;
+
+		/// <inheritdoc cref="PropertySetup.InvokeSetter{TValue}(TValue, MockBehavior)" />
+		protected override void InvokeSetter<TValue>(TValue value, MockBehavior behavior)
+		{
+			if (typeof(TValue) == typeof(T))
+			{
+				_value = Unsafe.As<TValue, T>(ref value);
+			}
+			else if (value is null && default(T) is null)
+			{
+				_value = default!;
+			}
+			else
+			{
+				throw new MockException(
+					$"The property value only supports '{typeof(T).FormatType()}', but is '{typeof(TValue).FormatType()}'.");
+			}
+		}
 
 		/// <inheritdoc cref="PropertySetup.InvokeGetter{TResult}(MockBehavior, Func{TResult})" />
 		protected override TResult InvokeGetter<TResult>(MockBehavior behavior, Func<TResult> defaultValueGenerator)
 		{
+			if (typeof(TResult) == typeof(T))
+			{
+				return Unsafe.As<T, TResult>(ref _value);
+			}
+
 			if (_value is TResult typedValue)
 			{
 				return typedValue;
 			}
 
-			TResult result = defaultValueGenerator.Invoke();
-			_value = result;
-			return result;
+			return defaultValueGenerator.Invoke();
 		}
 	}
 }
@@ -232,13 +252,13 @@ public class PropertySetup<T>(string name) : PropertySetup,
 			return Unsafe.As<T, TResult>(ref _value);
 		}
 
-		if (!TryCast(_value, out TResult result))
+		if (_value is null && default(TResult) is null)
 		{
-			throw new MockException(
-				$"The property only supports '{typeof(T).FormatType()}' and not '{typeof(TResult).FormatType()}'.");
+			return default!;
 		}
 
-		return result;
+		throw new MockException(
+			$"The property only supports '{typeof(T).FormatType()}' and not '{typeof(TResult).FormatType()}'.");
 
 		[DebuggerNonUserCode]
 		void Callback(int invocationCount, Action<int, T> @delegate)
@@ -253,13 +273,22 @@ public class PropertySetup<T>(string name) : PropertySetup,
 		}
 	}
 
-	/// <inheritdoc cref="PropertySetup.InvokeSetter(object?, MockBehavior)" />
-	protected override void InvokeSetter(object? value, MockBehavior behavior)
+	/// <inheritdoc cref="PropertySetup.InvokeSetter{TValue}(TValue, MockBehavior)" />
+	protected override void InvokeSetter<TValue>(TValue value, MockBehavior behavior)
 	{
-		if (!TryCast(value, out T newValue))
+		T newValue;
+		if (value is T v)
+		{
+			newValue = v;
+		}
+		else if (value is null && default(T) is null)
+		{
+			newValue = default!;
+		}
+		else
 		{
 			throw new MockException(
-				$"The property value only supports '{typeof(T).FormatType()}', but is '{value.GetType().FormatType()}'.");
+				$"The property value only supports '{typeof(T).FormatType()}', but is '{typeof(TValue).FormatType()}'.");
 		}
 
 		if (_setterCallbacks is not null)
@@ -308,18 +337,6 @@ public class PropertySetup<T>(string name) : PropertySetup,
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
 		=> $"{typeof(T).FormatType()} {name.SubstringAfterLast('.')}";
-
-	private static bool TryCast<TValue>([NotNullWhen(false)] object? value, out TValue result)
-	{
-		if (value is TValue typedValue)
-		{
-			result = typedValue;
-			return true;
-		}
-
-		result = default!;
-		return value is null;
-	}
 
 	#region IPropertySetup<T>
 

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -160,7 +160,6 @@ public class ReturnMethodSetup<TReturn>(string name)
 		return this;
 	}
 
-
 	/// <inheritdoc cref="IReturnMethodSetupReturnBuilder{TReturn}.When(Func{int, bool})" />
 	IReturnMethodSetupReturnWhenBuilder<TReturn> IReturnMethodSetupReturnBuilder<TReturn>.When(
 		Func<int, bool> predicate)
@@ -235,8 +234,8 @@ public class ReturnMethodSetup<TReturn>(string name)
 		}
 	}
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 	{
 		// No parameters to trigger
 	}
@@ -568,8 +567,8 @@ public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 		}
 	}
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />
@@ -927,8 +926,8 @@ public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 		}
 	}
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1, _match2,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />
@@ -1300,8 +1299,8 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		}
 	}
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1, _match2, _match3,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />
@@ -1573,7 +1572,6 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		return this;
 	}
 
-
 	/// <inheritdoc cref="IReturnMethodSetupReturnBuilder{TReturn, T1, T2, T3, T4}.When(Func{int, bool})" />
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>
 		IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>.When(Func<int, bool> predicate)
@@ -1689,8 +1687,8 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		}
 	}
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1, _match2, _match3, _match4,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -143,7 +143,6 @@ public class VoidMethodSetup(string name)
 		return this;
 	}
 
-
 	/// <inheritdoc cref="IVoidMethodSetupReturnBuilder.When(Func{int, bool})" />
 	IVoidMethodSetupReturnWhenBuilder IVoidMethodSetupReturnBuilder.When(Func<int, bool> predicate)
 	{
@@ -203,8 +202,8 @@ public class VoidMethodSetup(string name)
 		where TResult : default
 		=> throw new MockException("The method setup does not support return values.");
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 	{
 		// No parameters to trigger
 	}
@@ -478,8 +477,8 @@ public class VoidMethodSetup<T1> : MethodSetup,
 		where TResult : default
 		=> throw new MockException("The method setup does not support return values.");
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />
@@ -772,8 +771,8 @@ public class VoidMethodSetup<T1, T2> : MethodSetup,
 		where TResult : default
 		=> throw new MockException("The method setup does not support return values.");
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1, _match2,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />
@@ -1075,8 +1074,8 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 		where TResult : default
 		=> throw new MockException("The method setup does not support return values.");
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1, _match2, _match3,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />
@@ -1383,8 +1382,8 @@ public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 		where TResult : default
 		=> throw new MockException("The method setup does not support return values.");
 
-	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(object?[])" />
-	protected override void TriggerParameterCallbacks(object?[] parameters)
+	/// <inheritdoc cref="MethodSetup.TriggerParameterCallbacks(INamedParameterValue[])" />
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 		=> TriggerCallbacks([_match1, _match2, _match3, _match4,], parameters);
 
 	/// <inheritdoc cref="MethodSetup.GetSkipBaseClass()" />

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -327,7 +327,6 @@ public static class SetupExtensions
 			=> setup.Only(1);
 	}
 
-
 	/// <summary>
 	///     Extensions for method setup returning void without parameters.
 	/// </summary>

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -382,7 +382,6 @@ public static class VerificationResultExtensions
 					$"Expected that mock {string.Join(separator, expectations)} in order, but it {error}.");
 			}
 
-
 			bool VerifyInteractions(IInteraction[] interactions, IVerificationResult currentResult)
 			{
 				IInteraction? firstInteraction = interactions

--- a/Source/Mockolate/Web/HttpClientExtensions.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.cs
@@ -52,17 +52,6 @@ public static partial class HttpClientExtensions
 		params IHttpRequestMessageParameter[] parameters)
 		: IParameter
 	{
-		public bool Matches(object? value)
-		{
-			if (value is HttpRequestMessage requestMessage &&
-			    requestMessage.Method == method)
-			{
-				return parameters.All(parameter => parameter.Matches(requestMessage));
-			}
-
-			return false;
-		}
-
 		public bool Matches(INamedParameterValue value)
 		{
 			if (value.TryGetValue(out HttpRequestMessage requestMessage) &&
@@ -72,17 +61,6 @@ public static partial class HttpClientExtensions
 			}
 
 			return false;
-		}
-
-		public void InvokeCallbacks(object? value)
-		{
-			if (value is HttpRequestMessage typedValue)
-			{
-				foreach (IHttpRequestMessageParameter parameter in parameters)
-				{
-					parameter.InvokeCallbacks(typedValue);
-				}
-			}
 		}
 
 		public void InvokeCallbacks(INamedParameterValue value)
@@ -122,14 +100,14 @@ public static partial class HttpClientExtensions
 				return httpRequestMessageParameter.Matches(valueSelector(value), value);
 			}
 
-			return ((IParameter)parameter).Matches(valueSelector(value));
+			return ((IParameter)parameter).Matches(new NamedParameterValue<T>(string.Empty, valueSelector(value)));
 		}
 
 		public void InvokeCallbacks(HttpRequestMessage value)
 		{
 			if (parameter is IParameter invokableParameter)
 			{
-				invokableParameter.InvokeCallbacks(valueSelector(value));
+				invokableParameter.InvokeCallbacks(new NamedParameterValue<T>(string.Empty, valueSelector(value)));
 			}
 		}
 
@@ -154,15 +132,15 @@ public static partial class HttpClientExtensions
 			}
 
 			string requestUri1 = value.RequestUri.ToString();
-			return invokableParameter.Matches(requestUri1) ||
-			       (requestUri1.EndsWith('/') && invokableParameter.Matches(requestUri1.TrimEnd('/')));
+			return invokableParameter.Matches(new NamedParameterValue<string?>(string.Empty, requestUri1)) ||
+			       (requestUri1.EndsWith('/') && invokableParameter.Matches(new NamedParameterValue<string?>(string.Empty, requestUri1.TrimEnd('/'))));
 		}
 
 		public void InvokeCallbacks(HttpRequestMessage value)
 		{
 			if (parameter is IParameter invokableParameter)
 			{
-				invokableParameter.InvokeCallbacks(value.RequestUri?.ToString());
+				invokableParameter.InvokeCallbacks(new NamedParameterValue<string?>(string.Empty, value.RequestUri?.ToString()));
 			}
 		}
 

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.cs
@@ -145,22 +145,9 @@ public static partial class ItExtensions
 			return true;
 		}
 
-		/// <inheritdoc cref="IParameter.Matches(object?)" />
-		public bool Matches(object? value)
-			=> value is HttpContent typedValue && Matches(typedValue, null);
-
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 			=> value.TryGetValue<HttpContent>(out var typedValue) && Matches(typedValue, null);
-
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-		{
-			if (value is HttpContent httpContent)
-			{
-				_callbacks?.ForEach(a => a.Invoke(httpContent));
-			}
-		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)
@@ -346,21 +333,13 @@ public static partial class ItExtensions
 				return requestMessagePropertyParameter.Matches(value, requestMessage);
 			}
 
-			return Matches(value);
+			return Matches(new NamedParameterValue<HttpContent?>(string.Empty, value));
 		}
-
-		/// <inheritdoc cref="IParameter.Matches(object?)" />
-		public bool Matches(object? value)
-			=> ((IParameter)parameter).Matches(value);
 
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 			=> ((IParameter)parameter).Matches(value);
 
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-			=> ((IParameter)parameter).InvokeCallbacks(value);
-		
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)
 			=> ((IParameter)parameter).InvokeCallbacks(value);

--- a/Source/Mockolate/Web/ItExtensions.HttpRequestMessage.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpRequestMessage.cs
@@ -113,22 +113,9 @@ public static partial class ItExtensions
 			return GetThis;
 		}
 
-		/// <inheritdoc cref="IParameter.Matches(object?)" />
-		public bool Matches(object? value)
-			=> value is HttpRequestMessage typedValue && Matches(typedValue);
-
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 			=> value.TryGetValue<HttpRequestMessage>(out var typedValue) && Matches(typedValue);
-
-		/// <inheritdoc cref="IParameter.InvokeCallbacks(object?)" />
-		public void InvokeCallbacks(object? value)
-		{
-			if (value is HttpRequestMessage httpRequestMessage)
-			{
-				_callbacks?.ForEach(a => a.Invoke(httpRequestMessage));
-			}
-		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)
@@ -151,13 +138,13 @@ public static partial class ItExtensions
 			}
 
 			if (_uriParameter is not null &&
-			    !((IParameter)_uriParameter).Matches(value.RequestUri))
+			    !((IParameter)_uriParameter).Matches(new NamedParameterValue<Uri?>(string.Empty, value.RequestUri)))
 			{
 				return false;
 			}
 
 			if (_contentParameter is not null &&
-			    !((IParameter)_contentParameter).Matches(value.Content))
+			    !((IParameter)_contentParameter).Matches(new NamedParameterValue<HttpContent?>(string.Empty, value.Content)))
 			{
 				return false;
 			}

--- a/Source/Mockolate/Web/ItExtensions.HttpRequestMessage.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpRequestMessage.cs
@@ -115,7 +115,14 @@ public static partial class ItExtensions
 
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
-			=> value.TryGetValue<HttpRequestMessage>(out var typedValue) && Matches(typedValue);
+		{
+			if (!value.TryGetValue(out HttpRequestMessage? typedValue) || typedValue is null)
+			{
+				return false;
+			}
+
+			return Matches(typedValue);
+		}
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)

--- a/Source/Mockolate/Web/ItExtensions.Uri.cs
+++ b/Source/Mockolate/Web/ItExtensions.Uri.cs
@@ -89,9 +89,9 @@ public static partial class ItExtensions
 			=> value.TryGetValue<Uri>(out var uri) && Matches(uri);
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
-		public bool Matches(object? value)
+		private bool Matches(Uri? uri)
 		{
-			if (value is not Uri uri)
+			if (uri is null)
 			{
 				return false;
 			}
@@ -139,18 +139,12 @@ public static partial class ItExtensions
 		}
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
-		public void InvokeCallbacks(object? value)
-		{
-			if (value is Uri uri)
-			{
-				_callbacks?.ForEach(a => a.Invoke(uri));
-			}
-		}
+		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)
 		{
-			if (value.TryGetValue(out Uri uri))
+			if (_callbacks is not null && value.TryGetValue(out Uri uri))
 			{
-				_callbacks?.ForEach(a => a.Invoke(uri));
+				_callbacks.ForEach(a => a.Invoke(uri));
 			}
 		}
 

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -189,7 +189,9 @@ namespace Mockolate
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, params Mockolate.Parameters.NamedParameter[] parameters) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, Mockolate.Parameters.IParameter value, params Mockolate.Parameters.NamedParameter[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName) { }
         public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<TResult> defaultValue) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
@@ -198,7 +200,7 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> Property<T>(T subject, string propertyName, Mockolate.Parameters.IParameter value) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public bool SetIndexer<TResult>(TResult value, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
-        public bool SetProperty(string propertyName, object? value) { }
+        public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
         public void SetupMethod(Mockolate.Setup.MethodSetup methodSetup) { }
@@ -565,8 +567,8 @@ namespace Mockolate.Interactions
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess : Mockolate.Interactions.IndexerAccess
     {
-        public IndexerSetterAccess(Mockolate.Parameters.INamedParameterValue[] parameters, object? value) { }
-        public object? Value { get; }
+        public IndexerSetterAccess(Mockolate.Parameters.INamedParameterValue[] parameters, Mockolate.Parameters.INamedParameterValue value) { }
+        public Mockolate.Parameters.INamedParameterValue Value { get; }
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
@@ -602,8 +604,8 @@ namespace Mockolate.Interactions
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class PropertySetterAccess : Mockolate.Interactions.PropertyAccess
     {
-        public PropertySetterAccess(string propertyName, object? value) { }
-        public object? Value { get; }
+        public PropertySetterAccess(string propertyName, Mockolate.Parameters.INamedParameterValue value) { }
+        public Mockolate.Parameters.INamedParameterValue Value { get; }
         public override string ToString() { }
     }
 }
@@ -641,9 +643,7 @@ namespace Mockolate.Parameters
     public interface IParameter
     {
         void InvokeCallbacks(Mockolate.Parameters.INamedParameterValue value);
-        void InvokeCallbacks(object? value);
         bool Matches(Mockolate.Parameters.INamedParameterValue value);
-        bool Matches(object? value);
     }
     public interface IParameterMonitor<out T>
     {
@@ -964,13 +964,13 @@ namespace Mockolate.Setup
         T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
         bool? SkipBaseClass();
-        void TriggerCallbacks(object?[] parameters);
+        void TriggerCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters);
     }
     public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
     {
         void InitializeWith(object? value);
         TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
+        void InvokeSetter<T>(Mockolate.Interactions.IInteraction invocation, T value, Mockolate.MockBehavior behavior);
         bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
         bool? SkipBaseClass();
     }
@@ -1535,12 +1535,12 @@ namespace Mockolate.Setup
         protected virtual bool HasReturnCalls() { }
         protected abstract T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         protected abstract T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
-        public void TriggerCallbacks(object?[] parameters) { }
-        protected abstract void TriggerParameterCallbacks(object?[] parameters);
+        public void TriggerCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        protected abstract void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters);
         protected static string FormatType(System.Type type) { }
         protected static bool HasOutParameter<T>(Mockolate.Parameters.NamedParameter?[] namedParameters, string parameterName, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Mockolate.Parameters.IOutParameter<T>? parameter) { }
         protected static bool HasRefParameter<T>(Mockolate.Parameters.NamedParameter?[] namedParameters, string parameterName, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Mockolate.Parameters.IRefParameter<T>? parameter) { }
-        protected static void TriggerCallbacks(Mockolate.Parameters.NamedParameter?[] namedParameters, object?[] values) { }
+        protected static void TriggerCallbacks(Mockolate.Parameters.NamedParameter?[] namedParameters, Mockolate.Parameters.INamedParameterValue[] values) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
     public class MethodSetupResult
@@ -1550,7 +1550,7 @@ namespace Mockolate.Setup
         public bool SkipBaseClass { get; }
         public T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
-        public void TriggerCallbacks(params object?[]? parameters) { }
+        public void TriggerCallbacks(params Mockolate.Parameters.INamedParameterValue[]? parameters) { }
     }
     public class MethodSetupResult<TResult> : Mockolate.Setup.MethodSetupResult
     {
@@ -1564,7 +1564,7 @@ namespace Mockolate.Setup
         protected abstract bool? GetSkipBaseClass();
         protected abstract void InitializeValue(object? value);
         protected abstract TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
+        protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
@@ -1577,7 +1577,7 @@ namespace Mockolate.Setup
         protected override void InitializeValue(object? value) { }
         public Mockolate.Setup.IPropertySetup<T> InitializeWith(T value) { }
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
-        protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
+        protected override void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior) { }
         protected override bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess) { }
         public Mockolate.Setup.IPropertySetup<T> Register() { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
@@ -1617,7 +1617,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>
     {
@@ -1643,7 +1643,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>
     {
@@ -1669,7 +1669,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>
     {
@@ -1695,7 +1695,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>
     {
@@ -1721,7 +1721,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class SpanWrapper<T>
     {
@@ -1747,7 +1747,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
     {
@@ -1770,7 +1770,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
     {
@@ -1793,7 +1793,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
     {
@@ -1816,7 +1816,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
     {
@@ -1839,7 +1839,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
 }
 namespace Mockolate.Verify
@@ -1940,9 +1940,7 @@ namespace Mockolate.Web
             protected HttpContentParameterWrapper(Mockolate.Web.ItExtensions.IHttpContentParameter parameter, System.Func<string> parameterString) { }
             public Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> Do(System.Action<System.Net.Http.HttpContent?> callback) { }
             public void InvokeCallbacks(Mockolate.Parameters.INamedParameterValue value) { }
-            public void InvokeCallbacks(object? value) { }
             public bool Matches(Mockolate.Parameters.INamedParameterValue value) { }
-            public bool Matches(object? value) { }
             public override string ToString() { }
             public Mockolate.Web.ItExtensions.IHttpContentParameter WithBytes(System.Func<byte[], bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
             public Mockolate.Web.ItExtensions.IHttpContentHeaderParameter WithHeaders([System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -188,7 +188,9 @@ namespace Mockolate
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, params Mockolate.Parameters.NamedParameter[] parameters) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, Mockolate.Parameters.IParameter value, params Mockolate.Parameters.NamedParameter[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName) { }
         public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<TResult> defaultValue) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
@@ -197,7 +199,7 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> Property<T>(T subject, string propertyName, Mockolate.Parameters.IParameter value) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public bool SetIndexer<TResult>(TResult value, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
-        public bool SetProperty(string propertyName, object? value) { }
+        public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
         public void SetupMethod(Mockolate.Setup.MethodSetup methodSetup) { }
@@ -564,8 +566,8 @@ namespace Mockolate.Interactions
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess : Mockolate.Interactions.IndexerAccess
     {
-        public IndexerSetterAccess(Mockolate.Parameters.INamedParameterValue[] parameters, object? value) { }
-        public object? Value { get; }
+        public IndexerSetterAccess(Mockolate.Parameters.INamedParameterValue[] parameters, Mockolate.Parameters.INamedParameterValue value) { }
+        public Mockolate.Parameters.INamedParameterValue Value { get; }
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
@@ -601,8 +603,8 @@ namespace Mockolate.Interactions
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class PropertySetterAccess : Mockolate.Interactions.PropertyAccess
     {
-        public PropertySetterAccess(string propertyName, object? value) { }
-        public object? Value { get; }
+        public PropertySetterAccess(string propertyName, Mockolate.Parameters.INamedParameterValue value) { }
+        public Mockolate.Parameters.INamedParameterValue Value { get; }
         public override string ToString() { }
     }
 }
@@ -640,9 +642,7 @@ namespace Mockolate.Parameters
     public interface IParameter
     {
         void InvokeCallbacks(Mockolate.Parameters.INamedParameterValue value);
-        void InvokeCallbacks(object? value);
         bool Matches(Mockolate.Parameters.INamedParameterValue value);
-        bool Matches(object? value);
     }
     public interface IParameterMonitor<out T>
     {
@@ -963,13 +963,13 @@ namespace Mockolate.Setup
         T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
         bool? SkipBaseClass();
-        void TriggerCallbacks(object?[] parameters);
+        void TriggerCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters);
     }
     public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
     {
         void InitializeWith(object? value);
         TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
+        void InvokeSetter<T>(Mockolate.Interactions.IInteraction invocation, T value, Mockolate.MockBehavior behavior);
         bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
         bool? SkipBaseClass();
     }
@@ -1534,12 +1534,12 @@ namespace Mockolate.Setup
         protected virtual bool HasReturnCalls() { }
         protected abstract T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         protected abstract T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
-        public void TriggerCallbacks(object?[] parameters) { }
-        protected abstract void TriggerParameterCallbacks(object?[] parameters);
+        public void TriggerCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        protected abstract void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters);
         protected static string FormatType(System.Type type) { }
         protected static bool HasOutParameter<T>(Mockolate.Parameters.NamedParameter?[] namedParameters, string parameterName, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Mockolate.Parameters.IOutParameter<T>? parameter) { }
         protected static bool HasRefParameter<T>(Mockolate.Parameters.NamedParameter?[] namedParameters, string parameterName, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Mockolate.Parameters.IRefParameter<T>? parameter) { }
-        protected static void TriggerCallbacks(Mockolate.Parameters.NamedParameter?[] namedParameters, object?[] values) { }
+        protected static void TriggerCallbacks(Mockolate.Parameters.NamedParameter?[] namedParameters, Mockolate.Parameters.INamedParameterValue[] values) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
     public class MethodSetupResult
@@ -1549,7 +1549,7 @@ namespace Mockolate.Setup
         public bool SkipBaseClass { get; }
         public T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
-        public void TriggerCallbacks(params object?[]? parameters) { }
+        public void TriggerCallbacks(params Mockolate.Parameters.INamedParameterValue[]? parameters) { }
     }
     public class MethodSetupResult<TResult> : Mockolate.Setup.MethodSetupResult
     {
@@ -1563,7 +1563,7 @@ namespace Mockolate.Setup
         protected abstract bool? GetSkipBaseClass();
         protected abstract void InitializeValue(object? value);
         protected abstract TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
+        protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
@@ -1576,7 +1576,7 @@ namespace Mockolate.Setup
         protected override void InitializeValue(object? value) { }
         public Mockolate.Setup.IPropertySetup<T> InitializeWith(T value) { }
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
-        protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
+        protected override void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior) { }
         protected override bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess) { }
         public Mockolate.Setup.IPropertySetup<T> Register() { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
@@ -1616,7 +1616,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>
     {
@@ -1642,7 +1642,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>
     {
@@ -1668,7 +1668,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>
     {
@@ -1694,7 +1694,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>
     {
@@ -1720,7 +1720,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class SpanWrapper<T>
     {
@@ -1746,7 +1746,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
     {
@@ -1769,7 +1769,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
     {
@@ -1792,7 +1792,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
     {
@@ -1815,7 +1815,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
     {
@@ -1838,7 +1838,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
 }
 namespace Mockolate.Verify
@@ -1939,9 +1939,7 @@ namespace Mockolate.Web
             protected HttpContentParameterWrapper(Mockolate.Web.ItExtensions.IHttpContentParameter parameter, System.Func<string> parameterString) { }
             public Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> Do(System.Action<System.Net.Http.HttpContent?> callback) { }
             public void InvokeCallbacks(Mockolate.Parameters.INamedParameterValue value) { }
-            public void InvokeCallbacks(object? value) { }
             public bool Matches(Mockolate.Parameters.INamedParameterValue value) { }
-            public bool Matches(object? value) { }
             public override string ToString() { }
             public Mockolate.Web.ItExtensions.IHttpContentParameter WithBytes(System.Func<byte[], bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
             public Mockolate.Web.ItExtensions.IHttpContentHeaderParameter WithHeaders([System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -175,7 +175,9 @@ namespace Mockolate
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, params Mockolate.Parameters.NamedParameter[] parameters) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, Mockolate.Parameters.IParameter value, params Mockolate.Parameters.NamedParameter[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName) { }
         public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<TResult> defaultValue) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
@@ -184,7 +186,7 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> Property<T>(T subject, string propertyName, Mockolate.Parameters.IParameter value) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public bool SetIndexer<TResult>(TResult value, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
-        public bool SetProperty(string propertyName, object? value) { }
+        public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
         public void SetupMethod(Mockolate.Setup.MethodSetup methodSetup) { }
@@ -523,8 +525,8 @@ namespace Mockolate.Interactions
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess : Mockolate.Interactions.IndexerAccess
     {
-        public IndexerSetterAccess(Mockolate.Parameters.INamedParameterValue[] parameters, object? value) { }
-        public object? Value { get; }
+        public IndexerSetterAccess(Mockolate.Parameters.INamedParameterValue[] parameters, Mockolate.Parameters.INamedParameterValue value) { }
+        public Mockolate.Parameters.INamedParameterValue Value { get; }
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
@@ -560,8 +562,8 @@ namespace Mockolate.Interactions
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class PropertySetterAccess : Mockolate.Interactions.PropertyAccess
     {
-        public PropertySetterAccess(string propertyName, object? value) { }
-        public object? Value { get; }
+        public PropertySetterAccess(string propertyName, Mockolate.Parameters.INamedParameterValue value) { }
+        public Mockolate.Parameters.INamedParameterValue Value { get; }
         public override string ToString() { }
     }
 }
@@ -599,9 +601,7 @@ namespace Mockolate.Parameters
     public interface IParameter
     {
         void InvokeCallbacks(Mockolate.Parameters.INamedParameterValue value);
-        void InvokeCallbacks(object? value);
         bool Matches(Mockolate.Parameters.INamedParameterValue value);
-        bool Matches(object? value);
     }
     public interface IParameterMonitor<out T>
     {
@@ -918,13 +918,13 @@ namespace Mockolate.Setup
         T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
         bool? SkipBaseClass();
-        void TriggerCallbacks(object?[] parameters);
+        void TriggerCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters);
     }
     public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
     {
         void InitializeWith(object? value);
         TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        void InvokeSetter(Mockolate.Interactions.IInteraction invocation, object? value, Mockolate.MockBehavior behavior);
+        void InvokeSetter<T>(Mockolate.Interactions.IInteraction invocation, T value, Mockolate.MockBehavior behavior);
         bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
         bool? SkipBaseClass();
     }
@@ -1489,12 +1489,12 @@ namespace Mockolate.Setup
         protected virtual bool HasReturnCalls() { }
         protected abstract T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator);
         protected abstract T SetRefParameter<T>(string parameterName, T value, Mockolate.MockBehavior behavior);
-        public void TriggerCallbacks(object?[] parameters) { }
-        protected abstract void TriggerParameterCallbacks(object?[] parameters);
+        public void TriggerCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        protected abstract void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters);
         protected static string FormatType(System.Type type) { }
         protected static bool HasOutParameter<T>(Mockolate.Parameters.NamedParameter?[] namedParameters, string parameterName, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Mockolate.Parameters.IOutParameter<T>? parameter) { }
         protected static bool HasRefParameter<T>(Mockolate.Parameters.NamedParameter?[] namedParameters, string parameterName, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Mockolate.Parameters.IRefParameter<T>? parameter) { }
-        protected static void TriggerCallbacks(Mockolate.Parameters.NamedParameter?[] namedParameters, object?[] values) { }
+        protected static void TriggerCallbacks(Mockolate.Parameters.NamedParameter?[] namedParameters, Mockolate.Parameters.INamedParameterValue[] values) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
     public class MethodSetupResult
@@ -1504,7 +1504,7 @@ namespace Mockolate.Setup
         public bool SkipBaseClass { get; }
         public T SetOutParameter<T>(string parameterName, System.Func<T> defaultValueGenerator) { }
         public T SetRefParameter<T>(string parameterName, T value) { }
-        public void TriggerCallbacks(params object?[]? parameters) { }
+        public void TriggerCallbacks(params Mockolate.Parameters.INamedParameterValue[]? parameters) { }
     }
     public class MethodSetupResult<TResult> : Mockolate.Setup.MethodSetupResult
     {
@@ -1518,7 +1518,7 @@ namespace Mockolate.Setup
         protected abstract bool? GetSkipBaseClass();
         protected abstract void InitializeValue(object? value);
         protected abstract TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        protected abstract void InvokeSetter(object? value, Mockolate.MockBehavior behavior);
+        protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
     public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
@@ -1531,7 +1531,7 @@ namespace Mockolate.Setup
         protected override void InitializeValue(object? value) { }
         public Mockolate.Setup.IPropertySetup<T> InitializeWith(T value) { }
         protected override TResult InvokeGetter<TResult>(Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
-        protected override void InvokeSetter(object? value, Mockolate.MockBehavior behavior) { }
+        protected override void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior) { }
         protected override bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess) { }
         public Mockolate.Setup.IPropertySetup<T> Register() { }
         public Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback) { }
@@ -1564,7 +1564,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>
     {
@@ -1590,7 +1590,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>
     {
@@ -1616,7 +1616,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>
     {
@@ -1642,7 +1642,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>
     {
@@ -1668,7 +1668,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder, Mockolate.Setup.IVoidMethodSetupReturnBuilder, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder
     {
@@ -1687,7 +1687,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
     {
@@ -1710,7 +1710,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
     {
@@ -1733,7 +1733,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
     {
@@ -1756,7 +1756,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
     public class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
     {
@@ -1779,7 +1779,7 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
-        protected override void TriggerParameterCallbacks(object?[] parameters) { }
+        protected override void TriggerParameterCallbacks(Mockolate.Parameters.INamedParameterValue[] parameters) { }
     }
 }
 namespace Mockolate.Verify
@@ -1880,9 +1880,7 @@ namespace Mockolate.Web
             protected HttpContentParameterWrapper(Mockolate.Web.ItExtensions.IHttpContentParameter parameter, System.Func<string> parameterString) { }
             public Mockolate.Parameters.IParameter<System.Net.Http.HttpContent?> Do(System.Action<System.Net.Http.HttpContent?> callback) { }
             public void InvokeCallbacks(Mockolate.Parameters.INamedParameterValue value) { }
-            public void InvokeCallbacks(object? value) { }
             public bool Matches(Mockolate.Parameters.INamedParameterValue value) { }
-            public bool Matches(object? value) { }
             public override string ToString() { }
             public Mockolate.Web.ItExtensions.IHttpContentParameter WithBytes(System.Func<byte[], bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
             public Mockolate.Web.ItExtensions.IHttpContentHeaderParameter WithHeaders([System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/Tests/Mockolate.Internal.Tests/InteractionIndexTests.cs
+++ b/Tests/Mockolate.Internal.Tests/InteractionIndexTests.cs
@@ -42,7 +42,7 @@ public sealed class InteractionIndexTests
 	[Fact]
 	public async Task IndexerSetterAccess_SetIndexTwice_ShouldRemainUnchanged()
 	{
-		IndexerSetterAccess interaction = new([new NamedParameterValue<string>("p1", "SomeProperty"),], "foo");
+		IndexerSetterAccess interaction = new([new NamedParameterValue<string>("p1", "SomeProperty"),], new NamedParameterValue<string>("value", "foo"));
 		((ISettableInteraction)interaction).SetIndex(1);
 
 		((ISettableInteraction)interaction).SetIndex(2);

--- a/Tests/Mockolate.Internal.Tests/TestHelpers/FakeMethodSetup.cs
+++ b/Tests/Mockolate.Internal.Tests/TestHelpers/FakeMethodSetup.cs
@@ -1,4 +1,5 @@
 using Mockolate.Interactions;
+using Mockolate.Parameters;
 using Mockolate.Setup;
 
 namespace Mockolate.Internal.Tests.TestHelpers;
@@ -18,5 +19,5 @@ internal sealed class FakeMethodSetup : MethodSetup
 	protected override T SetRefParameter<T>(string parameterName, T value, MockBehavior behavior) => value;
 	protected override void ExecuteCallback(MethodInvocation invocation, MockBehavior behavior) { }
 	protected override TResult GetReturnValue<TResult>(MethodInvocation invocation, MockBehavior behavior, Func<TResult> defaultValueGenerator) => defaultValueGenerator();
-	protected override void TriggerParameterCallbacks(object?[] parameters) { }
+	protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters) { }
 }

--- a/Tests/Mockolate.Internal.Tests/WebTests.cs
+++ b/Tests/Mockolate.Internal.Tests/WebTests.cs
@@ -14,29 +14,19 @@ public class WebTests
 		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
 		IParameter parameter = (IParameter)sut;
 
-		bool result = parameter.Matches(new SomeOtherObject());
+		bool result = parameter.Matches(new NamedParameterValue<SomeOtherObject>(string.Empty, new SomeOtherObject()));
 
 		await That(result).IsFalse();
 	}
 
-	[Fact]
-	public async Task HttpContentParameter_MatchesWithNullContent_ShouldReturnFalse()
-	{
-		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
-		IHttpRequestMessagePropertyParameter<HttpContent?> parameter =
-			(IHttpRequestMessagePropertyParameter<HttpContent?>)sut;
-
-		bool result = parameter.Matches(null, new HttpRequestMessage());
-
-		await That(result).IsFalse();
-	}
+	// ...existing code...
 
 	[Fact]
 	public async Task WhenParameterDoesNotImplementIHttpRequestMessagePropertyParameter_ShouldFallbackToParameterMatch()
 	{
 		ItExtensions.IHttpContentParameter parameter =
 			ItExtensions.IHttpContentParameter.CreateMock().Implementing<IParameter>();
-		parameter.Mock.As<IParameter>().Setup.Matches(It.IsAny<object?>()).Returns(true);
+		parameter.Mock.As<IParameter>().Setup.Matches(It.IsAny<INamedParameterValue>()).Returns(true);
 
 		ItExtensions.IStringContentBodyParameter sut = parameter.WithString("foo");
 
@@ -44,7 +34,7 @@ public class WebTests
 
 		await That(result).IsTrue();
 		await That(parameter.Mock.As<IParameter>().Verify
-				.Matches(It.IsNull<object?>()))
+				.Matches(It.IsAny<INamedParameterValue>()))
 			.Once();
 	}
 
@@ -54,7 +44,7 @@ public class WebTests
 		ItExtensions.IHttpContentParameter parameter = ItExtensions.IHttpContentParameter.CreateMock()
 			.Implementing<IParameter>()
 			.Implementing<IHttpRequestMessagePropertyParameter<HttpContent?>>();
-		parameter.Mock.As<IParameter>().Setup.Matches(It.IsAny<object?>()).Returns(false);
+		parameter.Mock.As<IParameter>().Setup.Matches(It.IsAny<INamedParameterValue>()).Returns(false);
 		parameter.Mock.As<IHttpRequestMessagePropertyParameter<HttpContent?>>().Setup
 			.Matches(It.IsAny<HttpContent?>(), It.IsAny<HttpRequestMessage?>()).Returns(true);
 
@@ -67,7 +57,7 @@ public class WebTests
 				.Matches(It.IsNull<HttpContent?>(), It.IsNull<HttpRequestMessage?>()))
 			.Once();
 		await That(parameter.Mock.As<IParameter>().Verify
-				.Matches(It.IsNull<object?>()))
+				.Matches(It.IsAny<INamedParameterValue>()))
 			.Never();
 	}
 
@@ -77,7 +67,7 @@ public class WebTests
 		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
 		IParameter parameter = (IParameter)sut;
 
-		bool result = parameter.Matches(new MyHttpContent());
+		bool result = parameter.Matches(new NamedParameterValue<MyHttpContent>(string.Empty, new MyHttpContent()));
 
 		await That(result).IsTrue();
 	}
@@ -88,7 +78,7 @@ public class WebTests
 		ItExtensions.IHttpContentParameter sut = It.IsHttpContent("*");
 		IParameter parameter = (IParameter)sut;
 
-		bool result = parameter.Matches(new MyHttpContent());
+		bool result = parameter.Matches(new NamedParameterValue<MyHttpContent>(string.Empty, new MyHttpContent()));
 
 		await That(result).IsFalse();
 	}

--- a/Tests/Mockolate.Internal.Tests/WebTests.cs
+++ b/Tests/Mockolate.Internal.Tests/WebTests.cs
@@ -19,8 +19,6 @@ public class WebTests
 		await That(result).IsFalse();
 	}
 
-	// ...existing code...
-
 	[Fact]
 	public async Task WhenParameterDoesNotImplementIHttpRequestMessagePropertyParameter_ShouldFallbackToParameterMatch()
 	{

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -405,7 +405,6 @@ public class GeneralTests
 			.Contains("global::MyCode.N2.IMyInterface, IMockForIMyInterface_2, IMockSetupForIMyInterface_2, IMockVerifyForIMyInterface_2");
 	}
 
-
 	[Fact]
 	public async Task ObsoleteAttributes_ShouldBeRepeatedInMock()
 	{
@@ -796,7 +795,7 @@ public class GeneralTests
 			          			}
 			          			set
 			          			{
-			          				this.MockRegistry.SetProperty("global::MyCode.IMyService.SomeProperty", value);
+			          				this.MockRegistry.SetProperty<string>("global::MyCode.IMyService.SomeProperty", value);
 			          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 			          				{
 			          					wraps.SomeProperty = value;
@@ -815,11 +814,11 @@ public class GeneralTests
 			          				var baseResult = wraps.MyMethod(message);
 			          				if (!methodExecution.HasSetupResult)
 			          				{
-			          					methodExecution.TriggerCallbacks(message);
+			          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<string>("message", message));
 			          					return baseResult;
 			          				}
 			          			}
-			          			methodExecution.TriggerCallbacks(message);
+			          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<string>("message", message));
 			          			return methodExecution.Result;
 			          		}
 			          """).IgnoringNewlineStyle().And

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -168,7 +168,7 @@ public sealed partial class MockTests
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
 					.Contains("MethodSetupResult<int> methodExecution1 = this.MockRegistry.InvokeMethod<int>(")
 					.IgnoringNewlineStyle().And
-					.Contains("methodExecution1.TriggerCallbacks(methodExecution)")
+					.Contains("methodExecution1.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>(\"methodExecution\", methodExecution))")
 					.IgnoringNewlineStyle().And
 					.Contains("return methodExecution1.Result;")
 					.IgnoringNewlineStyle();
@@ -200,7 +200,7 @@ public sealed partial class MockTests
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
 					.Contains("MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>(")
 					.IgnoringNewlineStyle().And
-					.Contains("methodExecution.TriggerCallbacks(result)")
+					.Contains("methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>(\"result\", result))")
 					.IgnoringNewlineStyle().And
 					.Contains("return methodExecution.Result;")
 					.IgnoringNewlineStyle();
@@ -345,11 +345,11 @@ public sealed partial class MockTests
 					          				var baseResult = wraps.MyMethod1(index);
 					          				if (!methodExecution.HasSetupResult)
 					          				{
-					          					methodExecution.TriggerCallbacks(index);
+					          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
 					          					return baseResult;
 					          				}
 					          			}
-					          			methodExecution.TriggerCallbacks(index);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
 					          			return methodExecution.Result;
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -362,7 +362,7 @@ public sealed partial class MockTests
 					          			{
 					          				wraps.MyMethod2(index, isReadOnly);
 					          			}
-					          			methodExecution.TriggerCallbacks(index, isReadOnly);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly));
 					          		}
 					          """).IgnoringNewlineStyle();
 			}
@@ -416,11 +416,11 @@ public sealed partial class MockTests
 					          				var baseResult = wraps.MyDirectMethod(value);
 					          				if (!methodExecution.HasSetupResult)
 					          				{
-					          					methodExecution.TriggerCallbacks(value);
+					          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          					return baseResult;
 					          				}
 					          			}
-					          			methodExecution.TriggerCallbacks(value);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          			return methodExecution.Result;
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -434,11 +434,11 @@ public sealed partial class MockTests
 					          				var baseResult = wraps.MyBaseMethod1(value);
 					          				if (!methodExecution.HasSetupResult)
 					          				{
-					          					methodExecution.TriggerCallbacks(value);
+					          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          					return baseResult;
 					          				}
 					          			}
-					          			methodExecution.TriggerCallbacks(value);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          			return methodExecution.Result;
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -452,11 +452,11 @@ public sealed partial class MockTests
 					          				var baseResult = wraps.MyBaseMethod2(value);
 					          				if (!methodExecution.HasSetupResult)
 					          				{
-					          					methodExecution.TriggerCallbacks(value);
+					          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          					return baseResult;
 					          				}
 					          			}
-					          			methodExecution.TriggerCallbacks(value);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          			return methodExecution.Result;
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -470,11 +470,11 @@ public sealed partial class MockTests
 					          				var baseResult = wraps.MyBaseMethod3(value);
 					          				if (!methodExecution.HasSetupResult)
 					          				{
-					          					methodExecution.TriggerCallbacks(value);
+					          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          					return baseResult;
 					          				}
 					          			}
-					          			methodExecution.TriggerCallbacks(value);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
 					          			return methodExecution.Result;
 					          		}
 					          """).IgnoringNewlineStyle();
@@ -542,13 +542,13 @@ public sealed partial class MockTests
 					          					base.MyMethod1(index, ref value1, out flag);
 					          				}
 					          			}
-					          			methodExecution.TriggerCallbacks(index, value1, flag);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<int>("value1", value1), new global::Mockolate.Parameters.NamedParameterValue<bool>("flag", flag));
 
 					          			value1 = methodExecution.SetRefParameter<int>("value1", value1);
-					          			methodExecution.TriggerCallbacks(index, value1, flag);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<int>("value1", value1), new global::Mockolate.Parameters.NamedParameterValue<bool>("flag", flag));
 
 					          			flag = methodExecution.SetOutParameter<bool>("flag", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!));
-					          			methodExecution.TriggerCallbacks(index, value1, flag);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<int>("value1", value1), new global::Mockolate.Parameters.NamedParameterValue<bool>("flag", flag));
 					          		}
 					          """).IgnoringNewlineStyle().And
 					.Contains("""
@@ -571,7 +571,7 @@ public sealed partial class MockTests
 
 					          				if (!methodExecution.HasSetupResult)
 					          				{
-					          					methodExecution.TriggerCallbacks(index, isReadOnly, value1, flag);
+					          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly), new global::Mockolate.Parameters.NamedParameterValue<int>("value1", value1), new global::Mockolate.Parameters.NamedParameterValue<bool>("flag", flag));
 					          					return baseResult;
 					          				}
 					          			}
@@ -581,7 +581,7 @@ public sealed partial class MockTests
 					          				flag = methodExecution.SetOutParameter<bool>("flag", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!));
 					          			}
 
-					          			methodExecution.TriggerCallbacks(index, isReadOnly, value1, flag);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly), new global::Mockolate.Parameters.NamedParameterValue<int>("value1", value1), new global::Mockolate.Parameters.NamedParameterValue<bool>("flag", flag));
 					          			return methodExecution.Result;
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -590,7 +590,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyOtherService.SomeOtherMethod()" />
 					          		int global::MyCode.IMyOtherService.SomeOtherMethod()
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>("global::MyCode.IMyOtherService.SomeOtherMethod", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p));
+					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>("global::MyCode.IMyOtherService.SomeOtherMethod", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
 					          			methodExecution.TriggerCallbacks();
 					          			return methodExecution.Result;
 					          		}
@@ -705,6 +705,11 @@ public sealed partial class MockTests
 					         void MyMethod3(in MyReadonlyStruct p1);
 					         void MyMethod4(ref readonly MyReadonlyStruct p1);
 					     }
+					     
+					     public readonly struct MyReadonlyStruct
+					     {
+					         public int Value { get; init; }
+					     }
 					     """);
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
@@ -723,7 +728,7 @@ public sealed partial class MockTests
 
 					          			}
 					          			index = methodExecution.SetRefParameter<int>("index", index);
-					          			methodExecution.TriggerCallbacks(index);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
 					          		}
 					          """).IgnoringNewlineStyle().And
 					.Contains("""
@@ -741,37 +746,37 @@ public sealed partial class MockTests
 
 					          				if (!methodExecution.HasSetupResult)
 					          				{
-					          					methodExecution.TriggerCallbacks(index, isReadOnly);
+					          					methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly));
 					          					return baseResult;
 					          				}
 					          			}
 					          			isReadOnly = methodExecution.SetOutParameter<bool>("isReadOnly", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!));
-					          			methodExecution.TriggerCallbacks(index, isReadOnly);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly));
 					          			return methodExecution.Result;
 					          		}
 					          """).IgnoringNewlineStyle().And
 					.Contains("""
-					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod3(in MyReadonlyStruct)" />
-					          		public void MyMethod3(in MyReadonlyStruct p1)
+					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod3(in global::MyCode.MyReadonlyStruct)" />
+					          		public void MyMethod3(in global::MyCode.MyReadonlyStruct p1)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod3", new global::Mockolate.Parameters.NamedParameterValue<MyReadonlyStruct>("p1", p1));
+					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod3", new global::Mockolate.Parameters.NamedParameterValue<global::MyCode.MyReadonlyStruct>("p1", p1));
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				wraps.MyMethod3(in p1);
 					          			}
-					          			methodExecution.TriggerCallbacks(p1);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<global::MyCode.MyReadonlyStruct>("p1", p1));
 					          		}
 					          """).IgnoringNewlineStyle().And
 					.Contains("""
-					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod4(ref readonly MyReadonlyStruct)" />
-					          		public void MyMethod4(ref readonly MyReadonlyStruct p1)
+					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod4(ref readonly global::MyCode.MyReadonlyStruct)" />
+					          		public void MyMethod4(ref readonly global::MyCode.MyReadonlyStruct p1)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod4", new global::Mockolate.Parameters.NamedParameterValue<MyReadonlyStruct>("p1", p1));
+					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod4", new global::Mockolate.Parameters.NamedParameterValue<global::MyCode.MyReadonlyStruct>("p1", p1));
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				wraps.MyMethod4(in p1);
 					          			}
-					          			methodExecution.TriggerCallbacks(p1);
+					          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<global::MyCode.MyReadonlyStruct>("p1", p1));
 					          		}
 					          """).IgnoringNewlineStyle();
 			}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -84,7 +84,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyService.SomeProperty", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomeProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomeProperty = value;
@@ -108,7 +108,7 @@ public sealed partial class MockTests
 					          		{
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyService.SomeWriteOnlyProperty", value);
+					          				this.MockRegistry.SetProperty<bool?>("global::MyCode.IMyService.SomeWriteOnlyProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomeWriteOnlyProperty = value;
@@ -126,7 +126,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyService.SomeInternalProperty", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomeInternalProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomeInternalProperty = value;
@@ -144,7 +144,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyService.SomePrivateProperty", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomePrivateProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomePrivateProperty = value;
@@ -162,7 +162,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyService.SomePrivateProtectedProperty", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomePrivateProtectedProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomePrivateProtectedProperty = value;
@@ -221,7 +221,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyService.MyDirectProperty", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.MyDirectProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyDirectProperty = value;
@@ -239,7 +239,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyServiceBase1.MyBaseProperty1", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyServiceBase1.MyBaseProperty1", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyBaseProperty1 = value;
@@ -257,7 +257,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyServiceBase2.MyBaseProperty2", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyServiceBase2.MyBaseProperty2", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyBaseProperty2 = value;
@@ -275,7 +275,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyServiceBase3.MyBaseProperty3", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyServiceBase3.MyBaseProperty3", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyBaseProperty3 = value;
@@ -335,7 +335,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				if (!this.MockRegistry.SetProperty("global::MyCode.MyService.SomeProperty1", value))
+					          				if (!this.MockRegistry.SetProperty<int>("global::MyCode.MyService.SomeProperty1", value))
 					          				{
 					          					if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
 					          					{
@@ -359,7 +359,7 @@ public sealed partial class MockTests
 					          			}
 					          			protected set
 					          			{
-					          				if (!this.MockRegistry.SetProperty("global::MyCode.MyService.SomeProperty2", value))
+					          				if (!this.MockRegistry.SetProperty<int>("global::MyCode.MyService.SomeProperty2", value))
 					          				{
 					          					base.SomeProperty2 = value;
 					          				}
@@ -382,7 +382,7 @@ public sealed partial class MockTests
 					          		{
 					          			set
 					          			{
-					          				if (!this.MockRegistry.SetProperty("global::MyCode.MyService.SomeWriteOnlyProperty", value))
+					          				if (!this.MockRegistry.SetProperty<bool?>("global::MyCode.MyService.SomeWriteOnlyProperty", value))
 					          				{
 					          					base.SomeWriteOnlyProperty = value;
 					          				}
@@ -400,7 +400,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty("global::MyCode.IMyOtherService.SomeAdditionalProperty", value);
+					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyOtherService.SomeAdditionalProperty", value);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -83,7 +83,7 @@ public sealed partial class MockTests
 				          		private global::System.Span<char> Invoke(int x)
 				          		{
 				          			var result = this.MockRegistry.InvokeMethod<global::System.Span<char>>("global::MyCode.Program.DoSomething1.Invoke", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.SpanWrapper<char>)!, [new global::Mockolate.Parameters.NamedParameterValue<global::System.Func<char>>(string.Empty, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!)), ..p]), new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
-				          			result.TriggerCallbacks(x);
+				          			result.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
 				          			return result.Result;
 				          		}
 				          """).IgnoringNewlineStyle();
@@ -94,7 +94,7 @@ public sealed partial class MockTests
 				          		private global::System.ReadOnlySpan<char> Invoke(int x)
 				          		{
 				          			var result = this.MockRegistry.InvokeMethod<global::System.ReadOnlySpan<char>>("global::MyCode.Program.DoSomething2.Invoke", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.ReadOnlySpanWrapper<char>)!, [new global::Mockolate.Parameters.NamedParameterValue<global::System.Func<char>>(string.Empty, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!)), ..p]), new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
-				          			result.TriggerCallbacks(x);
+				          			result.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
 				          			return result.Result;
 				          		}
 				          """).IgnoringNewlineStyle();
@@ -256,7 +256,7 @@ public sealed partial class MockTests
 			await That(result.Sources).ContainsKey("Mock.Program_ProcessResult.g.cs").WhoseValue
 				.Contains("var result1 = this.MockRegistry.InvokeMethod<int>(")
 				.IgnoringNewlineStyle().And
-				.Contains("result1.TriggerCallbacks(result)")
+				.Contains("result1.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>(\"result\", result))")
 				.IgnoringNewlineStyle().And
 				.Contains("return result1.Result;")
 				.IgnoringNewlineStyle();
@@ -288,7 +288,7 @@ public sealed partial class MockTests
 				.IgnoringNewlineStyle().And
 				.Contains("value = result1.SetOutParameter<int>(\"value\", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));")
 				.IgnoringNewlineStyle().And
-				.Contains("result1.TriggerCallbacks(result, value)")
+				.Contains("result1.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<string>(\"result\", result), new global::Mockolate.Parameters.NamedParameterValue<int>(\"value\", value))")
 				.IgnoringNewlineStyle();
 		}
 

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -622,7 +622,7 @@ public sealed partial class MockTests
 			          			{
 			          				wraps.MyMethod(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
 			          			}
-			          			methodExecution.TriggerCallbacks(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+			          			methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<object>("v1", v1), new global::Mockolate.Parameters.NamedParameterValue<bool>("v2", v2), new global::Mockolate.Parameters.NamedParameterValue<string>("v3", v3), new global::Mockolate.Parameters.NamedParameterValue<char>("v4", v4), new global::Mockolate.Parameters.NamedParameterValue<byte>("v5", v5), new global::Mockolate.Parameters.NamedParameterValue<sbyte>("v6", v6), new global::Mockolate.Parameters.NamedParameterValue<short>("v7", v7), new global::Mockolate.Parameters.NamedParameterValue<ushort>("v8", v8), new global::Mockolate.Parameters.NamedParameterValue<int>("v9", v9), new global::Mockolate.Parameters.NamedParameterValue<uint>("v10", v10), new global::Mockolate.Parameters.NamedParameterValue<long>("v11", v11), new global::Mockolate.Parameters.NamedParameterValue<ulong>("v12", v12), new global::Mockolate.Parameters.NamedParameterValue<float>("v13", v13), new global::Mockolate.Parameters.NamedParameterValue<double>("v14", v14), new global::Mockolate.Parameters.NamedParameterValue<decimal>("v15", v15));
 			          		}
 			          """).IgnoringNewlineStyle();
 	}

--- a/Tests/Mockolate.Tests/ItTests.IsAnyOutTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsAnyOutTests.cs
@@ -6,18 +6,44 @@ public sealed partial class ItTests
 {
 	public sealed class IsAnyOutTests
 	{
-		[Theory]
-		[InlineData(42L, false)]
-		[InlineData("foo", false)]
-		[InlineData(null, true)]
-		[InlineData(123, true)]
-		public async Task ShouldCheckType(object? value, bool expectMatch)
+		[Fact]
+		public async Task ShouldNotMatchLong()
 		{
 			IOutParameter<int?> sut = It.IsAnyOut<int?>();
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<long>(string.Empty, 42L));
 
-			await That(result).IsEqualTo(expectMatch);
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task ShouldNotMatchString()
+		{
+			IOutParameter<int?> sut = It.IsAnyOut<int?>();
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
+
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task ShouldMatchNull()
+		{
+			IOutParameter<int?> sut = It.IsAnyOut<int?>();
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int?>(string.Empty, null));
+
+			await That(result).IsTrue();
+		}
+
+		[Fact]
+		public async Task ShouldMatchInt()
+		{
+			IOutParameter<int?> sut = It.IsAnyOut<int?>();
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int?>(string.Empty, 123));
+
+			await That(result).IsTrue();
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/ItTests.IsAnyReadOnlySpanTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsAnyReadOnlySpanTests.cs
@@ -17,7 +17,7 @@ public sealed partial class ItTests
 			ReadOnlySpan<char> valueSpan = value.AsSpan();
 			IVerifyReadOnlySpanParameter<char> sut = It.IsAnyReadOnlySpan<char>();
 
-			bool result = ((IParameter)sut).Matches((ReadOnlySpanWrapper<char>)valueSpan);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<ReadOnlySpanWrapper<char>>(string.Empty, (ReadOnlySpanWrapper<char>)valueSpan));
 
 			await That(result).IsTrue();
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsAnyRefTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsAnyRefTests.cs
@@ -6,18 +6,44 @@ public sealed partial class ItTests
 {
 	public sealed class IsAnyRefTests
 	{
-		[Theory]
-		[InlineData(42L, false)]
-		[InlineData("foo", false)]
-		[InlineData(null, true)]
-		[InlineData(123, true)]
-		public async Task ShouldCheckType(object? value, bool expectMatch)
+		[Fact]
+		public async Task ShouldNotMatchLong()
 		{
 			IRefParameter<int?> sut = It.IsAnyRef<int?>();
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<long>(string.Empty, 42L));
 
-			await That(result).IsEqualTo(expectMatch);
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task ShouldNotMatchString()
+		{
+			IRefParameter<int?> sut = It.IsAnyRef<int?>();
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
+
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task ShouldMatchNull()
+		{
+			IRefParameter<int?> sut = It.IsAnyRef<int?>();
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int?>(string.Empty, null));
+
+			await That(result).IsTrue();
+		}
+
+		[Fact]
+		public async Task ShouldMatchInt()
+		{
+			IRefParameter<int?> sut = It.IsAnyRef<int?>();
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int?>(string.Empty, 123));
+
+			await That(result).IsTrue();
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/ItTests.IsAnySpanTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsAnySpanTests.cs
@@ -17,7 +17,7 @@ public sealed partial class ItTests
 			Span<char> valueSpan = new(value.ToCharArray());
 			IVerifySpanParameter<char> sut = It.IsAnySpan<char>();
 
-			bool result = ((IParameter)sut).Matches((SpanWrapper<char>)valueSpan);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<SpanWrapper<char>>(string.Empty, (SpanWrapper<char>)valueSpan));
 
 			await That(result).IsTrue();
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsAnyTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsAnyTests.cs
@@ -14,7 +14,7 @@ public sealed partial class ItTests
 		{
 			IParameter<string> sut = It.IsAny<string>();
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string?>(string.Empty, value));
 
 			await That(result).IsTrue();
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsNotNullTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNotNullTests.cs
@@ -49,7 +49,7 @@ public sealed partial class ItTests
 		{
 			IParameter<string?> sut = It.IsNotNull<string?>();
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string?>(string.Empty, value));
 
 			await That(result).IsEqualTo(expectMatch);
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsNotOneOfTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNotOneOfTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.IsNotOneOf(5, 6, 7);
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsEqualTo(expectMatch);
 		}
@@ -98,7 +98,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.IsNotOneOf(4, 5, 6).Using(new AllEqualComparer());
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsFalse();
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsNotTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNotTests.cs
@@ -45,7 +45,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.IsNot(5);
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsEqualTo(expectMatch);
 		}
@@ -96,7 +96,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.IsNot(5).Using(new AllEqualComparer());
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsFalse();
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsNullTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNullTests.cs
@@ -38,7 +38,7 @@ public sealed partial class ItTests
 		{
 			IParameter<string?> sut = It.IsNull<string?>();
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string?>(string.Empty, value));
 
 			await That(result).IsEqualTo(expectMatch);
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsOneOfTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsOneOfTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.IsOneOf(5, 6, 7);
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsEqualTo(expectMatch);
 		}
@@ -102,7 +102,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.IsOneOf(4, 5, 6).Using(new AllEqualComparer());
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsTrue();
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsOutTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsOutTests.cs
@@ -40,14 +40,23 @@ public sealed partial class ItTests
 			await That(result).IsEqualTo(value);
 		}
 
-		[Theory]
-		[InlineData(42L)]
-		[InlineData("foo")]
-		public async Task WithOut_Verify_ShouldAlwaysMatch(object? value)
+		[Fact]
+		public async Task WithOut_Verify_Long_ShouldAlwaysMatch()
 		{
 			IVerifyOutParameter<int?> sut = It.IsOut<int?>();
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<long>(string.Empty, 42L));
+
+			await That(result).IsTrue();
+			await That(() => ((IParameter)sut).InvokeCallbacks(new NamedParameterValue<int>("", 0))).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WithOut_Verify_String_ShouldAlwaysMatch()
+		{
+			IVerifyOutParameter<int?> sut = It.IsOut<int?>();
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
 			await That(result).IsTrue();
 			await That(() => ((IParameter)sut).InvokeCallbacks(new NamedParameterValue<int>("", 0))).DoesNotThrow();

--- a/Tests/Mockolate.Tests/ItTests.IsReadOnlySpanTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsReadOnlySpanTests.cs
@@ -17,7 +17,7 @@ public sealed partial class ItTests
 			ReadOnlySpan<char> valueSpan = value.AsSpan();
 			IVerifyReadOnlySpanParameter<char> sut = It.IsReadOnlySpan<char>(c => c.Length > 0 && c[0] == 'b');
 
-			bool result = ((IParameter)sut).Matches((ReadOnlySpanWrapper<char>)valueSpan);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<ReadOnlySpanWrapper<char>>(string.Empty, (ReadOnlySpanWrapper<char>)valueSpan));
 
 			await That(result).IsEqualTo(expectSuccess);
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsRefTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsRefTests.cs
@@ -6,8 +6,6 @@ public sealed partial class ItTests
 {
 	public sealed class IsRefTests
 	{
-		// ...existing code...
-
 		[Fact]
 		public async Task WithRef_DifferentType_Long_ShouldNotMatch()
 		{
@@ -40,8 +38,6 @@ public sealed partial class ItTests
 			await That(result).IsEqualTo(predicateValue);
 		}
 
-		// ...existing code...
-
 		[Fact]
 		public async Task WithRef_Verify_Long_ShouldAlwaysMatch()
 		{
@@ -63,7 +59,5 @@ public sealed partial class ItTests
 			await That(result).IsTrue();
 			await That(() => ((IParameter)sut).InvokeCallbacks(new NamedParameterValue<int>("", 0))).DoesNotThrow();
 		}
-
-		// ...existing code...
 	}
 }

--- a/Tests/Mockolate.Tests/ItTests.IsRefTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsRefTests.cs
@@ -6,47 +6,24 @@ public sealed partial class ItTests
 {
 	public sealed class IsRefTests
 	{
-		[Fact]
-		public async Task ToString_ShouldReturnExpectedValue()
-		{
-			IRefParameter<int?> sut = It.IsRef<int?>(v => v * 3);
-			string expectedValue = "It.IsRef<int?>(v => v * 3)";
-
-			string? result = sut.ToString();
-
-			await That(result).IsEqualTo(expectedValue);
-		}
+		// ...existing code...
 
 		[Fact]
-		public async Task ToString_Verify_ShouldReturnExpectedValue()
-		{
-			IVerifyRefParameter<int> sut = It.IsRef<int>();
-			string expectedValue = "It.IsRef<int>()";
-
-			string? result = sut.ToString();
-
-			await That(result).IsEqualTo(expectedValue);
-		}
-
-		[Fact]
-		public async Task ToString_WithPredicate_ShouldReturnExpectedValue()
-		{
-			IRefParameter<int?> sut = It.IsRef<int?>(v => v > 3, v => v * 3);
-			string expectedValue = "It.IsRef<int?>(v => v > 3, v => v * 3)";
-
-			string? result = sut.ToString();
-
-			await That(result).IsEqualTo(expectedValue);
-		}
-
-		[Theory]
-		[InlineData(42L)]
-		[InlineData("foo")]
-		public async Task WithRef_DifferentType_ShouldNotMatch(object? value)
+		public async Task WithRef_DifferentType_Long_ShouldNotMatch()
 		{
 			IRefParameter<int?> sut = It.IsRef<int?>(_ => true, _ => null);
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<long>(string.Empty, 42L));
+
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task WithRef_DifferentType_String_ShouldNotMatch()
+		{
+			IRefParameter<int?> sut = It.IsRef<int?>(_ => true, _ => null);
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
 			await That(result).IsFalse();
 		}
@@ -58,46 +35,35 @@ public sealed partial class ItTests
 		{
 			IRefParameter<string> sut = It.IsRef<string>(_ => predicateValue, _ => "");
 
-			bool result = ((IParameter)sut).Matches("foo");
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
 			await That(result).IsEqualTo(predicateValue);
 		}
 
-		[Theory]
-		[InlineData(42)]
-		[InlineData(-2)]
-		public async Task WithRef_ShouldReturnValue(int? value)
-		{
-			IRefParameter<int?> sut = It.IsRef<int?>(v => v * 2);
+		// ...existing code...
 
-			int? result = sut.GetValue(value);
-
-			await That(result).IsEqualTo(2 * value);
-		}
-
-		[Theory]
-		[InlineData(42L)]
-		[InlineData("foo")]
-		public async Task WithRef_Verify_ShouldAlwaysMatch(object? value)
+		[Fact]
+		public async Task WithRef_Verify_Long_ShouldAlwaysMatch()
 		{
 			IVerifyRefParameter<int?> sut = It.IsRef<int?>();
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<long>(string.Empty, 42L));
 
 			await That(result).IsTrue();
 			await That(() => ((IParameter)sut).InvokeCallbacks(new NamedParameterValue<int>("", 0))).DoesNotThrow();
 		}
 
-		[Theory]
-		[InlineData(42)]
-		[InlineData(-2)]
-		public async Task WithRef_WithoutSetter_ShouldReturnOriginalValue(int? value)
+		[Fact]
+		public async Task WithRef_Verify_String_ShouldAlwaysMatch()
 		{
-			IRefParameter<int?> sut = It.IsRef<int?>(_ => true);
+			IVerifyRefParameter<int?> sut = It.IsRef<int?>();
 
-			int? result = sut.GetValue(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
-			await That(result).IsEqualTo(value);
+			await That(result).IsTrue();
+			await That(() => ((IParameter)sut).InvokeCallbacks(new NamedParameterValue<int>("", 0))).DoesNotThrow();
 		}
+
+		// ...existing code...
 	}
 }

--- a/Tests/Mockolate.Tests/ItTests.IsSpanTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsSpanTests.cs
@@ -17,7 +17,7 @@ public sealed partial class ItTests
 			Span<char> valueSpan = new(value.ToCharArray());
 			IVerifySpanParameter<char> sut = It.IsSpan<char>(c => c.Length > 0 && c[0] == 'b');
 
-			bool result = ((IParameter)sut).Matches((SpanWrapper<char>)valueSpan);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<SpanWrapper<char>>(string.Empty, (SpanWrapper<char>)valueSpan));
 
 			await That(result).IsEqualTo(expectSuccess);
 		}

--- a/Tests/Mockolate.Tests/ItTests.IsTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsTests.cs
@@ -15,7 +15,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.Is(5);
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsEqualTo(expectMatch);
 		}
@@ -66,7 +66,7 @@ public sealed partial class ItTests
 		{
 			IParameter<int> sut = It.Is(5).Using(new AllEqualComparer());
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int>(string.Empty, value));
 
 			await That(result).IsTrue();
 		}

--- a/Tests/Mockolate.Tests/ItTests.MatchesTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.MatchesTests.cs
@@ -94,11 +94,11 @@ public sealed partial class ItTests
 			match.CaseSensitive();
 			IParameter parameter = (IParameter)match;
 
-			bool result1 = parameter.Matches("foo");
+			bool result1 = parameter.Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
 			match.CaseSensitive(false);
 
-			bool result2 = parameter.Matches("foo");
+			bool result2 = parameter.Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
 			await That(result1).IsFalse();
 			await That(result2).IsFalse();

--- a/Tests/Mockolate.Tests/ItTests.SatisfiesTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.SatisfiesTests.cs
@@ -13,19 +13,27 @@ public sealed partial class ItTests
 		{
 			IParameter<int?> sut = It.Satisfies<int?>(v => v is null);
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<int?>(string.Empty, value));
 
 			await That(result).IsEqualTo(expectedResult);
 		}
 
-		[Theory]
-		[InlineData(42L)]
-		[InlineData("foo")]
-		public async Task DifferentType_ShouldNotMatch(object? value)
+		[Fact]
+		public async Task DifferentType_Long_ShouldNotMatch()
 		{
 			IParameter<int?> sut = It.Satisfies<int?>(_ => true);
 
-			bool result = ((IParameter)sut).Matches(value);
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<long>(string.Empty, 42L));
+
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task DifferentType_String_ShouldNotMatch()
+		{
+			IParameter<int?> sut = It.Satisfies<int?>(_ => true);
+
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
 			await That(result).IsFalse();
 		}
@@ -37,7 +45,7 @@ public sealed partial class ItTests
 		{
 			IParameter<string> sut = It.Satisfies<string>(_ => predicateValue);
 
-			bool result = ((IParameter)sut).Matches("foo");
+			bool result = ((IParameter)sut).Matches(new NamedParameterValue<string>(string.Empty, "foo"));
 
 			await That(result).IsEqualTo(predicateValue);
 		}

--- a/Tests/Mockolate.Tests/ItTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.cs
@@ -14,7 +14,7 @@ public sealed partial class ItTests
 		IParameter<int> sut = It.Satisfies<int>(_ => true)
 			.Do(v => isCalled += v);
 
-		((IParameter)sut).InvokeCallbacks(5);
+		((IParameter)sut).InvokeCallbacks(new NamedParameterValue<int>(string.Empty, 5));
 
 		await That(isCalled).IsEqualTo(5);
 	}
@@ -26,7 +26,7 @@ public sealed partial class ItTests
 		IParameter<int> sut = It.Satisfies<int>(_ => true)
 			.Do(v => isCalled += v);
 
-		((IParameter)sut).InvokeCallbacks("5");
+		((IParameter)sut).InvokeCallbacks(new NamedParameterValue<string>(string.Empty, "5"));
 
 		await That(isCalled).IsEqualTo(0);
 	}

--- a/Tests/Mockolate.Tests/MockIndexers/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/InteractionsTests.cs
@@ -30,7 +30,7 @@ public sealed class InteractionsTests
 			new NamedParameterValue<int>("p2", 4),
 			new NamedParameterValue<long?>("p3", null),
 			new NamedParameterValue<TimeSpan>("p4", 150.Seconds()),
-		], 6));
+		], new NamedParameterValue<int>("value", 6)));
 		string expectedValue = "[0] set indexer [SomeProperty, 4, null, 00:02:30] to 6";
 
 		await That(interaction.ToString()).IsEqualTo(expectedValue);
@@ -45,7 +45,7 @@ public sealed class InteractionsTests
 			new NamedParameterValue<int>("p2", 4),
 			new NamedParameterValue<long?>("p3", null),
 			new NamedParameterValue<TimeSpan>("p4", 150.Seconds()),
-		], null));
+		], new NamedParameterValue<string?>("value", null)));
 		string expectedValue = "[0] set indexer [SomeProperty, 4, null, 00:02:30] to null";
 
 		await That(interaction.ToString()).IsEqualTo(expectedValue);

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnGetTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnGetTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Mockolate.Interactions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
@@ -80,7 +80,7 @@ public sealed partial class SetupIndexerTests
 			indexerSetup.OnSet.Do(() => { callCount++; });
 			IndexerSetterAccess access = new([
 				new NamedParameterValue<int>("p1", 1),
-			], "bar");
+			], new NamedParameterValue<string>("value", "bar"));
 
 			indexerSetup.DoExecuteSetterCallback(access, 2L);
 
@@ -96,7 +96,7 @@ public sealed partial class SetupIndexerTests
 			IndexerSetterAccess access = new([
 				new NamedParameterValue<int>("p1", 1),
 				new NamedParameterValue<int>("p2", 1),
-			], "bar");
+			], new NamedParameterValue<string>("value", "bar"));
 
 			indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -111,7 +111,7 @@ public sealed partial class SetupIndexerTests
 			indexerSetup.OnSet.Do(() => { callCount++; });
 			IndexerSetterAccess access = new([
 				new NamedParameterValue<string>("p1", "expect-int"),
-			], "bar");
+			], new NamedParameterValue<string>("value", "bar"));
 
 			indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -124,7 +124,7 @@ public sealed partial class SetupIndexerTests
 			int callCount = 0;
 			MyIndexerSetup<int> indexerSetup = new();
 			indexerSetup.OnSet.Do(() => { callCount++; });
-			IndexerSetterAccess access = new([new NamedParameterValue<int>("p1", 1),], "bar");
+			IndexerSetterAccess access = new([new NamedParameterValue<int>("p1", 1),], new NamedParameterValue<string>("value", "bar"));
 
 			indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -491,7 +491,7 @@ public sealed partial class SetupIndexerTests
 				IndexerSetterAccess access = new([
 					new NamedParameterValue<int>("p1", 1),
 					new NamedParameterValue<int>("p2", 2),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, 2L);
 
@@ -508,7 +508,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p1", 1),
 					new NamedParameterValue<int>("p2", 2),
 					new NamedParameterValue<int>("p3", 3),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -527,7 +527,7 @@ public sealed partial class SetupIndexerTests
 				IndexerSetterAccess access = new([
 					new NamedParameterValue<object?>("p1", v1),
 					new NamedParameterValue<object?>("p2", v2),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -543,7 +543,7 @@ public sealed partial class SetupIndexerTests
 				IndexerSetterAccess access = new([
 					new NamedParameterValue<int>("p1", 1),
 					new NamedParameterValue<int>("p2", 2),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -906,7 +906,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p1", 1),
 					new NamedParameterValue<int>("p2", 2),
 					new NamedParameterValue<int>("p3", 3),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, 2L);
 
@@ -924,7 +924,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p2", 2),
 					new NamedParameterValue<int>("p3", 3),
 					new NamedParameterValue<int>("p4", 4),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -945,7 +945,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<object?>("p1", v1),
 					new NamedParameterValue<object?>("p2", v2),
 					new NamedParameterValue<object?>("p3", v3),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -962,7 +962,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p1", 1),
 					new NamedParameterValue<int>("p2", 2),
 					new NamedParameterValue<int>("p3", 3),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -1335,7 +1335,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p2", 2),
 					new NamedParameterValue<int>("p3", 3),
 					new NamedParameterValue<int>("p4", 4),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, 2L);
 
@@ -1354,7 +1354,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p3", 3),
 					new NamedParameterValue<int>("p4", 4),
 					new NamedParameterValue<int>("p5", 5),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -1377,7 +1377,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<object?>("p2", v2),
 					new NamedParameterValue<object?>("p3", v3),
 					new NamedParameterValue<object?>("p4", v4),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -1395,7 +1395,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p2", 2),
 					new NamedParameterValue<int>("p3", 3),
 					new NamedParameterValue<int>("p4", 4),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -1778,7 +1778,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p3", 3),
 					new NamedParameterValue<int>("p4", 4),
 					new NamedParameterValue<int>("p5", 5),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, 2L);
 
@@ -1798,7 +1798,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p4", 4),
 					new NamedParameterValue<int>("p5", 5),
 					new NamedParameterValue<int>("p6", 6),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -1823,7 +1823,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<object?>("p3", v3),
 					new NamedParameterValue<object?>("p4", v4),
 					new NamedParameterValue<object?>("p5", v5),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 
@@ -1842,7 +1842,7 @@ public sealed partial class SetupIndexerTests
 					new NamedParameterValue<int>("p3", 3),
 					new NamedParameterValue<int>("p4", 4),
 					new NamedParameterValue<int>("p5", 5),
-				], "bar");
+				], new NamedParameterValue<string>("value", "bar"));
 
 				indexerSetup.DoExecuteSetterCallback(access, "foo");
 

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.OutRefParameterTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.OutRefParameterTests.cs
@@ -1379,7 +1379,6 @@ public sealed partial class SetupMethodTests
 				await That(result).IsEqualTo(4);
 			}
 
-
 			private class MyVoidMethodSetup(string name) : VoidMethodSetup(name)
 			{
 				public T SetOutParameter<T>(string parameterName)

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.SkippingBaseClassTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.SkippingBaseClassTests.cs
@@ -222,7 +222,6 @@ public sealed partial class SetupMethodTests
 			public virtual void MyVoidMethodWith5Parameters(int p1, int p2, int p3, int p4, int p5)
 				=> MyVoidMethodWith5ParametersCallCount++;
 
-
 			public virtual int MyReturnMethodWithoutParameters()
 				=> MyReturnMethodWithoutParametersCallCount++;
 

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -181,7 +181,7 @@ public sealed partial class SetupMethodTests
 	}
 
 	[Fact]
-	public async Task MethodSetupResult_TriggerCallbacks_Null_ShouldTriggerCallbacksWithNullArray()
+	public async Task MethodSetupResult_TriggerCallbacks_Null_ShouldTriggerCallbacksWithEmptyArray()
 	{
 		IInteractiveMethodSetup methodSetup = IInteractiveMethodSetup.CreateMock();
 		MethodSetupResult sut = new(methodSetup, MockBehavior.Default);
@@ -189,8 +189,7 @@ public sealed partial class SetupMethodTests
 		sut.TriggerCallbacks(null);
 
 		await That(methodSetup.Mock.Verify.TriggerCallbacks(
-			// ReSharper disable once MergeIntoPattern
-			It.Satisfies<object?[]>(arr => arr.Length == 1 && arr[0] is null))).Once();
+			It.Satisfies<INamedParameterValue[]>(arr => arr.Length == 0))).Once();
 	}
 
 	[Fact]
@@ -538,7 +537,10 @@ public sealed partial class SetupMethodTests
 		IParameter<int> parameter = It.IsAny<int>().Monitor(out IParameterMonitor<int> monitor);
 		MyMethodSetup.DoTriggerCallbacks([
 			new NamedParameter("foo", (IParameter)parameter),
-		], [4, 5,]);
+		], [
+			new NamedParameterValue<int>("foo", 4),
+			new NamedParameterValue<int>("foo", 5),
+		]);
 
 		await That(monitor.Values).IsEmpty();
 	}
@@ -549,7 +551,9 @@ public sealed partial class SetupMethodTests
 		IParameter<int> parameter = It.IsAny<int>().Monitor(out IParameterMonitor<int> monitor);
 		MyMethodSetup.DoTriggerCallbacks([
 			new NamedParameter("foo", (IParameter)parameter),
-		], [4,]);
+		], [
+			new NamedParameterValue<int>("foo", 4),
+		]);
 
 		await That(monitor.Values).IsEqualTo([4,]);
 	}
@@ -2047,7 +2051,7 @@ public sealed partial class SetupMethodTests
 
 	public class MyMethodSetup() : MethodSetup(new MethodParameterMatch("", []))
 	{
-		public static void DoTriggerCallbacks(NamedParameter?[] namedParameters, object?[] values)
+		public static void DoTriggerCallbacks(NamedParameter?[] namedParameters, INamedParameterValue[] values)
 			=> TriggerCallbacks(namedParameters, values);
 
 		public bool GetHasReturnCalls()
@@ -2077,7 +2081,7 @@ public sealed partial class SetupMethodTests
 			Func<TResult> defaultValueGenerator)
 			=> throw new NotSupportedException();
 
-		protected override void TriggerParameterCallbacks(object?[] parameters)
+		protected override void TriggerParameterCallbacks(INamedParameterValue[] parameters)
 			=> throw new NotSupportedException();
 	}
 

--- a/Tests/Mockolate.Tests/MockProperties/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/InteractionsTests.cs
@@ -108,7 +108,7 @@ public sealed class InteractionsTests
 	{
 		MockInteractions interactions = new();
 		PropertySetterAccess interaction = ((IMockInteractions)interactions).RegisterInteraction(
-			new PropertySetterAccess("global::Mockolate.InteractionsTests.SomeProperty", 5));
+			new PropertySetterAccess("global::Mockolate.InteractionsTests.SomeProperty", new NamedParameterValue<int>("value", 5)));
 		string expectedValue = "[0] set property SomeProperty to 5";
 
 		await That(interaction.ToString()).IsEqualTo(expectedValue);
@@ -119,7 +119,7 @@ public sealed class InteractionsTests
 	{
 		MockInteractions interactions = new();
 		PropertySetterAccess interaction = ((IMockInteractions)interactions).RegisterInteraction(
-			new PropertySetterAccess("SomeProperty", null));
+			new PropertySetterAccess("SomeProperty", new NamedParameterValue<string?>("value", null)));
 		string expectedValue = "[0] set property SomeProperty to null";
 
 		await That(interaction.ToString()).IsEqualTo(expectedValue);

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
@@ -28,7 +28,7 @@ public sealed partial class SetupPropertyTests
 
 		void Act()
 		{
-			setup.InvokeSetter("foo");
+			setup.InvokeSetter<string>("foo");
 		}
 
 		await That(Act).Throws<MockException>()
@@ -155,7 +155,7 @@ public sealed partial class SetupPropertyTests
 
 	private sealed class MyPropertySetup<T>() : PropertySetup<T>("My.Property")
 	{
-		public void InvokeSetter(object? value)
+		public void InvokeSetter<TValue>(TValue value)
 			=> InvokeSetter(value, MockBehavior.Default);
 
 		public TResult InvokeGetter<TResult>()

--- a/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
@@ -449,7 +449,6 @@ public class VerificationResultExtensionsTests
 			sut.Dispense("Dark", value);
 		}
 
-
 		void Act()
 		{
 			sut.Mock.Verify.Dispense(It.IsAny<string>(), It.Is(2))

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
@@ -74,8 +74,8 @@ public sealed partial class HttpClientExtensionsTests
 		IInteractiveMethodSetup interactiveSetup = (IInteractiveMethodSetup)setup;
 
 		interactiveSetup.TriggerCallbacks([
-			new HttpRequestMessage(),
-			CancellationToken.None,
+			new NamedParameterValue<HttpRequestMessage>("request", new HttpRequestMessage()),
+			new NamedParameterValue<CancellationToken>("cancellationToken", CancellationToken.None),
 		]);
 
 		await That(callbackUri).IsNull();

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithQueryTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithQueryTests.cs
@@ -87,7 +87,6 @@ public sealed partial class ItExtensionsTests
 				await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
 			}
 
-
 			[Theory]
 			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "x", "123", true)]
 			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "y", "234", true)]

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.cs
@@ -89,16 +89,35 @@ public sealed partial class ItExtensionsTests
 				.IsEqualTo(HttpStatusCode.NotImplemented);
 		}
 
-		[Theory]
-		[InlineData("https://www.aweXpect.com")]
-		[InlineData(443)]
-		[InlineData(null)]
-		public async Task WhenTypeDoesNotMatch_ShouldReturnFalse(object? value)
+		[Fact]
+		public async Task WhenTypeDoesNotMatch_String_ShouldReturnFalse()
 		{
 			ItExtensions.IUriParameter sut = It.IsUri();
 			IParameter parameter = (IParameter)sut;
 
-			bool result = parameter.Matches(value);
+			bool result = parameter.Matches(new NamedParameterValue<string>(string.Empty, "https://www.aweXpect.com"));
+
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task WhenTypeDoesNotMatch_Int_ShouldReturnFalse()
+		{
+			ItExtensions.IUriParameter sut = It.IsUri();
+			IParameter parameter = (IParameter)sut;
+
+			bool result = parameter.Matches(new NamedParameterValue<int>(string.Empty, 443));
+
+			await That(result).IsFalse();
+		}
+
+		[Fact]
+		public async Task WhenTypeDoesNotMatch_Null_ShouldReturnFalse()
+		{
+			ItExtensions.IUriParameter sut = It.IsUri();
+			IParameter parameter = (IParameter)sut;
+
+			bool result = parameter.Matches(new NamedParameterValue<Uri?>(string.Empty, null));
 
 			await That(result).IsFalse();
 		}


### PR DESCRIPTION
Refactors Mockolate’s parameter matching/callback pipeline to avoid runtime casting by moving parameter values and callbacks to strongly-typed `INamedParameterValue` and introducing typed property/method invocation helpers.

**Changes:**
- Removes `IParameter.Matches(object?)` / `InvokeCallbacks(object?)` and updates call sites to pass `INamedParameterValue` / `NamedParameterValue<T>`.
- Introduces typed APIs for property/method invocation (e.g., `MockRegistry.SetProperty<T>(...)`, parameterless `InvokeMethod(...)` overloads).
- Updates source generators and a broad set of tests/API baselines to the new callback/value model.