### PR TITLE
refactor!: introduce ITypedIndexerMatch interfaces to avoid boxing for indexer parameters

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1201,16 +1201,15 @@ internal static partial class Sources
 
 					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is not ").Append(className).Append(" wraps)").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\treturn ").Append(mockRegistry).Append(".GetIndexer<").AppendTypeOrWrapper(property.Type)
-						.Append(">(").Append(FormatIndexerParametersAsNameOrWrapper(property.IndexerParameters.Value))
-						.Append(").GetResult(() => ")
+					sb.Append("\t\t\t\t\treturn ").Append(mockRegistry);
+					AppendGetIndexerCall(sb, property.Type, property.IndexerParameters.Value);
+					sb.Append(".GetResult(() => ")
 						.AppendDefaultValueGeneratorFor(property.Type, $"this.{mockRegistryName}.Behavior.DefaultValue")
 						.Append(");").AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
-					sb.Append("\t\t\t\tvar ").Append(indexerResultVarName).Append(" = this.").Append(mockRegistryName).Append(".GetIndexer<")
-						.AppendTypeOrWrapper(property.Type).Append(">(")
-						.Append(FormatIndexerParametersAsNameOrWrapper(property.IndexerParameters.Value))
-						.AppendLine(");");
+					sb.Append("\t\t\t\tvar ").Append(indexerResultVarName).Append(" = this.").Append(mockRegistryName);
+					AppendGetIndexerCall(sb, property.Type, property.IndexerParameters.Value);
+					sb.AppendLine(";");
 					sb.Append("\t\t\t\tvar ").Append(baseResultVarName).Append(" = wraps[")
 						.Append(FormatIndexerParametersAsNames(property.IndexerParameters.Value)).Append("];")
 						.AppendLine();
@@ -1243,10 +1242,9 @@ internal static partial class Sources
 						Helpers.GetUniqueLocalVariableName("indexerResult", property.IndexerParameters.Value);
 					string baseResultVarName =
 						Helpers.GetUniqueLocalVariableName("baseResult", property.IndexerParameters.Value);
-					sb.Append("\t\t\t\tvar ").Append(indexerResultVarName).Append(" = this.").Append(mockRegistryName).Append(".GetIndexer<")
-						.AppendTypeOrWrapper(property.Type).Append(">(")
-						.Append(FormatIndexerParametersAsNameOrWrapper(property.IndexerParameters.Value))
-						.AppendLine(");");
+					sb.Append("\t\t\t\tvar ").Append(indexerResultVarName).Append(" = this.").Append(mockRegistryName);
+					AppendGetIndexerCall(sb, property.Type, property.IndexerParameters.Value);
+					sb.AppendLine(";");
 					sb.Append("\t\t\t\tif (!").Append(indexerResultVarName).Append(".SkipBaseClass)").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					if (property.Getter?.IsProtected != true)
@@ -1292,10 +1290,9 @@ internal static partial class Sources
 			}
 			else if (property is { IsIndexer: true, IndexerParameters: not null, })
 			{
-				sb.Append("\t\t\t\treturn this.").Append(mockRegistryName).Append(".GetIndexer<")
-					.AppendTypeOrWrapper(property.Type).Append(">(")
-					.Append(FormatIndexerParametersAsNameOrWrapper(property.IndexerParameters.Value))
-					.Append(").GetResult(() => ")
+				sb.Append("\t\t\t\treturn this.").Append(mockRegistryName);
+				AppendGetIndexerCall(sb, property.Type, property.IndexerParameters.Value);
+				sb.Append(".GetResult(() => ")
 					.AppendDefaultValueGeneratorFor(property.Type, $"this.{mockRegistryName}.Behavior.DefaultValue")
 					.Append(");").AppendLine();
 			}
@@ -1326,11 +1323,9 @@ internal static partial class Sources
 			{
 				if (property is { IsIndexer: true, IndexerParameters: not null, })
 				{
-					sb.Append("\t\t\t\tthis.").Append(mockRegistryName).Append(".SetIndexer<")
-						.Append(property.Type.Fullname)
-						.Append(">(value, ")
-						.Append(FormatIndexerParametersAsNameOrWrapper(property.IndexerParameters.Value))
-						.Append(");").AppendLine();
+					sb.Append("\t\t\t\tthis.").Append(mockRegistryName);
+					AppendSetIndexerCall(sb, property.Type, property.IndexerParameters.Value);
+					sb.Append(";").AppendLine();
 
 					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className).Append(" wraps)").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
@@ -1356,10 +1351,9 @@ internal static partial class Sources
 			{
 				if (!isClassInterface && !property.IsAbstract)
 				{
-					sb.Append("\t\t\t\tif (!this.").Append(mockRegistryName).Append(".SetIndexer<").Append(property.Type.Fullname)
-						.Append(">(value, ")
-						.Append(FormatIndexerParametersAsNameOrWrapper(property.IndexerParameters.Value)).Append("))")
-						.AppendLine();
+					sb.Append("\t\t\t\tif (!this.").Append(mockRegistryName);
+					AppendSetIndexerCall(sb, property.Type, property.IndexerParameters.Value);
+					sb.Append(")").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					if (property.Setter?.IsProtected != true)
 					{
@@ -1387,11 +1381,9 @@ internal static partial class Sources
 				}
 				else
 				{
-					sb.Append("\t\t\t\tthis.").Append(mockRegistryName).Append(".SetIndexer<")
-						.Append(property.Type.Fullname)
-						.Append(">(value, ")
-						.Append(FormatIndexerParametersAsNameOrWrapper(property.IndexerParameters.Value))
-						.AppendLine(");");
+					sb.Append("\t\t\t\tthis.").Append(mockRegistryName);
+					AppendSetIndexerCall(sb, property.Type, property.IndexerParameters.Value);
+					sb.AppendLine(";");
 				}
 			}
 			else

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Mockolate.SourceGenerators.Entities;
 using Mockolate.SourceGenerators.Internals;
+using Type = Mockolate.SourceGenerators.Entities.Type;
 
 namespace Mockolate.SourceGenerators.Sources;
 
@@ -87,15 +88,15 @@ internal static partial class Sources
 	///     and falling back to the <c>params INamedParameterValue[]</c> overload otherwise.
 	/// </summary>
 	private static void AppendGetIndexerCall(
-		StringBuilder sb, Entities.Type propertyType, EquatableArray<MethodParameter> parameters)
+		StringBuilder sb, Type propertyType, EquatableArray<MethodParameter> parameters)
 	{
 		bool useTypedOverload = parameters.Count is >= 1 and <= MaxExplicitParameters;
 		sb.Append(".GetIndexer<").AppendTypeOrWrapper(propertyType);
 		if (useTypedOverload)
 		{
-			foreach (MethodParameter p in parameters)
+			foreach (Type? type in parameters.Select(p => p.Type))
 			{
-				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+				sb.Append(", ").AppendTypeOrWrapper(type);
 			}
 		}
 
@@ -110,7 +111,7 @@ internal static partial class Sources
 					sb.Append(", ");
 				}
 
-				sb.Append('"').Append(p.Name).Append("\", ").Append(p.Name);
+				sb.Append('"').Append(p.Name).Append("\", ").Append(p.ToNameOrWrapper());
 				first = false;
 			}
 		}
