### PR TITLE
perf: optimize storage handling in PropertySetups for improved performance

### DIFF
--- a/Source/Mockolate/Setup/MockSetups.Properties.cs
+++ b/Source/Mockolate/Setup/MockSetups.Properties.cs
@@ -46,6 +46,14 @@ internal partial class MockSetups
 				{
 					bool wasDefault = old[existingIndex] is PropertySetup.Default;
 					bool isDefault = setup is PropertySetup.Default;
+					// Never overwrite a user-configured setup with a default placeholder:
+					// a first property access can race with Setup...InitializeWith(...) and
+					// otherwise lose the user's setup.
+					if (isDefault && !wasDefault)
+					{
+						return;
+					}
+
 					PropertySetup[] next = new PropertySetup[old.Length];
 					Array.Copy(old, next, old.Length);
 					next[existingIndex] = setup;
@@ -53,10 +61,6 @@ internal partial class MockSetups
 					if (wasDefault && !isDefault)
 					{
 						Volatile.Write(ref _count, _count + 1);
-					}
-					else if (!wasDefault && isDefault)
-					{
-						Volatile.Write(ref _count, _count - 1);
 					}
 				}
 				else

--- a/Source/Mockolate/Setup/MockSetups.Properties.cs
+++ b/Source/Mockolate/Setup/MockSetups.Properties.cs
@@ -18,68 +18,72 @@ internal partial class MockSetups
 	internal sealed class PropertySetups
 	{
 		private int _count;
-		private List<PropertySetup>? _storage;
+		private PropertySetup[]? _storage;
+#if NET10_0_OR_GREATER
+		private readonly Lock _writeLock = new();
+#else
+		private readonly object _writeLock = new();
+#endif
 
-		// ReSharper disable once InconsistentlySynchronizedField
 		public int Count => Volatile.Read(ref _count);
-
-		private List<PropertySetup> GetOrCreateStorage()
-		{
-			if (_storage is null)
-			{
-				Interlocked.CompareExchange(ref _storage, [], null);
-			}
-
-			return _storage!;
-		}
 
 		public void Add(PropertySetup setup)
 		{
-			List<PropertySetup> storage = GetOrCreateStorage();
-			lock (storage)
+			lock (_writeLock)
 			{
-				for (int i = 0; i < storage.Count; i++)
+				PropertySetup[] old = _storage ?? [];
+				int existingIndex = -1;
+				for (int i = 0; i < old.Length; i++)
 				{
-					if (string.Equals(storage[i].Name, setup.Name, StringComparison.Ordinal))
+					if (string.Equals(old[i].Name, setup.Name, StringComparison.Ordinal))
 					{
-						bool wasDefault = storage[i] is PropertySetup.Default;
-						bool isDefault = setup is PropertySetup.Default;
-						storage[i] = setup;
-						if (wasDefault && !isDefault)
-						{
-							Volatile.Write(ref _count, _count + 1);
-						}
-						else if (!wasDefault && isDefault)
-						{
-							Volatile.Write(ref _count, _count - 1);
-						}
-
-						return;
+						existingIndex = i;
+						break;
 					}
 				}
 
-				storage.Add(setup);
-				if (setup is not PropertySetup.Default)
+				if (existingIndex >= 0)
 				{
-					Volatile.Write(ref _count, _count + 1);
+					bool wasDefault = old[existingIndex] is PropertySetup.Default;
+					bool isDefault = setup is PropertySetup.Default;
+					PropertySetup[] next = new PropertySetup[old.Length];
+					Array.Copy(old, next, old.Length);
+					next[existingIndex] = setup;
+					Volatile.Write(ref _storage, next);
+					if (wasDefault && !isDefault)
+					{
+						Volatile.Write(ref _count, _count + 1);
+					}
+					else if (!wasDefault && isDefault)
+					{
+						Volatile.Write(ref _count, _count - 1);
+					}
+				}
+				else
+				{
+					PropertySetup[] next = new PropertySetup[old.Length + 1];
+					Array.Copy(old, next, old.Length);
+					next[old.Length] = setup;
+					Volatile.Write(ref _storage, next);
+					if (setup is not PropertySetup.Default)
+					{
+						Volatile.Write(ref _count, _count + 1);
+					}
 				}
 			}
 		}
 
 		public bool TryGetValue(string propertyName, [NotNullWhen(true)] out PropertySetup? setup)
 		{
-			List<PropertySetup>? storage = _storage;
+			PropertySetup[]? storage = Volatile.Read(ref _storage);
 			if (storage is not null)
 			{
-				lock (storage)
+				for (int i = 0; i < storage.Length; i++)
 				{
-					for (int i = 0; i < storage.Count; i++)
+					if (string.Equals(storage[i].Name, propertyName, StringComparison.Ordinal))
 					{
-						if (string.Equals(storage[i].Name, propertyName, StringComparison.Ordinal))
-						{
-							setup = storage[i];
-							return true;
-						}
+						setup = storage[i];
+						return true;
 					}
 				}
 			}
@@ -90,57 +94,51 @@ internal partial class MockSetups
 
 		internal IEnumerable<PropertySetup> EnumerateUnusedSetupsBy(MockInteractions interactions)
 		{
-			List<PropertySetup>? storage = _storage;
-			if (storage is null)
+			PropertySetup[]? storage = Volatile.Read(ref _storage);
+			if (storage is null || storage.Length == 0)
 			{
 				return [];
 			}
 
-			lock (storage)
-			{
-				return storage.Where(propertySetup => interactions.OfType<PropertyAccess>()
-						.All(propertyAccess => !((IInteractivePropertySetup)propertySetup).Matches(propertyAccess)))
-					.ToList();
-			}
+			return storage.Where(propertySetup => interactions.OfType<PropertyAccess>()
+					.All(propertyAccess => !((IInteractivePropertySetup)propertySetup).Matches(propertyAccess)))
+				.ToList();
 		}
 
 		/// <inheritdoc cref="object.ToString()" />
 		[ExcludeFromCodeCoverage]
 		public override string ToString()
 		{
-			List<PropertySetup>? storage = _storage;
-			if (storage is null || storage.Count == 0)
+			PropertySetup[]? storage = Volatile.Read(ref _storage);
+			if (storage is null || storage.Length == 0)
 			{
 				return "0 properties";
 			}
 
-			lock (storage)
+			List<PropertySetup>? setups = null;
+			foreach (PropertySetup setup in storage)
 			{
-				List<PropertySetup>? setups = null;
-				foreach (PropertySetup setup in storage)
+				if (setup is not PropertySetup.Default)
 				{
-					if (setup is not PropertySetup.Default)
-					{
-						setups ??= [];
-						setups.Add(setup);
-					}
+					setups ??= [];
+					setups.Add(setup);
 				}
-
-				if (setups is null || setups.Count == 0)
-				{
-					return "0 properties";
-				}
-
-				StringBuilder sb = new();
-				sb.Append(setups.Count).Append(setups.Count == 1 ? " property:" : " properties:").AppendLine();
-				foreach (PropertySetup item in setups)
-				{
-					sb.Append(item).Append(' ').Append(item.Name).AppendLine();
-				}
-
-				sb.Length -= Environment.NewLine.Length;
-				return sb.ToString();
 			}
+
+			if (setups is null || setups.Count == 0)
+			{
+				return "0 properties";
+			}
+
+			StringBuilder sb = new();
+			sb.Append(setups.Count).Append(setups.Count == 1 ? " property:" : " properties:").AppendLine();
+			foreach (PropertySetup item in setups)
+			{
+				sb.Append(item).Append(' ').Append(item.Name).AppendLine();
+			}
+
+			sb.Length -= Environment.NewLine.Length;
+			return sb.ToString();
 		}
 	}
 }

