### PR TITLE
refactor: parametrize benchmark iterations for indexers, methods, and properties

### DIFF
--- a/.idea/.idea.Mockolate/.idea/.name
+++ b/.idea/.idea.Mockolate/.idea/.name
@@ -1,0 +1,1 @@
+Mockolate

--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -13,10 +13,13 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with an indexer, setup the indexer and verify
-///     the getter was called once.
+///     the getter was called exactly <see cref="InvocationCount" /> times.
 /// </summary>
 public class CompleteIndexerBenchmarks : BenchmarksBase
 {
+	[Params(1, 10)]
+	public int InvocationCount { get; set; }
+
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
 	/// </summary>
@@ -26,9 +29,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface sut = IMyIndexerInterface.CreateMock();
 		sut.Mock.Setup[It.IsAny<int>()].Returns("foo");
 
-		_ = sut[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = sut[42];
+		}
 
-		sut.Mock.Verify[It.IsAny<int>()].Got().Once();
+		sut.Mock.Verify[It.IsAny<int>()].Got().Exactly(InvocationCount);
 	}
 
 	/// <summary>
@@ -40,9 +46,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		Moq.Mock<IMyIndexerInterface> mock = new();
 		mock.Setup(x => x[Moq.It.IsAny<int>()]).Returns("foo");
 
-		_ = mock.Object[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object[42];
+		}
 
-		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Once());
+		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -54,9 +63,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface mock = Substitute.For<IMyIndexerInterface>();
 		mock[Arg.Any<int>()].Returns("foo");
 
-		_ = mock[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock[42];
+		}
 
-		_ = mock.Received(1)[Arg.Any<int>()];
+		_ = mock.Received(InvocationCount)[Arg.Any<int>()];
 	}
 
 	/// <summary>
@@ -68,9 +80,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface mock = A.Fake<IMyIndexerInterface>();
 		A.CallTo(() => mock[A<int>.Ignored]).Returns("foo");
 
-		_ = mock[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock[42];
+		}
 
-		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(1, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -82,9 +97,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterfaceImposter imposter = IMyIndexerInterface.Imposter();
 		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Returns("foo");
 
-		_ = imposter.Instance()[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = imposter.Instance()[42];
+		}
 
-		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Once());
+		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(InvocationCount));
 	}
 
 	/* Indexers not supported on TUnit.Mocks
@@ -97,9 +115,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		TUnit.Mocks.Mock<IMyIndexerInterface> mock = TUnit.Mocks.Mock.Of<IMyIndexerInterface>();
 		mock[Any<int>()].Returns("foo");
 
-		_ = mock.Object[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object[42];
+		}
 
-		mock[Any<int>()].WasCalled();
+		mock[Any<int>()].WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
 	}
 	*/
 

--- a/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
@@ -13,10 +13,13 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the simple case of an interface mock, setup a single method that gets called and
-///     verified to be called once.
+///     verified to be called exactly <see cref="InvocationCount" /> times.
 /// </summary>
 public class CompleteMethodBenchmarks : BenchmarksBase
 {
+	[Params(1, 10)]
+	public int InvocationCount { get; set; }
+
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
 	/// </summary>
@@ -26,9 +29,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface sut = IMyMethodInterface.CreateMock();
 		sut.Mock.Setup.MyFunc(It.IsAny<int>()).Returns(true);
 
-		sut.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			sut.MyFunc(42);
+		}
 
-		sut.Mock.Verify.MyFunc(It.IsAny<int>()).Once();
+		sut.Mock.Verify.MyFunc(It.IsAny<int>()).Exactly(InvocationCount);
 	}
 
 	/// <summary>
@@ -40,9 +46,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		Moq.Mock<IMyMethodInterface> mock = new();
 		mock.Setup(x => x.MyFunc(Moq.It.IsAny<int>())).Returns(true);
 
-		mock.Object.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.Object.MyFunc(42);
+		}
 
-		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Times.Once());
+		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Times.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -54,9 +63,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface mock = Substitute.For<IMyMethodInterface>();
 		mock.MyFunc(Arg.Any<int>()).Returns(true);
 