@@ -127,15 +128,15 @@ internal static partial class Sources
 	///     and falling back to the <c>params INamedParameterValue[]</c> overload otherwise.
 	/// </summary>
 	private static void AppendSetIndexerCall(
-		StringBuilder sb, Entities.Type propertyType, EquatableArray<MethodParameter> parameters)
+		StringBuilder sb, Type propertyType, EquatableArray<MethodParameter> parameters)
 	{
 		bool useTypedOverload = parameters.Count is >= 1 and <= MaxExplicitParameters;
 		sb.Append(".SetIndexer<").Append(propertyType.Fullname);
 		if (useTypedOverload)
 		{
-			foreach (MethodParameter p in parameters)
+			foreach (Type? type in parameters.Select(p => p.Type))
 			{
-				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+				sb.Append(", ").AppendTypeOrWrapper(type);
 			}
 		}
 
@@ -150,7 +151,7 @@ internal static partial class Sources
 					sb.Append(", ");
 				}
 
-				sb.Append('"').Append(p.Name).Append("\", ").Append(p.Name);
+				sb.Append('"').Append(p.Name).Append("\", ").Append(p.ToNameOrWrapper());
 				first = false;
 			}
 		}
@@ -227,9 +228,13 @@ internal static partial class Sources
 		{
 			sb.Append(paramRef).Append(" is null ? \"null\" : ");
 			if (parameter.Type.IsFormattable)
+			{
 				sb.Append("((global::System.IFormattable)").Append(paramRef).Append(").ToString(null, global::System.Globalization.CultureInfo.InvariantCulture)");
+			}
 			else
+			{
 				sb.Append(paramRef).Append(".ToString()");
+			}
 		}
 		else if (parameter.Type.IsFormattable)
 		{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -83,6 +83,86 @@ internal static partial class Sources
 				=> $"new global::Mockolate.Parameters.NamedParameterValue<{p.ToTypeOrWrapper()}>(\"{p.Name}\", {p.ToNameOrWrapper()})"));
 
 	/// <summary>
+	///     Appends a typed <c>GetIndexer</c> call, using the typed overload for 1–4 parameters
+	///     and falling back to the <c>params INamedParameterValue[]</c> overload otherwise.
+	/// </summary>
+	private static void AppendGetIndexerCall(
+		StringBuilder sb, Entities.Type propertyType, EquatableArray<MethodParameter> parameters)
+	{
+		bool useTypedOverload = parameters.Count is >= 1 and <= MaxExplicitParameters;
+		sb.Append(".GetIndexer<").AppendTypeOrWrapper(propertyType);
+		if (useTypedOverload)
+		{
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+		}
+
+		sb.Append(">(");
+		if (useTypedOverload)
+		{
+			bool first = true;
+			foreach (MethodParameter p in parameters)
+			{
+				if (!first)
+				{
+					sb.Append(", ");
+				}
+
+				sb.Append('"').Append(p.Name).Append("\", ").Append(p.Name);
+				first = false;
+			}
+		}
+		else
+		{
+			sb.Append(FormatIndexerParametersAsNameOrWrapper(parameters));
+		}
+
+		sb.Append(')');
+	}
+
+	/// <summary>
+	///     Appends a typed <c>SetIndexer</c> call, using the typed overload for 1–4 parameters
+	///     and falling back to the <c>params INamedParameterValue[]</c> overload otherwise.
+	/// </summary>
+	private static void AppendSetIndexerCall(
+		StringBuilder sb, Entities.Type propertyType, EquatableArray<MethodParameter> parameters)
+	{
+		bool useTypedOverload = parameters.Count is >= 1 and <= MaxExplicitParameters;
+		sb.Append(".SetIndexer<").Append(propertyType.Fullname);
+		if (useTypedOverload)
+		{
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+		}
+
+		sb.Append(">(value, ");
+		if (useTypedOverload)
+		{
+			bool first = true;
+			foreach (MethodParameter p in parameters)
+			{
+				if (!first)
+				{
+					sb.Append(", ");
+				}
+
+				sb.Append('"').Append(p.Name).Append("\", ").Append(p.Name);
+				first = false;
+			}
+		}
+		else
+		{
+			sb.Append(FormatIndexerParametersAsNameOrWrapper(parameters));
+		}
+
+		sb.Append(')');
+	}
+
+	/// <summary>
 	///     Formats indexer parameters as comma-separated names.
 	/// </summary>
 	private static string FormatIndexerParametersAsNames(EquatableArray<MethodParameter> parameters)

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -434,6 +434,80 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Gets the value from the indexer with one typed parameter.
+	///     Matching runs against the typed value directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public IndexerSetupResult<TResult> GetIndexer<TResult, T1>(string p1Name, T1 p1)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1);
+		INamedParameterValue[] parameters = [new NamedParameterValue<T1>(p1Name, p1)];
+		IndexerGetterAccess interaction = new(parameters);
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+		return new IndexerSetupResult<TResult>(matchingSetup, interaction, Behavior, GetIndexerValue,
+			Setup.Indexers.UpdateValue);
+	}
+
+	/// <summary>
+	///     Gets the value from the indexer with two typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2>(string p1Name, T1 p1, string p2Name, T2 p2)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1, p2Name, p2);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2)
+		];
+		IndexerGetterAccess interaction = new(parameters);
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+		return new IndexerSetupResult<TResult>(matchingSetup, interaction, Behavior, GetIndexerValue,
+			Setup.Indexers.UpdateValue);
+	}
+
+	/// <summary>
+	///     Gets the value from the indexer with three typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3>(
+		string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1, p2Name, p2, p3Name, p3);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3)
+		];
+		IndexerGetterAccess interaction = new(parameters);
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+		return new IndexerSetupResult<TResult>(matchingSetup, interaction, Behavior, GetIndexerValue,
+			Setup.Indexers.UpdateValue);
+	}
+
+	/// <summary>
+	///     Gets the value from the indexer with four typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	public IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3, T4>(
+		string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1, p2Name, p2, p3Name, p3, p4Name, p4);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3),
+			new NamedParameterValue<T4>(p4Name, p4)
+		];
+		IndexerGetterAccess interaction = new(parameters);
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+		return new IndexerSetupResult<TResult>(matchingSetup, interaction, Behavior, GetIndexerValue,
+			Setup.Indexers.UpdateValue);
+	}
+
+	/// <summary>
 	///     Gets the value from the indexer with the given parameters.
 	/// </summary>
 	public IndexerSetupResult<TResult> GetIndexer<TResult>(params INamedParameterValue[] parameters)