--- a/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
@@ -333,7 +333,7 @@ public sealed partial class MockTests
 				await Task.WhenAll(tasks);
 
 				// Each read sees either the pre-setup default or the configured value.
-				await That(stringValues).All().Satisfy(v => v is null or "" or "hello");
+				await That(stringValues).All().Satisfy(v => v is "" or "hello");
 				await That(guidValues).All().Satisfy(v => v == Guid.Empty || v == expectedGuid);
 				await That(sut.Mock.Verify.MyStringProperty.Got()).Exactly(readerCount * iterationsPerReader);
 				await That(sut.Mock.Verify.MyGuidProperty.Got()).Exactly(readerCount * iterationsPerReader);

--- a/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
@@ -335,8 +335,12 @@ public sealed partial class MockTests
 				// Each read sees either the pre-setup default or the configured value.
 				await That(stringValues).All().Satisfy(v => v is "" or "hello");
 				await That(guidValues).All().Satisfy(v => v == Guid.Empty || v == expectedGuid);
-				await That(sut.Mock.Verify.MyStringProperty.Got()).Exactly(readerCount * iterationsPerReader);
-				await That(sut.Mock.Verify.MyGuidProperty.Got()).Exactly(readerCount * iterationsPerReader);
+				// Both setup tasks have finished by now, so the configured value
+				// must win — a racing default insert must not have overwritten it.
+				await That(sut.MyStringProperty).IsEqualTo("hello");
+				await That(sut.MyGuidProperty).IsEqualTo(expectedGuid);
+				await That(sut.Mock.Verify.MyStringProperty.Got()).Exactly(readerCount * iterationsPerReader + 1);
+				await That(sut.Mock.Verify.MyGuidProperty.Got()).Exactly(readerCount * iterationsPerReader + 1);
 			}
 		}
 

