### PR TITLE
refactor!: introduce ITypedParameter and ITypedMethodMatch interfaces to avoid boxing for method parameters

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1509,13 +1509,22 @@ internal static partial class Sources
 		sb.AppendLine();
 		sb.AppendLine("\t\t{");
 		string methodExecutionVarName = Helpers.GetUniqueLocalVariableName("methodExecution", method.Parameters);
+		bool useTypedOverload = method.Parameters.Count is >= 1 and <= MaxExplicitParameters;
 		if (method.ReturnType != Type.Void)
 		{
 			sb.Append("\t\t\tglobal::Mockolate.Setup.MethodSetupResult<")
 				.AppendTypeOrWrapper(method.ReturnType).Append("> ").Append(methodExecutionVarName)
 				.Append(" = ").Append(mockRegistry).Append(".InvokeMethod<")
-				.AppendTypeOrWrapper(method.ReturnType).Append(">(").Append(method.GetUniqueNameString())
-				.Append(", ");
+				.AppendTypeOrWrapper(method.ReturnType);
+			if (useTypedOverload)
+			{
+				foreach (MethodParameter p in method.Parameters)
+				{
+					sb.Append(", ").AppendTypeOrWrapper(p.Type);
+				}
+			}
+
+			sb.Append(">(").Append(method.GetUniqueNameString()).Append(", ");
 			if (method.Parameters.Count == 0)
 			{
 				sb.Append("() => ")
@@ -1532,18 +1541,49 @@ internal static partial class Sources
 		else
 		{
 			sb.Append("\t\t\tglobal::Mockolate.Setup.MethodSetupResult ").Append(methodExecutionVarName)
-				.Append(" = ").Append(mockRegistry).Append(".InvokeMethod(")
-				.Append(method.GetUniqueNameString());
+				.Append(" = ").Append(mockRegistry).Append(".InvokeMethod");
+			if (useTypedOverload)
+			{
+				sb.Append('<');
+				bool first = true;
+				foreach (MethodParameter p in method.Parameters)
+				{
+					if (!first)
+					{
+						sb.Append(", ");
+					}
+
+					sb.AppendTypeOrWrapper(p.Type);
+					first = false;
+				}
+
+				sb.Append('>');
+			}
+
+			sb.Append('(').Append(method.GetUniqueNameString());
 		}
 
 		foreach (MethodParameter p in method.Parameters)
 		{
-			sb.Append(", new global::Mockolate.Parameters.NamedParameterValue<").AppendTypeOrWrapper(p.Type).Append(">(\"").Append(p.Name).Append("\", ").Append(
-				p.RefKind switch
-				{
-					RefKind.Out => "default",
-					_ => p.ToNameOrWrapper(),
-				}).Append(')');
+			if (useTypedOverload)
+			{
+				sb.Append(", \"").Append(p.Name).Append("\", ").Append(
+					p.RefKind switch
+					{
+						RefKind.Out => "default",
+						_ => p.ToNameOrWrapper(),
+					});
+			}
+			else
+			{
+				sb.Append(", new global::Mockolate.Parameters.NamedParameterValue<").AppendTypeOrWrapper(p.Type)
+					.Append(">(\"").Append(p.Name).Append("\", ").Append(
+						p.RefKind switch
+						{
+							RefKind.Out => "default",
+							_ => p.ToNameOrWrapper(),
+						}).Append(')');
+			}
 		}
 
 		sb.AppendLine(");");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -129,12 +129,20 @@ internal static partial class Sources
 			.Append(')').AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		string resultVarName = Helpers.GetUniqueLocalVariableName("result", delegateMethod.Parameters);
+		bool useTypedOverload = delegateMethod.Parameters.Count is >= 1 and <= MaxExplicitParameters;
 		if (delegateMethod.ReturnType != Type.Void)
 		{
 			sb.Append("\t\t\tvar ").Append(resultVarName).Append(" = this.").Append(mockRegistryName).Append(".InvokeMethod<")
-				.Append(delegateMethod.ReturnType.Fullname)
-				.Append(">(").Append(delegateMethod.GetUniqueNameString())
-				.Append(", ");
+				.Append(delegateMethod.ReturnType.Fullname);
+			if (useTypedOverload)
+			{
+				foreach (MethodParameter p in delegateMethod.Parameters)
+				{
+					sb.Append(", ").AppendTypeOrWrapper(p.Type);
+				}
+			}
+
+			sb.Append(">(").Append(delegateMethod.GetUniqueNameString()).Append(", ");
 			if (delegateMethod.Parameters.Count == 0)
 			{
 				sb.Append("() => ")
@@ -151,18 +159,49 @@ internal static partial class Sources
 		}
 		else
 		{
-			sb.Append("\t\t\tvar ").Append(resultVarName).Append(" = this.").Append(mockRegistryName).Append(".InvokeMethod(")
-				.Append(delegateMethod.GetUniqueNameString());
+			sb.Append("\t\t\tvar ").Append(resultVarName).Append(" = this.").Append(mockRegistryName).Append(".InvokeMethod");
+			if (useTypedOverload)
+			{
+				sb.Append('<');
+				bool first = true;
+				foreach (MethodParameter p in delegateMethod.Parameters)
+				{
+					if (!first)
+					{
+						sb.Append(", ");
+					}
+
+					sb.AppendTypeOrWrapper(p.Type);
+					first = false;
+				}
+
+				sb.Append('>');
+			}
+
+			sb.Append('(').Append(delegateMethod.GetUniqueNameString());
 		}
 
 		foreach (MethodParameter p in delegateMethod.Parameters)
 		{
-			sb.Append(", new global::Mockolate.Parameters.NamedParameterValue<").AppendTypeOrWrapper(p.Type).Append(">(\"").Append(p.Name).Append("\", ")
-				.Append(p.RefKind switch
-				{
-					RefKind.Out => "default",
-					_ => p.ToNameOrWrapper(),
-				}).Append(')');
+			if (useTypedOverload)
+			{
+				sb.Append(", \"").Append(p.Name).Append("\", ").Append(
+					p.RefKind switch
+					{
+						RefKind.Out => "default",
+						_ => p.ToNameOrWrapper(),
+					});
+			}
+			else
+			{
+				sb.Append(", new global::Mockolate.Parameters.NamedParameterValue<").AppendTypeOrWrapper(p.Type)
+					.Append(">(\"").Append(p.Name).Append("\", ")
+					.Append(p.RefKind switch
+					{
+						RefKind.Out => "default",
+						_ => p.ToNameOrWrapper(),
+					}).Append(')');
+			}
 		}
 
 		sb.AppendLine(");");

--- a/Source/Mockolate/It.IsOut.cs
+++ b/Source/Mockolate/It.IsOut.cs
@@ -58,7 +58,7 @@ public partial class It
 	///     Matches any <see langword="out" /> parameter.
 	/// </summary>
 	[DebuggerNonUserCode]
-	private sealed class InvokedOutParameterMatch<T> : IVerifyOutParameter<T>, IParameter
+	private sealed class InvokedOutParameterMatch<T> : IVerifyOutParameter<T>, IParameter, ITypedParameter<T>
 	{
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
@@ -70,6 +70,9 @@ public partial class It
 			// Do nothing
 		}
 
+		/// <inheritdoc cref="ITypedParameter{T}.MatchesValue" />
+		bool ITypedParameter<T>.MatchesValue(string name, T value) => true;
+
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => $"It.IsOut<{typeof(T).FormatType()}>()";
 	}
@@ -78,7 +81,7 @@ public partial class It
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
 	[DebuggerNonUserCode]
-	private abstract class TypedOutMatch<T> : IOutParameter<T>, IParameter
+	private abstract class TypedOutMatch<T> : IOutParameter<T>, IParameter, ITypedParameter<T>
 	{
 		private List<Action<T>>? _callbacks;
 
@@ -104,6 +107,9 @@ public partial class It
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
 			=> value.TryGetValue<T>(out _);
+
+		/// <inheritdoc cref="ITypedParameter{T}.MatchesValue" />
+		bool ITypedParameter<T>.MatchesValue(string name, T value) => true;
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)

--- a/Source/Mockolate/It.IsRef.cs
+++ b/Source/Mockolate/It.IsRef.cs
@@ -105,7 +105,7 @@ public partial class It
 	///     Matches a method <see langword="out" /> parameter against an expectation.
 	/// </summary>
 	[DebuggerNonUserCode]
-	private sealed class InvokedRefParameterMatch<T> : IVerifyRefParameter<T>, IParameter
+	private sealed class InvokedRefParameterMatch<T> : IVerifyRefParameter<T>, IParameter, ITypedParameter<T>
 	{
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
 		public bool Matches(INamedParameterValue value)
@@ -117,6 +117,9 @@ public partial class It
 			// Do nothing
 		}
 
+		/// <inheritdoc cref="ITypedParameter{T}.MatchesValue" />
+		bool ITypedParameter<T>.MatchesValue(string name, T value) => true;
+
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => $"It.IsRef<{typeof(T).FormatType()}>()";
 	}
@@ -125,7 +128,7 @@ public partial class It
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
 	[DebuggerNonUserCode]
-	private abstract class TypedRefMatch<T> : IRefParameter<T>, IParameter
+	private abstract class TypedRefMatch<T> : IRefParameter<T>, IParameter, ITypedParameter<T>
 	{
 		private List<Action<T>>? _callbacks;
 
@@ -146,6 +149,9 @@ public partial class It
 
 			return false;
 		}
+
+		/// <inheritdoc cref="ITypedParameter{T}.MatchesValue" />
+		bool ITypedParameter<T>.MatchesValue(string name, T value) => Matches(value);
 
 		/// <inheritdoc cref="IParameter.InvokeCallbacks(INamedParameterValue)" />
 		public void InvokeCallbacks(INamedParameterValue value)

--- a/Source/Mockolate/It.cs
+++ b/Source/Mockolate/It.cs
@@ -27,7 +27,7 @@ public partial class It
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
 	[DebuggerNonUserCode]
-	private abstract class TypedMatch<T> : IParameter<T>, IParameter
+	private abstract class TypedMatch<T> : IParameter<T>, IParameter, ITypedParameter<T>
 	{
 		private List<Action<T>>? _callbacks;
 
@@ -64,6 +64,9 @@ public partial class It
 			_callbacks.Add(callback);
 			return this;
 		}
+
+		/// <inheritdoc cref="ITypedParameter{T}.MatchesValue" />
+		bool ITypedParameter<T>.MatchesValue(string name, T value) => Matches(value);
 
 		/// <summary>
 		///     Verifies the expectation for the <paramref name="value" />.

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -24,6 +24,240 @@ public partial class MockRegistry
 		=> Interactions.Clear();
 
 	/// <summary>
+	///     Executes the method with <paramref name="methodName" /> and one typed parameter and gets the setup return value.
+	///     Matching runs against the typed value directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult<TResult> InvokeMethod<TResult, T1>(
+		string methodName, Func<INamedParameterValue[], TResult> defaultValue,
+		string p1Name, T1 p1)
+	{
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetupTyped(methodName, p1Name, p1);
+		INamedParameterValue[] parameters = [new NamedParameterValue<T1>(p1Name, p1)];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null)
+		{
+			if (Behavior.ThrowWhenNotSetup)
+			{
+				throw new MockNotSetupException(
+					$"The method '{methodName}({typeof(T1).FormatType()})' was invoked without prior setup.");
+			}
+
+			return new MethodSetupResult<TResult>(null, Behavior, defaultValue(parameters));
+		}
+
+		return new MethodSetupResult<TResult>(matchingSetup, Behavior,
+			matchingSetup.Invoke(methodInvocation, Behavior, () => defaultValue(parameters)));
+	}
+
+	/// <summary>
+	///     Executes the method with <paramref name="methodName" /> and two typed parameters and gets the setup return value.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2>(
+		string methodName, Func<INamedParameterValue[], TResult> defaultValue,
+		string p1Name, T1 p1, string p2Name, T2 p2)
+	{
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetupTyped(methodName, p1Name, p1, p2Name, p2);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2)
+		];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null)
+		{
+			if (Behavior.ThrowWhenNotSetup)
+			{
+				throw new MockNotSetupException(
+					$"The method '{methodName}({typeof(T1).FormatType()}, {typeof(T2).FormatType()})' was invoked without prior setup.");
+			}
+
+			return new MethodSetupResult<TResult>(null, Behavior, defaultValue(parameters));
+		}
+
+		return new MethodSetupResult<TResult>(matchingSetup, Behavior,
+			matchingSetup.Invoke(methodInvocation, Behavior, () => defaultValue(parameters)));
+	}
+
+	/// <summary>
+	///     Executes the method with <paramref name="methodName" /> and three typed parameters and gets the setup return value.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3>(
+		string methodName, Func<INamedParameterValue[], TResult> defaultValue,
+		string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3)
+	{
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetupTyped(methodName, p1Name, p1, p2Name, p2, p3Name, p3);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3)
+		];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null)
+		{
+			if (Behavior.ThrowWhenNotSetup)
+			{
+				throw new MockNotSetupException(
+					$"The method '{methodName}({typeof(T1).FormatType()}, {typeof(T2).FormatType()}, {typeof(T3).FormatType()})' was invoked without prior setup.");
+			}
+
+			return new MethodSetupResult<TResult>(null, Behavior, defaultValue(parameters));
+		}
+
+		return new MethodSetupResult<TResult>(matchingSetup, Behavior,
+			matchingSetup.Invoke(methodInvocation, Behavior, () => defaultValue(parameters)));
+	}
+
+	/// <summary>
+	///     Executes the method with <paramref name="methodName" /> and four typed parameters and gets the setup return value.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3, T4>(
+		string methodName, Func<INamedParameterValue[], TResult> defaultValue,
+		string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4)
+	{
+		IInteractiveMethodSetup? matchingSetup =
+			GetMethodSetupTyped(methodName, p1Name, p1, p2Name, p2, p3Name, p3, p4Name, p4);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3),
+			new NamedParameterValue<T4>(p4Name, p4)
+		];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null)
+		{
+			if (Behavior.ThrowWhenNotSetup)
+			{
+				throw new MockNotSetupException(
+					$"The method '{methodName}({typeof(T1).FormatType()}, {typeof(T2).FormatType()}, {typeof(T3).FormatType()}, {typeof(T4).FormatType()})' was invoked without prior setup.");
+			}
+
+			return new MethodSetupResult<TResult>(null, Behavior, defaultValue(parameters));
+		}
+
+		return new MethodSetupResult<TResult>(matchingSetup, Behavior,
+			matchingSetup.Invoke(methodInvocation, Behavior, () => defaultValue(parameters)));
+	}
+
+	/// <summary>
+	///     Executes the void method with <paramref name="methodName" /> and one typed parameter.
+	///     Matching runs against the typed value directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult InvokeMethod<T1>(
+		string methodName, string p1Name, T1 p1)
+	{
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetupTyped(methodName, p1Name, p1);
+		INamedParameterValue[] parameters = [new NamedParameterValue<T1>(p1Name, p1)];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null && Behavior.ThrowWhenNotSetup)
+		{
+			throw new MockNotSetupException(
+				$"The method '{methodName}({typeof(T1).FormatType()})' was invoked without prior setup.");
+		}
+
+		matchingSetup?.Invoke(methodInvocation, Behavior);
+		return new MethodSetupResult(matchingSetup, Behavior);
+	}
+
+	/// <summary>
+	///     Executes the void method with <paramref name="methodName" /> and two typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult InvokeMethod<T1, T2>(
+		string methodName, string p1Name, T1 p1, string p2Name, T2 p2)
+	{
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetupTyped(methodName, p1Name, p1, p2Name, p2);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2)
+		];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null && Behavior.ThrowWhenNotSetup)
+		{
+			throw new MockNotSetupException(
+				$"The method '{methodName}({typeof(T1).FormatType()}, {typeof(T2).FormatType()})' was invoked without prior setup.");
+		}
+
+		matchingSetup?.Invoke(methodInvocation, Behavior);
+		return new MethodSetupResult(matchingSetup, Behavior);
+	}
+
+	/// <summary>
+	///     Executes the void method with <paramref name="methodName" /> and three typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult InvokeMethod<T1, T2, T3>(
+		string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3)
+	{
+		IInteractiveMethodSetup? matchingSetup = GetMethodSetupTyped(methodName, p1Name, p1, p2Name, p2, p3Name, p3);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3)
+		];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null && Behavior.ThrowWhenNotSetup)
+		{
+			throw new MockNotSetupException(
+				$"The method '{methodName}({typeof(T1).FormatType()}, {typeof(T2).FormatType()}, {typeof(T3).FormatType()})' was invoked without prior setup.");
+		}
+
+		matchingSetup?.Invoke(methodInvocation, Behavior);
+		return new MethodSetupResult(matchingSetup, Behavior);
+	}
+
+	/// <summary>
+	///     Executes the void method with <paramref name="methodName" /> and four typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public MethodSetupResult InvokeMethod<T1, T2, T3, T4>(
+		string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4)
+	{
+		IInteractiveMethodSetup? matchingSetup =
+			GetMethodSetupTyped(methodName, p1Name, p1, p2Name, p2, p3Name, p3, p4Name, p4);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3),
+			new NamedParameterValue<T4>(p4Name, p4)
+		];
+		MethodInvocation methodInvocation =
+			((IMockInteractions)Interactions).RegisterInteraction(new MethodInvocation(methodName, parameters));
+
+		if (matchingSetup is null && Behavior.ThrowWhenNotSetup)
+		{
+			throw new MockNotSetupException(
+				$"The method '{methodName}({typeof(T1).FormatType()}, {typeof(T2).FormatType()}, {typeof(T3).FormatType()}, {typeof(T4).FormatType()})' was invoked without prior setup.");
+		}
+
+		matchingSetup?.Invoke(methodInvocation, Behavior);
+		return new MethodSetupResult(matchingSetup, Behavior);
+	}
+
+	/// <summary>
 	///     Executes the method with <paramref name="methodName" /> with no parameters and gets the setup return value.
 	/// </summary>
 	public MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, Func<TResult> defaultValue)

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -34,6 +34,7 @@ public partial class MockRegistry
 	/// </summary>
 	private MethodSetup? GetMethodSetupTyped<T1>(string methodName, string n1, T1 v1)
 	{
+		MethodInvocation? fallback = null;
 		return Setup.Methods.GetLatestOrDefault(Predicate);
 
 		[DebuggerNonUserCode]
@@ -45,8 +46,8 @@ public partial class MockRegistry
 				return typed.MatchesTyped(methodName, n1, v1);
 			}
 
