### PR TITLE
refactor!: use `Callbacks<T>` class

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -420,21 +420,16 @@ internal static partial class Sources
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterSetup<TValue, ").Append(typeParams).Append(">,").AppendLine();
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterSetup<TValue, ").Append(typeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\tprivate readonly global::System.Collections.Generic.List<Callback<global::System.Action<int, ").Append(typeParams)
-			.Append(", TValue>>> _getterCallbacks = [];")
+		sb.Append("\t\tprivate Callbacks<global::System.Action<int, ").Append(typeParams)
+			.Append(", TValue>>? _getterCallbacks;")
 			.AppendLine();
-		sb.Append("\t\tprivate readonly global::System.Collections.Generic.List<Callback<global::System.Action<int, ").Append(typeParams)
-			.Append(", TValue>>> _setterCallbacks = [];")
+		sb.Append("\t\tprivate Callbacks<global::System.Action<int, ").Append(typeParams)
+			.Append(", TValue>>? _setterCallbacks;")
 			.AppendLine();
-		sb.Append("\t\tprivate readonly global::System.Collections.Generic.List<Callback<global::System.Func<int, ").Append(typeParams)
-			.Append(", TValue, TValue>>> _returnCallbacks = [];")
+		sb.Append("\t\tprivate Callbacks<global::System.Func<int, ").Append(typeParams)
+			.Append(", TValue, TValue>>? _returnCallbacks;")
 			.AppendLine();
 		sb.Append("\t\tprivate bool? _skipBaseClass;").AppendLine();
-		sb.Append("\t\tprivate Callback? _currentCallback;").AppendLine();
-		sb.Append("\t\tprivate Callback? _currentReturnCallback;").AppendLine();
-		sb.Append("\t\tprivate int _currentGetterCallbacksIndex;").AppendLine();
-		sb.Append("\t\tprivate int _currentReturnCallbackIndex;").AppendLine();
-		sb.Append("\t\tprivate int _currentSetterCallbacksIndex;").AppendLine();
 		sb.Append("\t\tprivate global::System.Func<").Append(typeParams).Append(", TValue>? _initialization;").AppendLine();
 		sb.AppendLine();
 
@@ -498,7 +493,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", _) => callback());").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -514,7 +510,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(parameters).Append(", _) => callback(").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -530,7 +527,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(parameters).Append(", v) => callback(").Append(parameters).Append(", v));").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -547,7 +545,8 @@ internal static partial class Sources
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams)
 			.Append(", TValue>>? currentCallback = new(callback);")
 			.AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -561,7 +560,8 @@ internal static partial class Sources
 			.Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", _) => TransitionScenario(scenario));").AppendLine();
 		sb.Append("\t\t\tcurrentCallback.InParallel();").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -582,8 +582,9 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, _, ")
 			.Append(discards).Append(") => callback());").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
+		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -597,8 +598,9 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", v) => callback(v));").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
+		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -612,8 +614,9 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(parameters).Append(", v) => callback(").Append(parameters).Append(", v));").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
+		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -628,8 +631,9 @@ internal static partial class Sources
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams)
 			.Append(", TValue>>? currentCallback = new(callback);")
 			.AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
+		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -642,8 +646,9 @@ internal static partial class Sources
 			.Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", _) => TransitionScenario(scenario));").AppendLine();
 		sb.Append("\t\t\tcurrentCallback.InParallel();").AppendLine();
