### PR TITLE
refactor: avoid `DebuggerNonUserCode` attribute in DEBUG mode

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -27,7 +27,7 @@ internal static partial class Sources
 		          namespace Mockolate
 		          {
 		          """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""
@@ -290,7 +290,7 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.AppendXmlSummary($"Sets up a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -26,7 +26,11 @@ internal static partial class Sources
 
 		          namespace Mockolate
 		          {
-		          	[global::System.Diagnostics.DebuggerNonUserCode]
+		          """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
 		          	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		          	internal static class IndexerSetupExtensions
 		          	{
@@ -286,7 +290,9 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.AppendXmlSummary($"Sets up a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tinternal class IndexerSetup<TValue, ").Append(typeParams).Append(">(")
 			.Append(

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -32,7 +32,7 @@ internal static partial class Sources
 		          namespace Mockolate
 		          {
 		          """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""
@@ -262,7 +262,7 @@ internal static partial class Sources
 		sb.AppendXmlSummary(
 			$"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.",
 			"");
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
@@ -838,7 +838,7 @@ internal static partial class Sources
 		sb.AppendXmlSummary(
 			$"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.",
 			"\t");
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -31,7 +31,11 @@ internal static partial class Sources
 
 		          namespace Mockolate
 		          {
-		          	[global::System.Diagnostics.DebuggerNonUserCode]
+		          """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
 		          	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		          	internal static class MethodSetupExtensions
 		          	{
@@ -258,7 +262,9 @@ internal static partial class Sources
 		sb.AppendXmlSummary(
 			$"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <see langword=\"void\" />.",
 			"");
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("internal class VoidMethodSetup<").Append(typeParams)
 			.Append("> : global::Mockolate.Setup.MethodSetup,").AppendLine();
@@ -832,7 +838,9 @@ internal static partial class Sources
 		sb.AppendXmlSummary(
 			$"Sets up a method with {numberOfParameters} parameters {GetTypeParametersDescription(numberOfParameters)} returning <typeparamref name=\"TReturn\" />.",
 			"\t");
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tinternal class ReturnMethodSetup<TReturn, ").Append(typeParams)
 			.Append("> : global::Mockolate.Setup.MethodSetup,").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
@@ -24,7 +24,7 @@ internal static partial class Sources
 		              ///     If your type is a class without a default constructor, you can provide constructor parameters by passing an <c>object?[]?</c> to the corresponding <c>CreateMock(...)</c> overload.
 		              /// </remarks>
 		              """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
@@ -23,7 +23,11 @@ internal static partial class Sources
 		              ///     You can also provide a <see cref="global::Mockolate.MockBehavior"/> parameter to customize how the mock should behave in certain scenarios.<br />
 		              ///     If your type is a class without a default constructor, you can provide constructor parameters by passing an <c>object?[]?</c> to the corresponding <c>CreateMock(...)</c> overload.
 		              /// </remarks>
-		              [global::System.Diagnostics.DebuggerNonUserCode]
+		              """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
 		              [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		              internal static partial class Mock
 		              {

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
@@ -58,7 +58,7 @@ internal static partial class Sources
 		          	///     parameter <typeparamref name="T" />.
 		          	/// </summary>
 		          """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""
@@ -82,7 +82,7 @@ internal static partial class Sources
 			          	///     <paramref name="statusCode" />.
 			          	/// </summary>
 			          """);
-#if RELEASE
+#if !DEBUG
 			sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 			sb.AppendLine("""
@@ -106,7 +106,7 @@ internal static partial class Sources
 		          	///     Provides default values for common types used in mocking scenarios.
 		          	/// </summary>
 		          """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""
@@ -185,7 +185,7 @@ internal static partial class Sources
 		          		}
 
 		          """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""
@@ -209,7 +209,7 @@ internal static partial class Sources
 		              	}
 		              #if NET8_0_OR_GREATER
 		              """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""
@@ -239,7 +239,7 @@ internal static partial class Sources
 		              ///     Extensions on <see cref="IDefaultValueGenerator" />
 		              /// </summary>
 		              """);
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.AppendLine("""

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
@@ -57,19 +57,23 @@ internal static partial class Sources
 		          	///     A <see cref="IDefaultValueFactory" /> that returns a specified <paramref name="value" /> for the given type
 		          	///     parameter <typeparamref name="T" />.
 		          	/// </summary>
-		          	[global::System.Diagnostics.DebuggerNonUserCode]
-		          	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-		          	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
-		          	{
-		          		/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
-		          		public bool IsMatch(global::System.Type type)
-		          			=> type == typeof(T);
-		          	
-		          		/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, global::Mockolate.Parameters.INamedParameterValue[])" />
-		          		public object? Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
-		          			=> value;
-		          	}
-		          """).AppendLine();
+		          """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
+		              	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+		              	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
+		              	{
+		              		/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
+		              		public bool IsMatch(global::System.Type type)
+		              			=> type == typeof(T);
+		              	
+		              		/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, global::Mockolate.Parameters.INamedParameterValue[])" />
+		              		public object? Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
+		              			=> value;
+		              	}
+		              """).AppendLine();
 		if (includeHttpClient)
 		{
 			sb.Append("""
@@ -77,19 +81,23 @@ internal static partial class Sources
 			          	///     A <see cref="IDefaultValueFactory" /> that returns an empty <see cref="global::System.Net.Http.HttpResponseMessage" /> with the specified
 			          	///     <paramref name="statusCode" />.
 			          	/// </summary>
-			          	[global::System.Diagnostics.DebuggerNonUserCode]
-			          	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-			          	private sealed class HttpResponseMessageFactory(global::System.Net.HttpStatusCode statusCode) : IDefaultValueFactory
-			          	{
-			          		/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
-			          		public bool IsMatch(global::System.Type type)
-			          			=> type == typeof(global::System.Net.Http.HttpResponseMessage);
-			          	
-			          		/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, object[])" />
-			          		public object? Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
-			          			=> new global::System.Net.Http.HttpResponseMessage(statusCode) { Content = new global::System.Net.Http.StringContent(string.Empty) };
-			          	}
-			          """).AppendLine();
+			          """);
+#if RELEASE
+			sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+			sb.AppendLine("""
+			              	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+			              	private sealed class HttpResponseMessageFactory(global::System.Net.HttpStatusCode statusCode) : IDefaultValueFactory
+			              	{
+			              		/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
+			              		public bool IsMatch(global::System.Type type)
+			              			=> type == typeof(global::System.Net.Http.HttpResponseMessage);
+			              	
+			              		/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, object[])" />
+			              		public object? Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
+			              			=> new global::System.Net.Http.HttpResponseMessage(statusCode) { Content = new global::System.Net.Http.StringContent(string.Empty) };
+			              	}
+			              """).AppendLine();
 		}
 
 		sb.Append("""
@@ -97,13 +105,17 @@ internal static partial class Sources
 		          	/// <summary>
 		          	///     Provides default values for common types used in mocking scenarios.
 		          	/// </summary>
-		          	[global::System.Diagnostics.DebuggerNonUserCode]
-		          	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-		          	private class DefaultValueGenerator : IDefaultValueGenerator
-		          	{
-		          		private static readonly global::System.Collections.Concurrent.ConcurrentQueue<IDefaultValueFactory> _factories = new([
-		          			new TypedDefaultValueFactory<string>(""),
-		          """).AppendLine();
+		          """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
+		              	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+		              	private class DefaultValueGenerator : IDefaultValueGenerator
+		              	{
+		              		private static readonly global::System.Collections.Concurrent.ConcurrentQueue<IDefaultValueFactory> _factories = new([
+		              			new TypedDefaultValueFactory<string>(""),
+		              """).AppendLine();
 		if (includeHttpClient)
 		{
 			sb.Append("""
@@ -172,141 +184,153 @@ internal static partial class Sources
 		          			return false;
 		          		}
 
-		          		[global::System.Diagnostics.DebuggerNonUserCode]
-		          		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-		          		private sealed class CancellableTaskFactory : IDefaultValueFactory
-		          		{
-		          			/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
-		          			public bool IsMatch(global::System.Type type)
-		          				=> type == typeof(global::System.Threading.Tasks.Task);
-		          	
-		          			/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, object[])" />
-		          			public object Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
-		          			{
-		          				if (HasCanceledCancellationToken(parameters, out global::System.Threading.CancellationToken cancellationToken))
-		          				{
-		          					return global::System.Threading.Tasks.Task.FromCanceled(cancellationToken);
-		          				}
-		          	
-		          				return global::System.Threading.Tasks.Task.CompletedTask;
-		          			}
-		          		}
-		          	#if NET8_0_OR_GREATER
-		          		[global::System.Diagnostics.DebuggerNonUserCode]
-		          		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-		          		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
-		          		{
-		          			/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
-		          			public bool IsMatch(global::System.Type type)
-		          				=> type == typeof(global::System.Threading.Tasks.ValueTask);
-		          	
-		          			/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, object[])" />
-		          			public object Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
-		          			{
-		          				if (HasCanceledCancellationToken(parameters, out global::System.Threading.CancellationToken cancellationToken))
-		          				{
-		          					return global::System.Threading.Tasks.ValueTask.FromCanceled(cancellationToken);
-		          				}
-		          	
-		          				return global::System.Threading.Tasks.ValueTask.CompletedTask;
-		          			}
-		          		}
-		          	#endif
-		          	}
-		          }
+		          """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
+		              	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+		              	private sealed class CancellableTaskFactory : IDefaultValueFactory
+		              	{
+		              		/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
+		              		public bool IsMatch(global::System.Type type)
+		              			=> type == typeof(global::System.Threading.Tasks.Task);
 
-		          /// <summary>
-		          ///     Extensions on <see cref="IDefaultValueGenerator" />
-		          /// </summary>
-		          [global::System.Diagnostics.DebuggerNonUserCode]
-		          [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-		          internal static class DefaultValueGeneratorExtensions
-		          {
-		          	/// <summary>
-		          	///     Adds a generic <c>Generate</c> method for specific types.
-		          	/// </summary>
-		          	extension(IDefaultValueGenerator generator)
-		          	{
-		          		/// <summary>
-		          		///     Generates a <see cref="global::System.Threading.Tasks.Task" /> of <typeparamref name="T" />, with
-		          		///     the <paramref name="parameters" /> for context.
-		          		/// </summary>
-		          		public global::System.Threading.Tasks.Task<T> Generate<T>(global::System.Threading.Tasks.Task<T> nullValue, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
-		          		{
-		          			global::System.Threading.CancellationToken cancellationToken = global::System.Threading.CancellationToken.None;
-		          			foreach (var parameter in parameters)
-		          			{
-		          			    if (parameter.TryGetValue(out global::System.Threading.CancellationToken token))
-		          				{
-		          					cancellationToken = token;
-		          					break;
-		          				}
-		          			}
+		              		/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, object[])" />
+		              		public object Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
+		              		{
+		              			if (HasCanceledCancellationToken(parameters, out global::System.Threading.CancellationToken cancellationToken))
+		              			{
+		              				return global::System.Threading.Tasks.Task.FromCanceled(cancellationToken);
+		              			}
 
-		          			if (cancellationToken.IsCancellationRequested)
-		          			{
-		          				return global::System.Threading.Tasks.Task.FromCanceled<T>(cancellationToken);
-		          			}
+		              			return global::System.Threading.Tasks.Task.CompletedTask;
+		              		}
+		              	}
+		              #if NET8_0_OR_GREATER
+		              """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
+		              		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+		              		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
+		              		{
+		              			/// <inheritdoc cref="IDefaultValueFactory.IsMatch(global::System.Type)" />
+		              			public bool IsMatch(global::System.Type type)
+		              				=> type == typeof(global::System.Threading.Tasks.ValueTask);
+		              	
+		              			/// <inheritdoc cref="IDefaultValueFactory.Create(global::System.Type, IDefaultValueGenerator, object[])" />
+		              			public object Create(global::System.Type type, IDefaultValueGenerator defaultValueGenerator, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
+		              			{
+		              				if (HasCanceledCancellationToken(parameters, out global::System.Threading.CancellationToken cancellationToken))
+		              				{
+		              					return global::System.Threading.Tasks.ValueTask.FromCanceled(cancellationToken);
+		              				}
+		              	
+		              				return global::System.Threading.Tasks.ValueTask.CompletedTask;
+		              			}
+		              		}
+		              	#endif
+		              	}
+		              }
 
-		          			foreach (global::Mockolate.Parameters.INamedParameterValue parameter in parameters)
-		          			{
-		          				if (parameter.TryGetValue(out global::System.Func<T> func))
-		          				{
-		          					return global::System.Threading.Tasks.Task.FromResult(func());
-		          				}
-		          			}
+		              /// <summary>
+		              ///     Extensions on <see cref="IDefaultValueGenerator" />
+		              /// </summary>
+		              """);
+#if RELEASE
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.AppendLine("""
+		              [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+		              internal static class DefaultValueGeneratorExtensions
+		              {
+		              	/// <summary>
+		              	///     Adds a generic <c>Generate</c> method for specific types.
+		              	/// </summary>
+		              	extension(IDefaultValueGenerator generator)
+		              	{
+		              		/// <summary>
+		              		///     Generates a <see cref="global::System.Threading.Tasks.Task" /> of <typeparamref name="T" />, with
+		              		///     the <paramref name="parameters" /> for context.
+		              		/// </summary>
+		              		public global::System.Threading.Tasks.Task<T> Generate<T>(global::System.Threading.Tasks.Task<T> nullValue, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
+		              		{
+		              			global::System.Threading.CancellationToken cancellationToken = global::System.Threading.CancellationToken.None;
+		              			foreach (var parameter in parameters)
+		              			{
+		              			    if (parameter.TryGetValue(out global::System.Threading.CancellationToken token))
+		              				{
+		              					cancellationToken = token;
+		              					break;
+		              				}
+		              			}
 
-		          			return global::System.Threading.Tasks.Task.FromResult(generator.Generate(default(T)!, parameters));
-		          		}
+		              			if (cancellationToken.IsCancellationRequested)
+		              			{
+		              				return global::System.Threading.Tasks.Task.FromCanceled<T>(cancellationToken);
+		              			}
 
-		          #if NET8_0_OR_GREATER
-		          		/// <summary>
-		          		///     Generates a <see cref="global::System.Threading.Tasks.ValueTask" /> of <typeparamref name="T" />, with
-		          		///     the <paramref name="parameters" /> for context.
-		          		/// </summary>
-		          		public global::System.Threading.Tasks.ValueTask<T> Generate<T>(global::System.Threading.Tasks.ValueTask<T> nullValue, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
-		          		{
-		          			global::System.Threading.CancellationToken cancellationToken = global::System.Threading.CancellationToken.None;
-		          			foreach (var parameter in parameters)
-		          			{
-		          			    if (parameter.TryGetValue(out global::System.Threading.CancellationToken token))
-		          				{
-		          					cancellationToken = token;
-		          					break;
-		          				}
-		          			}
+		              			foreach (global::Mockolate.Parameters.INamedParameterValue parameter in parameters)
+		              			{
+		              				if (parameter.TryGetValue(out global::System.Func<T> func))
+		              				{
+		              					return global::System.Threading.Tasks.Task.FromResult(func());
+		              				}
+		              			}
 
-		          			if (cancellationToken.IsCancellationRequested)
-		          			{
-		          				return global::System.Threading.Tasks.ValueTask.FromCanceled<T>(cancellationToken);
-		          			}
+		              			return global::System.Threading.Tasks.Task.FromResult(generator.Generate(default(T)!, parameters));
+		              		}
 
-		          			foreach (global::Mockolate.Parameters.INamedParameterValue parameter in parameters)
-		          			{
-		          				if (parameter.TryGetValue(out global::System.Func<T> func))
-		          				{
-		          					return global::System.Threading.Tasks.ValueTask.FromResult(func());
-		          				}
-		          			}
+		              #if NET8_0_OR_GREATER
+		              		/// <summary>
+		              		///     Generates a <see cref="global::System.Threading.Tasks.ValueTask" /> of <typeparamref name="T" />, with
+		              		///     the <paramref name="parameters" /> for context.
+		              		/// </summary>
+		              		public global::System.Threading.Tasks.ValueTask<T> Generate<T>(global::System.Threading.Tasks.ValueTask<T> nullValue, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
+		              		{
+		              			global::System.Threading.CancellationToken cancellationToken = global::System.Threading.CancellationToken.None;
+		              			foreach (var parameter in parameters)
+		              			{
+		              			    if (parameter.TryGetValue(out global::System.Threading.CancellationToken token))
+		              				{
+		              					cancellationToken = token;
+		              					break;
+		              				}
+		              			}
 
-		          			return global::System.Threading.Tasks.ValueTask.FromResult(generator.Generate(default(T)!, parameters));
-		          		}
-		          #endif
+		              			if (cancellationToken.IsCancellationRequested)
+		              			{
+		              				return global::System.Threading.Tasks.ValueTask.FromCanceled<T>(cancellationToken);
+		              			}
 
-		          		/// <summary>
-		          		///     Generates a tuple of (<typeparamref name="T1" />, <typeparamref name="T2" />), with
-		          		///     the <paramref name="parameters" /> for context.
-		          		/// </summary>
-		          		public (T1, T2) Generate<T1, T2>((T1, T2) nullValue, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
-		          		{
-		          			if (parameters.Length >= 2 && parameters[0].TryGetValue(out global::System.Func<T1> func1) && parameters[1].TryGetValue(out global::System.Func<T2> func2))
-		          			{
-		          				return (func1(), func2());
-		          			}
+		              			foreach (global::Mockolate.Parameters.INamedParameterValue parameter in parameters)
+		              			{
+		              				if (parameter.TryGetValue(out global::System.Func<T> func))
+		              				{
+		              					return global::System.Threading.Tasks.ValueTask.FromResult(func());
+		              				}
+		              			}
 
-		          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters));
-		          		}
-		          """).AppendLine();
+		              			return global::System.Threading.Tasks.ValueTask.FromResult(generator.Generate(default(T)!, parameters));
+		              		}
+		              #endif
+
+		              		/// <summary>
+		              		///     Generates a tuple of (<typeparamref name="T1" />, <typeparamref name="T2" />), with
+		              		///     the <paramref name="parameters" /> for context.
+		              		/// </summary>
+		              		public (T1, T2) Generate<T1, T2>((T1, T2) nullValue, params global::Mockolate.Parameters.INamedParameterValue[] parameters)
+		              		{
+		              			if (parameters.Length >= 2 && parameters[0].TryGetValue(out global::System.Func<T1> func1) && parameters[1].TryGetValue(out global::System.Func<T2> func2))
+		              			{
+		              				return (func1(), func2());
+		              			}
+
+		              			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters));
+		              		}
+		              """).AppendLine();
 		for (int i = 3; i <= 8; i++)
 		{
 			string ts = string.Join(", ", Enumerable.Range(1, i).Select(x => $"T{x}"));

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -39,7 +39,7 @@ internal static partial class Sources
 		#region MockForXXXExtensions
 
 		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" />.", "");
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
@@ -362,7 +362,7 @@ internal static partial class Sources
 			}
 
 			sb.AppendLine();
-#if RELEASE
+#if !DEBUG
 			sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 			sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
@@ -412,7 +412,7 @@ internal static partial class Sources
 		sb.Append("{").AppendLine();
 		sb.AppendXmlSummary($"A mock implementation for <see cref=\"{escapedClassName}\" />.", "\t");
 		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
@@ -624,7 +624,7 @@ internal static partial class Sources
 		sb.AppendLine("\t}");
 
 		sb.AppendLine();
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -39,7 +39,9 @@ internal static partial class Sources
 		#region MockForXXXExtensions
 
 		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" />.", "");
+#if RELEASE
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("internal static partial class MockExtensionsFor").Append(name).AppendLine();
 		sb.Append("{").AppendLine();
@@ -360,7 +362,9 @@ internal static partial class Sources
 			}
 
 			sb.AppendLine();
+#if RELEASE
 			sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 			sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 			sb.Append("\tinternal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupFor").Append(name);
 			if (hasProtectedMembers)
@@ -408,7 +412,9 @@ internal static partial class Sources
 		sb.Append("{").AppendLine();
 		sb.AppendXmlSummary($"A mock implementation for <see cref=\"{escapedClassName}\" />.", "\t");
 		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tinternal class ").Append(name).Append(" :").AppendLine();
 		sb.Append("\t\t").Append(@class.ClassFullName);
@@ -618,7 +624,9 @@ internal static partial class Sources
 		sb.AppendLine("\t}");
 
 		sb.AppendLine();
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tprivate sealed class VerifyMonitor").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -35,7 +35,7 @@ internal static partial class Sources
 		#region Extensions
 
 		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" /> that also implements<br />\n///      - {string.Join("<br />\n///      - ", additionalInterfaces.Select(x => $"<see cref=\"{x.Class.ClassFullName.EscapeForXmlDoc()}\" />"))}.", "");
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
@@ -255,7 +255,7 @@ internal static partial class Sources
 		sb.Append("{").AppendLine();
 		sb.AppendXmlSummary($"A mock implementation for <see cref=\"{escapedClassName}\" /> that also implements<br />\n\t///      - {string.Join("<br />\n\t///      - ", additionalInterfaces.Select(x => $"<see cref=\"{x.Class.ClassFullName.EscapeForXmlDoc()}\" />"))}.", "\t");
 		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -35,7 +35,9 @@ internal static partial class Sources
 		#region Extensions
 
 		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" /> that also implements<br />\n///      - {string.Join("<br />\n///      - ", additionalInterfaces.Select(x => $"<see cref=\"{x.Class.ClassFullName.EscapeForXmlDoc()}\" />"))}.", "");
+#if RELEASE
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("internal static partial class MockExtensionsFor").Append(fileName).AppendLine();
 		sb.Append("{").AppendLine();
@@ -253,7 +255,9 @@ internal static partial class Sources
 		sb.Append("{").AppendLine();
 		sb.AppendXmlSummary($"A mock implementation for <see cref=\"{escapedClassName}\" /> that also implements<br />\n\t///      - {string.Join("<br />\n\t///      - ", additionalInterfaces.Select(x => $"<see cref=\"{x.Class.ClassFullName.EscapeForXmlDoc()}\" />"))}.", "\t");
 		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tinternal class ").Append(fileName).Append(" :").AppendLine();
 		sb.Append("\t\t").Append(@class.ClassFullName).Append(", ").Append("IMockFor").Append(name).Append(", IMockSetupFor").Append(name);

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -20,7 +20,7 @@ internal static partial class Sources
 		#region MockForXXXExtensions
 
 		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" />.", "");
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
@@ -101,7 +101,7 @@ internal static partial class Sources
 		sb.Append("\t///     A mock implementation for <see cref=\"").Append(escapedClassName).Append("\" />.").AppendLine();
 		sb.Append("\t/// </summary>").AppendLine();
 		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
@@ -300,7 +300,7 @@ internal static partial class Sources
 		sb.AppendLine("\t}");
 
 		sb.AppendLine();
-#if RELEASE
+#if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -20,7 +20,9 @@ internal static partial class Sources
 		#region MockForXXXExtensions
 
 		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" />.", "");
+#if RELEASE
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("internal static partial class MockExtensionsFor").Append(name).AppendLine();
 		sb.Append("{").AppendLine();
@@ -99,7 +101,9 @@ internal static partial class Sources
 		sb.Append("\t///     A mock implementation for <see cref=\"").Append(escapedClassName).Append("\" />.").AppendLine();
 		sb.Append("\t/// </summary>").AppendLine();
 		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tinternal class ").Append(name).Append(" :").AppendLine();
 		sb.Append("\t\tIMockFor").Append(name).Append(',').AppendLine();
@@ -296,7 +300,9 @@ internal static partial class Sources
 		sb.AppendLine("\t}");
 
 		sb.AppendLine();
+#if RELEASE
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tprivate sealed class VerifyMonitor").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
@@ -18,7 +18,7 @@ internal static partial class Sources
 		sb.Append("/// <summary>").AppendLine();
 		sb.Append("///     Extensions for setting up return values and throwing exceptions for <see langword=\"async\" /> methods.").AppendLine();
 		sb.Append("/// </summary>").AppendLine();
-#if RELEASE
+#if !DEBUG
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
@@ -18,7 +18,9 @@ internal static partial class Sources
 		sb.Append("/// <summary>").AppendLine();
 		sb.Append("///     Extensions for setting up return values and throwing exceptions for <see langword=\"async\" /> methods.").AppendLine();
 		sb.Append("/// </summary>").AppendLine();
+#if RELEASE
 		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
 		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("internal static class ReturnsThrowsAsyncExtensions2").AppendLine();
 		sb.Append("{").AppendLine();

--- a/Source/Mockolate/Interactions/EventSubscription.cs
+++ b/Source/Mockolate/Interactions/EventSubscription.cs
@@ -8,7 +8,9 @@ namespace Mockolate.Interactions;
 ///     A subscription to an event.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class EventSubscription(string name, object? target, MethodInfo method) : IInteraction, ISettableInteraction
 {
 	private int? _index;

--- a/Source/Mockolate/Interactions/EventSubscription.cs
+++ b/Source/Mockolate/Interactions/EventSubscription.cs
@@ -8,7 +8,7 @@ namespace Mockolate.Interactions;
 ///     A subscription to an event.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class EventSubscription(string name, object? target, MethodInfo method) : IInteraction, ISettableInteraction

--- a/Source/Mockolate/Interactions/EventUnsubscription.cs
+++ b/Source/Mockolate/Interactions/EventUnsubscription.cs
@@ -9,7 +9,7 @@ namespace Mockolate.Interactions;
 ///     An unsubscription from an event.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class EventUnsubscription(string name, object? target, MethodInfo method) : IInteraction, ISettableInteraction

--- a/Source/Mockolate/Interactions/EventUnsubscription.cs
+++ b/Source/Mockolate/Interactions/EventUnsubscription.cs
@@ -9,7 +9,9 @@ namespace Mockolate.Interactions;
 ///     An unsubscription from an event.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class EventUnsubscription(string name, object? target, MethodInfo method) : IInteraction, ISettableInteraction
 {
 	private int? _index;

--- a/Source/Mockolate/Interactions/IndexerAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerAccess.cs
@@ -6,7 +6,7 @@ namespace Mockolate.Interactions;
 /// <summary>
 ///     An access of an indexer.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public abstract class IndexerAccess(INamedParameterValue[] parameters) : IInteraction, ISettableInteraction

--- a/Source/Mockolate/Interactions/IndexerAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerAccess.cs
@@ -6,7 +6,9 @@ namespace Mockolate.Interactions;
 /// <summary>
 ///     An access of an indexer.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public abstract class IndexerAccess(INamedParameterValue[] parameters) : IInteraction, ISettableInteraction
 {
 	private int? _index;

--- a/Source/Mockolate/Interactions/IndexerGetterAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerGetterAccess.cs
@@ -8,7 +8,7 @@ namespace Mockolate.Interactions;
 ///     An access of an indexer getter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerGetterAccess(INamedParameterValue[] parameters) : IndexerAccess(parameters)

--- a/Source/Mockolate/Interactions/IndexerGetterAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerGetterAccess.cs
@@ -8,7 +8,9 @@ namespace Mockolate.Interactions;
 ///     An access of an indexer getter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerGetterAccess(INamedParameterValue[] parameters) : IndexerAccess(parameters)
 {
 	/// <inheritdoc cref="object.ToString()" />

--- a/Source/Mockolate/Interactions/IndexerSetterAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerSetterAccess.cs
@@ -8,7 +8,7 @@ namespace Mockolate.Interactions;
 ///     An access of an indexer setter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetterAccess(INamedParameterValue[] parameters, INamedParameterValue value) : IndexerAccess(parameters)

--- a/Source/Mockolate/Interactions/IndexerSetterAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerSetterAccess.cs
@@ -8,7 +8,9 @@ namespace Mockolate.Interactions;
 ///     An access of an indexer setter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerSetterAccess(INamedParameterValue[] parameters, INamedParameterValue value) : IndexerAccess(parameters)
 {
 	/// <summary>

--- a/Source/Mockolate/Interactions/MethodInvocation.cs
+++ b/Source/Mockolate/Interactions/MethodInvocation.cs
@@ -10,7 +10,7 @@ namespace Mockolate.Interactions;
 ///     An invocation of a method.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class MethodInvocation(string name, INamedParameterValue[] parameters) : IInteraction, ISettableInteraction

--- a/Source/Mockolate/Interactions/MethodInvocation.cs
+++ b/Source/Mockolate/Interactions/MethodInvocation.cs
@@ -10,7 +10,9 @@ namespace Mockolate.Interactions;
 ///     An invocation of a method.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class MethodInvocation(string name, INamedParameterValue[] parameters) : IInteraction, ISettableInteraction
 {
 	private int? _index;

--- a/Source/Mockolate/Interactions/MockInteractions.cs
+++ b/Source/Mockolate/Interactions/MockInteractions.cs
@@ -13,7 +13,9 @@ namespace Mockolate.Interactions;
 ///     Keeps track of the interactions on the mock and its verifications.
 /// </summary>
 [DebuggerDisplay("{_interactions.Count} interactions")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class MockInteractions : IReadOnlyCollection<IInteraction>, IMockInteractions
 {
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/Source/Mockolate/Interactions/MockInteractions.cs
+++ b/Source/Mockolate/Interactions/MockInteractions.cs
@@ -13,7 +13,7 @@ namespace Mockolate.Interactions;
 ///     Keeps track of the interactions on the mock and its verifications.
 /// </summary>
 [DebuggerDisplay("{_interactions.Count} interactions")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class MockInteractions : IReadOnlyCollection<IInteraction>, IMockInteractions

--- a/Source/Mockolate/Interactions/PropertyAccess.cs
+++ b/Source/Mockolate/Interactions/PropertyAccess.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Interactions;
 ///     An access of a property.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public abstract class PropertyAccess(string propertyName) : IInteraction, ISettableInteraction
 {
 	private int? _index;

--- a/Source/Mockolate/Interactions/PropertyAccess.cs
+++ b/Source/Mockolate/Interactions/PropertyAccess.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Interactions;
 ///     An access of a property.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public abstract class PropertyAccess(string propertyName) : IInteraction, ISettableInteraction

--- a/Source/Mockolate/Interactions/PropertyGetterAccess.cs
+++ b/Source/Mockolate/Interactions/PropertyGetterAccess.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Interactions;
 ///     An access of a property getter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class PropertyGetterAccess(string propertyName) : PropertyAccess(propertyName)

--- a/Source/Mockolate/Interactions/PropertyGetterAccess.cs
+++ b/Source/Mockolate/Interactions/PropertyGetterAccess.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Interactions;
 ///     An access of a property getter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class PropertyGetterAccess(string propertyName) : PropertyAccess(propertyName)
 {
 	/// <inheritdoc cref="object.ToString()" />

--- a/Source/Mockolate/Interactions/PropertySetterAccess.cs
+++ b/Source/Mockolate/Interactions/PropertySetterAccess.cs
@@ -8,7 +8,7 @@ namespace Mockolate.Interactions;
 ///     An access of a property setter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class PropertySetterAccess(string propertyName, INamedParameterValue value) : PropertyAccess(propertyName)

--- a/Source/Mockolate/Interactions/PropertySetterAccess.cs
+++ b/Source/Mockolate/Interactions/PropertySetterAccess.cs
@@ -8,7 +8,9 @@ namespace Mockolate.Interactions;
 ///     An access of a property setter.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class PropertySetterAccess(string propertyName, INamedParameterValue value) : PropertyAccess(propertyName)
 {
 	/// <summary>

--- a/Source/Mockolate/Internals/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/Mockolate/Internals/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -13,7 +13,9 @@ namespace System.Runtime.CompilerServices
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Parameter)]
 	[ExcludeFromCodeCoverage]
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	internal sealed class CallerArgumentExpressionAttribute : Attribute
 	{
 		/// <summary>

--- a/Source/Mockolate/Internals/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/Mockolate/Internals/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.CompilerServices
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Parameter)]
 	[ExcludeFromCodeCoverage]
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	internal sealed class CallerArgumentExpressionAttribute : Attribute

--- a/Source/Mockolate/Internals/Polyfills/StringExtensions.cs
+++ b/Source/Mockolate/Internals/Polyfills/StringExtensions.cs
@@ -9,7 +9,9 @@ namespace Mockolate.Internals.Polyfills;
 ///     Provides polyfill extension methods on <see langword="string" />.
 /// </summary>
 [ExcludeFromCodeCoverage]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 internal static class StringExtensionMethods
 {
 	/// <summary>

--- a/Source/Mockolate/Internals/Polyfills/StringExtensions.cs
+++ b/Source/Mockolate/Internals/Polyfills/StringExtensions.cs
@@ -9,7 +9,7 @@ namespace Mockolate.Internals.Polyfills;
 ///     Provides polyfill extension methods on <see langword="string" />.
 /// </summary>
 [ExcludeFromCodeCoverage]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 internal static class StringExtensionMethods

--- a/Source/Mockolate/Internals/StringExtensions.cs
+++ b/Source/Mockolate/Internals/StringExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Mockolate.Internals;
 
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 internal static class StringExtensions

--- a/Source/Mockolate/Internals/StringExtensions.cs
+++ b/Source/Mockolate/Internals/StringExtensions.cs
@@ -2,7 +2,9 @@
 
 namespace Mockolate.Internals;
 
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 internal static class StringExtensions
 {
 	internal static string SubstringUntilFirst(this string name, char c)

--- a/Source/Mockolate/Internals/TypeFormatter.cs
+++ b/Source/Mockolate/Internals/TypeFormatter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Mockolate.Internals;
 
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 internal static class TypeFormatter

--- a/Source/Mockolate/Internals/TypeFormatter.cs
+++ b/Source/Mockolate/Internals/TypeFormatter.cs
@@ -5,7 +5,9 @@ using System.Text;
 
 namespace Mockolate.Internals;
 
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 internal static class TypeFormatter
 {
 	private static readonly Dictionary<Type, string> Aliases = new()

--- a/Source/Mockolate/Internals/Wildcard.cs
+++ b/Source/Mockolate/Internals/Wildcard.cs
@@ -5,7 +5,9 @@ using System.Text.RegularExpressions;
 
 namespace Mockolate.Internals;
 
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 internal readonly struct Wildcard
 {
 	public Regex Regex { get; }

--- a/Source/Mockolate/Internals/Wildcard.cs
+++ b/Source/Mockolate/Internals/Wildcard.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace Mockolate.Internals;
 
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 internal readonly struct Wildcard

--- a/Source/Mockolate/It.Is.cs
+++ b/Source/Mockolate/It.Is.cs
@@ -30,7 +30,9 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class ParameterEqualsMatch<T> : TypedMatch<T>, IIsParameter<T>
 	{
 		private readonly T _value;

--- a/Source/Mockolate/It.Is.cs
+++ b/Source/Mockolate/It.Is.cs
@@ -30,7 +30,7 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class ParameterEqualsMatch<T> : TypedMatch<T>, IIsParameter<T>

--- a/Source/Mockolate/It.IsAny.cs
+++ b/Source/Mockolate/It.IsAny.cs
@@ -15,7 +15,7 @@ public partial class It
 	public static IParameter<T> IsAny<T>()
 		=> new AnyParameterMatch<T>();
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class AnyParameterMatch<T> : TypedMatch<T>

--- a/Source/Mockolate/It.IsAny.cs
+++ b/Source/Mockolate/It.IsAny.cs
@@ -15,7 +15,9 @@ public partial class It
 	public static IParameter<T> IsAny<T>()
 		=> new AnyParameterMatch<T>();
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class AnyParameterMatch<T> : TypedMatch<T>
 	{
 		protected override bool Matches(T value) => true;

--- a/Source/Mockolate/It.IsFalse.cs
+++ b/Source/Mockolate/It.IsFalse.cs
@@ -13,7 +13,7 @@ public partial class It
 	public static IParameter<bool> IsFalse()
 		=> new FalseParameterMatch();
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class FalseParameterMatch : TypedMatch<bool>

--- a/Source/Mockolate/It.IsFalse.cs
+++ b/Source/Mockolate/It.IsFalse.cs
@@ -13,7 +13,9 @@ public partial class It
 	public static IParameter<bool> IsFalse()
 		=> new FalseParameterMatch();
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class FalseParameterMatch : TypedMatch<bool>
 	{
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />

--- a/Source/Mockolate/It.IsInRange.cs
+++ b/Source/Mockolate/It.IsInRange.cs
@@ -37,7 +37,7 @@ public partial class It
 		IParameter<T> Inclusive();
 	}
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class InRangeMatch<T> : TypedMatch<T>, IInRangeParameter<T>

--- a/Source/Mockolate/It.IsInRange.cs
+++ b/Source/Mockolate/It.IsInRange.cs
@@ -37,7 +37,9 @@ public partial class It
 		IParameter<T> Inclusive();
 	}
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class InRangeMatch<T> : TypedMatch<T>, IInRangeParameter<T>
 		where T : IComparable<T>
 	{

--- a/Source/Mockolate/It.IsNot.cs
+++ b/Source/Mockolate/It.IsNot.cs
@@ -30,7 +30,9 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class ParameterEqualsNotMatch<T> : TypedMatch<T>, IIsNotParameter<T>
 	{
 		private readonly T _value;

--- a/Source/Mockolate/It.IsNot.cs
+++ b/Source/Mockolate/It.IsNot.cs
@@ -30,7 +30,7 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class ParameterEqualsNotMatch<T> : TypedMatch<T>, IIsNotParameter<T>

--- a/Source/Mockolate/It.IsNotNull.cs
+++ b/Source/Mockolate/It.IsNotNull.cs
@@ -14,7 +14,9 @@ public partial class It
 	public static IParameter<T> IsNotNull<T>(string? toString = null)
 		=> new NotNullParameterMatch<T>(toString);
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class NotNullParameterMatch<T>(string? toString) : TypedMatch<T>
 	{
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />

--- a/Source/Mockolate/It.IsNotNull.cs
+++ b/Source/Mockolate/It.IsNotNull.cs
@@ -14,7 +14,7 @@ public partial class It
 	public static IParameter<T> IsNotNull<T>(string? toString = null)
 		=> new NotNullParameterMatch<T>(toString);
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class NotNullParameterMatch<T>(string? toString) : TypedMatch<T>

--- a/Source/Mockolate/It.IsNotOneOf.cs
+++ b/Source/Mockolate/It.IsNotOneOf.cs
@@ -29,7 +29,7 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class ParameterIsNotOneOfMatch<T>(T[] values) : TypedMatch<T>, IIsNotOneOfParameter<T>

--- a/Source/Mockolate/It.IsNotOneOf.cs
+++ b/Source/Mockolate/It.IsNotOneOf.cs
@@ -29,7 +29,9 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class ParameterIsNotOneOfMatch<T>(T[] values) : TypedMatch<T>, IIsNotOneOfParameter<T>
 	{
 		private IEqualityComparer<T>? _comparer;

--- a/Source/Mockolate/It.IsNull.cs
+++ b/Source/Mockolate/It.IsNull.cs
@@ -14,7 +14,7 @@ public partial class It
 	public static IParameter<T> IsNull<T>(string? toString = null)
 		=> new NullParameterMatch<T>(toString);
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class NullParameterMatch<T>(string? toString) : TypedMatch<T>

--- a/Source/Mockolate/It.IsNull.cs
+++ b/Source/Mockolate/It.IsNull.cs
@@ -14,7 +14,9 @@ public partial class It
 	public static IParameter<T> IsNull<T>(string? toString = null)
 		=> new NullParameterMatch<T>(toString);
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class NullParameterMatch<T>(string? toString) : TypedMatch<T>
 	{
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />

--- a/Source/Mockolate/It.IsOneOf.cs
+++ b/Source/Mockolate/It.IsOneOf.cs
@@ -29,7 +29,9 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class ParameterIsOneOfMatch<T>(T[] values) : TypedMatch<T>, IIsOneOfParameter<T>
 	{
 		private IEqualityComparer<T>? _comparer;

--- a/Source/Mockolate/It.IsOneOf.cs
+++ b/Source/Mockolate/It.IsOneOf.cs
@@ -29,7 +29,7 @@ public partial class It
 			string doNotPopulateThisValue = "");
 	}
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class ParameterIsOneOfMatch<T>(T[] values) : TypedMatch<T>, IIsOneOfParameter<T>

--- a/Source/Mockolate/It.IsOut.cs
+++ b/Source/Mockolate/It.IsOut.cs
@@ -34,7 +34,9 @@ public partial class It
 	/// <summary>
 	///     Matches an <see langword="out" /> parameter against an expectation.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class OutParameterMatch<T>(Func<T> setter, string setterExpression) : TypedOutMatch<T>
 	{
 		/// <inheritdoc cref="IOutParameter{T}.GetValue(Func{T})" />
@@ -47,7 +49,9 @@ public partial class It
 	/// <summary>
 	///     Matches an <see langword="out" /> parameter against an expectation.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class AnyOutParameterMatch<T> : TypedOutMatch<T>
 	{
 		/// <inheritdoc cref="object.ToString()" />
@@ -57,7 +61,9 @@ public partial class It
 	/// <summary>
 	///     Matches any <see langword="out" /> parameter.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class InvokedOutParameterMatch<T> : IVerifyOutParameter<T>, IParameter, ITypedParameter<T>
 	{
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
@@ -80,7 +86,9 @@ public partial class It
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private abstract class TypedOutMatch<T> : IOutParameter<T>, IParameter, ITypedParameter<T>
 	{
 		private List<Action<T>>? _callbacks;

--- a/Source/Mockolate/It.IsOut.cs
+++ b/Source/Mockolate/It.IsOut.cs
@@ -34,7 +34,7 @@ public partial class It
 	/// <summary>
 	///     Matches an <see langword="out" /> parameter against an expectation.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class OutParameterMatch<T>(Func<T> setter, string setterExpression) : TypedOutMatch<T>
@@ -49,7 +49,7 @@ public partial class It
 	/// <summary>
 	///     Matches an <see langword="out" /> parameter against an expectation.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class AnyOutParameterMatch<T> : TypedOutMatch<T>
@@ -61,7 +61,7 @@ public partial class It
 	/// <summary>
 	///     Matches any <see langword="out" /> parameter.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class InvokedOutParameterMatch<T> : IVerifyOutParameter<T>, IParameter, ITypedParameter<T>
@@ -86,7 +86,7 @@ public partial class It
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private abstract class TypedOutMatch<T> : IOutParameter<T>, IParameter, ITypedParameter<T>

--- a/Source/Mockolate/It.IsReadOnlySpan.cs
+++ b/Source/Mockolate/It.IsReadOnlySpan.cs
@@ -27,7 +27,9 @@ public partial class It
 		string doNotPopulateThisValue = "")
 		=> new ReadOnlySpanParameterMatch<T>(predicate, doNotPopulateThisValue);
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class ReadOnlySpanParameterMatch<T>(Func<T[], bool>? predicate, string? predicateExpression = null)
 		: TypedMatch<ReadOnlySpanWrapper<T>>, IVerifyReadOnlySpanParameter<T>
 	{

--- a/Source/Mockolate/It.IsReadOnlySpan.cs
+++ b/Source/Mockolate/It.IsReadOnlySpan.cs
@@ -27,7 +27,7 @@ public partial class It
 		string doNotPopulateThisValue = "")
 		=> new ReadOnlySpanParameterMatch<T>(predicate, doNotPopulateThisValue);
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class ReadOnlySpanParameterMatch<T>(Func<T[], bool>? predicate, string? predicateExpression = null)

--- a/Source/Mockolate/It.IsRef.cs
+++ b/Source/Mockolate/It.IsRef.cs
@@ -54,7 +54,9 @@ public partial class It
 	/// <summary>
 	///     Matches a method <see langword="ref" /> parameter against an expectation.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class RefParameterMatch<T>(
 		Func<T, bool> predicate,
 		Func<T, T>? setter,
@@ -89,7 +91,9 @@ public partial class It
 	/// <summary>
 	///     Matches any method <see langword="ref" /> parameter.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class AnyRefParameterMatch<T> : TypedRefMatch<T>
 	{
 		/// <inheritdoc cref="object.ToString()" />
@@ -104,7 +108,9 @@ public partial class It
 	/// <summary>
 	///     Matches a method <see langword="out" /> parameter against an expectation.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class InvokedRefParameterMatch<T> : IVerifyRefParameter<T>, IParameter, ITypedParameter<T>
 	{
 		/// <inheritdoc cref="IParameter.Matches(INamedParameterValue)" />
@@ -127,7 +133,9 @@ public partial class It
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private abstract class TypedRefMatch<T> : IRefParameter<T>, IParameter, ITypedParameter<T>
 	{
 		private List<Action<T>>? _callbacks;

--- a/Source/Mockolate/It.IsRef.cs
+++ b/Source/Mockolate/It.IsRef.cs
@@ -54,7 +54,7 @@ public partial class It
 	/// <summary>
 	///     Matches a method <see langword="ref" /> parameter against an expectation.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class RefParameterMatch<T>(
@@ -91,7 +91,7 @@ public partial class It
 	/// <summary>
 	///     Matches any method <see langword="ref" /> parameter.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class AnyRefParameterMatch<T> : TypedRefMatch<T>
@@ -108,7 +108,7 @@ public partial class It
 	/// <summary>
 	///     Matches a method <see langword="out" /> parameter against an expectation.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class InvokedRefParameterMatch<T> : IVerifyRefParameter<T>, IParameter, ITypedParameter<T>
@@ -133,7 +133,7 @@ public partial class It
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private abstract class TypedRefMatch<T> : IRefParameter<T>, IParameter, ITypedParameter<T>

--- a/Source/Mockolate/It.IsSpan.cs
+++ b/Source/Mockolate/It.IsSpan.cs
@@ -27,7 +27,7 @@ public partial class It
 		string doNotPopulateThisValue = "")
 		=> new SpanParameterMatch<T>(predicate, doNotPopulateThisValue);
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class SpanParameterMatch<T>(Func<T[], bool>? predicate, string? predicateExpression = null)

--- a/Source/Mockolate/It.IsSpan.cs
+++ b/Source/Mockolate/It.IsSpan.cs
@@ -27,7 +27,9 @@ public partial class It
 		string doNotPopulateThisValue = "")
 		=> new SpanParameterMatch<T>(predicate, doNotPopulateThisValue);
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class SpanParameterMatch<T>(Func<T[], bool>? predicate, string? predicateExpression = null)
 		: TypedMatch<SpanWrapper<T>>, IVerifySpanParameter<T>
 	{

--- a/Source/Mockolate/It.IsTrue.cs
+++ b/Source/Mockolate/It.IsTrue.cs
@@ -13,7 +13,7 @@ public partial class It
 	public static IParameter<bool> IsTrue()
 		=> new TrueParameterMatch();
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class TrueParameterMatch : TypedMatch<bool>

--- a/Source/Mockolate/It.IsTrue.cs
+++ b/Source/Mockolate/It.IsTrue.cs
@@ -13,7 +13,9 @@ public partial class It
 	public static IParameter<bool> IsTrue()
 		=> new TrueParameterMatch();
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class TrueParameterMatch : TypedMatch<bool>
 	{
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />

--- a/Source/Mockolate/It.Matches.cs
+++ b/Source/Mockolate/It.Matches.cs
@@ -41,7 +41,7 @@ public partial class It
 			[CallerArgumentExpression("timeout")] string doNotPopulateThisValue2 = "");
 	}
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class MatchesAsWildcardMatch(string pattern) : TypedMatch<string>, IParameterMatches

--- a/Source/Mockolate/It.Matches.cs
+++ b/Source/Mockolate/It.Matches.cs
@@ -41,7 +41,9 @@ public partial class It
 			[CallerArgumentExpression("timeout")] string doNotPopulateThisValue2 = "");
 	}
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class MatchesAsWildcardMatch(string pattern) : TypedMatch<string>, IParameterMatches
 	{
 		private bool _caseSensitive;

--- a/Source/Mockolate/It.Satisfies.cs
+++ b/Source/Mockolate/It.Satisfies.cs
@@ -18,7 +18,7 @@ public partial class It
 		string doNotPopulateThisValue = "")
 		=> new SatisfiesPredicateMatch<T>(predicate, doNotPopulateThisValue);
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class SatisfiesPredicateMatch<T>(Func<T, bool> predicate, string predicateExpression) : TypedMatch<T>

--- a/Source/Mockolate/It.Satisfies.cs
+++ b/Source/Mockolate/It.Satisfies.cs
@@ -18,7 +18,9 @@ public partial class It
 		string doNotPopulateThisValue = "")
 		=> new SatisfiesPredicateMatch<T>(predicate, doNotPopulateThisValue);
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class SatisfiesPredicateMatch<T>(Func<T, bool> predicate, string predicateExpression) : TypedMatch<T>
 	{
 		protected override bool Matches(T value) => predicate(value);

--- a/Source/Mockolate/It.cs
+++ b/Source/Mockolate/It.cs
@@ -11,7 +11,9 @@ namespace Mockolate;
 /// <summary>
 ///     Specify a matching condition for a parameter.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public partial class It
 {
 	/// <summary>
@@ -26,7 +28,9 @@ public partial class It
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private abstract class TypedMatch<T> : IParameter<T>, IParameter, ITypedParameter<T>
 	{
 		private List<Action<T>>? _callbacks;

--- a/Source/Mockolate/It.cs
+++ b/Source/Mockolate/It.cs
@@ -11,7 +11,7 @@ namespace Mockolate;
 /// <summary>
 ///     Specify a matching condition for a parameter.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public partial class It
@@ -28,7 +28,7 @@ public partial class It
 	/// <summary>
 	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private abstract class TypedMatch<T> : IParameter<T>, IParameter, ITypedParameter<T>

--- a/Source/Mockolate/Match.AnyParameters.cs
+++ b/Source/Mockolate/Match.AnyParameters.cs
@@ -12,7 +12,9 @@ public partial class Match
 	public static IParameters AnyParameters()
 		=> new AnyParametersMatch();
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class AnyParametersMatch : IParameters
 	{
 		/// <inheritdoc cref="IParameters.Matches" />

--- a/Source/Mockolate/Match.AnyParameters.cs
+++ b/Source/Mockolate/Match.AnyParameters.cs
@@ -12,7 +12,7 @@ public partial class Match
 	public static IParameters AnyParameters()
 		=> new AnyParametersMatch();
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class AnyParametersMatch : IParameters

--- a/Source/Mockolate/Match.Parameters.cs
+++ b/Source/Mockolate/Match.Parameters.cs
@@ -16,7 +16,9 @@ public partial class Match
 		string doNotPopulateThisValue = "")
 		=> new ParametersMatch(predicate, doNotPopulateThisValue);
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class ParametersMatch(Func<INamedParameterValue[], bool> predicate, string predicateExpression) : IParameters
 	{
 		/// <inheritdoc cref="IParameters.Matches" />

--- a/Source/Mockolate/Match.Parameters.cs
+++ b/Source/Mockolate/Match.Parameters.cs
@@ -16,7 +16,7 @@ public partial class Match
 		string doNotPopulateThisValue = "")
 		=> new ParametersMatch(predicate, doNotPopulateThisValue);
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class ParametersMatch(Func<INamedParameterValue[], bool> predicate, string predicateExpression) : IParameters

--- a/Source/Mockolate/Match.WithDefaultParameters.cs
+++ b/Source/Mockolate/Match.WithDefaultParameters.cs
@@ -12,7 +12,9 @@ public partial class Match
 	public static IDefaultEventParameters WithDefaultParameters()
 		=> new DefaultEventParameters();
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	private sealed class DefaultEventParameters : IDefaultEventParameters
 	{
 		/// <inheritdoc cref="object.ToString()" />

--- a/Source/Mockolate/Match.WithDefaultParameters.cs
+++ b/Source/Mockolate/Match.WithDefaultParameters.cs
@@ -12,7 +12,7 @@ public partial class Match
 	public static IDefaultEventParameters WithDefaultParameters()
 		=> new DefaultEventParameters();
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	private sealed class DefaultEventParameters : IDefaultEventParameters

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -7,7 +7,9 @@ namespace Mockolate;
 /// <summary>
 ///     Specify a matching condition for a list of parameter.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public partial class Match
 {
 	/// <summary>

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -7,7 +7,7 @@ namespace Mockolate;
 /// <summary>
 ///     Specify a matching condition for a list of parameter.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public partial class Match

--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -10,7 +10,9 @@ namespace Mockolate;
 /// <summary>
 ///     The behavior of the mock.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public record MockBehavior : IMockBehaviorAccess
 {
 	private ConcurrentStack<IConstructorParameters>? _constructorParameters;

--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -10,7 +10,7 @@ namespace Mockolate;
 /// <summary>
 ///     The behavior of the mock.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public record MockBehavior : IMockBehaviorAccess

--- a/Source/Mockolate/MockBehaviorExtensions.cs
+++ b/Source/Mockolate/MockBehaviorExtensions.cs
@@ -6,7 +6,9 @@ namespace Mockolate;
 /// <summary>
 ///     Extension methods for <see cref="MockBehavior" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public static class MockBehaviorExtensions
 {
 	/// <inheritdoc cref="MockBehaviorExtensions" />

--- a/Source/Mockolate/MockBehaviorExtensions.cs
+++ b/Source/Mockolate/MockBehaviorExtensions.cs
@@ -6,7 +6,7 @@ namespace Mockolate;
 /// <summary>
 ///     Extension methods for <see cref="MockBehavior" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public static class MockBehaviorExtensions

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -11,7 +11,7 @@ namespace Mockolate;
 ///     It also gives access to constructor parameters and the wrapped instance.
 /// </remarks>
 [DebuggerDisplay("{Interactions} | {Setup}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public partial class MockRegistry

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -11,7 +11,9 @@ namespace Mockolate;
 ///     It also gives access to constructor parameters and the wrapped instance.
 /// </remarks>
 [DebuggerDisplay("{Interactions} | {Setup}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public partial class MockRegistry
 {
 	/// <inheritdoc cref="MockRegistry" />

--- a/Source/Mockolate/Monitor/MockMonitor.cs
+++ b/Source/Mockolate/Monitor/MockMonitor.cs
@@ -14,7 +14,7 @@ namespace Mockolate.Monitor;
 ///     which events were subscribed to, during a test session. Monitoring is session-based; begin a session with the Run
 ///     method and dispose the returned scope to finalize monitoring.
 /// </remarks>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public abstract class MockMonitor
@@ -107,7 +107,7 @@ public abstract class MockMonitor
 ///     Monitoring is session-based: begin a session with the <see cref="MockMonitor.Run()" /> method and
 ///     dispose the returned scope to finalize monitoring.
 /// </remarks>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public sealed class MockMonitor<T> : MockMonitor

--- a/Source/Mockolate/Monitor/MockMonitor.cs
+++ b/Source/Mockolate/Monitor/MockMonitor.cs
@@ -14,7 +14,9 @@ namespace Mockolate.Monitor;
 ///     which events were subscribed to, during a test session. Monitoring is session-based; begin a session with the Run
 ///     method and dispose the returned scope to finalize monitoring.
 /// </remarks>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public abstract class MockMonitor
 {
 	private readonly MockInteractions _monitoredInteractions;
@@ -105,7 +107,9 @@ public abstract class MockMonitor
 ///     Monitoring is session-based: begin a session with the <see cref="MockMonitor.Run()" /> method and
 ///     dispose the returned scope to finalize monitoring.
 /// </remarks>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public sealed class MockMonitor<T> : MockMonitor
 {
 	/// <inheritdoc cref="MockMonitor{T}" />

--- a/Source/Mockolate/ParameterExtensions.cs
+++ b/Source/Mockolate/ParameterExtensions.cs
@@ -7,7 +7,7 @@ namespace Mockolate;
 /// <summary>
 ///     Extension methods for <see cref="IParameter" />s.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public static class ParameterExtensions

--- a/Source/Mockolate/ParameterExtensions.cs
+++ b/Source/Mockolate/ParameterExtensions.cs
@@ -7,7 +7,9 @@ namespace Mockolate;
 /// <summary>
 ///     Extension methods for <see cref="IParameter" />s.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public static class ParameterExtensions
 {
 	/// <summary>

--- a/Source/Mockolate/Parameters/NamedParameter.cs
+++ b/Source/Mockolate/Parameters/NamedParameter.cs
@@ -8,7 +8,7 @@ namespace Mockolate.Parameters;
 /// </summary>
 /// <param name="Name">The name of the <paramref name="Parameter" />.</param>
 /// <param name="Parameter">The actual <see cref="IParameter" />.</param>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public record NamedParameter(string Name, IParameter Parameter)

--- a/Source/Mockolate/Parameters/NamedParameter.cs
+++ b/Source/Mockolate/Parameters/NamedParameter.cs
@@ -8,7 +8,9 @@ namespace Mockolate.Parameters;
 /// </summary>
 /// <param name="Name">The name of the <paramref name="Parameter" />.</param>
 /// <param name="Parameter">The actual <see cref="IParameter" />.</param>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public record NamedParameter(string Name, IParameter Parameter)
 {
 	/// <inheritdoc cref="object.ToString()" />

--- a/Source/Mockolate/Parameters/NamedParameterValue.cs
+++ b/Source/Mockolate/Parameters/NamedParameterValue.cs
@@ -9,7 +9,7 @@ namespace Mockolate.Parameters;
 /// </summary>
 /// <param name="Name">The name of the parameter.</param>
 /// <param name="Value">The parameter value.</param>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public record NamedParameterValue<T>(

--- a/Source/Mockolate/Parameters/NamedParameterValue.cs
+++ b/Source/Mockolate/Parameters/NamedParameterValue.cs
@@ -9,7 +9,9 @@ namespace Mockolate.Parameters;
 /// </summary>
 /// <param name="Name">The name of the parameter.</param>
 /// <param name="Value">The parameter value.</param>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public record NamedParameterValue<T>(
 	string Name,
 	T Value) : INamedParameterValue

--- a/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
+++ b/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
@@ -9,7 +9,9 @@ namespace Mockolate;
 /// <summary>
 ///     Extensions for setting up return values and throwing exceptions for <see langword="async" /> methods.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public static class ReturnsThrowsAsyncExtensions
 {
 	/// <summary>

--- a/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
+++ b/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
@@ -9,7 +9,7 @@ namespace Mockolate;
 /// <summary>
 ///     Extensions for setting up return values and throwing exceptions for <see langword="async" /> methods.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public static class ReturnsThrowsAsyncExtensions

--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -8,7 +8,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A callback wrapper that allows conditional invocation based on predicates.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class Callback
 {
 	private int? _forTimes;
@@ -98,7 +100,9 @@ public class Callback
 /// <summary>
 ///     A callback wrapper for the <paramref name="delegate" /> that allows conditional invocation based on predicates.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate : Delegate
 {
 	private int _forIterationCount;

--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -8,7 +8,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A callback wrapper that allows conditional invocation based on predicates.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class Callback
@@ -100,7 +100,7 @@ public class Callback
 /// <summary>
 ///     A callback wrapper for the <paramref name="delegate" /> that allows conditional invocation based on predicates.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate : Delegate

--- a/Source/Mockolate/Setup/EventSetup.cs
+++ b/Source/Mockolate/Setup/EventSetup.cs
@@ -10,7 +10,9 @@ namespace Mockolate.Setup;
 ///     Sets up event subscription and unsubscription callbacks.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class EventSetup(string name) : IEventSetup,
 	IEventSubscriptionSetup, IEventUnsubscriptionSetup,
 	IEventSetupCallbackBuilder, IEventSetupCallbackWhenBuilder

--- a/Source/Mockolate/Setup/EventSetup.cs
+++ b/Source/Mockolate/Setup/EventSetup.cs
@@ -10,7 +10,7 @@ namespace Mockolate.Setup;
 ///     Sets up event subscription and unsubscription callbacks.
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class EventSetup(string name) : IEventSetup,

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -12,7 +12,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for indexer setups.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public abstract class IndexerSetup : IInteractiveIndexerSetup
 {
 	/// <inheritdoc cref="IInteractiveIndexerSetup.Matches(IndexerAccess)" />
@@ -128,7 +130,9 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 /// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
 	IIndexerSetupCallbackBuilder<TValue, T1>, IIndexerSetupReturnBuilder<TValue, T1>,
 	IIndexerGetterSetup<TValue, T1>, IIndexerSetterSetup<TValue, T1>
@@ -570,7 +574,9 @@ public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
 /// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and <typeparamref name="T2" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerSetup<TValue, T1, T2>(NamedParameter match1, NamedParameter match2) : IndexerSetup
 	, IIndexerSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetupReturnBuilder<TValue, T1, T2>,
 	IIndexerGetterSetup<TValue, T1, T2>, IIndexerSetterSetup<TValue, T1, T2>
@@ -1019,7 +1025,9 @@ public class IndexerSetup<TValue, T1, T2>(NamedParameter match1, NamedParameter 
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />, <typeparamref name="T2" /> and
 ///     <typeparamref name="T3" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerSetup<TValue, T1, T2, T3>(
 	NamedParameter match1,
 	NamedParameter match2,
@@ -1479,7 +1487,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />,
 ///     <typeparamref name="T3" /> and <typeparamref name="T4" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	NamedParameter match1,
 	NamedParameter match2,

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -12,7 +12,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for indexer setups.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public abstract class IndexerSetup : IInteractiveIndexerSetup
@@ -130,7 +130,7 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 /// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
@@ -574,7 +574,7 @@ public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
 /// <summary>
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and <typeparamref name="T2" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetup<TValue, T1, T2>(NamedParameter match1, NamedParameter match2) : IndexerSetup
@@ -1025,7 +1025,7 @@ public class IndexerSetup<TValue, T1, T2>(NamedParameter match1, NamedParameter 
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />, <typeparamref name="T2" /> and
 ///     <typeparamref name="T3" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetup<TValue, T1, T2, T3>(
@@ -1487,7 +1487,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 ///     Sets up a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />,
 ///     <typeparamref name="T3" /> and <typeparamref name="T4" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetup<TValue, T1, T2, T3, T4>(

--- a/Source/Mockolate/Setup/IndexerSetupResult.cs
+++ b/Source/Mockolate/Setup/IndexerSetupResult.cs
@@ -10,7 +10,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A result of an indexer setup.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetupResult(IInteractiveIndexerSetup? setup, MockBehavior behavior)
@@ -25,7 +25,7 @@ public class IndexerSetupResult(IInteractiveIndexerSetup? setup, MockBehavior be
 /// <summary>
 ///     A result of an indexer setup with return type <typeparamref name="TResult" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetupResult<TResult>(

--- a/Source/Mockolate/Setup/IndexerSetupResult.cs
+++ b/Source/Mockolate/Setup/IndexerSetupResult.cs
@@ -10,7 +10,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A result of an indexer setup.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerSetupResult(IInteractiveIndexerSetup? setup, MockBehavior behavior)
 {
 	/// <summary>
@@ -23,7 +25,9 @@ public class IndexerSetupResult(IInteractiveIndexerSetup? setup, MockBehavior be
 /// <summary>
 ///     A result of an indexer setup with return type <typeparamref name="TResult" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class IndexerSetupResult<TResult>(
 	IInteractiveIndexerSetup? setup,
 	IndexerGetterAccess indexerAccess,

--- a/Source/Mockolate/Setup/MethodParameterMatch.cs
+++ b/Source/Mockolate/Setup/MethodParameterMatch.cs
@@ -15,7 +15,7 @@ namespace Mockolate.Setup;
 ///     and the <paramref name="parameters" /> are matched one by one against the corresponding parameter in the method
 ///     invocation.
 /// </remarks>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public readonly struct MethodParameterMatch(string methodName, NamedParameter[] parameters)

--- a/Source/Mockolate/Setup/MethodParameterMatch.cs
+++ b/Source/Mockolate/Setup/MethodParameterMatch.cs
@@ -15,7 +15,9 @@ namespace Mockolate.Setup;
 ///     and the <paramref name="parameters" /> are matched one by one against the corresponding parameter in the method
 ///     invocation.
 /// </remarks>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public readonly struct MethodParameterMatch(string methodName, NamedParameter[] parameters)
 	: IMethodMatch, ITypedMethodMatch
 {

--- a/Source/Mockolate/Setup/MethodParametersMatch.cs
+++ b/Source/Mockolate/Setup/MethodParametersMatch.cs
@@ -12,7 +12,7 @@ namespace Mockolate.Setup;
 ///     During verification, the <paramref name="methodName" /> is compared to the method name of the method invocation,
 ///     and the <paramref name="parameters" /> are matched against the parameters in the method invocation.
 /// </remarks>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public readonly struct MethodParametersMatch(string methodName, IParameters parameters) : IMethodMatch

--- a/Source/Mockolate/Setup/MethodParametersMatch.cs
+++ b/Source/Mockolate/Setup/MethodParametersMatch.cs
@@ -12,7 +12,9 @@ namespace Mockolate.Setup;
 ///     During verification, the <paramref name="methodName" /> is compared to the method name of the method invocation,
 ///     and the <paramref name="parameters" /> are matched against the parameters in the method invocation.
 /// </remarks>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public readonly struct MethodParametersMatch(string methodName, IParameters parameters) : IMethodMatch
 {
 	/// <inheritdoc cref="IMethodMatch.Matches(MethodInvocation)" />

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -10,7 +10,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for method setups.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public abstract class MethodSetup(IMethodMatch methodMatch) : IInteractiveMethodSetup, IVerifiableMethodSetup
 {
 	/// <summary>

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -10,7 +10,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for method setups.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public abstract class MethodSetup(IMethodMatch methodMatch) : IInteractiveMethodSetup, IVerifiableMethodSetup

--- a/Source/Mockolate/Setup/MethodSetupResult.cs
+++ b/Source/Mockolate/Setup/MethodSetupResult.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A result of a method setup invocation.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class MethodSetupResult(IInteractiveMethodSetup? setup, MockBehavior behavior)
@@ -66,7 +66,7 @@ public class MethodSetupResult(IInteractiveMethodSetup? setup, MockBehavior beha
 /// <summary>
 ///     A result of a method setup invocation with return type <typeparamref name="TResult" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class MethodSetupResult<TResult>(IInteractiveMethodSetup? setup, MockBehavior behavior, TResult result)

--- a/Source/Mockolate/Setup/MethodSetupResult.cs
+++ b/Source/Mockolate/Setup/MethodSetupResult.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     A result of a method setup invocation.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class MethodSetupResult(IInteractiveMethodSetup? setup, MockBehavior behavior)
 {
 	/// <summary>
@@ -64,7 +66,9 @@ public class MethodSetupResult(IInteractiveMethodSetup? setup, MockBehavior beha
 /// <summary>
 ///     A result of a method setup invocation with return type <typeparamref name="TResult" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class MethodSetupResult<TResult>(IInteractiveMethodSetup? setup, MockBehavior behavior, TResult result)
 	: MethodSetupResult(setup, behavior)
 {

--- a/Source/Mockolate/Setup/MockSetups.Events.cs
+++ b/Source/Mockolate/Setup/MockSetups.Events.cs
@@ -10,7 +10,7 @@ internal partial class MockSetups
 	internal EventSetups Events { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	internal sealed class EventSetups

--- a/Source/Mockolate/Setup/MockSetups.Events.cs
+++ b/Source/Mockolate/Setup/MockSetups.Events.cs
@@ -10,7 +10,9 @@ internal partial class MockSetups
 	internal EventSetups Events { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	internal sealed class EventSetups
 	{
 		private int _count;

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -15,7 +15,7 @@ internal partial class MockSetups
 	internal IndexerSetups Indexers { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	internal sealed class IndexerSetups

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -15,7 +15,9 @@ internal partial class MockSetups
 	internal IndexerSetups Indexers { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	internal sealed class IndexerSetups
 	{
 		private List<IndexerSetup>? _storage;

--- a/Source/Mockolate/Setup/MockSetups.Methods.cs
+++ b/Source/Mockolate/Setup/MockSetups.Methods.cs
@@ -14,7 +14,7 @@ internal partial class MockSetups
 	internal MethodSetups Methods { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	internal sealed class MethodSetups

--- a/Source/Mockolate/Setup/MockSetups.Methods.cs
+++ b/Source/Mockolate/Setup/MockSetups.Methods.cs
@@ -14,7 +14,9 @@ internal partial class MockSetups
 	internal MethodSetups Methods { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	internal sealed class MethodSetups
 	{
 		private List<MethodSetup>? _storage;

--- a/Source/Mockolate/Setup/MockSetups.Properties.cs
+++ b/Source/Mockolate/Setup/MockSetups.Properties.cs
@@ -14,7 +14,9 @@ internal partial class MockSetups
 	internal PropertySetups Properties { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	internal sealed class PropertySetups
 	{
 		private int _count;

--- a/Source/Mockolate/Setup/MockSetups.Properties.cs
+++ b/Source/Mockolate/Setup/MockSetups.Properties.cs
@@ -14,7 +14,7 @@ internal partial class MockSetups
 	internal PropertySetups Properties { get; } = new();
 
 	[DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	internal sealed class PropertySetups

--- a/Source/Mockolate/Setup/MockSetups.cs
+++ b/Source/Mockolate/Setup/MockSetups.cs
@@ -5,7 +5,9 @@ using System.Text;
 namespace Mockolate.Setup;
 
 [DebuggerDisplay("{ToString()}")]
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 internal partial class MockSetups
 {
 	/// <inheritdoc cref="object.ToString()" />

--- a/Source/Mockolate/Setup/MockSetups.cs
+++ b/Source/Mockolate/Setup/MockSetups.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Mockolate.Setup;
 
 [DebuggerDisplay("{ToString()}")]
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 internal partial class MockSetups

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -11,7 +11,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for property setups.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public abstract class PropertySetup : IInteractivePropertySetup
@@ -72,7 +72,7 @@ public abstract class PropertySetup : IInteractivePropertySetup
 	/// </summary>
 	protected abstract TResult InvokeGetter<TResult>(MockBehavior behavior, Func<TResult> defaultValueGenerator);
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	internal abstract class Default(string name) : PropertySetup
@@ -98,7 +98,7 @@ public abstract class PropertySetup : IInteractivePropertySetup
 			=> name.Equals(propertyAccess.Name);
 	}
 
-#if RELEASE
+#if !DEBUG
 	[DebuggerNonUserCode]
 #endif
 	internal sealed class Default<T>(string name, T initialValue) : Default(name)
@@ -144,7 +144,7 @@ public abstract class PropertySetup : IInteractivePropertySetup
 /// <summary>
 ///     Sets up a property.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class PropertySetup<T>(string name) : PropertySetup,

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -11,7 +11,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Base class for property setups.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public abstract class PropertySetup : IInteractivePropertySetup
 {
 	/// <summary>
@@ -70,7 +72,9 @@ public abstract class PropertySetup : IInteractivePropertySetup
 	/// </summary>
 	protected abstract TResult InvokeGetter<TResult>(MockBehavior behavior, Func<TResult> defaultValueGenerator);
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	internal abstract class Default(string name) : PropertySetup
 	{
 		/// <inheritdoc cref="PropertySetup.Name" />
@@ -94,7 +98,9 @@ public abstract class PropertySetup : IInteractivePropertySetup
 			=> name.Equals(propertyAccess.Name);
 	}
 
+#if RELEASE
 	[DebuggerNonUserCode]
+#endif
 	internal sealed class Default<T>(string name, T initialValue) : Default(name)
 	{
 		private T _value = initialValue;
@@ -138,7 +144,9 @@ public abstract class PropertySetup : IInteractivePropertySetup
 /// <summary>
 ///     Sets up a property.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class PropertySetup<T>(string name) : PropertySetup,
 	IPropertySetupCallbackBuilder<T>, IPropertySetupReturnBuilder<T>,
 	IPropertyGetterSetup<T>, IPropertySetterSetup<T>

--- a/Source/Mockolate/Setup/ReadOnlySpanWrapper.cs
+++ b/Source/Mockolate/Setup/ReadOnlySpanWrapper.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Wraps a <see cref="ReadOnlySpan{T}" /> of <typeparamref name="T" /> to be used as a generic type parameter.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class ReadOnlySpanWrapper<T>
 {
 	/// <inheritdoc cref="ReadOnlySpanWrapper{T}" />

--- a/Source/Mockolate/Setup/ReadOnlySpanWrapper.cs
+++ b/Source/Mockolate/Setup/ReadOnlySpanWrapper.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Wraps a <see cref="ReadOnlySpan{T}" /> of <typeparamref name="T" /> to be used as a generic type parameter.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class ReadOnlySpanWrapper<T>

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -11,7 +11,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Sets up a method returning <typeparamref name="TReturn" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class ReturnMethodSetup<TReturn>(string name)
@@ -266,7 +266,7 @@ public class ReturnMethodSetup<TReturn>(string name)
 /// <summary>
 ///     Setup for a method with one parameter <typeparamref name="T1" /> returning <typeparamref name="TReturn" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
@@ -616,7 +616,7 @@ public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 ///     Setup for a method with two parameters <typeparamref name="T1" /> and <typeparamref name="T2" /> returning
 ///     <typeparamref name="TReturn" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
@@ -977,7 +977,7 @@ public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 ///     Setup for a method with three parameters <typeparamref name="T1" />, <typeparamref name="T2" /> and
 ///     <typeparamref name="T3" /> returning <typeparamref name="TReturn" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
@@ -1353,7 +1353,7 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 ///     Setup for a method with four parameters <typeparamref name="T1" />, <typeparamref name="T2" />,
 ///     <typeparamref name="T3" /> and <typeparamref name="T4" /> returning <typeparamref name="TReturn" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -11,7 +11,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Sets up a method returning <typeparamref name="TReturn" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class ReturnMethodSetup<TReturn>(string name)
 	: MethodSetup(new MethodParameterMatch(name, [])),
 		IReturnMethodSetupCallbackBuilder<TReturn>, IReturnMethodSetupReturnBuilder<TReturn>
@@ -264,7 +266,9 @@ public class ReturnMethodSetup<TReturn>(string name)
 /// <summary>
 ///     Setup for a method with one parameter <typeparamref name="T1" /> returning <typeparamref name="TReturn" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1>, IReturnMethodSetupReturnBuilder<TReturn, T1>, IReturnMethodSetupParameterIgnorer<TReturn, T1>
 {
@@ -612,7 +616,9 @@ public class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 ///     Setup for a method with two parameters <typeparamref name="T1" /> and <typeparamref name="T2" /> returning
 ///     <typeparamref name="TReturn" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>
 {
@@ -971,7 +977,9 @@ public class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 ///     Setup for a method with three parameters <typeparamref name="T1" />, <typeparamref name="T2" /> and
 ///     <typeparamref name="T3" /> returning <typeparamref name="TReturn" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>
 {
@@ -1345,7 +1353,9 @@ public class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 ///     Setup for a method with four parameters <typeparamref name="T1" />, <typeparamref name="T2" />,
 ///     <typeparamref name="T3" /> and <typeparamref name="T4" /> returning <typeparamref name="TReturn" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>
 {

--- a/Source/Mockolate/Setup/SpanWrapper.cs
+++ b/Source/Mockolate/Setup/SpanWrapper.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Wraps a <see cref="Span{T}" /> of <typeparamref name="T" /> to be used as a generic type parameter.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class SpanWrapper<T>

--- a/Source/Mockolate/Setup/SpanWrapper.cs
+++ b/Source/Mockolate/Setup/SpanWrapper.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Wraps a <see cref="Span{T}" /> of <typeparamref name="T" /> to be used as a generic type parameter.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class SpanWrapper<T>
 {
 	/// <inheritdoc cref="SpanWrapper{T}" />

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -11,7 +11,9 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Sets up a method returning <see langword="void" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VoidMethodSetup(string name)
 	: MethodSetup(new MethodParameterMatch(name, [])),
 		IVoidMethodSetupCallbackBuilder, IVoidMethodSetupReturnBuilder
@@ -227,7 +229,9 @@ public class VoidMethodSetup(string name)
 /// <summary>
 ///     Setup for a method with one parameter <typeparamref name="T1" /> returning <see langword="void" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1>, IVoidMethodSetupReturnBuilder<T1>, IVoidMethodSetupParameterIgnorer<T1>
 {
@@ -518,7 +522,9 @@ public class VoidMethodSetup<T1> : MethodSetup,
 ///     Setup for a method with two parameters <typeparamref name="T1" /> and <typeparamref name="T2" /> returning
 ///     <see langword="void" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2>, IVoidMethodSetupReturnBuilder<T1, T2>, IVoidMethodSetupParameterIgnorer<T1, T2>
 {
@@ -812,7 +818,9 @@ public class VoidMethodSetup<T1, T2> : MethodSetup,
 ///     Setup for a method with three parameters <typeparamref name="T1" />, <typeparamref name="T2" /> and
 ///     <typeparamref name="T3" /> returning <see langword="void" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3>, IVoidMethodSetupReturnBuilder<T1, T2, T3>, IVoidMethodSetupParameterIgnorer<T1, T2, T3>
 {
@@ -1115,7 +1123,9 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 ///     Setup for a method with four parameters <typeparamref name="T1" />, <typeparamref name="T2" />,
 ///     <typeparamref name="T3" /> and <typeparamref name="T4" /> returning <see langword="void" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>
 {

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -11,7 +11,7 @@ namespace Mockolate.Setup;
 /// <summary>
 ///     Sets up a method returning <see langword="void" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VoidMethodSetup(string name)
@@ -229,7 +229,7 @@ public class VoidMethodSetup(string name)
 /// <summary>
 ///     Setup for a method with one parameter <typeparamref name="T1" /> returning <see langword="void" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VoidMethodSetup<T1> : MethodSetup,
@@ -522,7 +522,7 @@ public class VoidMethodSetup<T1> : MethodSetup,
 ///     Setup for a method with two parameters <typeparamref name="T1" /> and <typeparamref name="T2" /> returning
 ///     <see langword="void" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VoidMethodSetup<T1, T2> : MethodSetup,
@@ -818,7 +818,7 @@ public class VoidMethodSetup<T1, T2> : MethodSetup,
 ///     Setup for a method with three parameters <typeparamref name="T1" />, <typeparamref name="T2" /> and
 ///     <typeparamref name="T3" /> returning <see langword="void" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
@@ -1123,7 +1123,7 @@ public class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 ///     Setup for a method with four parameters <typeparamref name="T1" />, <typeparamref name="T2" />,
 ///     <typeparamref name="T3" /> and <typeparamref name="T4" /> returning <see langword="void" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -6,7 +6,9 @@ namespace Mockolate;
 /// <summary>
 ///     Extensions for indexer, property and method setups.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public static class SetupExtensions
 {
 	/// <summary>

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -6,7 +6,7 @@ namespace Mockolate;
 /// <summary>
 ///     Extensions for indexer, property and method setups.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public static class SetupExtensions

--- a/Source/Mockolate/Verify/VerificationEventResult.cs
+++ b/Source/Mockolate/Verify/VerificationEventResult.cs
@@ -5,7 +5,9 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Verifications on an event.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VerificationEventResult<TSubject>
 {
 	private readonly string _name;

--- a/Source/Mockolate/Verify/VerificationEventResult.cs
+++ b/Source/Mockolate/Verify/VerificationEventResult.cs
@@ -5,7 +5,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Verifications on an event.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VerificationEventResult<TSubject>

--- a/Source/Mockolate/Verify/VerificationIndexerResult.cs
+++ b/Source/Mockolate/Verify/VerificationIndexerResult.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Verifications on an indexer of type <typeparamref name="TParameter" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VerificationIndexerResult<TSubject, TParameter>
 {
 	private readonly MockRegistry _mockRegistry;

--- a/Source/Mockolate/Verify/VerificationIndexerResult.cs
+++ b/Source/Mockolate/Verify/VerificationIndexerResult.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Verifications on an indexer of type <typeparamref name="TParameter" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VerificationIndexerResult<TSubject, TParameter>

--- a/Source/Mockolate/Verify/VerificationPropertyResult.cs
+++ b/Source/Mockolate/Verify/VerificationPropertyResult.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Verifications on a property of type <typeparamref name="TParameter" />.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VerificationPropertyResult<TSubject, TParameter>

--- a/Source/Mockolate/Verify/VerificationPropertyResult.cs
+++ b/Source/Mockolate/Verify/VerificationPropertyResult.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Verifications on a property of type <typeparamref name="TParameter" />.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VerificationPropertyResult<TSubject, TParameter>
 {
 	private readonly MockRegistry _mockRegistry;

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -11,7 +11,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     The result of a verification containing the matching interactions.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerificationResult

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -11,7 +11,9 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     The result of a verification containing the matching interactions.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerificationResult
 {
 	private readonly Func<string> _expectationFactory;

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -11,7 +11,9 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     The expectation contains the matching interactions for verification.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public static class VerificationResultExtensions
 {
 	private static string ToTimes(this int amount, string verb = "")

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -11,7 +11,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     The expectation contains the matching interactions for verification.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public static class VerificationResultExtensions

--- a/Source/Mockolate/Verify/VerificationResultParameterIgnorer.cs
+++ b/Source/Mockolate/Verify/VerificationResultParameterIgnorer.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Represents the result of a verification that contains the matching interactions and allows ignoring explicit parameters.
 /// </summary>
-#if RELEASE
+#if !DEBUG
 [DebuggerNonUserCode]
 #endif
 public class VerificationResultParameterIgnorer<TVerify> : VerificationResult<TVerify>

--- a/Source/Mockolate/Verify/VerificationResultParameterIgnorer.cs
+++ b/Source/Mockolate/Verify/VerificationResultParameterIgnorer.cs
@@ -7,7 +7,9 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Represents the result of a verification that contains the matching interactions and allows ignoring explicit parameters.
 /// </summary>
+#if RELEASE
 [DebuggerNonUserCode]
+#endif
 public class VerificationResultParameterIgnorer<TVerify> : VerificationResult<TVerify>
 {
 	private readonly Func<VerificationResult<TVerify>> _anyParametersFactory;


### PR DESCRIPTION
This PR updates Mockolate’s library and generator code to conditionally apply the `DebuggerNonUserCode` attribute so it can be omitted during debugging-focused builds.

**Changes:**
- Wrapped most `[DebuggerNonUserCode]` attributes in `#if !DEBUG` / `#endif` across the main library.
- Updated source-generator templates to conditionally emit `[DebuggerNonUserCode]` in generated sources.
- Refactored some generator string-building blocks to accommodate conditional emission.