-			return ((IInteractiveMethodSetup)setup).Matches(
-				new MethodInvocation(methodName, [new NamedParameterValue<T1>(n1, v1)]));
+			fallback ??= new MethodInvocation(methodName, [new NamedParameterValue<T1>(n1, v1)]);
+			return ((IInteractiveMethodSetup)setup).Matches(fallback);
 		}
 	}
 
@@ -57,6 +58,7 @@ public partial class MockRegistry
 	private MethodSetup? GetMethodSetupTyped<T1, T2>(
 		string methodName, string n1, T1 v1, string n2, T2 v2)
 	{
+		MethodInvocation? fallback = null;
 		return Setup.Methods.GetLatestOrDefault(Predicate);
 
 		[DebuggerNonUserCode]
@@ -68,10 +70,10 @@ public partial class MockRegistry
 				return typed.MatchesTyped(methodName, n1, v1, n2, v2);
 			}
 
-			return ((IInteractiveMethodSetup)setup).Matches(
-				new MethodInvocation(methodName, [
-					new NamedParameterValue<T1>(n1, v1),
-					new NamedParameterValue<T2>(n2, v2)]));
+			fallback ??= new MethodInvocation(methodName, [
+				new NamedParameterValue<T1>(n1, v1),
+				new NamedParameterValue<T2>(n2, v2)]);
+			return ((IInteractiveMethodSetup)setup).Matches(fallback);
 		}
 	}
 