-		mock.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.MyFunc(42);
+		}
 
-		mock.Received(1).MyFunc(Arg.Any<int>());
+		mock.Received(InvocationCount).MyFunc(Arg.Any<int>());
 	}
 
 	/// <summary>
@@ -68,9 +80,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface mock = A.Fake<IMyMethodInterface>();
 		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).Returns(true);
 
-		mock.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.MyFunc(42);
+		}
 
-		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(1, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -82,9 +97,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterfaceImposter imposter = IMyMethodInterface.Imposter();
 		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Returns(true);
 
-		imposter.Instance().MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			imposter.Instance().MyFunc(42);
+		}
 
-		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Once());
+		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -96,9 +114,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		Mock<IMyMethodInterface> mock = TUnit.Mocks.Mock.Of<IMyMethodInterface>();
 		mock.MyFunc(Any<int>()).Returns(true);
 
-		mock.Object.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.Object.MyFunc(42);
+		}
 
-		mock.MyFunc(Any<int>()).WasCalled();
+		mock.MyFunc(Any<int>()).WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
 	}
 
 	public interface IMyMethodInterface

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -12,10 +12,13 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with a property, setup the property and verify
-///     the getter was called once.
+///     the getter was called exactly <see cref="InvocationCount" /> times.
 /// </summary>
 public class CompletePropertyBenchmarks : BenchmarksBase
 {
+	[Params(1, 10)]
+	public int InvocationCount { get; set; }
+
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
 	/// </summary>
@@ -25,9 +28,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface sut = IMyPropertyInterface.CreateMock();
 		sut.Mock.Setup.Counter.InitializeWith(42);
 
-		_ = sut.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = sut.Counter;
+		}
 
-		sut.Mock.Verify.Counter.Got().Once();
+		sut.Mock.Verify.Counter.Got().Exactly(InvocationCount);
 	}
 
 	/// <summary>
@@ -39,9 +45,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		Moq.Mock<IMyPropertyInterface> mock = new();
 		mock.SetupGet(x => x.Counter).Returns(42);
 
-		_ = mock.Object.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object.Counter;
+		}
 
-		mock.VerifyGet(x => x.Counter, Times.Once());
+		mock.VerifyGet(x => x.Counter, Times.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -53,9 +62,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface mock = Substitute.For<IMyPropertyInterface>();
 		mock.Counter.Returns(42);
 
-		_ = mock.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Counter;
+		}
 
-		_ = mock.Received(1).Counter;
+		_ = mock.Received(InvocationCount).Counter;
 	}
 
 	/// <summary>
@@ -67,9 +79,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface mock = A.Fake<IMyPropertyInterface>();
 		A.CallTo(() => mock.Counter).Returns(42);
 
-		_ = mock.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Counter;
+		}
 
-		A.CallTo(() => mock.Counter).MustHaveHappened(1, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock.Counter).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -81,9 +96,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterfaceImposter imposter = IMyPropertyInterface.Imposter();
 		imposter.Counter.Getter().Returns(42);
 
-		_ = imposter.Instance().Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = imposter.Instance().Counter;
+		}
 
-		imposter.Counter.Getter().Called(Count.Once());
+		imposter.Counter.Getter().Called(Count.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -95,9 +113,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		Mock<IMyPropertyInterface> mock = TUnit.Mocks.Mock.Of<IMyPropertyInterface>();
 		mock.Counter.Returns(42);
 
-		_ = mock.Object.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object.Counter;
+		}
 
-		mock.Counter.WasCalled();
+		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
 	}
 
 	public interface IMyPropertyInterface


### PR DESCRIPTION
Updates the benchmark suite to parameterize how many times indexers/methods/properties are invoked and verified, allowing comparison at multiple invocation counts.

**Changes:**
- Add a BenchmarkDotNet `[Params(1, 10)]` parameter to control invocation count.
- Wrap each benchmark’s invocation in a `for` loop and update verifications to assert `Exactly(N)` (or framework equivalents).