@@ -444,6 +518,100 @@ public partial class MockRegistry
 		IndexerSetup? matchingSetup = Setup.Indexers.GetLatestOrDefault(interaction);
 		return new IndexerSetupResult<TResult>(matchingSetup, interaction, Behavior, GetIndexerValue,
 			Setup.Indexers.UpdateValue);
+	}
+
+	/// <summary>
+	///     Sets the value of the indexer with one typed parameter.
+	///     Matching runs against the typed value directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	/// <remarks>
+	///     Returns a flag, indicating whether the base class implementation should be skipped.
+	/// </remarks>
+	public bool SetIndexer<TResult, T1>(TResult value, string p1Name, T1 p1)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1);
+		INamedParameterValue[] parameters = [new NamedParameterValue<T1>(p1Name, p1)];
+		IndexerSetterAccess interaction = new(parameters, new NamedParameterValue<TResult>("value", value));
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+
+		Setup.Indexers.UpdateValue(parameters, value);
+		matchingSetup?.InvokeSetter(interaction, value, Behavior);
+		return (matchingSetup as IInteractiveIndexerSetup)?.SkipBaseClass() ?? Behavior.SkipBaseClass;
+	}
+
+	/// <summary>
+	///     Sets the value of the indexer with two typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	/// <remarks>
+	///     Returns a flag, indicating whether the base class implementation should be skipped.
+	/// </remarks>
+	public bool SetIndexer<TResult, T1, T2>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1, p2Name, p2);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2)
+		];
+		IndexerSetterAccess interaction = new(parameters, new NamedParameterValue<TResult>("value", value));
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+
+		Setup.Indexers.UpdateValue(parameters, value);
+		matchingSetup?.InvokeSetter(interaction, value, Behavior);
+		return (matchingSetup as IInteractiveIndexerSetup)?.SkipBaseClass() ?? Behavior.SkipBaseClass;
+	}
+
+	/// <summary>
+	///     Sets the value of the indexer with three typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	/// <remarks>
+	///     Returns a flag, indicating whether the base class implementation should be skipped.
+	/// </remarks>
+	public bool SetIndexer<TResult, T1, T2, T3>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2,
+		string p3Name, T3 p3)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1, p2Name, p2, p3Name, p3);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3)
+		];
+		IndexerSetterAccess interaction = new(parameters, new NamedParameterValue<TResult>("value", value));
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+
+		Setup.Indexers.UpdateValue(parameters, value);
+		matchingSetup?.InvokeSetter(interaction, value, Behavior);
+		return (matchingSetup as IInteractiveIndexerSetup)?.SkipBaseClass() ?? Behavior.SkipBaseClass;
+	}
+
+	/// <summary>
+	///     Sets the value of the indexer with four typed parameters.
+	///     Matching runs against the typed values directly; <see cref="Parameters.NamedParameterValue{T}" /> is only
+	///     allocated for recording.
+	/// </summary>
+	/// <remarks>
+	///     Returns a flag, indicating whether the base class implementation should be skipped.
+	/// </remarks>
+	public bool SetIndexer<TResult, T1, T2, T3, T4>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2,
+		string p3Name, T3 p3, string p4Name, T4 p4)
+	{
+		IndexerSetup? matchingSetup = GetIndexerSetupTyped(p1Name, p1, p2Name, p2, p3Name, p3, p4Name, p4);
+		INamedParameterValue[] parameters = [
+			new NamedParameterValue<T1>(p1Name, p1),
+			new NamedParameterValue<T2>(p2Name, p2),
+			new NamedParameterValue<T3>(p3Name, p3),
+			new NamedParameterValue<T4>(p4Name, p4)
+		];
+		IndexerSetterAccess interaction = new(parameters, new NamedParameterValue<TResult>("value", value));
+		((IMockInteractions)Interactions).RegisterInteraction(interaction);
+
+		Setup.Indexers.UpdateValue(parameters, value);
+		matchingSetup?.InvokeSetter(interaction, value, Behavior);
+		return (matchingSetup as IInteractiveIndexerSetup)?.SkipBaseClass() ?? Behavior.SkipBaseClass;
 	}
 
 	/// <summary>

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -133,6 +133,104 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Retrieves the latest indexer setup that matches the single typed parameter,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private IndexerSetup? GetIndexerSetupTyped<T1>(string n1, T1 v1)
+	{
+		IndexerGetterAccess? fallback = null;
+		return Setup.Indexers.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(IndexerSetup setup)
+		{
+			if (setup is ITypedIndexerMatch typed)
+			{
+				return typed.MatchesTyped(n1, v1);
+			}
+
+			fallback ??= new IndexerGetterAccess([new NamedParameterValue<T1>(n1, v1)]);
+			return ((IInteractiveIndexerSetup)setup).Matches(fallback);
+		}
+	}
+
+	/// <summary>
+	///     Retrieves the latest indexer setup that matches the two typed parameters,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private IndexerSetup? GetIndexerSetupTyped<T1, T2>(string n1, T1 v1, string n2, T2 v2)
+	{
+		IndexerGetterAccess? fallback = null;
+		return Setup.Indexers.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(IndexerSetup setup)
+		{
+			if (setup is ITypedIndexerMatch typed)
+			{
+				return typed.MatchesTyped(n1, v1, n2, v2);
+			}
+
+			fallback ??= new IndexerGetterAccess([
+				new NamedParameterValue<T1>(n1, v1),
+				new NamedParameterValue<T2>(n2, v2)]);
+			return ((IInteractiveIndexerSetup)setup).Matches(fallback);
+		}
+	}
+
+	/// <summary>
+	///     Retrieves the latest indexer setup that matches the three typed parameters,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private IndexerSetup? GetIndexerSetupTyped<T1, T2, T3>(string n1, T1 v1, string n2, T2 v2, string n3, T3 v3)
+	{
+		IndexerGetterAccess? fallback = null;
+		return Setup.Indexers.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(IndexerSetup setup)
+		{
+			if (setup is ITypedIndexerMatch typed)
+			{
+				return typed.MatchesTyped(n1, v1, n2, v2, n3, v3);
+			}
+
+			fallback ??= new IndexerGetterAccess([
+				new NamedParameterValue<T1>(n1, v1),
+				new NamedParameterValue<T2>(n2, v2),
+				new NamedParameterValue<T3>(n3, v3)]);
+			return ((IInteractiveIndexerSetup)setup).Matches(fallback);
+		}
+	}
+
+	/// <summary>
+	///     Retrieves the latest indexer setup that matches the four typed parameters,
+	///     or returns <see langword="null" /> if no matching setup is found.
+	/// </summary>
+	private IndexerSetup? GetIndexerSetupTyped<T1, T2, T3, T4>(
+		string n1, T1 v1, string n2, T2 v2, string n3, T3 v3, string n4, T4 v4)
+	{
+		IndexerGetterAccess? fallback = null;
+		return Setup.Indexers.GetLatestOrDefault(Predicate);
+
+		[DebuggerNonUserCode]
+		bool Predicate(IndexerSetup setup)
+		{
+			if (setup is ITypedIndexerMatch typed)
+			{
+				return typed.MatchesTyped(n1, v1, n2, v2, n3, v3, n4, v4);
+			}
+
+			fallback ??= new IndexerGetterAccess([
+				new NamedParameterValue<T1>(n1, v1),
+				new NamedParameterValue<T2>(n2, v2),
+				new NamedParameterValue<T3>(n3, v3),
+				new NamedParameterValue<T4>(n4, v4)]);
+			return ((IInteractiveIndexerSetup)setup).Matches(fallback);
+		}
+	}
+
+	/// <summary>
 	///     Gets the indexer value for the given <paramref name="parameters" />.
 	/// </summary>
 	private TValue GetIndexerValue<TValue>(IInteractiveIndexerSetup? setup, Func<TValue> defaultValueGenerator,

--- a/Source/Mockolate/Setup/ITypedIndexerMatch.cs
+++ b/Source/Mockolate/Setup/ITypedIndexerMatch.cs
@@ -1,0 +1,31 @@
+namespace Mockolate.Setup;
+
+/// <summary>
+///     Matches an indexer access by typed parameters, without boxing through
+///     <see cref="Mockolate.Parameters.INamedParameterValue" />.
+/// </summary>
+internal interface ITypedIndexerMatch
+{
+	/// <summary>
+	///     Checks if the single parameter value matches.
+	/// </summary>
+	bool MatchesTyped<T1>(string n1, T1 v1);
+
+	/// <summary>
+	///     Checks if the two parameter values match.
+	/// </summary>
+	bool MatchesTyped<T1, T2>(string n1, T1 v1, string n2, T2 v2);
+
+	/// <summary>
+	///     Checks if the three parameter values match.
+	/// </summary>
+	bool MatchesTyped<T1, T2, T3>(string n1, T1 v1, string n2, T2 v2, string n3, T3 v3);
+
+#pragma warning disable S107 // Methods should not have too many parameters
+	/// <summary>
+	///     Checks if the four parameter values match.
+	/// </summary>
+	bool MatchesTyped<T1, T2, T3, T4>(string n1, T1 v1, string n2, T2 v2, string n3, T3 v3,
+		string n4, T4 v4);
+#pragma warning restore S107 // Methods should not have too many parameters
+}

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -125,6 +125,32 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 	/// </summary>
 	protected static string FormatType(Type type)
 		=> type.FormatType();
+
+	/// <summary>
+	///     Checks if the given <paramref name="namedParameter" /> matches the typed <paramref name="value" />,
+	///     using <see cref="ITypedParameter{T}" /> when available to avoid boxing.
+	/// </summary>
+	protected static bool MatchesParameter<T>(NamedParameter namedParameter, string name, T value)
+	{
+		if (!string.IsNullOrEmpty(name) &&
+		    !namedParameter.Name.Equals(name, StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		if (namedParameter.Parameter is ITypedParameter<T> typed)
+		{
+			return typed.MatchesValue(namedParameter.Name, value);
+		}
+
+		return namedParameter.Parameter.Matches(new NamedParameterValue<T>(name, value));
+	}
+
+	/// <summary>
+	///     Invokes the callbacks of the given <paramref name="namedParameter" /> with the typed <paramref name="value" />.
+	/// </summary>
+	protected static void InvokeCallbacksParameter<T>(NamedParameter namedParameter, string name, T value)
+		=> namedParameter.Parameter.InvokeCallbacks(new NamedParameterValue<T>(name, value));
 }
 
 /// <summary>
@@ -135,7 +161,7 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 #endif
 public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
 	IIndexerSetupCallbackBuilder<TValue, T1>, IIndexerSetupReturnBuilder<TValue, T1>,
-	IIndexerGetterSetup<TValue, T1>, IIndexerSetterSetup<TValue, T1>
+	IIndexerGetterSetup<TValue, T1>, IIndexerSetterSetup<TValue, T1>, ITypedIndexerMatch
 {
 	private readonly List<Callback<Action<int, T1, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, TValue, TValue>>> _returnCallbacks = [];
@@ -553,6 +579,29 @@ public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
 	protected override bool IsMatch(INamedParameterValue[] parameters)
 		=> Matches([match1,], parameters);
 
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1}(string, T1)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1>(string n1, TActual1 v1)
+	{
+		if (!MatchesParameter(match1, n1, v1))
+		{
+			return false;
+		}
+
+		InvokeCallbacksParameter(match1, n1, v1);
+		return true;
+	}
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2}(string, T1, string, T2)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2>(string n1, TActual1 v1, string n2, TActual2 v2) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3}(string, T1, string, T2, string, T3)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3,T4}(string, T1, string, T2, string, T3, string, T4)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3, TActual4>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3, string n4, TActual4 v4) => false;
+
 	/// <inheritdoc cref="IndexerSetup.GetInitialValue{T}" />
 	protected override void GetInitialValue<T>(MockBehavior behavior, Func<T> defaultValueGenerator,
 		INamedParameterValue[] parameters,
@@ -579,7 +628,7 @@ public class IndexerSetup<TValue, T1>(NamedParameter match1) : IndexerSetup,
 #endif
 public class IndexerSetup<TValue, T1, T2>(NamedParameter match1, NamedParameter match2) : IndexerSetup
 	, IIndexerSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetupReturnBuilder<TValue, T1, T2>,
-	IIndexerGetterSetup<TValue, T1, T2>, IIndexerSetterSetup<TValue, T1, T2>
+	IIndexerGetterSetup<TValue, T1, T2>, IIndexerSetterSetup<TValue, T1, T2>, ITypedIndexerMatch
 {
 	private readonly List<Callback<Action<int, T1, T2, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, T2, TValue, TValue>>> _returnCallbacks = [];
@@ -1002,6 +1051,30 @@ public class IndexerSetup<TValue, T1, T2>(NamedParameter match1, NamedParameter 
 	protected override bool IsMatch(INamedParameterValue[] parameters)
 		=> Matches([match1, match2,], parameters);
 
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1}(string, T1)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1>(string n1, TActual1 v1) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2}(string, T1, string, T2)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2>(string n1, TActual1 v1, string n2, TActual2 v2)
+	{
+		if (!MatchesParameter(match1, n1, v1) || !MatchesParameter(match2, n2, v2))
+		{
+			return false;
+		}
+
+		InvokeCallbacksParameter(match1, n1, v1);
+		InvokeCallbacksParameter(match2, n2, v2);
+		return true;
+	}
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3}(string, T1, string, T2, string, T3)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3,T4}(string, T1, string, T2, string, T3, string, T4)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3, TActual4>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3, string n4, TActual4 v4) => false;
+
 	/// <inheritdoc cref="IndexerSetup.GetInitialValue{T}" />
 	protected override void GetInitialValue<T>(MockBehavior behavior, Func<T> defaultValueGenerator,
 		INamedParameterValue[] parameters,
@@ -1033,7 +1106,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	NamedParameter match2,
 	NamedParameter match3) : IndexerSetup,
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3>,
-	IIndexerGetterSetup<TValue, T1, T2, T3>, IIndexerSetterSetup<TValue, T1, T2, T3>
+	IIndexerGetterSetup<TValue, T1, T2, T3>, IIndexerSetterSetup<TValue, T1, T2, T3>, ITypedIndexerMatch
 {
 	private readonly List<Callback<Action<int, T1, T2, T3, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, T2, T3, TValue, TValue>>> _returnCallbacks = [];
@@ -1462,6 +1535,32 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	protected override bool IsMatch(INamedParameterValue[] parameters)
 		=> Matches([match1, match2, match3,], parameters);
 
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1}(string, T1)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1>(string n1, TActual1 v1) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2}(string, T1, string, T2)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2>(string n1, TActual1 v1, string n2, TActual2 v2) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3}(string, T1, string, T2, string, T3)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3)
+	{
+		if (!MatchesParameter(match1, n1, v1) || !MatchesParameter(match2, n2, v2) ||
+		    !MatchesParameter(match3, n3, v3))
+		{
+			return false;
+		}
+
+		InvokeCallbacksParameter(match1, n1, v1);
+		InvokeCallbacksParameter(match2, n2, v2);
+		InvokeCallbacksParameter(match3, n3, v3);
+		return true;
+	}
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3,T4}(string, T1, string, T2, string, T3, string, T4)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3, TActual4>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3, string n4, TActual4 v4) => false;
+
 	/// <inheritdoc cref="IndexerSetup.GetInitialValue{T}" />
 	protected override void GetInitialValue<T>(MockBehavior behavior, Func<T> defaultValueGenerator,
 		INamedParameterValue[] parameters,
@@ -1497,7 +1596,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	NamedParameter match4)
 	: IndexerSetup,
 		IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>,