@@ -82,6 +84,7 @@ public partial class MockRegistry
 	private MethodSetup? GetMethodSetupTyped<T1, T2, T3>(
 		string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3)
 	{
+		MethodInvocation? fallback = null;
 		return Setup.Methods.GetLatestOrDefault(Predicate);
 
 		[DebuggerNonUserCode]
@@ -93,11 +96,11 @@ public partial class MockRegistry
 				return typed.MatchesTyped(methodName, n1, v1, n2, v2, n3, v3);
 			}
 
-			return ((IInteractiveMethodSetup)setup).Matches(
-				new MethodInvocation(methodName, [
-					new NamedParameterValue<T1>(n1, v1),
-					new NamedParameterValue<T2>(n2, v2),
-					new NamedParameterValue<T3>(n3, v3)]));
+			fallback ??= new MethodInvocation(methodName, [
+				new NamedParameterValue<T1>(n1, v1),
+				new NamedParameterValue<T2>(n2, v2),
+				new NamedParameterValue<T3>(n3, v3)]);
+			return ((IInteractiveMethodSetup)setup).Matches(fallback);
 		}
 	}
 
@@ -108,6 +111,7 @@ public partial class MockRegistry
 	private MethodSetup? GetMethodSetupTyped<T1, T2, T3, T4>(
 		string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3, string n4, T4 v4)
 	{
+		MethodInvocation? fallback = null;
 		return Setup.Methods.GetLatestOrDefault(Predicate);
 
 		[DebuggerNonUserCode]
@@ -119,12 +123,12 @@ public partial class MockRegistry
 				return typed.MatchesTyped(methodName, n1, v1, n2, v2, n3, v3, n4, v4);
 			}
 