-		sb.Append("\t\t\t_currentCallback = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_setterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
+		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -656,7 +661,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => returnValue);").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -670,7 +676,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => callback());").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -686,7 +693,8 @@ internal static partial class Sources
 			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", _) => callback(").Append(parameters)
 			.Append("));")
 			.AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -700,7 +708,8 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, v, ").Append(parameters).Append(") => callback(v, ").Append(parameters)
 			.Append("));").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -714,7 +723,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw new TException());").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -728,7 +738,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw exception);").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -742,7 +753,8 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw callback());").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -757,7 +769,8 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", _) => throw callback(").Append(parameters)
 			.Append("));").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -771,7 +784,8 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", v) => throw callback(").Append(parameters)
 			.Append(", v));").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback = currentCallback;").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
 		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -783,7 +797,7 @@ internal static partial class Sources
 			.Append("> IIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams)
 			.Append(">.When(global::System.Func<int, bool> predicate)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_currentCallback?.When(predicate);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks?.Active?.When(predicate);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -794,7 +808,7 @@ internal static partial class Sources
 			.Append("> IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append(">.InParallel()").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_currentCallback?.InParallel();").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks?.Active?.InParallel();").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -806,7 +820,7 @@ internal static partial class Sources
 			.Append(typeParams)
 			.Append(">.For(int times)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_currentCallback?.For(times);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks?.Active?.For(times);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -817,7 +831,7 @@ internal static partial class Sources
 			.Append(typeParams)
 			.Append(">.Only(int times)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_currentCallback?.Only(times);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks?.Active?.Only(times);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -828,7 +842,7 @@ internal static partial class Sources
 			.Append("> IIndexerSetupReturnBuilder<TValue, ").Append(typeParams)
 			.Append(">.When(global::System.Func<int, bool> predicate)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback?.When(predicate);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks?.Active?.When(predicate);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -840,7 +854,7 @@ internal static partial class Sources
 			.Append(typeParams)
 			.Append(">.For(int times)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback?.For(times);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks?.Active?.For(times);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -851,7 +865,7 @@ internal static partial class Sources
 			.Append(typeParams)
 			.Append(">.Only(int times)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_currentReturnCallback?.Only(times);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks?.Active?.Only(times);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -995,16 +1009,19 @@ internal static partial class Sources
 		sb.Append("\t\t\t\treturn;").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t\tbool wasInvoked = false;").AppendLine();
-		sb.Append("\t\t\tint currentSetterCallbacksIndex = _currentSetterCallbacksIndex;").AppendLine();
-		sb.Append("\t\t\tfor (int i = 0; i < _setterCallbacks.Count; i++)").AppendLine();
+		sb.Append("\t\t\tif (_setterCallbacks is not null)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>> setterCallback =").AppendLine();
-		sb.Append("\t\t\t\t\t_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\tif (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)").AppendLine();
-		sb.Append("\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", resultValue)))").AppendLine();
+		sb.Append("\t\t\t\tbool wasInvoked = false;").AppendLine();
+		sb.Append("\t\t\t\tint currentSetterCallbacksIndex = _setterCallbacks.CurrentIndex;").AppendLine();
+		sb.Append("\t\t\t\tfor (int i = 0; i < _setterCallbacks.Count; i++)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\twasInvoked = true;").AppendLine();
+		sb.Append("\t\t\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>> setterCallback =").AppendLine();
+		sb.Append("\t\t\t\t\t\t_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];").AppendLine();
+		sb.Append("\t\t\t\t\tif (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)").AppendLine();
+		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", resultValue)))").AppendLine();
+		sb.Append("\t\t\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();
+		sb.Append("\t\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 		sb.Append("\t\t}").AppendLine();
@@ -1014,16 +1031,19 @@ internal static partial class Sources
 		sb.Append("\t\tprivate TValue ExecuteGetterCallbacks(").Append(
 			string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i} p{i}"))).Append(", TValue currentValue)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tbool wasInvoked = false;").AppendLine();
-		sb.Append("\t\t\tint currentGetterCallbacksIndex = _currentGetterCallbacksIndex;").AppendLine();
-		sb.Append("\t\t\tfor (int i = 0; i < _getterCallbacks.Count; i++)").AppendLine();
+		sb.Append("\t\t\tif (_getterCallbacks is not null)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>> getterCallback =").AppendLine();
-		sb.Append("\t\t\t\t\t_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\tif (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)").AppendLine();
-		sb.Append("\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", currentValue)))").AppendLine();
+		sb.Append("\t\t\t\tbool wasInvoked = false;").AppendLine();
+		sb.Append("\t\t\t\tint currentGetterCallbacksIndex = _getterCallbacks.CurrentIndex;").AppendLine();
+		sb.Append("\t\t\t\tfor (int i = 0; i < _getterCallbacks.Count; i++)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\twasInvoked = true;").AppendLine();
+		sb.Append("\t\t\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>> getterCallback =").AppendLine();
+		sb.Append("\t\t\t\t\t\t_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];").AppendLine();
+		sb.Append("\t\t\t\t\tif (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)").AppendLine();
+		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", currentValue)))").AppendLine();
+		sb.Append("\t\t\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();
+		sb.Append("\t\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1036,15 +1056,18 @@ internal static partial class Sources
 			string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i} p{i}"))).Append(", TValue currentValue, out bool matched)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tmatched = false;").AppendLine();
-		sb.Append("\t\t\tforeach (Callback<global::System.Func<int, ").Append(typeParams).Append(", TValue, TValue>> _ in _returnCallbacks)").AppendLine();
+		sb.Append("\t\t\tif (_returnCallbacks is not null)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tCallback<global::System.Func<int, ").Append(typeParams).Append(", TValue, TValue>> returnCallback =").AppendLine();
-		sb.Append("\t\t\t\t\t_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\tif (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)").AppendLine();
-		sb.Append("\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", currentValue), out TValue? newValue))").AppendLine();
+		sb.Append("\t\t\t\tforeach (Callback<global::System.Func<int, ").Append(typeParams).Append(", TValue, TValue>> _ in _returnCallbacks)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\tmatched = true;").AppendLine();
-		sb.Append("\t\t\t\t\treturn newValue!;").AppendLine();
+		sb.Append("\t\t\t\t\tCallback<global::System.Func<int, ").Append(typeParams).Append(", TValue, TValue>> returnCallback =").AppendLine();
+		sb.Append("\t\t\t\t\t\t_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];").AppendLine();
+		sb.Append("\t\t\t\t\tif (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)").AppendLine();
+		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", currentValue), out TValue? newValue))").AppendLine();
+		sb.Append("\t\t\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t\t\tmatched = true;").AppendLine();
+		sb.Append("\t\t\t\t\t\treturn newValue!;").AppendLine();
+		sb.Append("\t\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 		sb.AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -40,9 +40,9 @@ internal static partial class Sources
 			string types = GetGenericTypeParameters(item);
 			sb.Append($$"""
 			            		/// <summary>
-			            		///     Extensions for indexer callback setups with {{item}} parameters.
+			            		///     Extensions for indexer getter callback setups with {{item}} parameters.
 			            		/// </summary>
-			            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, {{types}}> setup)
+			            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, {{types}}> setup)
 			            		{
 			            			/// <summary>
 			            			///     Executes the callback only once.
@@ -50,7 +50,19 @@ internal static partial class Sources
 			            			public global::Mockolate.Setup.IIndexerSetup<TValue, {{types}}> OnlyOnce()
 			            				=> setup.Only(1);
 			            		}
-			            		
+
+			            		/// <summary>
+			            		///     Extensions for indexer setter callback setups with {{item}} parameters.
+			            		/// </summary>
+			            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, {{types}}> setup)
+			            		{
+			            			/// <summary>
+			            			///     Executes the callback only once.
+			            			/// </summary>
+			            			public global::Mockolate.Setup.IIndexerSetup<TValue, {{types}}> OnlyOnce()
+			            				=> setup.Only(1);
+			            		}
+
 			            		/// <summary>
 			            		///     Extensions for indexer setups with {{item}} parameters.
 			            		/// </summary>
@@ -192,33 +204,33 @@ internal static partial class Sources
 		sb.Append("\tinternal interface IIndexerGetterSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action callback);")
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action callback);")
 			.AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
 		sb.AppendXmlRemarks("The callback receives the parameters of the indexer.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<")
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<")
 			.Append(typeParams)
 			.Append("> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
 		sb.AppendXmlRemarks("The callback receives the parameters of the indexer and the value of the indexer as last parameter.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<")
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<")
 			.Append(typeParams)
 			.Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's getter is accessed.");
 		sb.AppendXmlRemarks("The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value of the indexer as last parameter.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<int, ")
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<int, ")
 			.Append(typeParams)
 			.Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Transitions the scenario to the given <paramref name=\"scenario\" /> whenever the indexer is read.");
-		sb.Append("\t\tIIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append("> TransitionTo(string scenario);")
+		sb.Append("\t\tIIndexerGetterSetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append("> TransitionTo(string scenario);")
 			.AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
@@ -227,30 +239,30 @@ internal static partial class Sources
 		sb.Append("\tinternal interface IIndexerSetterSetup<TValue, ").Append(outTypeParams).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action callback);")
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action callback);")
 			.AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
 		sb.AppendXmlRemarks("The callback receives the value the indexer is set to as single parameter.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> Do(global::System.Action<TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
 		sb.AppendXmlRemarks("The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<")
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<")
 			.Append(typeParams).Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Registers a <paramref name=\"callback\"/> to be invoked whenever the indexer's setter is accessed.");
 		sb.AppendXmlRemarks("The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the value the indexer is set to as last parameter.");
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<int, ")
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append("> Do(global::System.Action<int, ")
 			.Append(typeParams).Append(", TValue> callback);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary("Transitions the scenario to the given <paramref name=\"scenario\" /> whenever the indexer is written to.");
-		sb.Append("\t\tIIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append("> TransitionTo(string scenario);")
+		sb.Append("\t\tIIndexerSetterSetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append("> TransitionTo(string scenario);")
 			.AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
@@ -340,42 +352,45 @@ internal static partial class Sources
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary($"Sets up a callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
-		sb.Append("\tinternal interface IIndexerSetupCallbackBuilder<TValue, ").Append(outTypeParams)
-			.Append("> : IIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
-		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary("Runs the callback in parallel to the other callbacks.");
-		sb.Append("\t\tIIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append("> InParallel();")
-			.AppendLine();
-		sb.Append("\t}").AppendLine();
-		sb.AppendLine();
+		foreach (string side in new[] { "Getter", "Setter" })
+		{
+			sb.AppendXmlSummary($"Sets up a {side.ToLowerInvariant()} callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
+			sb.Append("\tinternal interface IIndexer").Append(side).Append("SetupCallbackBuilder<TValue, ").Append(outTypeParams)
+				.Append("> : IIndexer").Append(side).Append("SetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
+			sb.Append("\t{").AppendLine();
+			sb.AppendXmlSummary("Runs the callback in parallel to the other callbacks.");
+			sb.Append("\t\tIIndexer").Append(side).Append("SetupParallelCallbackBuilder<TValue, ").Append(typeParams).Append("> InParallel();")
+				.AppendLine();
+			sb.Append("\t}").AppendLine();
+			sb.AppendLine();
 
-		sb.AppendXmlSummary($"Sets up a parallel callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
-		sb.Append("\tinternal interface IIndexerSetupParallelCallbackBuilder<TValue, ").Append(outTypeParams)
-			.Append("> : IIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
-		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary("Limits the callback to only execute for indexer accesses where the predicate returns true.");
-		sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the indexer has been accessed so far.");
-		sb.Append("\t\tIIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams)
-			.Append("> When(global::System.Func<int, bool> predicate);").AppendLine();
-		sb.Append("\t}").AppendLine();
-		sb.AppendLine();
+			sb.AppendXmlSummary($"Sets up a parallel {side.ToLowerInvariant()} callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
+			sb.Append("\tinternal interface IIndexer").Append(side).Append("SetupParallelCallbackBuilder<TValue, ").Append(outTypeParams)
+				.Append("> : IIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ").Append(typeParams).Append(">").AppendLine();
+			sb.Append("\t{").AppendLine();
+			sb.AppendXmlSummary("Limits the callback to only execute for indexer accesses where the predicate returns true.");
+			sb.AppendXmlRemarks("Provides a zero-based counter indicating how many times the indexer has been accessed so far.");
+			sb.Append("\t\tIIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ").Append(typeParams)
+				.Append("> When(global::System.Func<int, bool> predicate);").AppendLine();
+			sb.Append("\t}").AppendLine();
+			sb.AppendLine();
 
-		sb.AppendXmlSummary($"Sets up a when callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
-		sb.Append("\tinternal interface IIndexerSetupCallbackWhenBuilder<TValue, ").Append(outTypeParams)
-			.Append("> : global::Mockolate.Setup.IIndexerSetup<TValue, ").Append(typeParams).Append(">").AppendLine();
-		sb.Append("\t{").AppendLine();
+			sb.AppendXmlSummary($"Sets up a when {side.ToLowerInvariant()} callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
+			sb.Append("\tinternal interface IIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ").Append(outTypeParams)
+				.Append("> : global::Mockolate.Setup.IIndexerSetup<TValue, ").Append(typeParams).Append(">").AppendLine();
+			sb.Append("\t{").AppendLine();
 
-		sb.AppendXmlSummary("Repeats the callback for the given number of <paramref name=\"times\" />.");
-		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexerSetupParallelCallbackBuilder{{TValue, {typeParams}}}.When(global::System.Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
-		sb.Append("\t\tIIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams).Append("> For(int times);")
-			.AppendLine();
-		sb.AppendLine();
-		sb.AppendXmlSummary("Deactivates the callback after the given number of <paramref name=\"times\" />.");
-		sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexerSetupParallelCallbackBuilder{{TValue, {typeParams}}}.When(global::System.Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
-		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetup<TValue, ").Append(typeParams).Append("> Only(int times);").AppendLine();
-		sb.Append("\t}").AppendLine();
-		sb.AppendLine();
+			sb.AppendXmlSummary("Repeats the callback for the given number of <paramref name=\"times\" />.");
+			sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexer{side}SetupParallelCallbackBuilder{{TValue, {typeParams}}}.When(global::System.Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
+			sb.Append("\t\tIIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ").Append(typeParams).Append("> For(int times);")
+				.AppendLine();
+			sb.AppendLine();
+			sb.AppendXmlSummary("Deactivates the callback after the given number of <paramref name=\"times\" />.");
+			sb.AppendXmlRemarks($"The number of times is only counted for actual executions (<see cref=\"IIndexer{side}SetupParallelCallbackBuilder{{TValue, {typeParams}}}.When(global::System.Func{{int, bool}})\" /> evaluates to <see langword=\"true\" />).");
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetup<TValue, ").Append(typeParams).Append("> Only(int times);").AppendLine();
+			sb.Append("\t}").AppendLine();
+			sb.AppendLine();
+		}
 
 		sb.AppendXmlSummary($"Sets up a return/throw callback for a <typeparamref name=\"TValue\"/> indexer for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
 		sb.Append("\tinternal interface IIndexerSetupReturnBuilder<TValue, ").Append(outTypeParams)
@@ -415,7 +430,8 @@ internal static partial class Sources
 				string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"global::Mockolate.Parameters.IParameterMatch<T{i}> parameter{i}")))
 			.Append(") : global::Mockolate.Setup.IndexerSetup(mockRegistry),")
 			.AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterSetup<TValue, ").Append(typeParams).Append(">,").AppendLine();
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterSetup<TValue, ").Append(typeParams).Append(">").AppendLine();
@@ -487,22 +503,20 @@ internal static partial class Sources
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams)
 			.Append("}.Do(global::System.Action)\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", _) => callback());").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks = _getterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams).Append("}.Do(global::System.Action{")
 			.Append(typeParams).Append("})\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action<")
 			.Append(typeParams)
@@ -510,16 +524,14 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(parameters).Append(", _) => callback(").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks = _getterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams).Append("}.Do(global::System.Action{")
 			.Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action<")
 			.Append(typeParams)
@@ -527,16 +539,14 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(parameters).Append(", v) => callback(").Append(parameters).Append(", v));").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks = _getterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerGetterSetup{TValue, ").Append(typeParams)
 			.Append("}.Do(global::System.Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerGetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action<int, ")
 			.Append(typeParams)
@@ -545,14 +555,12 @@ internal static partial class Sources
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams)
 			.Append(", TValue>>? currentCallback = new(callback);")
 			.AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks = _getterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\tIIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerGetterSetupParallelCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerGetterSetup<TValue, ").Append(typeParams)
 			.Append(">.TransitionTo(string scenario)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -560,9 +568,7 @@ internal static partial class Sources
 			.Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", _) => TransitionScenario(scenario));").AppendLine();
 		sb.Append("\t\t\tcurrentCallback.InParallel();").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_getterCallbacks = _getterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -576,54 +582,48 @@ internal static partial class Sources
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams)
 			.Append("}.Do(global::System.Action)\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, _, ")
 			.Append(discards).Append(") => callback());").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_setterCallbacks = _setterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams)
 			.Append("}.Do(global::System.Action{TValue})\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action<TValue> callback)")
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", v) => callback(v));").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_setterCallbacks = _setterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams).Append("}.Do(global::System.Action{")
 			.Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action<")
 			.Append(typeParams).Append(", TValue> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>>? currentCallback = new((_, ")
 			.Append(parameters).Append(", v) => callback(").Append(parameters).Append(", v));").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_setterCallbacks = _setterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetterSetup{TValue, ").Append(typeParams)
 			.Append("}.Do(global::System.Action{int, ").Append(typeParams).Append(", TValue})\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
 			.Append(">.Do(global::System.Action<int, ")
 			.Append(typeParams).Append(", TValue> callback)").AppendLine();
@@ -631,14 +631,12 @@ internal static partial class Sources
 		sb.Append("\t\t\tCallback<global::System.Action<int, ").Append(typeParams)
 			.Append(", TValue>>? currentCallback = new(callback);")
 			.AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_setterCallbacks = _setterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\tIIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams)
+		sb.Append("\t\tIIndexerSetterSetupParallelCallbackBuilder<TValue, ").Append(typeParams)
 			.Append("> IIndexerSetterSetup<TValue, ").Append(typeParams)
 			.Append(">.TransitionTo(string scenario)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -646,9 +644,7 @@ internal static partial class Sources
 			.Append(", TValue>>? currentCallback = new((_, ")
 			.Append(discards).Append(", _) => TransitionScenario(scenario));").AppendLine();
 		sb.Append("\t\t\tcurrentCallback.InParallel();").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t(_setterCallbacks ??= []).Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_setterCallbacks = _setterCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -661,9 +657,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => returnValue);").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -676,9 +670,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => callback());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -693,9 +685,7 @@ internal static partial class Sources
 			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", _) => callback(").Append(parameters)
 			.Append("));")
 			.AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -708,9 +698,7 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, v, ").Append(parameters).Append(") => callback(v, ").Append(parameters)
 			.Append("));").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -723,9 +711,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw new TException());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -738,9 +724,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw exception);").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -753,9 +737,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(discards).Append(", _) => throw callback());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -769,9 +751,7 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", _) => throw callback(").Append(parameters)
 			.Append("));").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -784,57 +764,58 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new Callback<global::System.Func<int, ").Append(typeParams)
 			.Append(", TValue, TValue>>((_, ").Append(parameters).Append(", v) => throw callback(").Append(parameters)
 			.Append(", v));").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetupParallelCallbackBuilder{TValue, ").Append(typeParams)
-			.Append("}.When(global::System.Func{int, bool})\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams)
-			.Append("> IIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams)
-			.Append(">.When(global::System.Func<int, bool> predicate)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks?.Active?.When(predicate);").AppendLine();
-		sb.Append("\t\t\treturn this;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
+		foreach ((string side, string fieldName) in new[] { ("Getter", "_getterCallbacks"), ("Setter", "_setterCallbacks") })
+		{
+			sb.Append("\t\t/// <inheritdoc cref=\"IIndexer").Append(side).Append("SetupParallelCallbackBuilder{TValue, ").Append(typeParams)
+				.Append("}.When(global::System.Func{int, bool})\" />").AppendLine();
+			sb.Append("\t\tIIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ").Append(typeParams)
+				.Append("> IIndexer").Append(side).Append("SetupParallelCallbackBuilder<TValue, ").Append(typeParams)
+				.Append(">.When(global::System.Func<int, bool> predicate)").AppendLine();
+			sb.Append("\t\t{").AppendLine();
+			sb.Append("\t\t\t").Append(fieldName).Append("?.Active?.When(predicate);").AppendLine();
+			sb.Append("\t\t\treturn this;").AppendLine();
+			sb.Append("\t\t}").AppendLine();
+			sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetupCallbackBuilder{TValue, ").Append(typeParams)
-			.Append("}.InParallel()\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupParallelCallbackBuilder<TValue, ").Append(typeParams)
-			.Append("> IIndexerSetupCallbackBuilder<TValue, ").Append(typeParams)
-			.Append(">.InParallel()").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks?.Active?.InParallel();").AppendLine();
-		sb.Append("\t\t\treturn this;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
+			sb.Append("\t\t/// <inheritdoc cref=\"IIndexer").Append(side).Append("SetupCallbackBuilder{TValue, ").Append(typeParams)
+				.Append("}.InParallel()\" />").AppendLine();
+			sb.Append("\t\tIIndexer").Append(side).Append("SetupParallelCallbackBuilder<TValue, ").Append(typeParams)
+				.Append("> IIndexer").Append(side).Append("SetupCallbackBuilder<TValue, ").Append(typeParams)
+				.Append(">.InParallel()").AppendLine();
+			sb.Append("\t\t{").AppendLine();
+			sb.Append("\t\t\t").Append(fieldName).Append("?.Active?.InParallel();").AppendLine();
+			sb.Append("\t\t\treturn this;").AppendLine();
+			sb.Append("\t\t}").AppendLine();
+			sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetupCallbackWhenBuilder{TValue, ").Append(typeParams)
-			.Append("}.For(int)\" />").AppendLine();
-		sb.Append("\t\tIIndexerSetupCallbackWhenBuilder<TValue, ").Append(typeParams)
-			.Append("> IIndexerSetupCallbackWhenBuilder<TValue, ")
-			.Append(typeParams)
-			.Append(">.For(int times)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks?.Active?.For(times);").AppendLine();
-		sb.Append("\t\t\treturn this;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
+			sb.Append("\t\t/// <inheritdoc cref=\"IIndexer").Append(side).Append("SetupCallbackWhenBuilder{TValue, ").Append(typeParams)
+				.Append("}.For(int)\" />").AppendLine();
+			sb.Append("\t\tIIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ").Append(typeParams)
+				.Append("> IIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ")
+				.Append(typeParams)
+				.Append(">.For(int times)").AppendLine();
+			sb.Append("\t\t{").AppendLine();
+			sb.Append("\t\t\t").Append(fieldName).Append("?.Active?.For(times);").AppendLine();
+			sb.Append("\t\t\treturn this;").AppendLine();
+			sb.Append("\t\t}").AppendLine();
+			sb.AppendLine();
 
-		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetupCallbackWhenBuilder{TValue, ").Append(typeParams)
-			.Append("}.Only(int)\" />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetup<TValue, ").Append(typeParams).Append("> IIndexerSetupCallbackWhenBuilder<TValue, ")
-			.Append(typeParams)
-			.Append(">.Only(int times)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\t_getterCallbacks?.Active?.Only(times);").AppendLine();
-		sb.Append("\t\t\treturn this;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
+			sb.Append("\t\t/// <inheritdoc cref=\"IIndexer").Append(side).Append("SetupCallbackWhenBuilder{TValue, ").Append(typeParams)
+				.Append("}.Only(int)\" />").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetup<TValue, ").Append(typeParams).Append("> IIndexer").Append(side).Append("SetupCallbackWhenBuilder<TValue, ")
+				.Append(typeParams)
+				.Append(">.Only(int times)").AppendLine();
+			sb.Append("\t\t{").AppendLine();
+			sb.Append("\t\t\t").Append(fieldName).Append("?.Active?.Only(times);").AppendLine();
+			sb.Append("\t\t\treturn this;").AppendLine();
+			sb.Append("\t\t}").AppendLine();
+			sb.AppendLine();
+		}
 
 		sb.Append("\t\t/// <inheritdoc cref=\"IIndexerSetupReturnBuilder{TValue, ").Append(typeParams)
 			.Append("}.When(global::System.Func{int, bool})\" />").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -364,9 +364,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ")
 			.Append(discards).Append(") => callback());").AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -378,9 +376,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ")
 			.Append(parameters).Append(") => callback(").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -392,9 +388,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new(callback);")
 			.AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -407,9 +401,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ").Append(discards).Append(") => _mockRegistry.TransitionTo(scenario));").AppendLine();
 		sb.Append("\t\t\tcurrentCallback.InParallel();").AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -422,9 +414,7 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>((_, ")
 			.Append(string.Join(", ", Enumerable.Range(0, numberOfParameters).Select(_ => "_")))
 			.Append(") => { });").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -437,9 +427,7 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>((_, ")
 			.Append(string.Join(", ", Enumerable.Range(0, numberOfParameters).Select(_ => "_")))
 			.Append(") => throw new TException());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -452,9 +440,7 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>((_, ")
 			.Append(string.Join(", ", Enumerable.Range(0, numberOfParameters).Select(_ => "_")))
 			.Append(") => throw exception);").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -467,9 +453,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>((_, ")
 			.Append(parameters).Append(") => throw callback(").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -485,9 +469,7 @@ internal static partial class Sources
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>((_, ")
 			.Append(string.Join(", ", Enumerable.Range(0, numberOfParameters).Select(_ => "_")))
 			.Append(") => throw callback());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1015,9 +997,7 @@ internal static partial class Sources
 			.Append(">.Do(global::System.Action callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ").Append(discards).Append(") => callback());").AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1029,9 +1009,7 @@ internal static partial class Sources
 			.Append(">.Do(global::System.Action<").Append(typeParams).Append("> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ").Append(parameters).Append(") => callback(").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1043,9 +1021,7 @@ internal static partial class Sources
 			.Append(">.Do(global::System.Action<int, ").Append(typeParams).Append("> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new(callback);").AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1058,9 +1034,7 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Setup.Callback<global::System.Action<int, ").Append(typeParams).Append(">>? currentCallback = new((_, ").Append(discards).Append(") => _mockRegistry.TransitionTo(scenario));").AppendLine();
 		sb.Append("\t\t\tcurrentCallback.InParallel();").AppendLine();
-		sb.Append("\t\t\t_callbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_callbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_callbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_callbacks = _callbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1072,9 +1046,7 @@ internal static partial class Sources
 			.Append(">.Returns(global::System.Func<").Append(typeParams).Append(", TReturn> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Func<int, ").Append(typeParams).Append(", TReturn>>((_, ").Append(parameters).Append(") => callback(").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1086,9 +1058,7 @@ internal static partial class Sources
 			.Append(">.Returns(global::System.Func<TReturn> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Func<int, ").Append(typeParams).Append(", TReturn>>((_, ").Append(discards).Append(") => callback());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1100,9 +1070,7 @@ internal static partial class Sources
 			.Append(">.Returns(TReturn returnValue)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Func<int, ").Append(typeParams).Append(", TReturn>>((_, ").Append(discards).Append(") => returnValue);").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1114,9 +1082,7 @@ internal static partial class Sources
 			.Append(">.Throws<TException>()").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Func<int, ").Append(typeParams).Append(", TReturn>>((_, ").Append(discards).Append(") => throw new TException());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1128,9 +1094,7 @@ internal static partial class Sources
 			.Append(">.Throws(global::System.Exception exception)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Func<int, ").Append(typeParams).Append(", TReturn>>((_, ").Append(discards).Append(") => throw exception);").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1142,9 +1106,7 @@ internal static partial class Sources
 			.Append(">.Throws(global::System.Func<").Append(typeParams).Append(", global::System.Exception> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Func<int, ").Append(typeParams).Append(", TReturn>>((_, ").Append(parameters).Append(") => throw callback(").Append(parameters).Append("));").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1156,9 +1118,7 @@ internal static partial class Sources
 			.Append(">.Throws(global::System.Func<global::System.Exception> callback)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tvar currentCallback = new global::Mockolate.Setup.Callback<global::System.Func<int, ").Append(typeParams).Append(", TReturn>>((_, ").Append(discards).Append(") => throw callback());").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks ??= [];").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Active = currentCallback;").AppendLine();
-		sb.Append("\t\t\t_returnCallbacks.Add(currentCallback);").AppendLine();
+		sb.Append("\t\t\t_returnCallbacks = _returnCallbacks.Register(currentCallback);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();

--- a/Source/Mockolate/Setup/Callbacks.cs
+++ b/Source/Mockolate/Setup/Callbacks.cs
@@ -22,5 +22,5 @@ public class Callbacks<T> : List<Callback<T>> where T : Delegate
 	/// <remarks>
 	///     This is used to fluently specify options like `Once` or `InParallel` on the currently active callback.
 	/// </remarks>
-	public Callback<T>? Active { get; set; }
+	public Callback<T>? Active { get; internal set; }
 }

--- a/Source/Mockolate/Setup/CallbacksExtensions.cs
+++ b/Source/Mockolate/Setup/CallbacksExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Mockolate.Setup;
+
+/// <summary>
+///     Extension methods for <see cref="Callbacks{T}" />.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public static class CallbacksExtensions
+{
+	/// <summary>
+	///     Appends the <paramref name="callback" /> to the <paramref name="callbacks" /> list
+	///     and marks it as the currently active callback. Creates the list if it is <see langword="null" />.
+	/// </summary>
+	public static Callbacks<T> Register<T>(this Callbacks<T>? callbacks, Callback<T> callback)
+		where T : Delegate
+	{
+		callbacks ??= [];
+		callbacks.Active = callback;
+		callbacks.Add(callback);
+		return callbacks;
+	}
+}

--- a/Source/Mockolate/Setup/EventSetup.cs
+++ b/Source/Mockolate/Setup/EventSetup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Mockolate.Internals;
@@ -18,11 +17,8 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 		IEventUnsubscriptionSetup,
 		IEventSetupCallbackBuilder
 {
-	private Callback? _currentCallback;
-	private int _currentSubscribedCallbacksIndex;
-	private int _currentUnsubscribedCallbacksIndex;
-	private List<Callback<Action<int, object?, MethodInfo>>>? _subscribedCallbacks;
-	private List<Callback<Action<int, object?, MethodInfo>>>? _unsubscribedCallbacks;
+	private Callbacks<Action<int, object?, MethodInfo>>? _subscribedCallbacks;
+	private Callbacks<Action<int, object?, MethodInfo>>? _unsubscribedCallbacks;
 
 	/// <summary>
 	///     The fully-qualified name of the event.
@@ -38,28 +34,28 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	/// <inheritdoc cref="IEventSetupParallelCallbackBuilder.When(Func{int, bool})" />
 	IEventSetupCallbackWhenBuilder IEventSetupParallelCallbackBuilder.When(Func<int, bool> predicate)
 	{
-		_currentCallback?.When(predicate);
+		_subscribedCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IEventSetupCallbackBuilder.InParallel()" />
 	IEventSetupParallelCallbackBuilder IEventSetupCallbackBuilder.InParallel()
 	{
-		_currentCallback?.InParallel();
+		_subscribedCallbacks?.Active?.InParallel();
 		return this;
 	}
 
 	/// <inheritdoc cref="IEventSetupCallbackWhenBuilder.For(int)" />
 	IEventSetupCallbackWhenBuilder IEventSetupCallbackWhenBuilder.For(int times)
 	{
-		_currentCallback?.For(times);
+		_subscribedCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IEventSetupCallbackWhenBuilder.Only(int)" />
 	IEventSetup IEventSetupCallbackWhenBuilder.Only(int times)
 	{
-		_currentCallback?.Only(times);
+		_subscribedCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -67,8 +63,9 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	IEventSetupCallbackBuilder IEventSubscriptionSetup.Do(Action callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_currentCallback = item;
-		(_subscribedCallbacks ??= []).Add(item);
+		_subscribedCallbacks ??= [];
+		_subscribedCallbacks.Active = item;
+		_subscribedCallbacks.Add(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -82,8 +79,9 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	IEventSetupCallbackBuilder IEventSubscriptionSetup.Do(Action<object?, MethodInfo> callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_currentCallback = item;
-		(_subscribedCallbacks ??= []).Add(item);
+		_subscribedCallbacks ??= [];
+		_subscribedCallbacks.Active = item;
+		_subscribedCallbacks.Add(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -97,8 +95,9 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new((_, _, _) => mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_currentCallback = item;
-		(_subscribedCallbacks ??= []).Add(item);
+		_subscribedCallbacks ??= [];
+		_subscribedCallbacks.Active = item;
+		_subscribedCallbacks.Add(item);
 		return this;
 	}
 
@@ -106,7 +105,8 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	IEventSetupCallbackBuilder IEventUnsubscriptionSetup.Do(Action callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_currentCallback = item;
+		_subscribedCallbacks ??= [];
+		_subscribedCallbacks.Active = item;
 		(_unsubscribedCallbacks ??= []).Add(item);
 		return this;
 
@@ -121,7 +121,8 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	IEventSetupCallbackBuilder IEventUnsubscriptionSetup.Do(Action<object?, MethodInfo> callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_currentCallback = item;
+		_subscribedCallbacks ??= [];
+		_subscribedCallbacks.Active = item;
 		(_unsubscribedCallbacks ??= []).Add(item);
 		return this;
 
@@ -136,7 +137,8 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new((_, _, _) => mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_currentCallback = item;
+		_subscribedCallbacks ??= [];
+		_subscribedCallbacks.Active = item;
 		(_unsubscribedCallbacks ??= []).Add(item);
 		return this;
 	}
@@ -152,12 +154,12 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 		}
 
 		bool wasInvoked = false;
-		int currentIndex = _currentSubscribedCallbacksIndex;
+		int currentIndex = _subscribedCallbacks.CurrentIndex;
 		for (int i = 0; i < _subscribedCallbacks.Count; i++)
 		{
 			Callback<Action<int, object?, MethodInfo>> callback =
 				_subscribedCallbacks[(currentIndex + i) % _subscribedCallbacks.Count];
-			if (callback.Invoke(wasInvoked, ref _currentSubscribedCallbacksIndex, Dispatch))
+			if (callback.Invoke(wasInvoked, ref _subscribedCallbacks.CurrentIndex, Dispatch))
 			{
 				wasInvoked = true;
 			}
@@ -181,12 +183,12 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 		}
 
 		bool wasInvoked = false;
-		int currentIndex = _currentUnsubscribedCallbacksIndex;
+		int currentIndex = _unsubscribedCallbacks.CurrentIndex;
 		for (int i = 0; i < _unsubscribedCallbacks.Count; i++)
 		{
 			Callback<Action<int, object?, MethodInfo>> callback =
 				_unsubscribedCallbacks[(currentIndex + i) % _unsubscribedCallbacks.Count];
-			if (callback.Invoke(wasInvoked, ref _currentUnsubscribedCallbacksIndex, Dispatch))
+			if (callback.Invoke(wasInvoked, ref _unsubscribedCallbacks.CurrentIndex, Dispatch))
 			{
 				wasInvoked = true;
 			}

--- a/Source/Mockolate/Setup/EventSetup.cs
+++ b/Source/Mockolate/Setup/EventSetup.cs
@@ -15,7 +15,8 @@ namespace Mockolate.Setup;
 public class EventSetup(MockRegistry mockRegistry, string name)
 	: IEventSubscriptionSetup,
 		IEventUnsubscriptionSetup,
-		IEventSetupCallbackBuilder
+		IEventSubscriptionSetupCallbackBuilder,
+		IEventUnsubscriptionSetupCallbackBuilder
 {
 	private Callbacks<Action<int, object?, MethodInfo>>? _subscribedCallbacks;
 	private Callbacks<Action<int, object?, MethodInfo>>? _unsubscribedCallbacks;
@@ -31,41 +32,67 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	/// <inheritdoc cref="IEventSetup.OnUnsubscribed" />
 	public IEventUnsubscriptionSetup OnUnsubscribed => this;
 
-	/// <inheritdoc cref="IEventSetupParallelCallbackBuilder.When(Func{int, bool})" />
-	IEventSetupCallbackWhenBuilder IEventSetupParallelCallbackBuilder.When(Func<int, bool> predicate)
+	/// <inheritdoc cref="IEventSubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" />
+	IEventSubscriptionSetupCallbackWhenBuilder IEventSubscriptionSetupParallelCallbackBuilder.When(Func<int, bool> predicate)
 	{
 		_subscribedCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
-	/// <inheritdoc cref="IEventSetupCallbackBuilder.InParallel()" />
-	IEventSetupParallelCallbackBuilder IEventSetupCallbackBuilder.InParallel()
+	/// <inheritdoc cref="IEventSubscriptionSetupCallbackBuilder.InParallel()" />
+	IEventSubscriptionSetupParallelCallbackBuilder IEventSubscriptionSetupCallbackBuilder.InParallel()
 	{
 		_subscribedCallbacks?.Active?.InParallel();
 		return this;
 	}
 
-	/// <inheritdoc cref="IEventSetupCallbackWhenBuilder.For(int)" />
-	IEventSetupCallbackWhenBuilder IEventSetupCallbackWhenBuilder.For(int times)
+	/// <inheritdoc cref="IEventSubscriptionSetupCallbackWhenBuilder.For(int)" />
+	IEventSubscriptionSetupCallbackWhenBuilder IEventSubscriptionSetupCallbackWhenBuilder.For(int times)
 	{
 		_subscribedCallbacks?.Active?.For(times);
 		return this;
 	}
 
-	/// <inheritdoc cref="IEventSetupCallbackWhenBuilder.Only(int)" />
-	IEventSetup IEventSetupCallbackWhenBuilder.Only(int times)
+	/// <inheritdoc cref="IEventSubscriptionSetupCallbackWhenBuilder.Only(int)" />
+	IEventSetup IEventSubscriptionSetupCallbackWhenBuilder.Only(int times)
 	{
 		_subscribedCallbacks?.Active?.Only(times);
 		return this;
 	}
 
+	/// <inheritdoc cref="IEventUnsubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" />
+	IEventUnsubscriptionSetupCallbackWhenBuilder IEventUnsubscriptionSetupParallelCallbackBuilder.When(Func<int, bool> predicate)
+	{
+		_unsubscribedCallbacks?.Active?.When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IEventUnsubscriptionSetupCallbackBuilder.InParallel()" />
+	IEventUnsubscriptionSetupParallelCallbackBuilder IEventUnsubscriptionSetupCallbackBuilder.InParallel()
+	{
+		_unsubscribedCallbacks?.Active?.InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IEventUnsubscriptionSetupCallbackWhenBuilder.For(int)" />
+	IEventUnsubscriptionSetupCallbackWhenBuilder IEventUnsubscriptionSetupCallbackWhenBuilder.For(int times)
+	{
+		_unsubscribedCallbacks?.Active?.For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IEventUnsubscriptionSetupCallbackWhenBuilder.Only(int)" />
+	IEventSetup IEventUnsubscriptionSetupCallbackWhenBuilder.Only(int times)
+	{
+		_unsubscribedCallbacks?.Active?.Only(times);
+		return this;
+	}
+
 	/// <inheritdoc cref="IEventSubscriptionSetup.Do(Action)" />
-	IEventSetupCallbackBuilder IEventSubscriptionSetup.Do(Action callback)
+	IEventSubscriptionSetupCallbackBuilder IEventSubscriptionSetup.Do(Action callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_subscribedCallbacks ??= [];
-		_subscribedCallbacks.Active = item;
-		_subscribedCallbacks.Add(item);
+		_subscribedCallbacks = _subscribedCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -76,12 +103,10 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	}
 
 	/// <inheritdoc cref="IEventSubscriptionSetup.Do(Action{object?, MethodInfo})" />
-	IEventSetupCallbackBuilder IEventSubscriptionSetup.Do(Action<object?, MethodInfo> callback)
+	IEventSubscriptionSetupCallbackBuilder IEventSubscriptionSetup.Do(Action<object?, MethodInfo> callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_subscribedCallbacks ??= [];
-		_subscribedCallbacks.Active = item;
-		_subscribedCallbacks.Add(item);
+		_subscribedCallbacks = _subscribedCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -91,23 +116,19 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 		}
 	}
 
-	IEventSetupParallelCallbackBuilder IEventSubscriptionSetup.TransitionTo(string scenario)
+	IEventSubscriptionSetupParallelCallbackBuilder IEventSubscriptionSetup.TransitionTo(string scenario)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new((_, _, _) => mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_subscribedCallbacks ??= [];
-		_subscribedCallbacks.Active = item;
-		_subscribedCallbacks.Add(item);
+		_subscribedCallbacks = _subscribedCallbacks.Register(item);
 		return this;
 	}
 
 	/// <inheritdoc cref="IEventUnsubscriptionSetup.Do(Action)" />
-	IEventSetupCallbackBuilder IEventUnsubscriptionSetup.Do(Action callback)
+	IEventUnsubscriptionSetupCallbackBuilder IEventUnsubscriptionSetup.Do(Action callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_subscribedCallbacks ??= [];
-		_subscribedCallbacks.Active = item;
-		(_unsubscribedCallbacks ??= []).Add(item);
+		_unsubscribedCallbacks = _unsubscribedCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -118,12 +139,10 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 	}
 
 	/// <inheritdoc cref="IEventUnsubscriptionSetup.Do(Action{object?, MethodInfo})" />
-	IEventSetupCallbackBuilder IEventUnsubscriptionSetup.Do(Action<object?, MethodInfo> callback)
+	IEventUnsubscriptionSetupCallbackBuilder IEventUnsubscriptionSetup.Do(Action<object?, MethodInfo> callback)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new(Delegate);
-		_subscribedCallbacks ??= [];
-		_subscribedCallbacks.Active = item;
-		(_unsubscribedCallbacks ??= []).Add(item);
+		_unsubscribedCallbacks = _unsubscribedCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -133,13 +152,11 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 		}
 	}
 
-	IEventSetupParallelCallbackBuilder IEventUnsubscriptionSetup.TransitionTo(string scenario)
+	IEventUnsubscriptionSetupParallelCallbackBuilder IEventUnsubscriptionSetup.TransitionTo(string scenario)
 	{
 		Callback<Action<int, object?, MethodInfo>> item = new((_, _, _) => mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_subscribedCallbacks ??= [];
-		_subscribedCallbacks.Active = item;
-		(_unsubscribedCallbacks ??= []).Add(item);
+		_unsubscribedCallbacks = _unsubscribedCallbacks.Register(item);
 		return this;
 	}
 

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Mockolate.Exceptions;
@@ -107,14 +106,9 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 		IIndexerSetupCallbackBuilder<TValue, T1>, IIndexerSetupReturnBuilder<TValue, T1>,
 		IIndexerGetterSetup<TValue, T1>, IIndexerSetterSetup<TValue, T1>
 {
-	private readonly List<Callback<Action<int, T1, TValue>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, T1, TValue, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, T1, TValue>>> _setterCallbacks = [];
-	private Callback? _currentCallback;
-	private int _currentGetterCallbacksIndex;
-	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex;
-	private int _currentSetterCallbacksIndex;
+	private Callbacks<Action<int, T1, TValue>>? _getterCallbacks;
+	private Callbacks<Func<int, T1, TValue, TValue>>? _returnCallbacks;
+	private Callbacks<Action<int, T1, TValue>>? _setterCallbacks;
 	private Func<T1, TValue>? _initialization;
 	private bool? _skipBaseClass;
 
@@ -122,7 +116,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -137,7 +132,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -152,7 +148,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -167,7 +164,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -176,7 +174,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -185,8 +184,9 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -200,8 +200,9 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -215,8 +216,9 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -230,8 +232,9 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -239,8 +242,9 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -287,7 +291,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -302,7 +307,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -317,7 +323,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -332,7 +339,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -348,7 +356,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -363,7 +372,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -378,7 +388,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -393,7 +404,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, Exception> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -408,7 +420,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -423,49 +436,49 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	IIndexerSetupCallbackWhenBuilder<TValue, T1> IIndexerSetupParallelCallbackBuilder<TValue, T1>.When(
 		Func<int, bool> predicate)
 	{
-		_currentCallback?.When(predicate);
+		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackBuilder{TValue, T1}.InParallel()" />
 	IIndexerSetupParallelCallbackBuilder<TValue, T1> IIndexerSetupCallbackBuilder<TValue, T1>.InParallel()
 	{
-		_currentCallback?.InParallel();
+		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1}.For(int)" />
 	IIndexerSetupCallbackWhenBuilder<TValue, T1> IIndexerSetupCallbackWhenBuilder<TValue, T1>.For(int times)
 	{
-		_currentCallback?.For(times);
+		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1}.Only(int)" />
 	IIndexerSetup<TValue, T1> IIndexerSetupCallbackWhenBuilder<TValue, T1>.Only(int times)
 	{
-		_currentCallback?.Only(times);
+		_getterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupReturnBuilder{TValue, T1}.When(Func{int, bool})" />
 	IIndexerSetupReturnWhenBuilder<TValue, T1> IIndexerSetupReturnBuilder<TValue, T1>.When(Func<int, bool> predicate)
 	{
-		_currentReturnCallback?.When(predicate);
+		_returnCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue,T1}.For(int)" />
 	IIndexerSetupReturnWhenBuilder<TValue, T1> IIndexerSetupReturnWhenBuilder<TValue, T1>.For(int times)
 	{
-		_currentReturnCallback?.For(times);
+		_returnCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue,T1}.Only(int)" />
 	IIndexerSetup<TValue, T1> IIndexerSetupReturnWhenBuilder<TValue, T1>.Only(int times)
 	{
-		_currentReturnCallback?.Only(times);
+		_returnCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -573,32 +586,38 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 			return;
 		}
 
-		bool wasInvoked = false;
-		int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
-		for (int i = 0; i < _setterCallbacks.Count; i++)
+		if (_setterCallbacks is not null)
 		{
-			Callback<Action<int, T1, TValue>> setterCallback =
-				_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-			if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, resultValue)))
+			bool wasInvoked = false;
+			int currentSetterCallbacksIndex = _setterCallbacks.CurrentIndex;
+			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, TValue>> setterCallback =
+					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, resultValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 	}
 
 	private TValue ExecuteGetterCallbacks(T1 p1, TValue currentValue)
 	{
-		bool wasInvoked = false;
-		int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
-		for (int i = 0; i < _getterCallbacks.Count; i++)
+		if (_getterCallbacks is not null)
 		{
-			Callback<Action<int, T1, TValue>> getterCallback =
-				_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-			if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, currentValue)))
+			bool wasInvoked = false;
+			int currentGetterCallbacksIndex = _getterCallbacks.CurrentIndex;
+			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, TValue>> getterCallback =
+					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, currentValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 
@@ -608,15 +627,18 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	private TValue ExecuteReturnCallbacks(T1 p1, TValue currentValue, out bool matched)
 	{
 		matched = false;
-		foreach (Callback<Func<int, T1, TValue, TValue>> _ in _returnCallbacks)
+		if (_returnCallbacks is not null)
 		{
-			Callback<Func<int, T1, TValue, TValue>> returnCallback =
-				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
-			if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, currentValue), out TValue? newValue))
+			foreach (Callback<Func<int, T1, TValue, TValue>> _ in _returnCallbacks)
 			{
-				matched = true;
-				return newValue!;
+				Callback<Func<int, T1, TValue, TValue>> returnCallback =
+					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, currentValue), out TValue? newValue))
+				{
+					matched = true;
+					return newValue!;
+				}
 			}
 		}
 
@@ -655,14 +677,9 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetupReturnBuilder<TValue, T1, T2>,
 	IIndexerGetterSetup<TValue, T1, T2>, IIndexerSetterSetup<TValue, T1, T2>
 {
-	private readonly List<Callback<Action<int, T1, T2, TValue>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, T1, T2, TValue, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, T1, T2, TValue>>> _setterCallbacks = [];
-	private Callback? _currentCallback;
-	private int _currentGetterCallbacksIndex;
-	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex;
-	private int _currentSetterCallbacksIndex;
+	private Callbacks<Action<int, T1, T2, TValue>>? _getterCallbacks;
+	private Callbacks<Func<int, T1, T2, TValue, TValue>>? _returnCallbacks;
+	private Callbacks<Action<int, T1, T2, TValue>>? _setterCallbacks;
 	private Func<T1, T2, TValue>? _initialization;
 	private bool? _skipBaseClass;
 
@@ -670,7 +687,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -685,7 +703,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -700,7 +719,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -716,7 +736,8 @@ public class IndexerSetup<TValue, T1, T2>(
 		Action<int, T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -725,7 +746,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -734,8 +756,9 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -749,8 +772,9 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -764,8 +788,9 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -780,8 +805,9 @@ public class IndexerSetup<TValue, T1, T2>(
 		Action<int, T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -789,8 +815,9 @@ public class IndexerSetup<TValue, T1, T2>(
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -837,7 +864,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -852,7 +880,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -867,7 +896,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -882,7 +912,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -898,7 +929,8 @@ public class IndexerSetup<TValue, T1, T2>(
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -913,7 +945,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -928,7 +961,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -943,7 +977,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -958,7 +993,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -973,28 +1009,28 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>.When(
 		Func<int, bool> predicate)
 	{
-		_currentCallback?.When(predicate);
+		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
 	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerSetupCallbackBuilder<TValue, T1, T2>.InParallel()
 	{
-		_currentCallback?.InParallel();
+		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2}.For(int)" />
 	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>.For(int times)
 	{
-		_currentCallback?.For(times);
+		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2}.Only(int)" />
 	IIndexerSetup<TValue, T1, T2> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>.Only(int times)
 	{
-		_currentCallback?.Only(times);
+		_getterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -1002,21 +1038,21 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupReturnWhenBuilder<TValue, T1, T2> IIndexerSetupReturnBuilder<TValue, T1, T2>.When(
 		Func<int, bool> predicate)
 	{
-		_currentReturnCallback?.When(predicate);
+		_returnCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue,T1,T2}.For(int)" />
 	IIndexerSetupReturnWhenBuilder<TValue, T1, T2> IIndexerSetupReturnWhenBuilder<TValue, T1, T2>.For(int times)
 	{
-		_currentReturnCallback?.For(times);
+		_returnCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue,T1,T2}.Only(int)" />
 	IIndexerSetup<TValue, T1, T2> IIndexerSetupReturnWhenBuilder<TValue, T1, T2>.Only(int times)
 	{
-		_currentReturnCallback?.Only(times);
+		_returnCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -1125,32 +1161,38 @@ public class IndexerSetup<TValue, T1, T2>(
 			return;
 		}
 
-		bool wasInvoked = false;
-		int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
-		for (int i = 0; i < _setterCallbacks.Count; i++)
+		if (_setterCallbacks is not null)
 		{
-			Callback<Action<int, T1, T2, TValue>> setterCallback =
-				_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-			if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, resultValue)))
+			bool wasInvoked = false;
+			int currentSetterCallbacksIndex = _setterCallbacks.CurrentIndex;
+			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, T2, TValue>> setterCallback =
+					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, resultValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 	}
 
 	private TValue ExecuteGetterCallbacks(T1 p1, T2 p2, TValue currentValue)
 	{
-		bool wasInvoked = false;
-		int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
-		for (int i = 0; i < _getterCallbacks.Count; i++)
+		if (_getterCallbacks is not null)
 		{
-			Callback<Action<int, T1, T2, TValue>> getterCallback =
-				_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-			if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, currentValue)))
+			bool wasInvoked = false;
+			int currentGetterCallbacksIndex = _getterCallbacks.CurrentIndex;
+			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, T2, TValue>> getterCallback =
+					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, currentValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 
@@ -1160,15 +1202,18 @@ public class IndexerSetup<TValue, T1, T2>(
 	private TValue ExecuteReturnCallbacks(T1 p1, T2 p2, TValue currentValue, out bool matched)
 	{
 		matched = false;
-		foreach (Callback<Func<int, T1, T2, TValue, TValue>> _ in _returnCallbacks)
+		if (_returnCallbacks is not null)
 		{
-			Callback<Func<int, T1, T2, TValue, TValue>> returnCallback =
-				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
-			if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, currentValue), out TValue? newValue))
+			foreach (Callback<Func<int, T1, T2, TValue, TValue>> _ in _returnCallbacks)
 			{
-				matched = true;
-				return newValue!;
+				Callback<Func<int, T1, T2, TValue, TValue>> returnCallback =
+					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, currentValue), out TValue? newValue))
+				{
+					matched = true;
+					return newValue!;
+				}
 			}
 		}
 
@@ -1212,14 +1257,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3>,
 	IIndexerGetterSetup<TValue, T1, T2, T3>, IIndexerSetterSetup<TValue, T1, T2, T3>
 {
-	private readonly List<Callback<Action<int, T1, T2, T3, TValue>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, T1, T2, T3, TValue, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, T1, T2, T3, TValue>>> _setterCallbacks = [];
-	private Callback? _currentCallback;
-	private int _currentGetterCallbacksIndex;
-	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex;
-	private int _currentSetterCallbacksIndex;
+	private Callbacks<Action<int, T1, T2, T3, TValue>>? _getterCallbacks;
+	private Callbacks<Func<int, T1, T2, T3, TValue, TValue>>? _returnCallbacks;
+	private Callbacks<Action<int, T1, T2, T3, TValue>>? _setterCallbacks;
 	private Func<T1, T2, T3, TValue>? _initialization;
 	private bool? _skipBaseClass;
 
@@ -1227,7 +1267,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -1243,7 +1284,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Action<T1, T2, T3> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -1259,7 +1301,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Action<T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -1275,7 +1318,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Action<int, T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -1286,7 +1330,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -1295,8 +1340,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1311,8 +1357,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Action<TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1327,8 +1374,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Action<T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1343,8 +1391,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Action<int, T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -1354,8 +1403,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -1402,7 +1452,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1417,7 +1468,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1432,7 +1484,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1447,7 +1500,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1463,7 +1517,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1478,7 +1533,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1493,7 +1549,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1508,7 +1565,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1523,7 +1581,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1538,14 +1597,14 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>.When(
 		Func<int, bool> predicate)
 	{
-		_currentCallback?.When(predicate);
+		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
 	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>.InParallel()
 	{
-		_currentCallback?.InParallel();
+		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
@@ -1553,14 +1612,14 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>.For(
 		int times)
 	{
-		_currentCallback?.For(times);
+		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2,T3}.Only(int)" />
 	IIndexerSetup<TValue, T1, T2, T3> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>.Only(int times)
 	{
-		_currentCallback?.Only(times);
+		_getterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -1568,7 +1627,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> IIndexerSetupReturnBuilder<TValue, T1, T2, T3>.When(
 		Func<int, bool> predicate)
 	{
-		_currentReturnCallback?.When(predicate);
+		_returnCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
@@ -1576,14 +1635,14 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>.For(
 		int times)
 	{
-		_currentReturnCallback?.For(times);
+		_returnCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue,T1,T2,T3}.Only(int)" />
 	IIndexerSetup<TValue, T1, T2, T3> IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>.Only(int times)
 	{
-		_currentReturnCallback?.Only(times);
+		_returnCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -1693,32 +1752,38 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 			return;
 		}
 
-		bool wasInvoked = false;
-		int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
-		for (int i = 0; i < _setterCallbacks.Count; i++)
+		if (_setterCallbacks is not null)
 		{
-			Callback<Action<int, T1, T2, T3, TValue>> setterCallback =
-				_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-			if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, p3, resultValue)))
+			bool wasInvoked = false;
+			int currentSetterCallbacksIndex = _setterCallbacks.CurrentIndex;
+			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, T2, T3, TValue>> setterCallback =
+					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, p3, resultValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 	}
 
 	private TValue ExecuteGetterCallbacks(T1 p1, T2 p2, T3 p3, TValue currentValue)
 	{
-		bool wasInvoked = false;
-		int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
-		for (int i = 0; i < _getterCallbacks.Count; i++)
+		if (_getterCallbacks is not null)
 		{
-			Callback<Action<int, T1, T2, T3, TValue>> getterCallback =
-				_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-			if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, p3, currentValue)))
+			bool wasInvoked = false;
+			int currentGetterCallbacksIndex = _getterCallbacks.CurrentIndex;
+			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, T2, T3, TValue>> getterCallback =
+					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, p3, currentValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 
@@ -1728,15 +1793,18 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	private TValue ExecuteReturnCallbacks(T1 p1, T2 p2, T3 p3, TValue currentValue, out bool matched)
 	{
 		matched = false;
-		foreach (Callback<Func<int, T1, T2, T3, TValue, TValue>> _ in _returnCallbacks)
+		if (_returnCallbacks is not null)
 		{
-			Callback<Func<int, T1, T2, T3, TValue, TValue>> returnCallback =
-				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
-			if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, p3, currentValue), out TValue? newValue))
+			foreach (Callback<Func<int, T1, T2, T3, TValue, TValue>> _ in _returnCallbacks)
 			{
-				matched = true;
-				return newValue!;
+				Callback<Func<int, T1, T2, T3, TValue, TValue>> returnCallback =
+					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, p3, currentValue), out TValue? newValue))
+				{
+					matched = true;
+					return newValue!;
+				}
 			}
 		}
 
@@ -1784,14 +1852,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>,
 	IIndexerGetterSetup<TValue, T1, T2, T3, T4>, IIndexerSetterSetup<TValue, T1, T2, T3, T4>
 {
-	private readonly List<Callback<Action<int, T1, T2, T3, T4, TValue>>> _getterCallbacks = [];
-	private readonly List<Callback<Func<int, T1, T2, T3, T4, TValue, TValue>>> _returnCallbacks = [];
-	private readonly List<Callback<Action<int, T1, T2, T3, T4, TValue>>> _setterCallbacks = [];
-	private Callback? _currentCallback;
-	private int _currentGetterCallbacksIndex;
-	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex;
-	private int _currentSetterCallbacksIndex;
+	private Callbacks<Action<int, T1, T2, T3, T4, TValue>>? _getterCallbacks;
+	private Callbacks<Func<int, T1, T2, T3, T4, TValue, TValue>>? _returnCallbacks;
+	private Callbacks<Action<int, T1, T2, T3, T4, TValue>>? _setterCallbacks;
 	private Func<T1, T2, T3, T4, TValue>? _initialization;
 	private bool? _skipBaseClass;
 
@@ -1799,7 +1862,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -1815,7 +1879,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Action<T1, T2, T3, T4> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -1831,7 +1896,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Action<T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 
@@ -1847,7 +1913,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Action<int, T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -1858,7 +1925,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
 		_getterCallbacks.Add(currentCallback);
 		return this;
 	}
@@ -1867,8 +1935,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1883,8 +1952,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Action<TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1899,8 +1969,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Action<T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1915,8 +1986,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Action<int, T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -1926,8 +1998,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_currentCallback = currentCallback;
-		_setterCallbacks.Add(currentCallback);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = currentCallback;
+		(_setterCallbacks ??= []).Add(currentCallback);
 		return this;
 	}
 
@@ -1974,7 +2047,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -1989,7 +2063,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2004,7 +2079,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2019,7 +2095,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2035,7 +2112,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2050,7 +2128,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2065,7 +2144,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2080,7 +2160,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2095,7 +2176,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
 		_returnCallbacks.Add(currentCallback);
 		return this;
 
@@ -2110,7 +2192,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>.When(
 		Func<int, bool> predicate)
 	{
-		_currentCallback?.When(predicate);
+		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
@@ -2118,7 +2200,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>.
 		InParallel()
 	{
-		_currentCallback?.InParallel();
+		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
@@ -2126,14 +2208,14 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.
 		For(int times)
 	{
-		_currentCallback?.For(times);
+		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2,T3,T4}.Only(int)" />
 	IIndexerSetup<TValue, T1, T2, T3, T4> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
 	{
-		_currentCallback?.Only(times);
+		_getterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -2141,7 +2223,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>.When(
 		Func<int, bool> predicate)
 	{
-		_currentReturnCallback?.When(predicate);
+		_returnCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
@@ -2149,14 +2231,14 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>.For(
 		int times)
 	{
-		_currentReturnCallback?.For(times);
+		_returnCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue,T1,T2,T3,T4}.Only(int)" />
 	IIndexerSetup<TValue, T1, T2, T3, T4> IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
 	{
-		_currentReturnCallback?.Only(times);
+		_returnCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -2269,32 +2351,38 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 			return;
 		}
 
-		bool wasInvoked = false;
-		int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
-		for (int i = 0; i < _setterCallbacks.Count; i++)
+		if (_setterCallbacks is not null)
 		{
-			Callback<Action<int, T1, T2, T3, T4, TValue>> setterCallback =
-				_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-			if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, p3, p4, resultValue)))
+			bool wasInvoked = false;
+			int currentSetterCallbacksIndex = _setterCallbacks.CurrentIndex;
+			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, T2, T3, T4, TValue>> setterCallback =
+					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, p3, p4, resultValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 	}
 
 	private TValue ExecuteGetterCallbacks(T1 p1, T2 p2, T3 p3, T4 p4, TValue currentValue)
 	{
-		bool wasInvoked = false;
-		int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
-		for (int i = 0; i < _getterCallbacks.Count; i++)
+		if (_getterCallbacks is not null)
 		{
-			Callback<Action<int, T1, T2, T3, T4, TValue>> getterCallback =
-				_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-			if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, p3, p4, currentValue)))
+			bool wasInvoked = false;
+			int currentGetterCallbacksIndex = _getterCallbacks.CurrentIndex;
+			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
-				wasInvoked = true;
+				Callback<Action<int, T1, T2, T3, T4, TValue>> getterCallback =
+					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, p3, p4, currentValue)))
+				{
+					wasInvoked = true;
+				}
 			}
 		}
 
@@ -2304,15 +2392,18 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	private TValue ExecuteReturnCallbacks(T1 p1, T2 p2, T3 p3, T4 p4, TValue currentValue, out bool matched)
 	{
 		matched = false;
-		foreach (Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> _ in _returnCallbacks)
+		if (_returnCallbacks is not null)
 		{
-			Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> returnCallback =
-				_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
-			if (returnCallback.Invoke(ref _currentReturnCallbackIndex, (invocationCount, @delegate)
-				    => @delegate(invocationCount, p1, p2, p3, p4, currentValue), out TValue? newValue))
+			foreach (Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> _ in _returnCallbacks)
 			{
-				matched = true;
-				return newValue!;
+				Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> returnCallback =
+					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
+					    => @delegate(invocationCount, p1, p2, p3, p4, currentValue), out TValue? newValue))
+				{
+					matched = true;
+					return newValue!;
+				}
 			}
 		}
 

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -103,7 +103,8 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 #endif
 public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch<T1> parameter1)
 	: IndexerSetup(mockRegistry),
-		IIndexerSetupCallbackBuilder<TValue, T1>, IIndexerSetupReturnBuilder<TValue, T1>,
+		IIndexerGetterSetupCallbackBuilder<TValue, T1>, IIndexerSetterSetupCallbackBuilder<TValue, T1>,
+		IIndexerSetupReturnBuilder<TValue, T1>,
 		IIndexerGetterSetup<TValue, T1>, IIndexerSetterSetup<TValue, T1>
 {
 	private Callbacks<Action<int, T1, TValue>>? _getterCallbacks;
@@ -113,12 +114,10 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	private bool? _skipBaseClass;
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -129,12 +128,10 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action{T1})" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1> callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -145,12 +142,10 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action{T1, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -161,32 +156,26 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action{int, T1, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.TransitionTo(string scenario)
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> IIndexerGetterSetup<TValue, T1>.TransitionTo(string scenario)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -197,12 +186,10 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action{TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<TValue> callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -213,12 +200,10 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action{T1, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -229,22 +214,18 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action{int, T1, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.Do(Action<int, T1, TValue> callback)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.TransitionTo(string scenario)
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> IIndexerSetterSetup<TValue, T1>.TransitionTo(string scenario)
 	{
 		Callback<Action<int, T1, TValue>> currentCallback = new((_, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -291,9 +272,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -307,9 +286,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -323,9 +300,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -339,9 +314,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -356,9 +329,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -372,9 +343,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -388,9 +357,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -404,9 +371,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, Exception> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -420,9 +385,7 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 	public IIndexerSetupReturnBuilder<TValue, T1> Throws(Func<T1, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -432,32 +395,61 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 		}
 	}
 
-	/// <inheritdoc cref="IIndexerSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1> IIndexerSetupParallelCallbackBuilder<TValue, T1>.When(
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>.When(
 		Func<int, bool> predicate)
 	{
 		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackBuilder{TValue, T1}.InParallel()" />
-	IIndexerSetupParallelCallbackBuilder<TValue, T1> IIndexerSetupCallbackBuilder<TValue, T1>.InParallel()
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1}.InParallel()" />
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> IIndexerGetterSetupCallbackBuilder<TValue, T1>.InParallel()
 	{
 		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1}.For(int)" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1> IIndexerSetupCallbackWhenBuilder<TValue, T1>.For(int times)
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1}.For(int)" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>.For(int times)
 	{
 		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1}.Only(int)" />
-	IIndexerSetup<TValue, T1> IIndexerSetupCallbackWhenBuilder<TValue, T1>.Only(int times)
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1}.Only(int)" />
+	IIndexerSetup<TValue, T1> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>.Only(int times)
 	{
 		_getterCallbacks?.Active?.Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>.When(
+		Func<int, bool> predicate)
+	{
+		_setterCallbacks?.Active?.When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1}.InParallel()" />
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> IIndexerSetterSetupCallbackBuilder<TValue, T1>.InParallel()
+	{
+		_setterCallbacks?.Active?.InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1}.For(int)" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>.For(int times)
+	{
+		_setterCallbacks?.Active?.For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1}.Only(int)" />
+	IIndexerSetup<TValue, T1> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>.Only(int times)
+	{
+		_setterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -674,7 +666,8 @@ public class IndexerSetup<TValue, T1, T2>(
 	MockRegistry mockRegistry,
 	IParameterMatch<T1> parameter1,
 	IParameterMatch<T2> parameter2) : IndexerSetup(mockRegistry),
-	IIndexerSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetupReturnBuilder<TValue, T1, T2>,
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>,
+	IIndexerSetupReturnBuilder<TValue, T1, T2>,
 	IIndexerGetterSetup<TValue, T1, T2>, IIndexerSetterSetup<TValue, T1, T2>
 {
 	private Callbacks<Action<int, T1, T2, TValue>>? _getterCallbacks;
@@ -684,12 +677,10 @@ public class IndexerSetup<TValue, T1, T2>(
 	private bool? _skipBaseClass;
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -700,12 +691,10 @@ public class IndexerSetup<TValue, T1, T2>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action{T1, T2})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2> callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -716,12 +705,10 @@ public class IndexerSetup<TValue, T1, T2>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -732,33 +719,27 @@ public class IndexerSetup<TValue, T1, T2>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.Do(
 		Action<int, T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.TransitionTo(string scenario)
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerGetterSetup<TValue, T1, T2>.TransitionTo(string scenario)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -769,12 +750,10 @@ public class IndexerSetup<TValue, T1, T2>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action{TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<TValue> callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -785,12 +764,10 @@ public class IndexerSetup<TValue, T1, T2>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(Action<T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -801,23 +778,19 @@ public class IndexerSetup<TValue, T1, T2>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.Do(
 		Action<int, T1, T2, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.TransitionTo(string scenario)
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerSetterSetup<TValue, T1, T2>.TransitionTo(string scenario)
 	{
 		Callback<Action<int, T1, T2, TValue>> currentCallback = new((_, _, _, _) => TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -864,9 +837,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -880,9 +851,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -896,9 +865,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -912,9 +879,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -929,9 +894,7 @@ public class IndexerSetup<TValue, T1, T2>(
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -945,9 +908,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -961,9 +922,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -977,9 +936,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -993,9 +950,7 @@ public class IndexerSetup<TValue, T1, T2>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1005,32 +960,61 @@ public class IndexerSetup<TValue, T1, T2>(
 		}
 	}
 
-	/// <inheritdoc cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>.When(
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>.When(
 		Func<int, bool> predicate)
 	{
 		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerSetupCallbackBuilder<TValue, T1, T2>.InParallel()
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>.InParallel()
 	{
 		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2}.For(int)" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>.For(int times)
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1,T2}.For(int)" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>.For(int times)
 	{
 		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2}.Only(int)" />
-	IIndexerSetup<TValue, T1, T2> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>.Only(int times)
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1,T2}.Only(int)" />
+	IIndexerSetup<TValue, T1, T2> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>.Only(int times)
 	{
 		_getterCallbacks?.Active?.Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>.When(
+		Func<int, bool> predicate)
+	{
+		_setterCallbacks?.Active?.When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>.InParallel()
+	{
+		_setterCallbacks?.Active?.InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1,T2}.For(int)" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>.For(int times)
+	{
+		_setterCallbacks?.Active?.For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1,T2}.Only(int)" />
+	IIndexerSetup<TValue, T1, T2> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>.Only(int times)
+	{
+		_setterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -1254,7 +1238,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IParameterMatch<T1> parameter1,
 	IParameterMatch<T2> parameter2,
 	IParameterMatch<T3> parameter3) : IndexerSetup(mockRegistry),
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3>,
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>,
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3>,
 	IIndexerGetterSetup<TValue, T1, T2, T3>, IIndexerSetterSetup<TValue, T1, T2, T3>
 {
 	private Callbacks<Action<int, T1, T2, T3, TValue>>? _getterCallbacks;
@@ -1264,12 +1249,10 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	private bool? _skipBaseClass;
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(Action callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1280,13 +1263,11 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
 		Action<T1, T2, T3> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1297,13 +1278,11 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
 		Action<T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1314,35 +1293,29 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.Do(
 		Action<int, T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.TransitionTo(
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetup<TValue, T1, T2, T3>.TransitionTo(
 		string scenario)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(Action callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1353,13 +1326,11 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action{TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
 		Action<TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1370,13 +1341,11 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
 		Action<T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1387,25 +1356,21 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.Do(
 		Action<int, T1, T2, T3, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.TransitionTo(
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetup<TValue, T1, T2, T3>.TransitionTo(
 		string scenario)
 	{
 		Callback<Action<int, T1, T2, T3, TValue>> currentCallback = new((_, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1452,9 +1417,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1468,9 +1431,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1484,9 +1445,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1500,9 +1459,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1517,9 +1474,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1533,9 +1488,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1549,9 +1502,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1565,9 +1516,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1581,9 +1530,7 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1593,33 +1540,63 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		}
 	}
 
-	/// <inheritdoc cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>.When(
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>.When(
 		Func<int, bool> predicate)
 	{
 		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>.InParallel()
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>.InParallel()
 	{
 		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2,T3}.For(int)" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>.For(
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1,T2,T3}.For(int)" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>.For(
 		int times)
 	{
 		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2,T3}.Only(int)" />
-	IIndexerSetup<TValue, T1, T2, T3> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>.Only(int times)
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1,T2,T3}.Only(int)" />
+	IIndexerSetup<TValue, T1, T2, T3> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>.Only(int times)
 	{
 		_getterCallbacks?.Active?.Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>.When(
+		Func<int, bool> predicate)
+	{
+		_setterCallbacks?.Active?.When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>.InParallel()
+	{
+		_setterCallbacks?.Active?.InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1,T2,T3}.For(int)" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>.For(
+		int times)
+	{
+		_setterCallbacks?.Active?.For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1,T2,T3}.Only(int)" />
+	IIndexerSetup<TValue, T1, T2, T3> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>.Only(int times)
+	{
+		_setterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -1849,7 +1826,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IParameterMatch<T2> parameter2,
 	IParameterMatch<T3> parameter3,
 	IParameterMatch<T4> parameter4) : IndexerSetup(mockRegistry),
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>,
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>,
+	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>,
 	IIndexerGetterSetup<TValue, T1, T2, T3, T4>, IIndexerSetterSetup<TValue, T1, T2, T3, T4>
 {
 	private Callbacks<Action<int, T1, T2, T3, T4, TValue>>? _getterCallbacks;
@@ -1859,12 +1837,10 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	private bool? _skipBaseClass;
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1875,13 +1851,11 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
 		Action<T1, T2, T3, T4> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1892,13 +1866,11 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
 		Action<T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1909,35 +1881,29 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	}
 
 	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.Do(
 		Action<int, T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.TransitionTo(
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetup<TValue, T1, T2, T3, T4>.TransitionTo(
 		string scenario)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		_getterCallbacks.Add(currentCallback);
+		_getterCallbacks = _getterCallbacks.Register(currentCallback);
 		return this;
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1948,13 +1914,11 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action{TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
 		Action<TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1965,13 +1929,11 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
 		Action<T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1982,25 +1944,21 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	}
 
 	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.Do(
 		Action<int, T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.TransitionTo(
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetup<TValue, T1, T2, T3, T4>.TransitionTo(
 		string scenario)
 	{
 		Callback<Action<int, T1, T2, T3, T4, TValue>> currentCallback = new((_, _, _, _, _, _) =>
 			TransitionScenario(scenario));
 		currentCallback.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = currentCallback;
-		(_setterCallbacks ??= []).Add(currentCallback);
+		_setterCallbacks = _setterCallbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -2047,9 +2005,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2063,9 +2019,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2079,9 +2033,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2095,9 +2047,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue, TValue> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2112,9 +2062,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2128,9 +2076,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Exception exception)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2144,9 +2090,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2160,9 +2104,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2176,9 +2118,7 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	public IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, TValue, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -2188,34 +2128,65 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		}
 	}
 
-	/// <inheritdoc cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>.When(
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>.When(
 		Func<int, bool> predicate)
 	{
 		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackBuilder{TValue, T1, T2, T3, T4}.InParallel()" />
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>.
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1, T2, T3, T4}.InParallel()" />
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>.
 		InParallel()
 	{
 		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2,T3,T4}.For(int)" />
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1,T2,T3,T4}.For(int)" />
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.
 		For(int times)
 	{
 		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
-	/// <inheritdoc cref="IIndexerSetupCallbackWhenBuilder{TValue,T1,T2,T3,T4}.Only(int)" />
-	IIndexerSetup<TValue, T1, T2, T3, T4> IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue,T1,T2,T3,T4}.Only(int)" />
+	IIndexerSetup<TValue, T1, T2, T3, T4> IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
 	{
 		_getterCallbacks?.Active?.Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>.When(
+		Func<int, bool> predicate)
+	{
+		_setterCallbacks?.Active?.When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1, T2, T3, T4}.InParallel()" />
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>.
+		InParallel()
+	{
+		_setterCallbacks?.Active?.InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1,T2,T3,T4}.For(int)" />
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.
+		For(int times)
+	{
+		_setterCallbacks?.Active?.For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue,T1,T2,T3,T4}.Only(int)" />
+	IIndexerSetup<TValue, T1, T2, T3, T4> IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
+	{
+		_setterCallbacks?.Active?.Only(times);
 		return this;
 	}
 

--- a/Source/Mockolate/Setup/Interfaces.EventSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.EventSetup.cs
@@ -27,7 +27,7 @@ public interface IEventSubscriptionSetup
 	/// <summary>
 	///     Registers a callback to be invoked whenever a handler is subscribed to the event.
 	/// </summary>
-	IEventSetupCallbackBuilder Do(Action callback);
+	IEventSubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever a handler is subscribed to the event.
@@ -35,13 +35,13 @@ public interface IEventSubscriptionSetup
 	/// <remarks>
 	///     The callback receives the target object and method of the subscribed handler.
 	/// </remarks>
-	IEventSetupCallbackBuilder Do(Action<object?, MethodInfo> callback);
+	IEventSubscriptionSetupCallbackBuilder Do(Action<object?, MethodInfo> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever a handler is subscribed to the event.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+	IEventSubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -52,7 +52,7 @@ public interface IEventUnsubscriptionSetup
 	/// <summary>
 	///     Registers a callback to be invoked whenever a handler is unsubscribed from the event.
 	/// </summary>
-	IEventSetupCallbackBuilder Do(Action callback);
+	IEventUnsubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever a handler is unsubscribed from the event.
@@ -60,20 +60,20 @@ public interface IEventUnsubscriptionSetup
 	/// <remarks>
 	///     The callback receives the target object and method of the unsubscribed handler.
 	/// </remarks>
-	IEventSetupCallbackBuilder Do(Action<object?, MethodInfo> callback);
+	IEventUnsubscriptionSetupCallbackBuilder Do(Action<object?, MethodInfo> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever a handler is unsubscribed from the
 	///     event.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+	IEventUnsubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
 }
 
 /// <summary>
-///     Interface for setting up an event with fluent syntax.
+///     Interface for setting up an event subscription with fluent syntax.
 /// </summary>
-public interface IEventSetupParallelCallbackBuilder : IEventSetupCallbackWhenBuilder
+public interface IEventSubscriptionSetupParallelCallbackBuilder : IEventSubscriptionSetupCallbackWhenBuilder
 {
 	/// <summary>
 	///     Limits the callback to only execute for event interactions where the predicate returns true.
@@ -81,40 +81,89 @@ public interface IEventSetupParallelCallbackBuilder : IEventSetupCallbackWhenBui
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the event has been interacted with so far.
 	/// </remarks>
-	IEventSetupCallbackWhenBuilder When(Func<int, bool> predicate);
+	IEventSubscriptionSetupCallbackWhenBuilder When(Func<int, bool> predicate);
 }
 
 /// <summary>
-///     Interface for setting up an event with fluent syntax.
+///     Interface for setting up an event subscription with fluent syntax.
 /// </summary>
-public interface IEventSetupCallbackBuilder : IEventSetupParallelCallbackBuilder
+public interface IEventSubscriptionSetupCallbackBuilder : IEventSubscriptionSetupParallelCallbackBuilder
 {
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
-	IEventSetupParallelCallbackBuilder InParallel();
+	IEventSubscriptionSetupParallelCallbackBuilder InParallel();
 }
 
 /// <summary>
-///     Interface for setting up an event with fluent syntax.
+///     Interface for setting up an event subscription with fluent syntax.
 /// </summary>
-public interface IEventSetupCallbackWhenBuilder : IEventSetup
+public interface IEventSubscriptionSetupCallbackWhenBuilder : IEventSetup
 {
 	/// <summary>
 	///     Repeats the callback for the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IEventSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	///     <see cref="IEventSubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
-	IEventSetupCallbackWhenBuilder For(int times);
+	IEventSubscriptionSetupCallbackWhenBuilder For(int times);
 
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IEventSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	///     <see cref="IEventSubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	/// </remarks>
+	IEventSetup Only(int times);
+}
+
+/// <summary>
+///     Interface for setting up an event unsubscription with fluent syntax.
+/// </summary>
+public interface IEventUnsubscriptionSetupParallelCallbackBuilder : IEventUnsubscriptionSetupCallbackWhenBuilder
+{
+	/// <summary>
+	///     Limits the callback to only execute for event interactions where the predicate returns true.
+	/// </summary>
+	/// <remarks>
+	///     Provides a zero-based counter indicating how many times the event has been interacted with so far.
+	/// </remarks>
+	IEventUnsubscriptionSetupCallbackWhenBuilder When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Interface for setting up an event unsubscription with fluent syntax.
+/// </summary>
+public interface IEventUnsubscriptionSetupCallbackBuilder : IEventUnsubscriptionSetupParallelCallbackBuilder
+{
+	/// <summary>
+	///     Runs the callback in parallel to the other callbacks.
+	/// </summary>
+	IEventUnsubscriptionSetupParallelCallbackBuilder InParallel();
+}
+
+/// <summary>
+///     Interface for setting up an event unsubscription with fluent syntax.
+/// </summary>
+public interface IEventUnsubscriptionSetupCallbackWhenBuilder : IEventSetup
+{
+	/// <summary>
+	///     Repeats the callback for the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IEventUnsubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	/// </remarks>
+	IEventUnsubscriptionSetupCallbackWhenBuilder For(int times);
+
+	/// <summary>
+	///     Deactivates the callback after the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IEventUnsubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
 	IEventSetup Only(int times);
 }

--- a/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
@@ -27,7 +27,7 @@ public interface IIndexerGetterSetup<TValue, out T1>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -35,7 +35,7 @@ public interface IIndexerGetterSetup<TValue, out T1>
 	/// <remarks>
 	///     The callback receives the parameter of the indexer.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<T1> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(Action<T1> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -43,7 +43,7 @@ public interface IIndexerGetterSetup<TValue, out T1>
 	/// <remarks>
 	///     The callback receives the parameter of the indexer and the value of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -52,13 +52,13 @@ public interface IIndexerGetterSetup<TValue, out T1>
 	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value
 	///     of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is read.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -69,7 +69,7 @@ public interface IIndexerSetterSetup<TValue, out T1>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -77,7 +77,7 @@ public interface IIndexerSetterSetup<TValue, out T1>
 	/// <remarks>
 	///     The callback receives the value the indexer is set to as single parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -85,7 +85,7 @@ public interface IIndexerSetterSetup<TValue, out T1>
 	/// <remarks>
 	///     The callback receives the parameter of the indexer and the value the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -94,13 +94,13 @@ public interface IIndexerSetterSetup<TValue, out T1>
 	///     The callback receives an incrementing access counter as first parameter, the parameter of the indexer and the value
 	///     the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is written to.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -200,20 +200,20 @@ public interface IIndexerSetup<TValue, out T1>
 /// <summary>
 ///     Sets up a callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
 /// </summary>
-public interface IIndexerSetupCallbackBuilder<TValue, out T1>
-	: IIndexerSetupParallelCallbackBuilder<TValue, T1>
+public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1>
+	: IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>
 {
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1> InParallel();
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
 }
 
 /// <summary>
 ///     Sets up a parallel callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
 /// </summary>
-public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1>
-	: IIndexerSetupCallbackWhenBuilder<TValue, T1>
+public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1>
+	: IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>
 {
 	/// <summary>
 	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
@@ -221,13 +221,13 @@ public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1> When(Func<int, bool> predicate);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> When(Func<int, bool> predicate);
 }
 
 /// <summary>
 ///     Sets up a when callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
 /// </summary>
-public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1>
+public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1>
 	: IIndexerSetup<TValue, T1>
 {
 	/// <summary>
@@ -235,17 +235,71 @@ public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1>
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" /> evaluates to <see langword="true" />
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" /> evaluates to <see langword="true" />
 	///     ).
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1> For(int times);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
 
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" /> evaluates to <see langword="true" />
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" /> evaluates to <see langword="true" />
+	///     ).
+	/// </remarks>
+	IIndexerSetup<TValue, T1> Only(int times);
+}
+
+/// <summary>
+///     Sets up a setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1>
+	: IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>
+{
+	/// <summary>
+	///     Runs the callback in parallel to the other callbacks.
+	/// </summary>
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1>
+	: IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>
+{
+	/// <summary>
+	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
+	/// </summary>
+	/// <remarks>
+	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1>
+	: IIndexerSetup<TValue, T1>
+{
+	/// <summary>
+	///     Repeats the callback for the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" /> evaluates to <see langword="true" />
+	///     ).
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
+
+	/// <summary>
+	///     Deactivates the callback after the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" /> evaluates to <see langword="true" />
 	///     ).
 	/// </remarks>
 	IIndexerSetup<TValue, T1> Only(int times);
@@ -301,7 +355,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -309,7 +363,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -317,7 +371,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -326,13 +380,13 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2>
 	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the
 	///     value of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is read.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -344,7 +398,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -352,7 +406,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2>
 	/// <remarks>
 	///     The callback receives the value the indexer is set to as single parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -360,7 +414,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -369,13 +423,13 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2>
 	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the
 	///     value the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is written to.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -476,21 +530,21 @@ public interface IIndexerSetup<TValue, out T1, out T2>
 ///     Sets up a callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
 ///     <typeparamref name="T2" />.
 /// </summary>
-public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2>
-	: IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>
+public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>
 {
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
 }
 
 /// <summary>
 ///     Sets up a parallel callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
 ///     <typeparamref name="T2" />.
 /// </summary>
-public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2>
-	: IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>
+public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>
 {
 	/// <summary>
 	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
@@ -498,14 +552,14 @@ public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> When(Func<int, bool> predicate);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> When(Func<int, bool> predicate);
 }
 
 /// <summary>
 ///     Sets up a when callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
 ///     <typeparamref name="T2" />.
 /// </summary>
-public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2>
+public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2>
 	: IIndexerSetup<TValue, T1, T2>
 {
 	/// <summary>
@@ -513,17 +567,74 @@ public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2>
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" /> evaluates to
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
 
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" /> evaluates to
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" /> evaluates to
+	///     <see langword="true" />).
+	/// </remarks>
+	IIndexerSetup<TValue, T1, T2> Only(int times);
+}
+
+/// <summary>
+///     Sets up a setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
+///     <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>
+{
+	/// <summary>
+	///     Runs the callback in parallel to the other callbacks.
+	/// </summary>
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
+///     <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>
+{
+	/// <summary>
+	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
+	/// </summary>
+	/// <remarks>
+	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
+///     <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2>
+	: IIndexerSetup<TValue, T1, T2>
+{
+	/// <summary>
+	///     Repeats the callback for the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" /> evaluates to
+	///     <see langword="true" />).
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+
+	/// <summary>
+	///     Deactivates the callback after the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
 	IIndexerSetup<TValue, T1, T2> Only(int times);
@@ -584,7 +695,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -592,7 +703,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -600,7 +711,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -609,13 +720,13 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
 	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the
 	///     value of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is read.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -628,7 +739,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -636,7 +747,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
 	/// <remarks>
 	///     The callback receives the value the indexer is set to as single parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -644,7 +755,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -653,13 +764,13 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
 	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the
 	///     value the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is written to.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -761,21 +872,21 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3>
 ///     Sets up a callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
 ///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
 /// </summary>
-public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3>
-	: IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>
+public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>
 {
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
 }
 
 /// <summary>
 ///     Sets up a parallel callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
 ///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
 /// </summary>
-public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3>
-	: IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>
+public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>
 {
 	/// <summary>
 	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
@@ -783,14 +894,14 @@ public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, ou
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(Func<int, bool> predicate);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(Func<int, bool> predicate);
 }
 
 /// <summary>
 ///     Sets up a when callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
 ///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
 /// </summary>
-public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3>
+public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3>
 	: IIndexerSetup<TValue, T1, T2, T3>
 {
 	/// <summary>
@@ -798,18 +909,76 @@ public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" /> evaluates to
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
 
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" /> evaluates to
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" /> evaluates to
+	///     <see langword="true" />).
+	/// </remarks>
+	IIndexerSetup<TValue, T1, T2, T3> Only(int times);
+}
+
+/// <summary>
+///     Sets up a setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>
+{
+	/// <summary>
+	///     Runs the callback in parallel to the other callbacks.
+	/// </summary>
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>
+{
+	/// <summary>
+	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
+	/// </summary>
+	/// <remarks>
+	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerSetup<TValue, T1, T2, T3>
+{
+	/// <summary>
+	///     Repeats the callback for the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" /> evaluates to
+	///     <see langword="true" />
+	///     ).
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+
+	/// <summary>
+	///     Deactivates the callback after the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
 	IIndexerSetup<TValue, T1, T2, T3> Only(int times);
@@ -871,7 +1040,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -879,7 +1048,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -887,7 +1056,7 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer and the value of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's getter is accessed.
@@ -896,13 +1065,13 @@ public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
 	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the
 	///     value of the indexer as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
+	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is read.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -914,7 +1083,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
 	/// </summary>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -922,7 +1091,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <remarks>
 	///     The callback receives the value the indexer is set to as single parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -930,7 +1099,7 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
 	/// <remarks>
 	///     The callback receives the parameters of the indexer and the value the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the indexer's setter is accessed.
@@ -939,13 +1108,13 @@ public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
 	///     The callback receives an incrementing access counter as first parameter, the parameters of the indexer and the
 	///     value the indexer is set to as last parameter.
 	/// </remarks>
-	IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
+	IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the indexer is written to.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -1048,13 +1217,13 @@ public interface IIndexerSetup<TValue, out T1, out T2, out T3, out T4>
 ///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
 /// </summary>
 public interface
-	IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
-	: IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>
+	IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>
 {
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
-	IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
 }
 
 /// <summary>
@@ -1062,8 +1231,8 @@ public interface
 ///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
 /// </summary>
 public interface
-	IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
-	: IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>
+	IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>
 {
 	/// <summary>
 	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
@@ -1071,14 +1240,14 @@ public interface
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(Func<int, bool> predicate);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(Func<int, bool> predicate);
 }
 
 /// <summary>
 ///     Sets up a when callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
 ///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
 /// </summary>
-public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4>
+public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4>
 	: IIndexerSetup<TValue, T1, T2, T3, T4>
 {
 	/// <summary>
@@ -1086,17 +1255,76 @@ public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
-	IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+	IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
 
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IIndexerSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
+	///     <see cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
+	///     <see langword="true" />).
+	/// </remarks>
+	IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
+}
+
+/// <summary>
+///     Sets up a setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface
+	IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>
+{
+	/// <summary>
+	///     Runs the callback in parallel to the other callbacks.
+	/// </summary>
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface
+	IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>
+{
+	/// <summary>
+	///     Limits the callback to only execute for indexer accesses where the predicate returns true.
+	/// </summary>
+	/// <remarks>
+	///     Provides a zero-based counter indicating how many times the indexer has been accessed so far.
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerSetup<TValue, T1, T2, T3, T4>
+{
+	/// <summary>
+	///     Repeats the callback for the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
+	///     <see langword="true" />).
+	/// </remarks>
+	IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+
+	/// <summary>
+	///     Deactivates the callback after the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
 	IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -46,7 +46,7 @@ public interface IPropertyGetterSetup<T>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's getter is accessed.
 	/// </summary>
-	IPropertySetupCallbackBuilder<T> Do(Action callback);
+	IPropertyGetterSetupCallbackBuilder<T> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's getter is accessed.
@@ -54,7 +54,7 @@ public interface IPropertyGetterSetup<T>
 	/// <remarks>
 	///     The callback receives the value of the property as single parameter.
 	/// </remarks>
-	IPropertySetupCallbackBuilder<T> Do(Action<T> callback);
+	IPropertyGetterSetupCallbackBuilder<T> Do(Action<T> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's getter is accessed.
@@ -63,13 +63,13 @@ public interface IPropertyGetterSetup<T>
 	///     The callback receives an incrementing access counter as first parameter and the value of the property as second
 	///     parameter.
 	/// </remarks>
-	IPropertySetupCallbackBuilder<T> Do(Action<int, T> callback);
+	IPropertyGetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the property is read.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+	IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -80,7 +80,7 @@ public interface IPropertySetterSetup<T>
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's value is set.
 	/// </summary>
-	IPropertySetupCallbackBuilder<T> Do(Action callback);
+	IPropertySetterSetupCallbackBuilder<T> Do(Action callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's value is set.
@@ -88,7 +88,7 @@ public interface IPropertySetterSetup<T>
 	/// <remarks>
 	///     The callback receives the value the property is set to as single parameter.
 	/// </remarks>
-	IPropertySetupCallbackBuilder<T> Do(Action<T> callback);
+	IPropertySetterSetupCallbackBuilder<T> Do(Action<T> callback);
 
 	/// <summary>
 	///     Registers a callback to be invoked whenever the property's value is set.
@@ -97,13 +97,13 @@ public interface IPropertySetterSetup<T>
 	///     The callback receives an incrementing access counter as first parameter and the value the property is set to as
 	///     second parameter.
 	/// </remarks>
-	IPropertySetupCallbackBuilder<T> Do(Action<int, T> callback);
+	IPropertySetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
 	/// <summary>
 	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the property is written to.
 	/// </summary>
 	/// <param name="scenario">The name of the new scenario.</param>
-	IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+	IPropertySetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
 }
 
 /// <summary>
@@ -183,9 +183,9 @@ public interface IPropertySetup<T>
 }
 
 /// <summary>
-///     Interface for setting up a property with fluent syntax.
+///     Interface for setting up a property getter with fluent syntax.
 /// </summary>
-public interface IPropertySetupParallelCallbackBuilder<T> : IPropertySetupCallbackWhenBuilder<T>
+public interface IPropertyGetterSetupParallelCallbackBuilder<T> : IPropertyGetterSetupCallbackWhenBuilder<T>
 {
 	/// <summary>
 	///     Limits the callback to only execute for property accesses where the predicate returns true.
@@ -193,40 +193,89 @@ public interface IPropertySetupParallelCallbackBuilder<T> : IPropertySetupCallba
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the property has been accessed so far.
 	/// </remarks>
-	IPropertySetupCallbackWhenBuilder<T> When(Func<int, bool> predicate);
+	IPropertyGetterSetupCallbackWhenBuilder<T> When(Func<int, bool> predicate);
 }
 
 /// <summary>
-///     Interface for setting up a property with fluent syntax.
+///     Interface for setting up a property getter with fluent syntax.
 /// </summary>
-public interface IPropertySetupCallbackBuilder<T> : IPropertySetupParallelCallbackBuilder<T>
+public interface IPropertyGetterSetupCallbackBuilder<T> : IPropertyGetterSetupParallelCallbackBuilder<T>
 {
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
-	IPropertySetupParallelCallbackBuilder<T> InParallel();
+	IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
 }
 
 /// <summary>
-///     Interface for setting up a property with fluent syntax.
+///     Interface for setting up a property getter with fluent syntax.
 /// </summary>
-public interface IPropertySetupCallbackWhenBuilder<T> : IPropertySetup<T>
+public interface IPropertyGetterSetupCallbackWhenBuilder<T> : IPropertySetup<T>
 {
 	/// <summary>
 	///     Repeats the callback for the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IPropertySetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	///     <see cref="IPropertyGetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
-	IPropertySetupCallbackWhenBuilder<T> For(int times);
+	IPropertyGetterSetupCallbackWhenBuilder<T> For(int times);
 
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
-	///     <see cref="IPropertySetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	///     <see cref="IPropertyGetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	/// </remarks>
+	IPropertySetup<T> Only(int times);
+}
+
+/// <summary>
+///     Interface for setting up a property setter with fluent syntax.
+/// </summary>
+public interface IPropertySetterSetupParallelCallbackBuilder<T> : IPropertySetterSetupCallbackWhenBuilder<T>
+{
+	/// <summary>
+	///     Limits the callback to only execute for property accesses where the predicate returns true.
+	/// </summary>
+	/// <remarks>
+	///     Provides a zero-based counter indicating how many times the property has been accessed so far.
+	/// </remarks>
+	IPropertySetterSetupCallbackWhenBuilder<T> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Interface for setting up a property setter with fluent syntax.
+/// </summary>
+public interface IPropertySetterSetupCallbackBuilder<T> : IPropertySetterSetupParallelCallbackBuilder<T>
+{
+	/// <summary>
+	///     Runs the callback in parallel to the other callbacks.
+	/// </summary>
+	IPropertySetterSetupParallelCallbackBuilder<T> InParallel();
+}
+
+/// <summary>
+///     Interface for setting up a property setter with fluent syntax.
+/// </summary>
+public interface IPropertySetterSetupCallbackWhenBuilder<T> : IPropertySetup<T>
+{
+	/// <summary>
+	///     Repeats the callback for the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IPropertySetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
+	/// </remarks>
+	IPropertySetterSetupCallbackWhenBuilder<T> For(int times);
+
+	/// <summary>
+	///     Deactivates the callback after the given number of <paramref name="times" />.
+	/// </summary>
+	/// <remarks>
+	///     The number of times is only counted for actual executions (
+	///     <see cref="IPropertySetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
 	IPropertySetup<T> Only(int times);
 }

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -148,7 +148,8 @@ public abstract class PropertySetup : IInteractivePropertySetup
 [DebuggerNonUserCode]
 #endif
 public class PropertySetup<T> : PropertySetup,
-	IPropertySetupCallbackBuilder<T>, IPropertySetupReturnBuilder<T>,
+	IPropertyGetterSetupCallbackBuilder<T>, IPropertySetterSetupCallbackBuilder<T>,
+	IPropertySetupReturnBuilder<T>,
 	IPropertyGetterSetup<T>, IPropertySetterSetup<T>
 {
 	private readonly MockRegistry _mockRegistry;
@@ -175,31 +176,59 @@ public class PropertySetup<T> : PropertySetup,
 	/// <inheritdoc cref="PropertySetup.IsValueInitialized" />
 	internal override bool IsValueInitialized => _isInitialized;
 
-	/// <inheritdoc cref="IPropertySetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
-	IPropertySetupCallbackWhenBuilder<T> IPropertySetupParallelCallbackBuilder<T>.When(Func<int, bool> predicate)
+	/// <inheritdoc cref="IPropertyGetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
+	IPropertyGetterSetupCallbackWhenBuilder<T> IPropertyGetterSetupParallelCallbackBuilder<T>.When(Func<int, bool> predicate)
 	{
 		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetupCallbackBuilder{T}.InParallel()" />
-	IPropertySetupParallelCallbackBuilder<T> IPropertySetupCallbackBuilder<T>.InParallel()
+	/// <inheritdoc cref="IPropertyGetterSetupCallbackBuilder{T}.InParallel()" />
+	IPropertyGetterSetupParallelCallbackBuilder<T> IPropertyGetterSetupCallbackBuilder<T>.InParallel()
 	{
 		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetupCallbackWhenBuilder{T}.For(int)" />
-	IPropertySetupCallbackWhenBuilder<T> IPropertySetupCallbackWhenBuilder<T>.For(int times)
+	/// <inheritdoc cref="IPropertyGetterSetupCallbackWhenBuilder{T}.For(int)" />
+	IPropertyGetterSetupCallbackWhenBuilder<T> IPropertyGetterSetupCallbackWhenBuilder<T>.For(int times)
 	{
 		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
-	/// <inheritdoc cref="IPropertySetupCallbackWhenBuilder{T}.Only(int)" />
-	IPropertySetup<T> IPropertySetupCallbackWhenBuilder<T>.Only(int times)
+	/// <inheritdoc cref="IPropertyGetterSetupCallbackWhenBuilder{T}.Only(int)" />
+	IPropertySetup<T> IPropertyGetterSetupCallbackWhenBuilder<T>.Only(int times)
 	{
 		_getterCallbacks?.Active?.Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
+	IPropertySetterSetupCallbackWhenBuilder<T> IPropertySetterSetupParallelCallbackBuilder<T>.When(Func<int, bool> predicate)
+	{
+		_setterCallbacks?.Active?.When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterSetupCallbackBuilder{T}.InParallel()" />
+	IPropertySetterSetupParallelCallbackBuilder<T> IPropertySetterSetupCallbackBuilder<T>.InParallel()
+	{
+		_setterCallbacks?.Active?.InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterSetupCallbackWhenBuilder{T}.For(int)" />
+	IPropertySetterSetupCallbackWhenBuilder<T> IPropertySetterSetupCallbackWhenBuilder<T>.For(int times)
+	{
+		_setterCallbacks?.Active?.For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterSetupCallbackWhenBuilder{T}.Only(int)" />
+	IPropertySetup<T> IPropertySetterSetupCallbackWhenBuilder<T>.Only(int times)
+	{
+		_setterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -377,12 +406,10 @@ public class PropertySetup<T> : PropertySetup,
 		=> this;
 
 	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action)" />
-	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action callback)
+	IPropertyGetterSetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		_getterCallbacks.Add(item);
+		_getterCallbacks = _getterCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -393,12 +420,10 @@ public class PropertySetup<T> : PropertySetup,
 	}
 
 	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action{T})" />
-	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<T> callback)
+	IPropertyGetterSetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<T> callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		_getterCallbacks.Add(item);
+		_getterCallbacks = _getterCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -409,32 +434,26 @@ public class PropertySetup<T> : PropertySetup,
 	}
 
 	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action{int, T})" />
-	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<int, T> callback)
+	IPropertyGetterSetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<int, T> callback)
 	{
 		Callback<Action<int, T>> item = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		_getterCallbacks.Add(item);
+		_getterCallbacks = _getterCallbacks.Register(item);
 		return this;
 	}
 
-	IPropertySetupParallelCallbackBuilder<T> IPropertySetterSetup<T>.TransitionTo(string scenario)
+	IPropertySetterSetupParallelCallbackBuilder<T> IPropertySetterSetup<T>.TransitionTo(string scenario)
 	{
 		Callback<Action<int, T>> item = new((_, _) => _mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		(_setterCallbacks ??= []).Add(item);
+		_setterCallbacks = _setterCallbacks.Register(item);
 		return this;
 	}
 
-	IPropertySetupParallelCallbackBuilder<T> IPropertyGetterSetup<T>.TransitionTo(string scenario)
+	IPropertyGetterSetupParallelCallbackBuilder<T> IPropertyGetterSetup<T>.TransitionTo(string scenario)
 	{
 		Callback<Action<int, T>> item = new((_, _) => _mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		_getterCallbacks.Add(item);
+		_getterCallbacks = _getterCallbacks.Register(item);
 		return this;
 	}
 
@@ -443,12 +462,10 @@ public class PropertySetup<T> : PropertySetup,
 		=> this;
 
 	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action)" />
-	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action callback)
+	IPropertySetterSetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		(_setterCallbacks ??= []).Add(item);
+		_setterCallbacks = _setterCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -459,12 +476,10 @@ public class PropertySetup<T> : PropertySetup,
 	}
 
 	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action{T})" />
-	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<T> callback)
+	IPropertySetterSetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<T> callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		(_setterCallbacks ??= []).Add(item);
+		_setterCallbacks = _setterCallbacks.Register(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -475,12 +490,10 @@ public class PropertySetup<T> : PropertySetup,
 	}
 
 	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action{int, T})" />
-	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<int, T> callback)
+	IPropertySetterSetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<int, T> callback)
 	{
 		Callback<Action<int, T>> item = new(callback);
-		_getterCallbacks ??= [];
-		_getterCallbacks.Active = item;
-		(_setterCallbacks ??= []).Add(item);
+		_setterCallbacks = _setterCallbacks.Register(item);
 		return this;
 	}
 
@@ -488,9 +501,7 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Returns(T returnValue)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -504,9 +515,7 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Returns(Func<T> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -520,9 +529,7 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Returns(Func<T, T> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -537,9 +544,7 @@ public class PropertySetup<T> : PropertySetup,
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -553,9 +558,7 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Throws(Exception exception)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -569,9 +572,7 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -585,9 +586,7 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Throws(Func<T, Exception> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Mockolate.Exceptions;
@@ -154,15 +153,10 @@ public class PropertySetup<T> : PropertySetup,
 {
 	private readonly MockRegistry _mockRegistry;
 	private readonly string _name;
-	private Callback? _currentCallback;
-	private int _currentGetterCallbacksIndex;
-	private Callback? _currentReturnCallback;
-	private int _currentReturnCallbackIndex;
-	private int _currentSetterCallbacksIndex;
-	private List<Callback<Action<int, T>>>? _getterCallbacks;
+	private Callbacks<Action<int, T>>? _getterCallbacks;
 	private bool _isInitialized;
-	private List<Callback<Func<int, T, T>>>? _returnCallbacks;
-	private List<Callback<Action<int, T>>>? _setterCallbacks;
+	private Callbacks<Func<int, T, T>>? _returnCallbacks;
+	private Callbacks<Action<int, T>>? _setterCallbacks;
 	private bool? _skipBaseClass;
 	private T _value = default!;
 
@@ -184,49 +178,49 @@ public class PropertySetup<T> : PropertySetup,
 	/// <inheritdoc cref="IPropertySetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
 	IPropertySetupCallbackWhenBuilder<T> IPropertySetupParallelCallbackBuilder<T>.When(Func<int, bool> predicate)
 	{
-		_currentCallback?.When(predicate);
+		_getterCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IPropertySetupCallbackBuilder{T}.InParallel()" />
 	IPropertySetupParallelCallbackBuilder<T> IPropertySetupCallbackBuilder<T>.InParallel()
 	{
-		_currentCallback?.InParallel();
+		_getterCallbacks?.Active?.InParallel();
 		return this;
 	}
 
 	/// <inheritdoc cref="IPropertySetupCallbackWhenBuilder{T}.For(int)" />
 	IPropertySetupCallbackWhenBuilder<T> IPropertySetupCallbackWhenBuilder<T>.For(int times)
 	{
-		_currentCallback?.For(times);
+		_getterCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IPropertySetupCallbackWhenBuilder{T}.Only(int)" />
 	IPropertySetup<T> IPropertySetupCallbackWhenBuilder<T>.Only(int times)
 	{
-		_currentCallback?.Only(times);
+		_getterCallbacks?.Active?.Only(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IPropertySetupReturnBuilder{T}.When(Func{int, bool})" />
 	IPropertySetupReturnWhenBuilder<T> IPropertySetupReturnBuilder<T>.When(Func<int, bool> predicate)
 	{
-		_currentReturnCallback?.When(predicate);
+		_returnCallbacks?.Active?.When(predicate);
 		return this;
 	}
 
 	/// <inheritdoc cref="IPropertySetupReturnWhenBuilder{T}.For(int)" />
 	IPropertySetupReturnWhenBuilder<T> IPropertySetupReturnWhenBuilder<T>.For(int times)
 	{
-		_currentReturnCallback?.For(times);
+		_returnCallbacks?.Active?.For(times);
 		return this;
 	}
 
 	/// <inheritdoc cref="IPropertySetupReturnWhenBuilder{T}.Only(int)" />
 	IPropertySetup<T> IPropertySetupReturnWhenBuilder<T>.Only(int times)
 	{
-		_currentReturnCallback?.Only(times);
+		_returnCallbacks?.Active?.Only(times);
 		return this;
 	}
 
@@ -240,12 +234,12 @@ public class PropertySetup<T> : PropertySetup,
 		if (_getterCallbacks is not null)
 		{
 			bool wasInvoked = false;
-			int currentGetterCallbacksIndex = _currentGetterCallbacksIndex;
+			int currentGetterCallbacksIndex = _getterCallbacks.CurrentIndex;
 			for (int i = 0; i < _getterCallbacks.Count; i++)
 			{
 				Callback<Action<int, T>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-				if (getterCallback.Invoke(wasInvoked, ref _currentGetterCallbacksIndex, Callback))
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, Callback))
 				{
 					wasInvoked = true;
 				}
@@ -257,8 +251,8 @@ public class PropertySetup<T> : PropertySetup,
 			foreach (Callback<Func<int, T, T>> _ in _returnCallbacks)
 			{
 				Callback<Func<int, T, T>> returnCallback =
-					_returnCallbacks[_currentReturnCallbackIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _currentReturnCallbackIndex, ReturnCallback, out T? newValue))
+					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, ReturnCallback, out T? newValue))
 				{
 					_value = newValue;
 					_isInitialized = true;
@@ -314,12 +308,12 @@ public class PropertySetup<T> : PropertySetup,
 		if (_setterCallbacks is not null)
 		{
 			bool wasInvoked = false;
-			int currentSetterCallbacksIndex = _currentSetterCallbacksIndex;
+			int currentSetterCallbacksIndex = _setterCallbacks.CurrentIndex;
 			for (int i = 0; i < _setterCallbacks.Count; i++)
 			{
 				Callback<Action<int, T>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-				if (setterCallback.Invoke(wasInvoked, ref _currentSetterCallbacksIndex, Callback))
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, Callback))
 				{
 					wasInvoked = true;
 				}
@@ -386,8 +380,9 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_currentCallback = item;
-		(_getterCallbacks ??= []).Add(item);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
+		_getterCallbacks.Add(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -401,8 +396,9 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<T> callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_currentCallback = item;
-		(_getterCallbacks ??= []).Add(item);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
+		_getterCallbacks.Add(item);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -416,8 +412,9 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertySetupCallbackBuilder<T> IPropertyGetterSetup<T>.Do(Action<int, T> callback)
 	{
 		Callback<Action<int, T>> item = new(callback);
-		_currentCallback = item;
-		(_getterCallbacks ??= []).Add(item);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
+		_getterCallbacks.Add(item);
 		return this;
 	}
 
@@ -425,7 +422,8 @@ public class PropertySetup<T> : PropertySetup,
 	{
 		Callback<Action<int, T>> item = new((_, _) => _mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_currentCallback = item;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
 		(_setterCallbacks ??= []).Add(item);
 		return this;
 	}
@@ -434,8 +432,9 @@ public class PropertySetup<T> : PropertySetup,
 	{
 		Callback<Action<int, T>> item = new((_, _) => _mockRegistry.TransitionTo(scenario));
 		item.InParallel();
-		_currentCallback = item;
-		(_getterCallbacks ??= []).Add(item);
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
+		_getterCallbacks.Add(item);
 		return this;
 	}
 
@@ -447,7 +446,8 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_currentCallback = item;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
 		(_setterCallbacks ??= []).Add(item);
 		return this;
 
@@ -462,7 +462,8 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<T> callback)
 	{
 		Callback<Action<int, T>> item = new(Delegate);
-		_currentCallback = item;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
 		(_setterCallbacks ??= []).Add(item);
 		return this;
 
@@ -477,7 +478,8 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertySetupCallbackBuilder<T> IPropertySetterSetup<T>.Do(Action<int, T> callback)
 	{
 		Callback<Action<int, T>> item = new(callback);
-		_currentCallback = item;
+		_getterCallbacks ??= [];
+		_getterCallbacks.Active = item;
 		(_setterCallbacks ??= []).Add(item);
 		return this;
 	}
@@ -486,8 +488,9 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Returns(T returnValue)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
-		(_returnCallbacks ??= []).Add(currentCallback);
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
+		_returnCallbacks.Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -501,8 +504,9 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Returns(Func<T> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
-		(_returnCallbacks ??= []).Add(currentCallback);
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
+		_returnCallbacks.Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -516,8 +520,9 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Returns(Func<T, T> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
-		(_returnCallbacks ??= []).Add(currentCallback);
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
+		_returnCallbacks.Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -532,8 +537,9 @@ public class PropertySetup<T> : PropertySetup,
 		where TException : Exception, new()
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
-		(_returnCallbacks ??= []).Add(currentCallback);
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
+		_returnCallbacks.Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -547,8 +553,9 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Throws(Exception exception)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
-		(_returnCallbacks ??= []).Add(currentCallback);
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
+		_returnCallbacks.Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -562,8 +569,9 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
-		(_returnCallbacks ??= []).Add(currentCallback);
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
+		_returnCallbacks.Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -577,8 +585,9 @@ public class PropertySetup<T> : PropertySetup,
 	public IPropertySetupReturnBuilder<T> Throws(Func<T, Exception> callback)
 	{
 		Callback<Func<int, T, T>> currentCallback = new(Delegate);
-		_currentReturnCallback = currentCallback;
-		(_returnCallbacks ??= []).Add(currentCallback);
+		_returnCallbacks ??= [];
+		_returnCallbacks.Active = currentCallback;
+		_returnCallbacks.Add(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -37,9 +37,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	IReturnMethodSetupCallbackBuilder<TReturn> IReturnMethodSetup<TReturn>.Do(Action callback)
 	{
 		Callback<Action<int>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -53,9 +51,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	IReturnMethodSetupCallbackBuilder<TReturn> IReturnMethodSetup<TReturn>.Do(Action<int> callback)
 	{
 		Callback<Action<int>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -64,9 +60,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	{
 		Callback<Action<int>> currentCallback = new(_ => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -74,9 +68,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	IReturnMethodSetupReturnBuilder<TReturn> IReturnMethodSetup<TReturn>.Returns(Func<TReturn> callback)
 	{
 		Callback<Func<int, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -90,9 +82,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	IReturnMethodSetupReturnBuilder<TReturn> IReturnMethodSetup<TReturn>.Returns(TReturn returnValue)
 	{
 		Callback<Func<int, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -106,9 +96,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	IReturnMethodSetupReturnBuilder<TReturn> IReturnMethodSetup<TReturn>.Throws<TException>()
 	{
 		Callback<Func<int, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -122,9 +110,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	IReturnMethodSetupReturnBuilder<TReturn> IReturnMethodSetup<TReturn>.Throws(Exception exception)
 	{
 		Callback<Func<int, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -138,9 +124,7 @@ public abstract class ReturnMethodSetup<TReturn>
 	IReturnMethodSetupReturnBuilder<TReturn> IReturnMethodSetup<TReturn>.Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -329,9 +313,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Do(Action callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -345,9 +327,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Do(Action<T1> callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -361,9 +341,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Do(Action<int, T1> callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -373,9 +351,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	{
 		Callback<Action<int, T1>> currentCallback = new((_, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -383,9 +359,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Returns(Func<T1, TReturn> callback)
 	{
 		Callback<Func<int, T1, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -399,9 +373,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Returns(Func<TReturn> callback)
 	{
 		Callback<Func<int, T1, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -415,9 +387,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Returns(TReturn returnValue)
 	{
 		Callback<Func<int, T1, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -431,9 +401,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Throws<TException>()
 	{
 		Callback<Func<int, T1, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -447,9 +415,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Throws(Exception exception)
 	{
 		Callback<Func<int, T1, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -463,9 +429,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Throws(Func<Exception> callback)
 	{
 		Callback<Func<int, T1, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -479,9 +443,7 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1> IReturnMethodSetup<TReturn, T1>.Throws(Func<T1, Exception> callback)
 	{
 		Callback<Func<int, T1, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -733,9 +695,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> IReturnMethodSetup<TReturn, T1, T2>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -749,9 +709,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> IReturnMethodSetup<TReturn, T1, T2>.Do(Action<T1, T2> callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -766,9 +724,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 		Action<int, T1, T2> callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -778,9 +734,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new((_, _, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -789,9 +743,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 		Func<T1, T2, TReturn> callback)
 	{
 		Callback<Func<int, T1, T2, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -805,9 +757,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> IReturnMethodSetup<TReturn, T1, T2>.Returns(Func<TReturn> callback)
 	{
 		Callback<Func<int, T1, T2, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -821,9 +771,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> IReturnMethodSetup<TReturn, T1, T2>.Returns(TReturn returnValue)
 	{
 		Callback<Func<int, T1, T2, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -837,9 +785,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> IReturnMethodSetup<TReturn, T1, T2>.Throws<TException>()
 	{
 		Callback<Func<int, T1, T2, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -853,9 +799,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> IReturnMethodSetup<TReturn, T1, T2>.Throws(Exception exception)
 	{
 		Callback<Func<int, T1, T2, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -870,9 +814,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 		Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -887,9 +829,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 		Func<T1, T2, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1154,9 +1094,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> IReturnMethodSetup<TReturn, T1, T2, T3>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1171,9 +1109,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		Action<T1, T2, T3> callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1188,9 +1124,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		Action<int, T1, T2, T3> callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1200,9 +1134,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new((_, _, _, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1211,9 +1143,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		Func<T1, T2, T3, TReturn> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1228,9 +1158,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		Func<TReturn> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1245,9 +1173,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		TReturn returnValue)
 	{
 		Callback<Func<int, T1, T2, T3, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1261,9 +1187,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> IReturnMethodSetup<TReturn, T1, T2, T3>.Throws<TException>()
 	{
 		Callback<Func<int, T1, T2, T3, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1278,9 +1202,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		Exception exception)
 	{
 		Callback<Func<int, T1, T2, T3, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1295,9 +1217,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1312,9 +1232,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		Func<T1, T2, T3, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1595,9 +1513,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1612,9 +1528,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Action<T1, T2, T3, T4> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1629,9 +1543,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Action<int, T1, T2, T3, T4> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1641,9 +1553,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new((_, _, _, _, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1652,9 +1562,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Func<T1, T2, T3, T4, TReturn> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1669,9 +1577,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Func<TReturn> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1686,9 +1592,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		TReturn returnValue)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1703,9 +1607,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Throws<TException>()
 	{
 		Callback<Func<int, T1, T2, T3, T4, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1720,9 +1622,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Exception exception)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1737,9 +1637,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Func<Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1754,9 +1652,7 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		Func<T1, T2, T3, T4, Exception> callback)
 	{
 		Callback<Func<int, T1, T2, T3, T4, TReturn>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -37,9 +37,7 @@ public abstract class VoidMethodSetup : MethodSetup,
 	IVoidMethodSetupCallbackBuilder IVoidMethodSetup.Do(Action callback)
 	{
 		Callback<Action<int>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -53,9 +51,7 @@ public abstract class VoidMethodSetup : MethodSetup,
 	IVoidMethodSetupCallbackBuilder IVoidMethodSetup.Do(Action<int> callback)
 	{
 		Callback<Action<int>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -64,9 +60,7 @@ public abstract class VoidMethodSetup : MethodSetup,
 	{
 		Callback<Action<int>> currentCallback = new(_ => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -74,9 +68,7 @@ public abstract class VoidMethodSetup : MethodSetup,
 	IVoidMethodSetup IVoidMethodSetup.DoesNotThrow()
 	{
 		Callback<Action<int>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -89,9 +81,7 @@ public abstract class VoidMethodSetup : MethodSetup,
 	IVoidMethodSetupReturnBuilder IVoidMethodSetup.Throws<TException>()
 	{
 		Callback<Action<int>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -105,9 +95,7 @@ public abstract class VoidMethodSetup : MethodSetup,
 	IVoidMethodSetupReturnBuilder IVoidMethodSetup.Throws(Exception exception)
 	{
 		Callback<Action<int>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -121,9 +109,7 @@ public abstract class VoidMethodSetup : MethodSetup,
 	IVoidMethodSetupReturnBuilder IVoidMethodSetup.Throws(Func<Exception> callback)
 	{
 		Callback<Action<int>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -292,9 +278,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1> IVoidMethodSetup<T1>.Do(Action callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -308,9 +292,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1> IVoidMethodSetup<T1>.Do(Action<T1> callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -324,9 +306,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1> IVoidMethodSetup<T1>.Do(Action<int, T1> callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -335,9 +315,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	{
 		Callback<Action<int, T1>> currentCallback = new((_, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -345,9 +323,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetup<T1> IVoidMethodSetup<T1>.DoesNotThrow()
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -360,9 +336,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1> IVoidMethodSetup<T1>.Throws<TException>()
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -376,9 +350,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1> IVoidMethodSetup<T1>.Throws(Exception exception)
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -392,9 +364,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1> IVoidMethodSetup<T1>.Throws(Func<Exception> callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -408,9 +378,7 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1> IVoidMethodSetup<T1>.Throws(Func<T1, Exception> callback)
 	{
 		Callback<Action<int, T1>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -640,9 +608,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2> IVoidMethodSetup<T1, T2>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -656,9 +622,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2> IVoidMethodSetup<T1, T2>.Do(Action<T1, T2> callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -672,9 +636,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2> IVoidMethodSetup<T1, T2>.Do(Action<int, T1, T2> callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -683,9 +645,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new((_, _, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -693,9 +653,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetup<T1, T2> IVoidMethodSetup<T1, T2>.DoesNotThrow()
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -708,9 +666,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2> IVoidMethodSetup<T1, T2>.Throws<TException>()
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -724,9 +680,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2> IVoidMethodSetup<T1, T2>.Throws(Exception exception)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -740,9 +694,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2> IVoidMethodSetup<T1, T2>.Throws(Func<Exception> callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -756,9 +708,7 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2> IVoidMethodSetup<T1, T2>.Throws(Func<T1, T2, Exception> callback)
 	{
 		Callback<Action<int, T1, T2>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -999,9 +949,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1015,9 +963,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.Do(Action<T1, T2, T3> callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1031,9 +977,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.Do(Action<int, T1, T2, T3> callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1042,9 +986,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new((_, _, _, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1052,9 +994,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetup<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.DoesNotThrow()
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1067,9 +1007,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.Throws<TException>()
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1083,9 +1021,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.Throws(Exception exception)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1099,9 +1035,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.Throws(Func<Exception> callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1115,9 +1049,7 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.Throws(Func<T1, T2, T3, Exception> callback)
 	{
 		Callback<Action<int, T1, T2, T3>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1369,9 +1301,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.Do(Action callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1385,9 +1315,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.Do(Action<T1, T2, T3, T4> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1401,9 +1329,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.Do(Action<int, T1, T2, T3, T4> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(callback);
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1412,9 +1338,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new((_, _, _, _, _) => _mockRegistry.TransitionTo(scenario));
 		currentCallback.InParallel();
-		_callbacks ??= [];
-		_callbacks.Active = currentCallback;
-		_callbacks.Add(currentCallback);
+		_callbacks = _callbacks.Register(currentCallback);
 		return this;
 	}
 
@@ -1422,9 +1346,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetup<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.DoesNotThrow()
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1437,9 +1359,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.Throws<TException>()
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1453,9 +1373,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.Throws(Exception exception)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1469,9 +1387,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.Throws(Func<Exception> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]
@@ -1485,9 +1401,7 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.Throws(Func<T1, T2, T3, T4, Exception> callback)
 	{
 		Callback<Action<int, T1, T2, T3, T4>> currentCallback = new(Delegate);
-		_returnCallbacks ??= [];
-		_returnCallbacks.Active = currentCallback;
-		_returnCallbacks.Add(currentCallback);
+		_returnCallbacks = _returnCallbacks.Register(currentCallback);
 		return this;
 
 		[DebuggerNonUserCode]

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -29,9 +29,9 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
-	///     Extensions for property callback setups.
+	///     Extensions for property getter callback setups.
 	/// </summary>
-	extension<T>(IPropertySetupCallbackWhenBuilder<T> setup)
+	extension<T>(IPropertyGetterSetupCallbackWhenBuilder<T> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -41,9 +41,39 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
-	///     Extensions for event callback setups.
+	///     Extensions for property setter callback setups.
 	/// </summary>
-	extension(IEventSetupCallbackWhenBuilder setup)
+	extension<T>(IPropertySetterSetupCallbackWhenBuilder<T> setup)
+	{
+		/// <summary>
+		///     Executes the callback only once.
+		/// </summary>
+		public IPropertySetup<T> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for event subscription callback setups.
+	/// </summary>
+	extension(IEventSubscriptionSetupCallbackWhenBuilder setup)
+	{
+		/// <summary>
+		///     Repeats the callback forever.
+		/// </summary>
+		public void Forever()
+			=> setup.For(int.MaxValue);
+
+		/// <summary>
+		///     Executes the callback only once.
+		/// </summary>
+		public IEventSetup OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for event unsubscription callback setups.
+	/// </summary>
+	extension(IEventUnsubscriptionSetupCallbackWhenBuilder setup)
 	{
 		/// <summary>
 		///     Repeats the callback forever.
@@ -77,9 +107,21 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
-	///     Extensions for indexer callback setups with one parameter.
+	///     Extensions for indexer getter callback setups with one parameter.
 	/// </summary>
-	extension<TValue, T1>(IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
+	extension<TValue, T1>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
+	{
+		/// <summary>
+		///     Executes the callback only once.
+		/// </summary>
+		public IIndexerSetup<TValue, T1> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for indexer setter callback setups with one parameter.
+	/// </summary>
+	extension<TValue, T1>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -107,9 +149,21 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
-	///     Extensions for indexer callback setups with two parameters.
+	///     Extensions for indexer getter callback setups with two parameters.
 	/// </summary>
-	extension<TValue, T1, T2>(IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+	extension<TValue, T1, T2>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+	{
+		/// <summary>
+		///     Executes the callback only once.
+		/// </summary>
+		public IIndexerSetup<TValue, T1, T2> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for indexer setter callback setups with two parameters.
+	/// </summary>
+	extension<TValue, T1, T2>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -137,9 +191,21 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
-	///     Extensions for indexer callback setups with three parameters.
+	///     Extensions for indexer getter callback setups with three parameters.
 	/// </summary>
-	extension<TValue, T1, T2, T3>(IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+	extension<TValue, T1, T2, T3>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+	{
+		/// <summary>
+		///     Executes the callback only once.
+		/// </summary>
+		public IIndexerSetup<TValue, T1, T2, T3> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for indexer setter callback setups with three parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.
@@ -167,9 +233,21 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
-	///     Extensions for indexer callback setups with four parameters.
+	///     Extensions for indexer getter callback setups with four parameters.
 	/// </summary>
-	extension<TValue, T1, T2, T3, T4>(IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+	extension<TValue, T1, T2, T3, T4>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+	{
+		/// <summary>
+		///     Executes the callback only once.
+		/// </summary>
+		public IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for indexer setter callback setups with four parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3, T4>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
 		///     Executes the callback only once.

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -291,12 +291,22 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> setup)
+        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> setup)
             where T :  notnull
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventSetupCallbackWhenBuilder setup)
+        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> setup)
+            where T :  notnull
+        {
+            public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
+        }
+        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IEventSetup OnlyOnce() { }
+        }
+        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
@@ -308,7 +318,13 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
@@ -322,7 +338,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -338,7 +361,15 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+            where T3 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -356,7 +387,16 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+            where T3 :  notnull
+            where T4 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -844,15 +884,20 @@ namespace Mockolate.Setup
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }
+    public static class CallbacksExtensions
+    {
+        public static Mockolate.Setup.Callbacks<T> Register<T>(this Mockolate.Setup.Callbacks<T>? callbacks, Mockolate.Setup.Callback<T> callback)
+            where T : System.Delegate { }
+    }
     public class Callbacks<T> : System.Collections.Generic.List<Mockolate.Setup.Callback<T>>
         where T : System.Delegate
     {
         public int CurrentIndex;
         public Callbacks() { }
-        public Mockolate.Setup.Callback<T>? Active { get; set; }
+        public Mockolate.Setup.Callback<T>? Active { get; }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public class EventSetup : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackBuilder, Mockolate.Setup.IEventSetupCallbackWhenBuilder, Mockolate.Setup.IEventSetupParallelCallbackBuilder, Mockolate.Setup.IEventSubscriptionSetup, Mockolate.Setup.IEventUnsubscriptionSetup
+    public class EventSetup : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder, Mockolate.Setup.IEventUnsubscriptionSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder
     {
         public EventSetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public string Name { get; }
@@ -865,146 +910,211 @@ namespace Mockolate.Setup
         Mockolate.Setup.IEventSubscriptionSetup OnSubscribed { get; }
         Mockolate.Setup.IEventUnsubscriptionSetup OnUnsubscribed { get; }
     }
-    public interface IEventSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackWhenBuilder, Mockolate.Setup.IEventSetupParallelCallbackBuilder
-    {
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder InParallel();
-    }
-    public interface IEventSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
-    {
-        Mockolate.Setup.IEventSetupCallbackWhenBuilder For(int times);
-        Mockolate.Setup.IEventSetup Only(int times);
-    }
-    public interface IEventSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackWhenBuilder
-    {
-        Mockolate.Setup.IEventSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
-    }
     public interface IEventSubscriptionSetup
     {
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action callback);
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+        Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder Do(System.Action callback);
+        Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
+        Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
+    }
+    public interface IEventSubscriptionSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder
+    {
+        Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder InParallel();
+    }
+    public interface IEventSubscriptionSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
+    {
+        Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder For(int times);
+        Mockolate.Setup.IEventSetup Only(int times);
+    }
+    public interface IEventSubscriptionSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder
+    {
+        Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
     public interface IEventUnsubscriptionSetup
     {
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action callback);
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder Do(System.Action callback);
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
+        Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
+    }
+    public interface IEventUnsubscriptionSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder InParallel();
+    }
+    public interface IEventUnsubscriptionSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder For(int times);
+        Mockolate.Setup.IEventSetup Only(int times);
+    }
+    public interface IEventUnsubscriptionSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
     }
     public interface IIndexerGetterSetup<TValue, out T1>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
     }
     public interface IIndexerSetterSetup<TValue, out T1>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
     }
     public interface IIndexerSetupReturnBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -1136,32 +1246,45 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertyGetterSetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetup<T> Only(int times);
+    }
+    public interface IPropertyGetterSetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
     public interface IPropertyGetterSetup<T>
     {
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertySetterSetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetup<T> Only(int times);
+    }
+    public interface IPropertySetterSetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
     }
     public interface IPropertySetterSetup<T>
     {
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
-    }
-    public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> InParallel();
-    }
-    public interface IPropertySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> For(int times);
-        Mockolate.Setup.IPropertySetup<T> Only(int times);
-    }
-    public interface IPropertySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
     }
     public interface IPropertySetupReturnBuilder<T> : Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -1602,7 +1725,7 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
@@ -1629,7 +1752,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
@@ -1656,7 +1779,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
@@ -1683,7 +1806,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
@@ -1727,7 +1850,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -290,12 +290,22 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> setup)
+        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> setup)
             where T :  notnull
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventSetupCallbackWhenBuilder setup)
+        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> setup)
+            where T :  notnull
+        {
+            public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
+        }
+        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IEventSetup OnlyOnce() { }
+        }
+        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
@@ -307,7 +317,13 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
@@ -321,7 +337,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -337,7 +360,15 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+            where T3 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -355,7 +386,16 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+            where T3 :  notnull
+            where T4 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -843,15 +883,20 @@ namespace Mockolate.Setup
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }
+    public static class CallbacksExtensions
+    {
+        public static Mockolate.Setup.Callbacks<T> Register<T>(this Mockolate.Setup.Callbacks<T>? callbacks, Mockolate.Setup.Callback<T> callback)
+            where T : System.Delegate { }
+    }
     public class Callbacks<T> : System.Collections.Generic.List<Mockolate.Setup.Callback<T>>
         where T : System.Delegate
     {
         public int CurrentIndex;
         public Callbacks() { }
-        public Mockolate.Setup.Callback<T>? Active { get; set; }
+        public Mockolate.Setup.Callback<T>? Active { get; }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public class EventSetup : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackBuilder, Mockolate.Setup.IEventSetupCallbackWhenBuilder, Mockolate.Setup.IEventSetupParallelCallbackBuilder, Mockolate.Setup.IEventSubscriptionSetup, Mockolate.Setup.IEventUnsubscriptionSetup
+    public class EventSetup : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder, Mockolate.Setup.IEventUnsubscriptionSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder
     {
         public EventSetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public string Name { get; }
@@ -864,146 +909,211 @@ namespace Mockolate.Setup
         Mockolate.Setup.IEventSubscriptionSetup OnSubscribed { get; }
         Mockolate.Setup.IEventUnsubscriptionSetup OnUnsubscribed { get; }
     }
-    public interface IEventSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackWhenBuilder, Mockolate.Setup.IEventSetupParallelCallbackBuilder
-    {
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder InParallel();
-    }
-    public interface IEventSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
-    {
-        Mockolate.Setup.IEventSetupCallbackWhenBuilder For(int times);
-        Mockolate.Setup.IEventSetup Only(int times);
-    }
-    public interface IEventSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackWhenBuilder
-    {
-        Mockolate.Setup.IEventSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
-    }
     public interface IEventSubscriptionSetup
     {
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action callback);
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+        Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder Do(System.Action callback);
+        Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
+        Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
+    }
+    public interface IEventSubscriptionSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder
+    {
+        Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder InParallel();
+    }
+    public interface IEventSubscriptionSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
+    {
+        Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder For(int times);
+        Mockolate.Setup.IEventSetup Only(int times);
+    }
+    public interface IEventSubscriptionSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder
+    {
+        Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
     public interface IEventUnsubscriptionSetup
     {
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action callback);
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder Do(System.Action callback);
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
+        Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
+    }
+    public interface IEventUnsubscriptionSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder InParallel();
+    }
+    public interface IEventUnsubscriptionSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder For(int times);
+        Mockolate.Setup.IEventSetup Only(int times);
+    }
+    public interface IEventUnsubscriptionSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
     }
     public interface IIndexerGetterSetup<TValue, out T1>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
     }
     public interface IIndexerSetterSetup<TValue, out T1>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
     }
     public interface IIndexerSetupReturnBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -1135,32 +1245,45 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertyGetterSetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetup<T> Only(int times);
+    }
+    public interface IPropertyGetterSetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
     public interface IPropertyGetterSetup<T>
     {
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertySetterSetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetup<T> Only(int times);
+    }
+    public interface IPropertySetterSetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
     }
     public interface IPropertySetterSetup<T>
     {
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
-    }
-    public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> InParallel();
-    }
-    public interface IPropertySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> For(int times);
-        Mockolate.Setup.IPropertySetup<T> Only(int times);
-    }
-    public interface IPropertySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
     }
     public interface IPropertySetupReturnBuilder<T> : Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -1601,7 +1724,7 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
@@ -1628,7 +1751,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
@@ -1655,7 +1778,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
@@ -1682,7 +1805,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
@@ -1726,7 +1849,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -249,12 +249,22 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> setup)
+        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> setup)
             where T :  notnull
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventSetupCallbackWhenBuilder setup)
+        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> setup)
+            where T :  notnull
+        {
+            public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
+        }
+        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IEventSetup OnlyOnce() { }
+        }
+        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
@@ -266,7 +276,13 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> setup)
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
             where TValue :  notnull
             where T1 :  notnull
         {
@@ -280,7 +296,14 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -296,7 +319,15 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+            where T3 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -314,7 +345,16 @@ namespace Mockolate
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+            where TValue :  notnull
+            where T1 :  notnull
+            where T2 :  notnull
+            where T3 :  notnull
+            where T4 :  notnull
+        {
+            public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
             where TValue :  notnull
             where T1 :  notnull
             where T2 :  notnull
@@ -798,15 +838,20 @@ namespace Mockolate.Setup
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }
+    public static class CallbacksExtensions
+    {
+        public static Mockolate.Setup.Callbacks<T> Register<T>(this Mockolate.Setup.Callbacks<T>? callbacks, Mockolate.Setup.Callback<T> callback)
+            where T : System.Delegate { }
+    }
     public class Callbacks<T> : System.Collections.Generic.List<Mockolate.Setup.Callback<T>>
         where T : System.Delegate
     {
         public int CurrentIndex;
         public Callbacks() { }
-        public Mockolate.Setup.Callback<T>? Active { get; set; }
+        public Mockolate.Setup.Callback<T>? Active { get; }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public class EventSetup : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackBuilder, Mockolate.Setup.IEventSetupCallbackWhenBuilder, Mockolate.Setup.IEventSetupParallelCallbackBuilder, Mockolate.Setup.IEventSubscriptionSetup, Mockolate.Setup.IEventUnsubscriptionSetup
+    public class EventSetup : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder, Mockolate.Setup.IEventUnsubscriptionSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder
     {
         public EventSetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public string Name { get; }
@@ -819,146 +864,211 @@ namespace Mockolate.Setup
         Mockolate.Setup.IEventSubscriptionSetup OnSubscribed { get; }
         Mockolate.Setup.IEventUnsubscriptionSetup OnUnsubscribed { get; }
     }
-    public interface IEventSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackWhenBuilder, Mockolate.Setup.IEventSetupParallelCallbackBuilder
-    {
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder InParallel();
-    }
-    public interface IEventSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
-    {
-        Mockolate.Setup.IEventSetupCallbackWhenBuilder For(int times);
-        Mockolate.Setup.IEventSetup Only(int times);
-    }
-    public interface IEventSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSetupCallbackWhenBuilder
-    {
-        Mockolate.Setup.IEventSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
-    }
     public interface IEventSubscriptionSetup
     {
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action callback);
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+        Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder Do(System.Action callback);
+        Mockolate.Setup.IEventSubscriptionSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
+        Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
+    }
+    public interface IEventSubscriptionSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder
+    {
+        Mockolate.Setup.IEventSubscriptionSetupParallelCallbackBuilder InParallel();
+    }
+    public interface IEventSubscriptionSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
+    {
+        Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder For(int times);
+        Mockolate.Setup.IEventSetup Only(int times);
+    }
+    public interface IEventSubscriptionSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder
+    {
+        Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
     public interface IEventUnsubscriptionSetup
     {
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action callback);
-        Mockolate.Setup.IEventSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
-        Mockolate.Setup.IEventSetupParallelCallbackBuilder TransitionTo(string scenario);
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder Do(System.Action callback);
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackBuilder Do(System.Action<object?, System.Reflection.MethodInfo> callback);
+        Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
+    }
+    public interface IEventUnsubscriptionSetupCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder, Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupParallelCallbackBuilder InParallel();
+    }
+    public interface IEventUnsubscriptionSetupCallbackWhenBuilder : Mockolate.Setup.IEventSetup
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder For(int times);
+        Mockolate.Setup.IEventSetup Only(int times);
+    }
+    public interface IEventUnsubscriptionSetupParallelCallbackBuilder : Mockolate.Setup.IEventSetup, Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder
+    {
+        Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
     }
     public interface IIndexerGetterSetup<TValue, out T1>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
     }
     public interface IIndexerGetterSetup<TValue, out T1, out T2, out T3, out T4>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerSetterSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
     }
     public interface IIndexerSetterSetup<TValue, out T1>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
     }
     public interface IIndexerSetterSetup<TValue, out T1, out T2, out T3, out T4>
     {
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
-    }
-    public interface IIndexerSetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> Only(int times);
-    }
-    public interface IIndexerSetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
-        Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
-    }
-    public interface IIndexerSetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
-    {
-        Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
     }
     public interface IIndexerSetupReturnBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -1090,32 +1200,45 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertyGetterSetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetup<T> Only(int times);
+    }
+    public interface IPropertyGetterSetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
     public interface IPropertyGetterSetup<T>
     {
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertySetterSetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetup<T> Only(int times);
+    }
+    public interface IPropertySetterSetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
     }
     public interface IPropertySetterSetup<T>
     {
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<T> callback);
-        Mockolate.Setup.IPropertySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
-    }
-    public interface IPropertySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T> InParallel();
-    }
-    public interface IPropertySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> For(int times);
-        Mockolate.Setup.IPropertySetup<T> Only(int times);
-    }
-    public interface IPropertySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
-    {
-        Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
     }
     public interface IPropertySetupReturnBuilder<T> : Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -1556,7 +1679,7 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
@@ -1583,7 +1706,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
@@ -1610,7 +1733,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
@@ -1637,7 +1760,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
@@ -1681,7 +1804,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnGetTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.OnGetTests.cs
@@ -209,10 +209,10 @@ public sealed partial class SetupIndexerTests
 		}
 
 		[Fact]
-		public async Task WithoutCallback_IIndexerSetupCallbackBuilder_ShouldNotThrow()
+		public async Task WithoutCallback_IIndexerGetterSetupCallbackBuilder_ShouldNotThrow()
 		{
 			IIndexerService sut = IIndexerService.CreateMock();
-			IIndexerSetupCallbackBuilder<string, int> setup =
+			IIndexerGetterSetupCallbackBuilder<string, int> setup =
 				sut.Mock.Setup[It.IsAny<int>()];
 
 			void ActWhen()
@@ -236,10 +236,10 @@ public sealed partial class SetupIndexerTests
 		}
 
 		[Fact]
-		public async Task WithoutCallback_IIndexerSetupCallbackWhenBuilder_ShouldNotThrow()
+		public async Task WithoutCallback_IIndexerGetterSetupCallbackWhenBuilder_ShouldNotThrow()
 		{
 			IIndexerService sut = IIndexerService.CreateMock();
-			IIndexerSetupCallbackWhenBuilder<string, int> setup =
+			IIndexerGetterSetupCallbackWhenBuilder<string, int> setup =
 				sut.Mock.Setup[It.IsAny<int>()];
 
 			void ActFor()
@@ -461,10 +461,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackBuilder<string, int, int> setup =
+				IIndexerGetterSetupCallbackBuilder<string, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(),
 						It.IsAny<int>()];
 
@@ -489,10 +489,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackWhenBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackWhenBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackWhenBuilder<string, int, int> setup =
+				IIndexerGetterSetupCallbackWhenBuilder<string, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>()];
 
 				void ActFor()
@@ -720,10 +720,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackBuilder<string, int, int, int> setup =
+				IIndexerGetterSetupCallbackBuilder<string, int, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()];
 
 				void ActWhen()
@@ -747,10 +747,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackWhenBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackWhenBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackWhenBuilder<string, int, int, int> setup =
+				IIndexerGetterSetupCallbackWhenBuilder<string, int, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()];
 
 				void ActFor()
@@ -979,10 +979,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackBuilder<string, int, int, int, int> setup =
+				IIndexerGetterSetupCallbackBuilder<string, int, int, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()];
 
 				void ActWhen()
@@ -1006,10 +1006,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackWhenBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackWhenBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackWhenBuilder<string, int, int, int, int> setup =
+				IIndexerGetterSetupCallbackWhenBuilder<string, int, int, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()];
 
 				void ActFor()
@@ -1241,10 +1241,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackBuilder<string, int, int, int, int, int> setup =
+				IIndexerGetterSetupCallbackBuilder<string, int, int, int, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()];
 
 				void ActWhen()
@@ -1268,10 +1268,10 @@ public sealed partial class SetupIndexerTests
 			}
 
 			[Fact]
-			public async Task WithoutCallback_IIndexerSetupCallbackWhenBuilder_ShouldNotThrow()
+			public async Task WithoutCallback_IIndexerGetterSetupCallbackWhenBuilder_ShouldNotThrow()
 			{
 				IIndexerService sut = IIndexerService.CreateMock();
-				IIndexerSetupCallbackWhenBuilder<string, int, int, int, int, int> setup =
+				IIndexerGetterSetupCallbackWhenBuilder<string, int, int, int, int, int> setup =
 					sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()];
 
 				void ActFor()

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnGetTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnGetTests.cs
@@ -241,10 +241,10 @@ public sealed partial class SetupPropertyTests
 		}
 
 		[Fact]
-		public async Task WithoutCallback_IPropertySetupCallbackBuilder_ShouldNotThrow()
+		public async Task WithoutCallback_IPropertyGetterSetupCallbackBuilder_ShouldNotThrow()
 		{
 			IPropertyService sut = IPropertyService.CreateMock();
-			IPropertySetupCallbackBuilder<int> setup =
+			IPropertyGetterSetupCallbackBuilder<int> setup =
 				sut.Mock.Setup.MyProperty;
 
 			void ActWhen()
@@ -268,10 +268,10 @@ public sealed partial class SetupPropertyTests
 		}
 
 		[Fact]
-		public async Task WithoutCallback_IPropertySetupWhenBuilder_ShouldNotThrow()
+		public async Task WithoutCallback_IPropertyGetterSetupWhenBuilder_ShouldNotThrow()
 		{
 			IPropertyService sut = IPropertyService.CreateMock();
-			IPropertySetupCallbackWhenBuilder<int> setup =
+			IPropertyGetterSetupCallbackWhenBuilder<int> setup =
 				sut.Mock.Setup.MyProperty;
 
 			void ActFor()

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnGetTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.OnGetTests.cs
@@ -268,7 +268,7 @@ public sealed partial class SetupPropertyTests
 		}
 
 		[Fact]
-		public async Task WithoutCallback_IPropertyGetterSetupWhenBuilder_ShouldNotThrow()
+		public async Task WithoutCallback_IPropertyGetterSetupCallbackWhenBuilder_ShouldNotThrow()
 		{
 			IPropertyService sut = IPropertyService.CreateMock();
 			IPropertyGetterSetupCallbackWhenBuilder<int> setup =


### PR DESCRIPTION
Refactors callback registration to use the new `Callbacks<T>` helper and updates the fluent setup API to distinguish getter vs. setter (and subscription vs. unsubscription) callback builder interfaces, with corresponding test and API-baseline updates.

**Changes:**
- Introduces `CallbacksExtensions.Register` and adopts it across method/property/event setup implementations to centralize “add + mark active callback” logic.
- Splits callback builder interfaces into getter/setter (properties, indexers) and subscription/unsubscription (events), updating `SetupExtensions` and tests accordingly.
- Updates source-generator templates and API snapshot expectation files for netstandard2.0/net8.0/net10.0.