-		IIndexerGetterSetup<TValue, T1, T2, T3, T4>, IIndexerSetterSetup<TValue, T1, T2, T3, T4>
+		IIndexerGetterSetup<TValue, T1, T2, T3, T4>, IIndexerSetterSetup<TValue, T1, T2, T3, T4>, ITypedIndexerMatch
 {
 	private readonly List<Callback<Action<int, T1, T2, T3, T4, TValue>>> _getterCallbacks = [];
 	private readonly List<Callback<Func<int, T1, T2, T3, T4, TValue, TValue>>> _returnCallbacks = [];
@@ -1930,6 +2029,33 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	/// <inheritdoc cref="IsMatch(INamedParameterValue[])" />
 	protected override bool IsMatch(INamedParameterValue[] parameters)
 		=> Matches([match1, match2, match3, match4,], parameters);
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1}(string, T1)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1>(string n1, TActual1 v1) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2}(string, T1, string, T2)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2>(string n1, TActual1 v1, string n2, TActual2 v2) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3}(string, T1, string, T2, string, T3)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3) => false;
+
+	/// <inheritdoc cref="ITypedIndexerMatch.MatchesTyped{T1,T2,T3,T4}(string, T1, string, T2, string, T3, string, T4)" />
+	bool ITypedIndexerMatch.MatchesTyped<TActual1, TActual2, TActual3, TActual4>(
+		string n1, TActual1 v1, string n2, TActual2 v2, string n3, TActual3 v3, string n4, TActual4 v4)
+	{
+		if (!MatchesParameter(match1, n1, v1) || !MatchesParameter(match2, n2, v2) ||
+		    !MatchesParameter(match3, n3, v3) || !MatchesParameter(match4, n4, v4))
+		{
+			return false;
+		}
+
+		InvokeCallbacksParameter(match1, n1, v1);
+		InvokeCallbacksParameter(match2, n2, v2);
+		InvokeCallbacksParameter(match3, n3, v3);
+		InvokeCallbacksParameter(match4, n4, v4);
+		return true;
+	}
 
 	/// <inheritdoc cref="IndexerSetup.GetInitialValue{T}" />
 	protected override void GetInitialValue<T>(MockBehavior behavior, Func<T> defaultValueGenerator,

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -72,6 +72,28 @@ internal partial class MockSetups
 			return null;
 		}
 