-			return ((IInteractiveMethodSetup)setup).Matches(
-				new MethodInvocation(methodName, [
-					new NamedParameterValue<T1>(n1, v1),
-					new NamedParameterValue<T2>(n2, v2),
-					new NamedParameterValue<T3>(n3, v3),
-					new NamedParameterValue<T4>(n4, v4)]));
+			fallback ??= new MethodInvocation(methodName, [
+				new NamedParameterValue<T1>(n1, v1),
+				new NamedParameterValue<T2>(n2, v2),
+				new NamedParameterValue<T3>(n3, v3),
+				new NamedParameterValue<T4>(n4, v4)]);
+			return ((IInteractiveMethodSetup)setup).Matches(fallback);
 		}
 	}
 

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -29,6 +29,106 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Retrieves the latest method setup that matches the method name and single typed parameter,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private MethodSetup? GetMethodSetupTyped<T1>(string methodName, string n1, T1 v1)
+	{
+		return Setup.Methods.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(MethodSetup setup)
+		{
+			IMethodMatch match = setup.GetMatch();
+			if (match is ITypedMethodMatch typed)
+			{
+				return typed.MatchesTyped(methodName, n1, v1);
+			}
+
+			return ((IInteractiveMethodSetup)setup).Matches(
+				new MethodInvocation(methodName, [new NamedParameterValue<T1>(n1, v1)]));
+		}
+	}
+
+	/// <summary>
+	///     Retrieves the latest method setup that matches the method name and two typed parameters,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private MethodSetup? GetMethodSetupTyped<T1, T2>(
+		string methodName, string n1, T1 v1, string n2, T2 v2)
+	{
+		return Setup.Methods.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(MethodSetup setup)
+		{
+			IMethodMatch match = setup.GetMatch();
+			if (match is ITypedMethodMatch typed)
+			{
+				return typed.MatchesTyped(methodName, n1, v1, n2, v2);
+			}
+
+			return ((IInteractiveMethodSetup)setup).Matches(
+				new MethodInvocation(methodName, [
+					new NamedParameterValue<T1>(n1, v1),
+					new NamedParameterValue<T2>(n2, v2)]));
+		}
+	}
+
+	/// <summary>
+	///     Retrieves the latest method setup that matches the method name and three typed parameters,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private MethodSetup? GetMethodSetupTyped<T1, T2, T3>(
+		string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3)
+	{
+		return Setup.Methods.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(MethodSetup setup)
+		{
+			IMethodMatch match = setup.GetMatch();
+			if (match is ITypedMethodMatch typed)
+			{
+				return typed.MatchesTyped(methodName, n1, v1, n2, v2, n3, v3);
+			}
+
+			return ((IInteractiveMethodSetup)setup).Matches(
+				new MethodInvocation(methodName, [
+					new NamedParameterValue<T1>(n1, v1),
+					new NamedParameterValue<T2>(n2, v2),
+					new NamedParameterValue<T3>(n3, v3)]));
+		}
+	}
+
+	/// <summary>
+	///     Retrieves the latest method setup that matches the method name and four typed parameters,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private MethodSetup? GetMethodSetupTyped<T1, T2, T3, T4>(
+		string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3, string n4, T4 v4)
+	{
+		return Setup.Methods.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(MethodSetup setup)
+		{
+			IMethodMatch match = setup.GetMatch();
+			if (match is ITypedMethodMatch typed)
+			{
+				return typed.MatchesTyped(methodName, n1, v1, n2, v2, n3, v3, n4, v4);
+			}
+
+			return ((IInteractiveMethodSetup)setup).Matches(
+				new MethodInvocation(methodName, [
+					new NamedParameterValue<T1>(n1, v1),
+					new NamedParameterValue<T2>(n2, v2),
+					new NamedParameterValue<T3>(n3, v3),
+					new NamedParameterValue<T4>(n4, v4)]));
+		}
+	}
+
+	/// <summary>
 	///     Gets the indexer value for the given <paramref name="parameters" />.
 	/// </summary>
 	private TValue GetIndexerValue<TValue>(IInteractiveIndexerSetup? setup, Func<TValue> defaultValueGenerator,

--- a/Source/Mockolate/Parameters/ITypedParameter.cs
+++ b/Source/Mockolate/Parameters/ITypedParameter.cs
@@ -4,7 +4,7 @@ namespace Mockolate.Parameters;
 ///     Matches a method parameter of type <typeparamref name="T" /> against an expectation
 ///     using a typed value directly, without boxing through <see cref="INamedParameterValue" />.
 /// </summary>
-internal interface ITypedParameter<T>
+internal interface ITypedParameter<in T>
 {
 	/// <summary>
 	///     Checks if the <paramref name="value" /> matches the expectation.

--- a/Source/Mockolate/Parameters/ITypedParameter.cs
+++ b/Source/Mockolate/Parameters/ITypedParameter.cs
@@ -1,0 +1,13 @@
+namespace Mockolate.Parameters;
+
+/// <summary>
+///     Matches a method parameter of type <typeparamref name="T" /> against an expectation
+///     using a typed value directly, without boxing through <see cref="INamedParameterValue" />.
+/// </summary>
+internal interface ITypedParameter<T>
+{
+	/// <summary>
+	///     Checks if the <paramref name="value" /> matches the expectation.
+	/// </summary>
+	bool MatchesValue(string name, T value);
+}

--- a/Source/Mockolate/Setup/ITypedMethodMatch.cs
+++ b/Source/Mockolate/Setup/ITypedMethodMatch.cs
@@ -21,9 +21,11 @@ internal interface ITypedMethodMatch
 	/// </summary>
 	bool MatchesTyped<T1, T2, T3>(string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3);
 
+#pragma warning disable S107 // Methods should not have too many parameters
 	/// <summary>
 	///     Checks if the method name and four parameter values match.
 	/// </summary>
 	bool MatchesTyped<T1, T2, T3, T4>(string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3,
 		string n4, T4 v4);
+#pragma warning restore S107 // Methods should not have too many parameters
 }

--- a/Source/Mockolate/Setup/ITypedMethodMatch.cs
+++ b/Source/Mockolate/Setup/ITypedMethodMatch.cs
@@ -1,0 +1,29 @@
+namespace Mockolate.Setup;
+
+/// <summary>
+///     Matches a method call by name and typed parameters, without boxing through
+///     <see cref="Mockolate.Parameters.INamedParameterValue" />.
+/// </summary>
+internal interface ITypedMethodMatch
+{
+	/// <summary>
+	///     Checks if the method name and single parameter value match.
+	/// </summary>
+	bool MatchesTyped<T1>(string methodName, string n1, T1 v1);
+
+	/// <summary>
+	///     Checks if the method name and two parameter values match.
+	/// </summary>
+	bool MatchesTyped<T1, T2>(string methodName, string n1, T1 v1, string n2, T2 v2);
+
+	/// <summary>
+	///     Checks if the method name and three parameter values match.
+	/// </summary>
+	bool MatchesTyped<T1, T2, T3>(string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3);
+
+	/// <summary>
+	///     Checks if the method name and four parameter values match.
+	/// </summary>
+	bool MatchesTyped<T1, T2, T3, T4>(string methodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3,
+		string n4, T4 v4);
+}

--- a/Source/Mockolate/Setup/MethodParameterMatch.cs
+++ b/Source/Mockolate/Setup/MethodParameterMatch.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Linq;
 using Mockolate.Interactions;
@@ -15,7 +16,8 @@ namespace Mockolate.Setup;
 ///     invocation.
 /// </remarks>
 [DebuggerNonUserCode]
-public readonly struct MethodParameterMatch(string methodName, NamedParameter[] parameters) : IMethodMatch
+public readonly struct MethodParameterMatch(string methodName, NamedParameter[] parameters)
+	: IMethodMatch, ITypedMethodMatch
 {
 	/// <inheritdoc cref="IMethodMatch.Matches(MethodInvocation)" />
 	public bool Matches(MethodInvocation methodInvocation)
@@ -35,6 +37,77 @@ public readonly struct MethodParameterMatch(string methodName, NamedParameter[] 
 		}
 
 		return true;
+	}
+
+	/// <inheritdoc cref="ITypedMethodMatch.MatchesTyped{T1}" />
+	bool ITypedMethodMatch.MatchesTyped<T1>(string callMethodName, string n1, T1 v1)
+	{
+		if (!callMethodName.Equals(methodName) || parameters.Length != 1)
+		{
+			return false;
+		}
+
+		return MatchesParameter(parameters[0], n1, v1);
+	}
+
+	/// <inheritdoc cref="ITypedMethodMatch.MatchesTyped{T1,T2}" />
+	bool ITypedMethodMatch.MatchesTyped<T1, T2>(
+		string callMethodName, string n1, T1 v1, string n2, T2 v2)
+	{
+		if (!callMethodName.Equals(methodName) || parameters.Length != 2)
+		{
+			return false;
+		}
+
+		return MatchesParameter(parameters[0], n1, v1)
+		    && MatchesParameter(parameters[1], n2, v2);
+	}
+
+	/// <inheritdoc cref="ITypedMethodMatch.MatchesTyped{T1,T2,T3}" />
+	bool ITypedMethodMatch.MatchesTyped<T1, T2, T3>(
+		string callMethodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3)
+	{
+		if (!callMethodName.Equals(methodName) || parameters.Length != 3)
+		{
+			return false;
+		}
+
+		return MatchesParameter(parameters[0], n1, v1)
+		    && MatchesParameter(parameters[1], n2, v2)
+		    && MatchesParameter(parameters[2], n3, v3);
+	}
+
+	/// <inheritdoc cref="ITypedMethodMatch.MatchesTyped{T1,T2,T3,T4}" />
+	bool ITypedMethodMatch.MatchesTyped<T1, T2, T3, T4>(
+		string callMethodName, string n1, T1 v1, string n2, T2 v2, string n3, T3 v3, string n4, T4 v4)
+	{
+		if (!callMethodName.Equals(methodName) || parameters.Length != 4)
+		{
+			return false;
+		}
+
+		return MatchesParameter(parameters[0], n1, v1)
+		    && MatchesParameter(parameters[1], n2, v2)
+		    && MatchesParameter(parameters[2], n3, v3)
+		    && MatchesParameter(parameters[3], n4, v4);
+	}
+
+	private static bool MatchesParameter<T>(NamedParameter namedParameter, string name, T value)
+	{
+		if (!string.IsNullOrEmpty(name) &&
+		    !namedParameter.Name.Equals(name, StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		if (namedParameter.Parameter is ITypedParameter<T> typed)
+		{
+			return typed.MatchesValue(namedParameter.Name, value);
+		}
+
+		// Fallback for IParameter implementations that don't implement ITypedParameter<T>
+		// (e.g., custom matchers, Web extension matchers).
+		return namedParameter.Parameter.Matches(new NamedParameterValue<T>(name, value));
 	}
 
 	/// <inheritdoc cref="object.ToString()" />

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -193,6 +193,14 @@ namespace Mockolate
         public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<TResult> defaultValue) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1>(string methodName, string p1Name, T1 p1) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2, T3>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2, T3, T4>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3, T4>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public Mockolate.Verify.VerificationResultParameterIgnorer<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch, string methodName) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -192,6 +192,14 @@ namespace Mockolate
         public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<TResult> defaultValue) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1>(string methodName, string p1Name, T1 p1) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2, T3>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2, T3, T4>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3, T4>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public Mockolate.Verify.VerificationResultParameterIgnorer<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch, string methodName) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -179,6 +179,14 @@ namespace Mockolate
         public Mockolate.Setup.MethodSetupResult InvokeMethod(string methodName, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<TResult> defaultValue) { }
         public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1>(string methodName, string p1Name, T1 p1) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2, T3>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.MethodSetupResult InvokeMethod<T1, T2, T3, T4>(string methodName, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
+        public Mockolate.Setup.MethodSetupResult<TResult> InvokeMethod<TResult, T1, T2, T3, T4>(string methodName, System.Func<Mockolate.Parameters.INamedParameterValue[], TResult> defaultValue, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public Mockolate.Verify.VerificationResultParameterIgnorer<T> Method<T>(T subject, Mockolate.Setup.IMethodMatch methodMatch, string methodName) { }

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -808,7 +808,7 @@ public class GeneralTests
 			          		[global::System.ComponentModel.Localizable(false)]
 			          		public string MyMethod(string message)
 			          		{
-			          			global::Mockolate.Setup.MethodSetupResult<string> methodExecution = this.MockRegistry.InvokeMethod<string>("global::MyCode.IMyService.MyMethod", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(string)!, p), new global::Mockolate.Parameters.NamedParameterValue<string>("message", message));
+			          			global::Mockolate.Setup.MethodSetupResult<string> methodExecution = this.MockRegistry.InvokeMethod<string, string>("global::MyCode.IMyService.MyMethod", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(string)!, p), "message", message);
 			          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 			          			{
 			          				var baseResult = wraps.MyMethod(message);

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -166,7 +166,7 @@ public sealed partial class MockTests
 					     """);
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-					.Contains("MethodSetupResult<int> methodExecution1 = this.MockRegistry.InvokeMethod<int>(")
+					.Contains("MethodSetupResult<int> methodExecution1 = this.MockRegistry.InvokeMethod<int, int>(")
 					.IgnoringNewlineStyle().And
 					.Contains("methodExecution1.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>(\"methodExecution\", methodExecution))")
 					.IgnoringNewlineStyle().And
@@ -198,7 +198,7 @@ public sealed partial class MockTests
 					     """);
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-					.Contains("MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>(")
+					.Contains("MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int, int>(")
 					.IgnoringNewlineStyle().And
 					.Contains("methodExecution.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>(\"result\", result))")
 					.IgnoringNewlineStyle().And
@@ -339,7 +339,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod1(int)" />
 					          		public bool MyMethod1(int index)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<bool> methodExecution = this.MockRegistry.InvokeMethod<bool>("global::MyCode.IMyService.MyMethod1", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
+					          			global::Mockolate.Setup.MethodSetupResult<bool> methodExecution = this.MockRegistry.InvokeMethod<bool, int>("global::MyCode.IMyService.MyMethod1", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), "index", index);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				var baseResult = wraps.MyMethod1(index);
@@ -357,7 +357,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod2(int, bool)" />
 					          		public void MyMethod2(int index, bool isReadOnly)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod2", new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly));
+					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod<int, bool>("global::MyCode.IMyService.MyMethod2", "index", index, "isReadOnly", isReadOnly);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				wraps.MyMethod2(index, isReadOnly);
@@ -410,7 +410,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyDirectMethod(int)" />
 					          		public int MyDirectMethod(int value)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>("global::MyCode.IMyService.MyDirectMethod", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
+					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int, int>("global::MyCode.IMyService.MyDirectMethod", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), "value", value);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				var baseResult = wraps.MyDirectMethod(value);
@@ -428,7 +428,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase1.MyBaseMethod1(int)" />
 					          		public int MyBaseMethod1(int value)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>("global::MyCode.IMyServiceBase1.MyBaseMethod1", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
+					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int, int>("global::MyCode.IMyServiceBase1.MyBaseMethod1", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), "value", value);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				var baseResult = wraps.MyBaseMethod1(value);
@@ -446,7 +446,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase2.MyBaseMethod2(int)" />
 					          		public int MyBaseMethod2(int value)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>("global::MyCode.IMyServiceBase2.MyBaseMethod2", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
+					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int, int>("global::MyCode.IMyServiceBase2.MyBaseMethod2", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), "value", value);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				var baseResult = wraps.MyBaseMethod2(value);
@@ -464,7 +464,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase3.MyBaseMethod3(int)" />
 					          		public int MyBaseMethod3(int value)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int>("global::MyCode.IMyServiceBase3.MyBaseMethod3", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>("value", value));
+					          			global::Mockolate.Setup.MethodSetupResult<int> methodExecution = this.MockRegistry.InvokeMethod<int, int>("global::MyCode.IMyServiceBase3.MyBaseMethod3", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, p), "value", value);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				var baseResult = wraps.MyBaseMethod3(value);
@@ -530,7 +530,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.MyService.MyMethod1(int, ref int, out bool)" />
 					          		public override void MyMethod1(int index, ref int value1, out bool flag)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.MyService.MyMethod1", new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<int>("value1", value1), new global::Mockolate.Parameters.NamedParameterValue<bool>("flag", default));