--- a/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
@@ -291,6 +291,56 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task Property_ConcurrentSetupAndRead_ShouldBeThreadSafe()
+		{
+			for (int round = 0; round < 10; round++)
+			{
+				IMyThreadSafetyService sut = IMyThreadSafetyService.CreateMock();
+				Guid expectedGuid = Guid.NewGuid();
+				ManualResetEventSlim barrier = new(false);
+				int readerCount = 30;
+				int iterationsPerReader = 50;
+				Task[] tasks = new Task[readerCount + 2];
+				ConcurrentQueue<string?> stringValues = [];
+				ConcurrentQueue<Guid> guidValues = [];
+
+				tasks[0] = Task.Run(() =>
+				{
+					barrier.Wait();
+					sut.Mock.Setup.MyStringProperty.InitializeWith("hello");
+				}, CancellationToken.None);
+
+				tasks[1] = Task.Run(() =>
+				{
+					barrier.Wait();
+					sut.Mock.Setup.MyGuidProperty.InitializeWith(expectedGuid);
+				}, CancellationToken.None);
+
+				for (int i = 0; i < readerCount; i++)
+				{
+					tasks[2 + i] = Task.Run(() =>
+					{
+						barrier.Wait();
+						for (int j = 0; j < iterationsPerReader; j++)
+						{
+							stringValues.Enqueue(sut.MyStringProperty);
+							guidValues.Enqueue(sut.MyGuidProperty);
+						}
+					}, CancellationToken.None);
+				}
+
+				barrier.Set();
+				await Task.WhenAll(tasks);
+
+				// Each read sees either the pre-setup default or the configured value.
+				await That(stringValues).All().Satisfy(v => v is null or "" or "hello");
+				await That(guidValues).All().Satisfy(v => v == Guid.Empty || v == expectedGuid);
+				await That(sut.Mock.Verify.MyStringProperty.Got()).Exactly(readerCount * iterationsPerReader);
+				await That(sut.Mock.Verify.MyGuidProperty.Got()).Exactly(readerCount * iterationsPerReader);
+			}
+		}
+
+		[Fact]
 		public async Task Property_HighContention_ShouldBeThreadSafe()
 		{
 			for (int round = 0; round < 10; round++)


### PR DESCRIPTION
Improves thread-safety/performance of property setup lookups in Mockolate by switching `PropertySetups` storage to a copy-on-write array for lock-free reads, and adds a regression test covering concurrent property setup and reads.

**Changes:**
- Add a new thread-safety test for concurrent property setup + reads.
- Refactor `MockSetups.PropertySetups` from `List<T>` + lock-per-read to copy-on-write `PropertySetup[]` with a dedicated write lock and `Volatile.Read/Write` snapshotting.