+		public IndexerSetup? GetLatestOrDefault(Predicate<IndexerSetup> predicate)
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					if (predicate(storage[i]))
+					{
+						return storage[i];
+					}
+				}
+			}
+
+			return null;
+		}
+
 		/// <inheritdoc cref="object.ToString()" />
 		[ExcludeFromCodeCoverage]
 		public override string ToString()

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -185,6 +185,10 @@ namespace Mockolate
         public void AddEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void ClearAllInteractions() { }
         public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult>(params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1>(string p1Name, T1 p1) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2>(string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3>(string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3, T4>(string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, params Mockolate.Parameters.NamedParameter[] parameters) { }
@@ -208,6 +212,10 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> Property<T>(T subject, string propertyName, Mockolate.Parameters.IParameter value) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public bool SetIndexer<TResult>(TResult value, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public bool SetIndexer<TResult, T1>(TResult value, string p1Name, T1 p1) { }
+        public bool SetIndexer<TResult, T1, T2>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public bool SetIndexer<TResult, T1, T2, T3>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public bool SetIndexer<TResult, T1, T2, T3, T4>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
@@ -1406,7 +1414,9 @@ namespace Mockolate.Setup
         protected abstract bool? GetSkipBaseClass();
         protected abstract bool IsMatch(Mockolate.Parameters.INamedParameterValue[] parameters);
         protected static string FormatType(System.Type type) { }
+        protected static void InvokeCallbacksParameter<T>(Mockolate.Parameters.NamedParameter namedParameter, string name, T value) { }
         protected static bool Matches(Mockolate.Parameters.NamedParameter[] namedParameters, Mockolate.Parameters.INamedParameterValue[] values) { }
+        protected static bool MatchesParameter<T>(Mockolate.Parameters.NamedParameter namedParameter, string name, T value) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
     public class IndexerSetupResult

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -184,6 +184,10 @@ namespace Mockolate
         public void AddEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void ClearAllInteractions() { }
         public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult>(params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1>(string p1Name, T1 p1) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2>(string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3>(string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3, T4>(string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, params Mockolate.Parameters.NamedParameter[] parameters) { }
@@ -207,6 +211,10 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> Property<T>(T subject, string propertyName, Mockolate.Parameters.IParameter value) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public bool SetIndexer<TResult>(TResult value, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public bool SetIndexer<TResult, T1>(TResult value, string p1Name, T1 p1) { }
+        public bool SetIndexer<TResult, T1, T2>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public bool SetIndexer<TResult, T1, T2, T3>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public bool SetIndexer<TResult, T1, T2, T3, T4>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
@@ -1405,7 +1413,9 @@ namespace Mockolate.Setup
         protected abstract bool? GetSkipBaseClass();
         protected abstract bool IsMatch(Mockolate.Parameters.INamedParameterValue[] parameters);
         protected static string FormatType(System.Type type) { }
+        protected static void InvokeCallbacksParameter<T>(Mockolate.Parameters.NamedParameter namedParameter, string name, T value) { }
         protected static bool Matches(Mockolate.Parameters.NamedParameter[] namedParameters, Mockolate.Parameters.INamedParameterValue[] values) { }
+        protected static bool MatchesParameter<T>(Mockolate.Parameters.NamedParameter namedParameter, string name, T value) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
     public class IndexerSetupResult

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -171,6 +171,10 @@ namespace Mockolate
         public void AddEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void ClearAllInteractions() { }
         public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult>(params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1>(string p1Name, T1 p1) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2>(string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3>(string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public Mockolate.Setup.IndexerSetupResult<TResult> GetIndexer<TResult, T1, T2, T3, T4>(string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> Indexer<T>(T subject, params Mockolate.Parameters.NamedParameter[] parameters) { }
@@ -194,6 +198,10 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> Property<T>(T subject, string propertyName, Mockolate.Parameters.IParameter value) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public bool SetIndexer<TResult>(TResult value, params Mockolate.Parameters.INamedParameterValue[] parameters) { }
+        public bool SetIndexer<TResult, T1>(TResult value, string p1Name, T1 p1) { }
+        public bool SetIndexer<TResult, T1, T2>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2) { }
+        public bool SetIndexer<TResult, T1, T2, T3>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3) { }
+        public bool SetIndexer<TResult, T1, T2, T3, T4>(TResult value, string p1Name, T1 p1, string p2Name, T2 p2, string p3Name, T3 p3, string p4Name, T4 p4) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
@@ -1360,7 +1368,9 @@ namespace Mockolate.Setup
         protected abstract bool? GetSkipBaseClass();
         protected abstract bool IsMatch(Mockolate.Parameters.INamedParameterValue[] parameters);
         protected static string FormatType(System.Type type) { }
+        protected static void InvokeCallbacksParameter<T>(Mockolate.Parameters.NamedParameter namedParameter, string name, T value) { }
         protected static bool Matches(Mockolate.Parameters.NamedParameter[] namedParameters, Mockolate.Parameters.INamedParameterValue[] values) { }
+        protected static bool MatchesParameter<T>(Mockolate.Parameters.NamedParameter namedParameter, string name, T value) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
     public class IndexerSetupResult

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -31,9 +31,9 @@ public sealed partial class MockTests
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
 					.Contains(
-						"return this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<int>(\"indexerResult\", indexerResult)).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));")
+						"return this.MockRegistry.GetIndexer<int, int>(\"indexerResult\", indexerResult).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));")
 					.IgnoringNewlineStyle().And
-					.Contains("this.MockRegistry.SetIndexer<int>(value, new global::Mockolate.Parameters.NamedParameterValue<int>(\"indexerResult\", indexerResult));")
+					.Contains("this.MockRegistry.SetIndexer<int, int>(value, \"indexerResult\", indexerResult);")
 					.IgnoringNewlineStyle();
 			}
 
@@ -71,15 +71,15 @@ public sealed partial class MockTests
 					          			{
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
-					          					return this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index)).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          					return this.MockRegistry.GetIndexer<int, int>("index", index).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
 					          				}
-					          				var indexerResult = this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
+					          				var indexerResult = this.MockRegistry.GetIndexer<int, int>("index", index);
 					          				var baseResult = wraps[index];
 					          				return indexerResult.GetResult(baseResult);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetIndexer<int>(value, new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
+					          				this.MockRegistry.SetIndexer<int, int>(value, "index", index);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps[index] = value;
@@ -95,9 +95,9 @@ public sealed partial class MockTests
 					          			{
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
-					          					return this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool?>("isReadOnly", isReadOnly)).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          					return this.MockRegistry.GetIndexer<int, int, bool?>("index", index, "isReadOnly", isReadOnly).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
 					          				}
-					          				var indexerResult = this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool?>("isReadOnly", isReadOnly));
+					          				var indexerResult = this.MockRegistry.GetIndexer<int, int, bool?>("index", index, "isReadOnly", isReadOnly);
 					          				var baseResult = wraps[index, isReadOnly];
 					          				return indexerResult.GetResult(baseResult);
 					          			}
@@ -109,7 +109,7 @@ public sealed partial class MockTests
 					          		{
 					          			set
 					          			{
-					          				this.MockRegistry.SetIndexer<int>(value, new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<string>("isWriteOnly", isWriteOnly));
+					          				this.MockRegistry.SetIndexer<int, int, string>(value, "index", index, "isWriteOnly", isWriteOnly);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps[index, isWriteOnly] = value;
@@ -163,7 +163,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				var indexerResult = this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index));
+					          				var indexerResult = this.MockRegistry.GetIndexer<int, int>("index", index);
 					          				if (!indexerResult.SkipBaseClass)
 					          				{
 					          					var baseResult = this.MockRegistry.Wraps is global::MyCode.MyService wraps ? wraps[index] : base[index];
@@ -173,7 +173,7 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				if (!this.MockRegistry.SetIndexer<int>(value, new global::Mockolate.Parameters.NamedParameterValue<int>("index", index)))
+					          				if (!this.MockRegistry.SetIndexer<int, int>(value, "index", index))
 					          				{
 					          					if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
 					          					{
@@ -193,7 +193,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				var indexerResult = this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<bool>("isReadOnly", isReadOnly));
+					          				var indexerResult = this.MockRegistry.GetIndexer<int, int, bool>("index", index, "isReadOnly", isReadOnly);
 					          				if (!indexerResult.SkipBaseClass)
 					          				{
 					          					var baseResult = base[index, isReadOnly];
@@ -209,7 +209,7 @@ public sealed partial class MockTests
 					          		{
 					          			set
 					          			{
-					          				if (!this.MockRegistry.SetIndexer<int>(value, new global::Mockolate.Parameters.NamedParameterValue<int>("index", index), new global::Mockolate.Parameters.NamedParameterValue<string>("isWriteOnly", isWriteOnly)))
+					          				if (!this.MockRegistry.SetIndexer<int, int, string>(value, "index", index, "isWriteOnly", isWriteOnly))
 					          				{
 					          					base[index, isWriteOnly] = value;
 					          				}
@@ -223,11 +223,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetIndexer<int>(new global::Mockolate.Parameters.NamedParameterValue<string>("someAdditionalIndex", someAdditionalIndex)).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          				return this.MockRegistry.GetIndexer<int, string>("someAdditionalIndex", someAdditionalIndex).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetIndexer<int>(value, new global::Mockolate.Parameters.NamedParameterValue<string>("someAdditionalIndex", someAdditionalIndex));
+					          				this.MockRegistry.SetIndexer<int, string>(value, "someAdditionalIndex", someAdditionalIndex);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -232,6 +232,81 @@ public sealed partial class MockTests
 					          		}
 					          """).IgnoringNewlineStyle();
 			}
+
+			[Fact]
+			public async Task ShouldSupportSpanAndReadOnlySpanIndexerParameters()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using System;
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyService
+					     {
+					         int this[Span<char> buffer] { get; set; }
+					         int this[ReadOnlySpan<int> values] { get; set; }
+					     }
+					     """);
+
+				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
+					.Contains("""
+					          		/// <inheritdoc cref="global::MyCode.IMyService.this[global::System.Span{char}]" />
+					          		public int this[global::System.Span<char> buffer]
+					          		{
+					          			get
+					          			{
+					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
+					          				{
+					          					return this.MockRegistry.GetIndexer<int, global::Mockolate.Setup.SpanWrapper<char>>("buffer", new global::Mockolate.Setup.SpanWrapper<char>(buffer)).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          				}
+					          				var indexerResult = this.MockRegistry.GetIndexer<int, global::Mockolate.Setup.SpanWrapper<char>>("buffer", new global::Mockolate.Setup.SpanWrapper<char>(buffer));
+					          				var baseResult = wraps[buffer];
+					          				return indexerResult.GetResult(baseResult);
+					          			}
+					          			set
+					          			{
+					          				this.MockRegistry.SetIndexer<int, global::Mockolate.Setup.SpanWrapper<char>>(value, "buffer", new global::Mockolate.Setup.SpanWrapper<char>(buffer));
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				{
+					          					wraps[buffer] = value;
+					          				}
+					          			}
+					          		}
+					          """).IgnoringNewlineStyle().And
+					.Contains("""
+					          		/// <inheritdoc cref="global::MyCode.IMyService.this[global::System.ReadOnlySpan{int}]" />
+					          		public int this[global::System.ReadOnlySpan<int> values]
+					          		{
+					          			get
+					          			{
+					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
+					          				{
+					          					return this.MockRegistry.GetIndexer<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>("values", new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values)).GetResult(() => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          				}
+					          				var indexerResult = this.MockRegistry.GetIndexer<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>("values", new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values));
+					          				var baseResult = wraps[values];
+					          				return indexerResult.GetResult(baseResult);
+					          			}
+					          			set
+					          			{
+					          				this.MockRegistry.SetIndexer<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>(value, "values", new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values));
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				{
+					          					wraps[values] = value;
+					          				}
+					          			}
+					          		}
+					          """).IgnoringNewlineStyle();
+			}
 		}
 	}
 }

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -286,6 +286,52 @@ public sealed partial class SetupIndexerTests
 			.WithMessage("The indexer [null, 1, 2] was accessed without prior setup.");
 	}
 
+#if NET8_0_OR_GREATER
+	[Fact]
+	public async Task WithReadOnlySpanIndexerParameters_ShouldCompile()
+	{
+		ReadOnlySpan<int> readOnlySpan123 = ((int[])[1, 2, 3,]).AsSpan();
+		ReadOnlySpan<int> readOnlySpan456 = ((int[])[4, 5, 6,]).AsSpan();
+		IMyServiceWithSpanIndexerParameters sut = IMyServiceWithSpanIndexerParameters.CreateMock();
+		sut.Mock.Setup[It.IsReadOnlySpan<int>(x => x[0] == 1)].InitializeWith(42);
+
+		int result1 = sut[readOnlySpan123];
+		int result2 = sut[readOnlySpan456];
+
+		await That(result1).IsEqualTo(42);
+		await That(result2).IsEqualTo(0);
+		await That(sut.Mock.Verify[It.IsReadOnlySpan<int>(x => x[0] == 1)].Got()).Once();
+		await That(sut.Mock.Verify[It.IsReadOnlySpan<int>(x => x[0] == 4)].Got()).Once();
+		await That(sut.Mock.Verify[It.IsReadOnlySpan<int>(x => x[0] == 9)].Got()).Never();
+	}
+#endif
+
+#if NET8_0_OR_GREATER
+	[Fact]
+	public async Task WithSpanIndexerParameters_ShouldCompile()
+	{
+		Span<char> fooSpan = "foo".ToCharArray().AsSpan();
+		Span<char> barSpan = "bar".ToCharArray().AsSpan();
+		IMyServiceWithSpanIndexerParameters sut = IMyServiceWithSpanIndexerParameters.CreateMock();
+		sut.Mock.Setup[It.IsSpan<char>(x => x[0] == 'f')].InitializeWith(42);
+
+		int result1 = sut[fooSpan];
+		int result2 = sut[barSpan];
+
+		await That(result1).IsEqualTo(42);
+		await That(result2).IsEqualTo(0);
+		await That(sut.Mock.Verify[It.IsSpan<char>(x => x[0] == 'f')].Got()).Once();
+		await That(sut.Mock.Verify[It.IsSpan<char>(x => x[0] == 'b')].Got()).Once();
+		await That(sut.Mock.Verify[It.IsSpan<char>(x => x[0] == 'x')].Got()).Never();
+	}
+#endif
+
+	public interface IMyServiceWithSpanIndexerParameters
+	{
+		int this[Span<char> buffer] { get; set; }
+		int this[ReadOnlySpan<int> values] { get; set; }
+	}
+
 	public class IndexerWith1Parameter
 	{
 		[Fact]


### PR DESCRIPTION
Introduces typed indexer-matching and typed `GetIndexer`/`SetIndexer` overloads intended to reduce overhead (notably around parameter handling) when interacting with indexers.

**Changes:**
- Added typed `MockRegistry.GetIndexer<TResult, T1..T4>` and `MockRegistry.SetIndexer<TResult, T1..T4>` overloads (plus supporting typed setup resolution).
- Introduced `ITypedIndexerMatch` and implemented typed matching paths in `IndexerSetup<...>` variants.
- Updated source generator output (and generator tests) to emit the new typed indexer calls.