+					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod<int, int, bool>("global::MyCode.MyService.MyMethod1", "index", index, "value1", value1, "flag", default);
 					          			if (!methodExecution.SkipBaseClass)
 					          			{
 					          				if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
@@ -555,7 +555,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.MyService.MyMethod2(int, bool, ref int, out bool)" />
 					          		protected override bool MyMethod2(int index, bool isReadOnly, ref int value1, out bool flag)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<bool> methodExecution = this.MockRegistry.InvokeMethod<bool>("global::MyCode.MyService.MyMethod2", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly), new global::Mockolate.Parameters.NamedParameterValue<int>("value1", value1), new global::Mockolate.Parameters.NamedParameterValue<bool>("flag", default));
+					          			global::Mockolate.Setup.MethodSetupResult<bool> methodExecution = this.MockRegistry.InvokeMethod<bool, int, bool, int, bool>("global::MyCode.MyService.MyMethod2", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), "index", index, "isReadOnly", isReadOnly, "value1", value1, "flag", default);
 					          			if (!methodExecution.SkipBaseClass)
 					          			{
 					          				var baseResult = base.MyMethod2(index, isReadOnly, ref value1, out flag);
@@ -717,7 +717,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod1(ref int)" />
 					          		public void MyMethod1(ref int index)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod1", new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
+					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod<int>("global::MyCode.IMyService.MyMethod1", "index", index);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				wraps.MyMethod1(ref index);
@@ -735,7 +735,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod2(int, out bool)" />
 					          		public bool MyMethod2(int index, out bool isReadOnly)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult<bool> methodExecution = this.MockRegistry.InvokeMethod<bool>("global::MyCode.IMyService.MyMethod2", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", default));
+					          			global::Mockolate.Setup.MethodSetupResult<bool> methodExecution = this.MockRegistry.InvokeMethod<bool, int, bool>("global::MyCode.IMyService.MyMethod2", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), "index", index, "isReadOnly", default);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				var baseResult = wraps.MyMethod2(index, out isReadOnly);
@@ -759,7 +759,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod3(in global::MyCode.MyReadonlyStruct)" />
 					          		public void MyMethod3(in global::MyCode.MyReadonlyStruct p1)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod3", new global::Mockolate.Parameters.NamedParameterValue<global::MyCode.MyReadonlyStruct>("p1", p1));
+					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod<global::MyCode.MyReadonlyStruct>("global::MyCode.IMyService.MyMethod3", "p1", p1);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				wraps.MyMethod3(in p1);
@@ -771,7 +771,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod4(ref readonly global::MyCode.MyReadonlyStruct)" />
 					          		public void MyMethod4(ref readonly global::MyCode.MyReadonlyStruct p1)
 					          		{
-					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod("global::MyCode.IMyService.MyMethod4", new global::Mockolate.Parameters.NamedParameterValue<global::MyCode.MyReadonlyStruct>("p1", p1));
+					          			global::Mockolate.Setup.MethodSetupResult methodExecution = this.MockRegistry.InvokeMethod<global::MyCode.MyReadonlyStruct>("global::MyCode.IMyService.MyMethod4", "p1", p1);
 					          			if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          			{
 					          				wraps.MyMethod4(in p1);

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -82,7 +82,7 @@ public sealed partial class MockTests
 				          		public global::MyCode.Program.DoSomething1 Object => new(Invoke);
 				          		private global::System.Span<char> Invoke(int x)
 				          		{
-				          			var result = this.MockRegistry.InvokeMethod<global::System.Span<char>>("global::MyCode.Program.DoSomething1.Invoke", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.SpanWrapper<char>)!, [new global::Mockolate.Parameters.NamedParameterValue<global::System.Func<char>>(string.Empty, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!)), ..p]), new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
+				          			var result = this.MockRegistry.InvokeMethod<global::System.Span<char>, int>("global::MyCode.Program.DoSomething1.Invoke", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.SpanWrapper<char>)!, [new global::Mockolate.Parameters.NamedParameterValue<global::System.Func<char>>(string.Empty, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!)), ..p]), "x", x);
 				          			result.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
 				          			return result.Result;
 				          		}
@@ -93,7 +93,7 @@ public sealed partial class MockTests
 				          		public global::MyCode.Program.DoSomething2 Object => new(Invoke);
 				          		private global::System.ReadOnlySpan<char> Invoke(int x)
 				          		{
-				          			var result = this.MockRegistry.InvokeMethod<global::System.ReadOnlySpan<char>>("global::MyCode.Program.DoSomething2.Invoke", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.ReadOnlySpanWrapper<char>)!, [new global::Mockolate.Parameters.NamedParameterValue<global::System.Func<char>>(string.Empty, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!)), ..p]), new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
+				          			var result = this.MockRegistry.InvokeMethod<global::System.ReadOnlySpan<char>, int>("global::MyCode.Program.DoSomething2.Invoke", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.ReadOnlySpanWrapper<char>)!, [new global::Mockolate.Parameters.NamedParameterValue<global::System.Func<char>>(string.Empty, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!)), ..p]), "x", x);
 				          			result.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>("x", x));
 				          			return result.Result;
 				          		}
@@ -169,7 +169,7 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Func_int_bool.g.cs").WhoseValue
-				.Contains("this.MockRegistry.InvokeMethod<bool>(\"global::System.Func<int, bool>.Invoke\", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), new global::Mockolate.Parameters.NamedParameterValue<int>(\"arg\", arg));")
+				.Contains("this.MockRegistry.InvokeMethod<bool, int>(\"global::System.Func<int, bool>.Invoke\", p => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, p), \"arg\", arg);")
 				.IgnoringNewlineStyle().And
 				.Contains("global::System.Func<int, bool> Object").IgnoringNewlineStyle();
 		}
@@ -254,7 +254,7 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Program_ProcessResult.g.cs").WhoseValue
-				.Contains("var result1 = this.MockRegistry.InvokeMethod<int>(")
+				.Contains("var result1 = this.MockRegistry.InvokeMethod<int, int>(")
 				.IgnoringNewlineStyle().And
 				.Contains("result1.TriggerCallbacks(new global::Mockolate.Parameters.NamedParameterValue<int>(\"result\", result))")
 				.IgnoringNewlineStyle().And
@@ -284,7 +284,7 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Program_ProcessResult.g.cs").WhoseValue
-				.Contains("var result1 = this.MockRegistry.InvokeMethod(")
+				.Contains("var result1 = this.MockRegistry.InvokeMethod<string, int>(")
 				.IgnoringNewlineStyle().And
 				.Contains("value = result1.SetOutParameter<int>(\"value\", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));")
 				.IgnoringNewlineStyle().And


### PR DESCRIPTION
Introduces typed parameter/method-matching and typed `MockRegistry.InvokeMethod` overloads to reduce boxing for method-parameter matching, and updates the source generator + tests to use those overloads for up to 4 parameters.

**Changes:**
- Added `ITypedParameter<T>` / `ITypedMethodMatch` and implemented typed matching in core matchers and `It.*` parameter matchers.
- Added new typed `MockRegistry.InvokeMethod` overloads (1–4 params, void + TResult) and corresponding typed setup lookup helpers.
- Updated source generator output and test baselines (generator string assertions + API expected surface) to use the typed overloads when applicable.