### PR TITLE
feat: allow opt-out of interaction recording

### DIFF
--- a/Docs/pages/01-create-mocks.md
+++ b/Docs/pages/01-create-mocks.md
@@ -35,6 +35,11 @@ MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock(["Dark", 42], b
 - `ThrowWhenNotSetup` (bool):
   - If `false` (default), the mock will return a default value (see `DefaultValue`), when no matching setup is found.
   - If `true`, the mock will throw an exception when no matching setup is found.
+- `SkipInteractionRecording` (bool):
+  - If `false` (default), every interaction with the mock is recorded and can be verified later.
+  - If `true`, the mock skips recording interactions for faster execution.
+    Setups, returns, callbacks and base-class delegation continue to work - only verification is disabled. Any
+    attempt to call `.Verify.X()` throws a `MockException`.
 - `DefaultValue` (IDefaultValueGenerator):
   - Customizes how default values are generated for methods/properties that are not set up.
   - The default implementation provides sensible defaults for the most common use cases:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock(["Dark", 42], b
 - `ThrowWhenNotSetup` (bool):
   - If `false` (default), the mock will return a default value (see `DefaultValue`), when no matching setup is found.
   - If `true`, the mock will throw an exception when no matching setup is found.
+- `SkipInteractionRecording` (bool):
+  - If `false` (default), every interaction with the mock is recorded and can be verified later.
+  - If `true`, the mock skips recording interactions for faster execution.
+    Setups, returns, callbacks and base-class delegation continue to work - only verification is disabled. Any
+    attempt to call `.Verify.X()` throws a `MockException`.
 - `DefaultValue` (IDefaultValueGenerator):
   - Customizes how default values are generated for methods/properties that are not set up.
   - The default implementation provides sensible defaults for the most common use cases:

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2019,7 +2019,9 @@ internal static partial class Sources
 			sb.Append("\t\t\t}").AppendLine();
 		}
 
-		sb.Append("\t\t\t").Append(mockRegistry)
+		sb.Append("\t\t\tif (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t").Append(mockRegistry)
 			.Append(".RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation");
 		if (method.Parameters.Count > 0)
 		{
@@ -2033,6 +2035,7 @@ internal static partial class Sources
 		}
 
 		sb.Append("));").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
 
 		string displayMethodName = $"{method.ContainingType}.{method.Name}({string.Join(", ", method.Parameters.Select(p => p.Type.DisplayName))})";
 		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && !").Append(hasWrappedResult).Append(" && ").Append(mockRegistry).Append(".Behavior.ThrowWhenNotSetup)").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -232,7 +232,9 @@ internal static partial class Sources
 			sb.Append("\t\t\t}").AppendLine();
 		}
 
-		sb.Append("\t\t\t").Append(mockRegistryName)
+		sb.Append("\t\t\tif (").Append(mockRegistryName).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t").Append(mockRegistryName)
 			.Append(".RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation");
 		if (delegateMethod.Parameters.Count > 0)
 		{
@@ -246,6 +248,7 @@ internal static partial class Sources
 		}
 
 		sb.Append("));").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
 
 		string displayDelegateName = $"{delegateMethod.ContainingType}.{delegateMethod.Name}({string.Join(", ", delegateMethod.Parameters.Select(p => p.Type.DisplayName))})";
 		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && this.").Append(mockRegistryName).Append(".Behavior.ThrowWhenNotSetup)").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -129,8 +129,11 @@ internal static partial class Sources
 		AppendIndexerParameterArguments(sb, parameters);
 		sb.Append(");").AppendLine();
 
-		sb.Append(indent).Append(mockRegistry).Append(".RegisterInteraction(").Append(accessVarName).Append(");")
+		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append(indent).Append("{").AppendLine();
+		sb.Append(indent).Append('\t').Append(mockRegistry).Append(".RegisterInteraction(").Append(accessVarName).Append(");")
 			.AppendLine();
+		sb.Append(indent).Append("}").AppendLine();
 
 		sb.Append(indent).Append("global::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(propertyType);
 		foreach (MethodParameter p in parameters)
@@ -162,8 +165,11 @@ internal static partial class Sources
 		AppendIndexerParameterArguments(sb, parameters);
 		sb.Append(", value);").AppendLine();
 
-		sb.Append(indent).Append(mockRegistry).Append(".RegisterInteraction(").Append(accessVarName).Append(");")
+		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append(indent).Append("{").AppendLine();
+		sb.Append(indent).Append('\t').Append(mockRegistry).Append(".RegisterInteraction(").Append(accessVarName).Append(");")
 			.AppendLine();
+		sb.Append(indent).Append("}").AppendLine();
 
 		sb.Append(indent).Append("global::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(propertyType);
 		foreach (MethodParameter p in parameters)

--- a/Source/Mockolate/Interactions/MethodInvocation.cs
+++ b/Source/Mockolate/Interactions/MethodInvocation.cs
@@ -29,7 +29,7 @@ public class MethodInvocation(string name) : IMethodInteraction
 #if !DEBUG
 [DebuggerNonUserCode]
 #endif
-public class MethodInvocation<T1>(string name, string parameterName1, T1 parameter1) : IMethodInteraction
+public struct MethodInvocation<T1>(string name, string parameterName1, T1 parameter1) : IMethodInteraction
 {
 	/// <summary>
 	///     The name of the method.

--- a/Source/Mockolate/Interactions/MethodInvocation.cs
+++ b/Source/Mockolate/Interactions/MethodInvocation.cs
@@ -29,7 +29,7 @@ public class MethodInvocation(string name) : IMethodInteraction
 #if !DEBUG
 [DebuggerNonUserCode]
 #endif
-public struct MethodInvocation<T1>(string name, string parameterName1, T1 parameter1) : IMethodInteraction
+public class MethodInvocation<T1>(string name, string parameterName1, T1 parameter1) : IMethodInteraction
 {
 	/// <summary>
 	///     The name of the method.

--- a/Source/Mockolate/Interactions/MockInteractions.cs
+++ b/Source/Mockolate/Interactions/MockInteractions.cs
@@ -33,15 +33,24 @@ public class MockInteractions : IReadOnlyCollection<IInteraction>, IMockInteract
 	private HashSet<IInteraction>? _verified;
 
 	/// <summary>
-	///     Whether interactions are being recorded. When <see langword="false" />, the mock does not
-	///     record any interactions and attempts to verify throw a
-	///     <see cref="Mockolate.Exceptions.MockException" />.
+	///     Whether interactions are being recorded. When <see langword="false" />,
+	///     <see cref="IMockInteractions.RegisterInteraction{TInteraction}(TInteraction)" /> is a no-op and
+	///     attempts to verify throw a <see cref="Mockolate.Exceptions.MockException" />.
 	/// </summary>
-	public bool RecordingEnabled { get; init; } = true;
+	/// <remarks>
+	///     Mirrors <see cref="MockBehavior.SkipInteractionRecording" /> at construction time; kept internal
+	///     because the public knob for this is on <see cref="MockBehavior" />.
+	/// </remarks>
+	internal bool RecordingEnabled { get; init; } = true;
 
 	/// <inheritdoc cref="IMockInteractions.RegisterInteraction{TInteraction}(TInteraction)" />
 	TInteraction IMockInteractions.RegisterInteraction<TInteraction>(TInteraction interaction)
 	{
+		if (!RecordingEnabled)
+		{
+			return interaction;
+		}
+
 		lock (_listLock)
 		{
 			_interactions.Add(interaction);

--- a/Source/Mockolate/Interactions/MockInteractions.cs
+++ b/Source/Mockolate/Interactions/MockInteractions.cs
@@ -32,6 +32,13 @@ public class MockInteractions : IReadOnlyCollection<IInteraction>, IMockInteract
 
 	private HashSet<IInteraction>? _verified;
 
+	/// <summary>
+	///     Whether interactions are being recorded. When <see langword="false" />, the mock does not
+	///     record any interactions and attempts to verify throw a
+	///     <see cref="Mockolate.Exceptions.MockException" />.
+	/// </summary>
+	public bool RecordingEnabled { get; init; } = true;
+
 	/// <inheritdoc cref="IMockInteractions.RegisterInteraction{TInteraction}(TInteraction)" />
 	TInteraction IMockInteractions.RegisterInteraction<TInteraction>(TInteraction interaction)
 	{

--- a/Source/Mockolate/Interactions/MockInteractions.cs
+++ b/Source/Mockolate/Interactions/MockInteractions.cs
@@ -41,12 +41,12 @@ public class MockInteractions : IReadOnlyCollection<IInteraction>, IMockInteract
 	///     Mirrors <see cref="MockBehavior.SkipInteractionRecording" /> at construction time; kept internal
 	///     because the public knob for this is on <see cref="MockBehavior" />.
 	/// </remarks>
-	internal bool RecordingEnabled { get; init; } = true;
+	internal bool SkipInteractionRecording { get; init; } = false;
 
 	/// <inheritdoc cref="IMockInteractions.RegisterInteraction{TInteraction}(TInteraction)" />
 	TInteraction IMockInteractions.RegisterInteraction<TInteraction>(TInteraction interaction)
 	{
-		if (!RecordingEnabled)
+		if (SkipInteractionRecording)
 		{
 			return interaction;
 		}

--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -39,6 +40,21 @@ public record MockBehavior : IMockBehaviorAccess
 	///     its return values are used as default values.
 	/// </remarks>
 	public bool SkipBaseClass { get; init; }
+
+	/// <summary>
+	///     Flag indicating whether interaction recording is skipped for performance.
+	/// </summary>
+	/// <remarks>
+	///     If set to <see langword="false" /> (default value), every interaction with the mock is recorded and
+	///     can be verified later.
+	///     <para />
+	///     When set to <see langword="true" />, the mock skips allocating interaction records, avoids the
+	///     interaction-list lock, and does not raise the
+	///     <see cref="Mockolate.Interactions.MockInteractions" /> added-event. Setups, returns, callbacks, and
+	///     base-class delegation continue to work normally - only verification is disabled. Any attempt to
+	///     verify throws a <see cref="Mockolate.Exceptions.MockException" />.
+	/// </remarks>
+	public bool SkipInteractionRecording { get; init; }
 
 	/// <summary>
 	///     The generator for default values when not specified by a setup.
@@ -132,13 +148,25 @@ public record MockBehavior : IMockBehaviorAccess
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
 	{
-		string baseString = (ThrowWhenNotSetup, SkipBaseClass) switch
+		List<string>? parts = null;
+		if (ThrowWhenNotSetup)
 		{
-			(true, false) => nameof(MockBehaviorExtensions.ThrowingWhenNotSetup),
-			(false, true) => nameof(MockBehaviorExtensions.SkippingBaseClass),
-			(true, true) => $"{nameof(MockBehaviorExtensions.ThrowingWhenNotSetup)} and {nameof(MockBehaviorExtensions.SkippingBaseClass)}",
-			_ => "Default",
-		};
+			(parts ??= []).Add(nameof(MockBehaviorExtensions.ThrowingWhenNotSetup));
+		}
+
+		if (SkipBaseClass)
+		{
+			(parts ??= []).Add(nameof(MockBehaviorExtensions.SkippingBaseClass));
+		}
+
+		if (SkipInteractionRecording)
+		{
+			(parts ??= []).Add(nameof(MockBehaviorExtensions.SkippingInteractionRecording));
+		}
+
+		string baseString = parts is null
+			? "Default"
+			: string.Join(" and ", parts);
 
 		if (_constructorParameters is not null)
 		{

--- a/Source/Mockolate/MockBehaviorExtensions.cs
+++ b/Source/Mockolate/MockBehaviorExtensions.cs
@@ -41,6 +41,27 @@ public static class MockBehaviorExtensions
 			};
 
 		/// <summary>
+		///     Specifies whether interaction recording should be skipped.
+		/// </summary>
+		/// <remarks>
+		///     If set to <see langword="false" /> (default value), every interaction with the mock is recorded
+		///     and can be verified later.
+		///     <para />
+		///     Skipping interaction recording avoids the per-call allocation of an interaction record, the
+		///     interaction-list lock, and the <see cref="Mockolate.Interactions.MockInteractions" />
+		///     added-event. Setups, returns, callbacks, and base-class delegation continue to work normally -
+		///     only verification is disabled. Any attempt to verify throws a
+		///     <see cref="Mockolate.Exceptions.MockException" />.
+		///     <para />
+		///     Sets the <see cref="MockBehavior.SkipInteractionRecording" /> to <paramref name="skipInteractionRecording" />.
+		/// </remarks>
+		public MockBehavior SkippingInteractionRecording(bool skipInteractionRecording = true)
+			=> mockBehavior with
+			{
+				SkipInteractionRecording = skipInteractionRecording,
+			};
+
+		/// <summary>
 		///     Uses the given <paramref name="factory" /> to create default values for <typeparamref name="T" />.
 		/// </summary>
 		public MockBehavior WithDefaultValueFor<T>(Func<T> factory)

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -203,7 +203,7 @@ public partial class MockRegistry
 			propertyName, defaultValueGenerator, baseValueAccessor,
 			baseValueAccessor is not null);
 
-		return ((IInteractivePropertySetup)matchingSetup).InvokeGetter(interaction!, Behavior,
+		return ((IInteractivePropertySetup)matchingSetup).InvokeGetter(interaction, Behavior,
 			defaultValueGenerator);
 	}
 
@@ -225,7 +225,7 @@ public partial class MockRegistry
 
 		PropertySetup matchingSetup = ResolvePropertySetup<T>(propertyName, null, null, false);
 
-		((IInteractivePropertySetup)matchingSetup).InvokeSetter(interaction!, value, Behavior);
+		((IInteractivePropertySetup)matchingSetup).InvokeSetter(interaction, value, Behavior);
 		return ((IInteractivePropertySetup)matchingSetup).SkipBaseClass() ?? Behavior.SkipBaseClass;
 	}
 

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -151,8 +151,16 @@ public partial class MockRegistry
 	/// <summary>
 	///     Register an <paramref name="interaction" /> with the mock.
 	/// </summary>
+	/// <remarks>
+	///     Has no effect when <see cref="MockBehavior.SkipInteractionRecording" /> is <see langword="true" />.
+	/// </remarks>
 	public void RegisterInteraction(IInteraction interaction)
-		=> ((IMockInteractions)Interactions).RegisterInteraction(interaction);
+	{
+		if (!Behavior.SkipInteractionRecording)
+		{
+			((IMockInteractions)Interactions).RegisterInteraction(interaction);
+		}
+	}
 
 	private IEnumerable<EventSetup> GetEventSetupsByName(string name)
 	{
@@ -184,14 +192,18 @@ public partial class MockRegistry
 	public TResult GetProperty<TResult>(string propertyName, Func<TResult> defaultValueGenerator,
 		Func<TResult>? baseValueAccessor)
 	{
-		IInteraction interaction =
-			((IMockInteractions)Interactions).RegisterInteraction(new PropertyGetterAccess(propertyName));
+		IInteraction? interaction = null;
+		if (!Behavior.SkipInteractionRecording)
+		{
+			interaction = ((IMockInteractions)Interactions).RegisterInteraction(
+				new PropertyGetterAccess(propertyName));
+		}
 
 		PropertySetup matchingSetup = ResolvePropertySetup(
 			propertyName, defaultValueGenerator, baseValueAccessor,
 			baseValueAccessor is not null);
 
-		return ((IInteractivePropertySetup)matchingSetup).InvokeGetter(interaction, Behavior,
+		return ((IInteractivePropertySetup)matchingSetup).InvokeGetter(interaction!, Behavior,
 			defaultValueGenerator);
 	}
 
@@ -204,12 +216,16 @@ public partial class MockRegistry
 	/// </remarks>
 	public bool SetProperty<T>(string propertyName, T value)
 	{
-		IInteraction interaction =
-			((IMockInteractions)Interactions).RegisterInteraction(new PropertySetterAccess<T>(propertyName, value));
+		IInteraction? interaction = null;
+		if (!Behavior.SkipInteractionRecording)
+		{
+			interaction = ((IMockInteractions)Interactions).RegisterInteraction(
+				new PropertySetterAccess<T>(propertyName, value));
+		}
 
 		PropertySetup matchingSetup = ResolvePropertySetup<T>(propertyName, null, null, false);
 
-		((IInteractivePropertySetup)matchingSetup).InvokeSetter(interaction, value, Behavior);
+		((IInteractivePropertySetup)matchingSetup).InvokeSetter(interaction!, value, Behavior);
 		return ((IInteractivePropertySetup)matchingSetup).SkipBaseClass() ?? Behavior.SkipBaseClass;
 	}
 
@@ -287,7 +303,11 @@ public partial class MockRegistry
 			throw new MockException("The method of an event subscription may not be null.");
 		}
 
-		((IMockInteractions)Interactions).RegisterInteraction(new EventSubscription(name, target, method));
+		if (!Behavior.SkipInteractionRecording)
+		{
+			((IMockInteractions)Interactions).RegisterInteraction(new EventSubscription(name, target, method));
+		}
+
 		foreach (EventSetup setup in GetEventSetupsByName(name))
 		{
 			setup.InvokeSubscribed(target, method);
@@ -305,7 +325,11 @@ public partial class MockRegistry
 			throw new MockException("The method of an event unsubscription may not be null.");
 		}
 
-		((IMockInteractions)Interactions).RegisterInteraction(new EventUnsubscription(name, target, method));
+		if (!Behavior.SkipInteractionRecording)
+		{
+			((IMockInteractions)Interactions).RegisterInteraction(new EventUnsubscription(name, target, method));
+		}
+
 		foreach (EventSetup setup in GetEventSetupsByName(name))
 		{
 			setup.InvokeUnsubscribed(target, method);

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -24,7 +24,7 @@ public partial class MockRegistry
 	{
 		Behavior = behavior;
 		ConstructorParameters = constructorParameters;
-		Interactions = new MockInteractions();
+		Interactions = new MockInteractions { RecordingEnabled = !behavior.SkipInteractionRecording };
 		Setup = new MockSetups();
 		_scenarioState = new ScenarioState();
 		Wraps = null;
@@ -35,7 +35,7 @@ public partial class MockRegistry
 	{
 		Behavior = registry.Behavior;
 		ConstructorParameters = registry.ConstructorParameters;
-		Interactions = new MockInteractions();
+		Interactions = new MockInteractions { RecordingEnabled = !registry.Behavior.SkipInteractionRecording };
 		Setup = registry.Setup;
 		_scenarioState = registry._scenarioState;
 		Wraps = wraps;

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -24,7 +24,7 @@ public partial class MockRegistry
 	{
 		Behavior = behavior;
 		ConstructorParameters = constructorParameters;
-		Interactions = new MockInteractions { RecordingEnabled = !behavior.SkipInteractionRecording };
+		Interactions = new MockInteractions { SkipInteractionRecording = behavior.SkipInteractionRecording };
 		Setup = new MockSetups();
 		_scenarioState = new ScenarioState();
 		Wraps = null;
@@ -35,7 +35,7 @@ public partial class MockRegistry
 	{
 		Behavior = registry.Behavior;
 		ConstructorParameters = registry.ConstructorParameters;
-		Interactions = new MockInteractions { RecordingEnabled = !registry.Behavior.SkipInteractionRecording };
+		Interactions = new MockInteractions { SkipInteractionRecording = registry.Behavior.SkipInteractionRecording };
 		Setup = registry.Setup;
 		_scenarioState = registry._scenarioState;
 		Wraps = wraps;

--- a/Source/Mockolate/Monitor/MockMonitor.cs
+++ b/Source/Mockolate/Monitor/MockMonitor.cs
@@ -25,7 +25,7 @@ public abstract class MockMonitor
 	protected MockMonitor(MockInteractions mockInteractions)
 	{
 		_monitoredInteractions = mockInteractions;
-		Interactions = new MockInteractions();
+		Interactions = new MockInteractions { SkipInteractionRecording = mockInteractions.SkipInteractionRecording };
 	}
 
 	/// <summary>

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -11,13 +11,21 @@ public interface IInteractivePropertySetup : ISetup
 	/// <summary>
 	///     Invokes the setter logic for the <paramref name="invocation" /> and <paramref name="value" />.
 	/// </summary>
-	void InvokeSetter<T>(IInteraction invocation, T value, MockBehavior behavior);
+	/// <remarks>
+	///     <paramref name="invocation" /> may be <see langword="null" /> when interaction recording is skipped
+	///     (see <see cref="MockBehavior.SkipInteractionRecording" />).
+	/// </remarks>
+	void InvokeSetter<T>(IInteraction? invocation, T value, MockBehavior behavior);
 
 	/// <summary>
 	///     Invokes the getter logic for the <paramref name="invocation" /> and returns the value of type
 	///     <typeparamref name="TResult" />.
 	/// </summary>
-	TResult InvokeGetter<TResult>(IInteraction invocation, MockBehavior behavior, Func<TResult> defaultValueGenerator);
+	/// <remarks>
+	///     <paramref name="invocation" /> may be <see langword="null" /> when interaction recording is skipped
+	///     (see <see cref="MockBehavior.SkipInteractionRecording" />).
+	/// </remarks>
+	TResult InvokeGetter<TResult>(IInteraction? invocation, MockBehavior behavior, Func<TResult> defaultValueGenerator);
 
 	/// <summary>
 	///     Checks if the <paramref name="propertyAccess" /> matches the setup.

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -25,12 +25,12 @@ public abstract class PropertySetup : IInteractivePropertySetup
 	/// </summary>
 	internal abstract bool IsValueInitialized { get; }
 
-	/// <inheritdoc cref="IInteractivePropertySetup.InvokeSetter{T}(IInteraction, T, MockBehavior)" />
-	void IInteractivePropertySetup.InvokeSetter<T>(IInteraction invocation, T value, MockBehavior behavior)
+	/// <inheritdoc cref="IInteractivePropertySetup.InvokeSetter{T}(IInteraction?, T, MockBehavior)" />
+	void IInteractivePropertySetup.InvokeSetter<T>(IInteraction? invocation, T value, MockBehavior behavior)
 		=> InvokeSetter(value, behavior);
 
-	/// <inheritdoc cref="IInteractivePropertySetup.InvokeGetter{TResult}(IInteraction, MockBehavior, Func{TResult}?)" />
-	TResult IInteractivePropertySetup.InvokeGetter<TResult>(IInteraction invocation, MockBehavior behavior,
+	/// <inheritdoc cref="IInteractivePropertySetup.InvokeGetter{TResult}(IInteraction?, MockBehavior, Func{TResult}?)" />
+	TResult IInteractivePropertySetup.InvokeGetter<TResult>(IInteraction? invocation, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator)
 		=> InvokeGetter(behavior, defaultValueGenerator);
 

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -58,6 +58,16 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 	private void ReplacePredicate(Func<IInteraction, bool> predicate)
 		=> _predicate = predicate;
 
+	private static void ThrowIfRecordingDisabled(MockInteractions interactions)
+	{
+		if (!interactions.RecordingEnabled)
+		{
+			throw new MockException(
+				"Cannot verify interactions because MockBehavior.SkipInteractionRecording is true. " +
+				"Remove SkippingInteractionRecording from the mock's MockBehavior to use verifications.");
+		}
+	}
+
 	/// <summary>
 	///     Makes the verification result awaitable, using the specified <paramref name="timeout" /> to wait for the expected
 	///     interactions to occur.
@@ -105,6 +115,7 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 		/// <inheritdoc cref="IVerificationResult.Verify(Func{IInteraction[], Boolean})" />
 		bool IVerificationResult.Verify(Func<IInteraction[], bool> predicate)
 		{
+			ThrowIfRecordingDisabled(_interactions);
 			IInteraction[] matchingInteractions = _interactions.Where(_predicate).ToArray();
 			_interactions.Verified(matchingInteractions);
 			bool result = predicate(matchingInteractions);
@@ -119,6 +130,7 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 		/// <inheritdoc cref="IAsyncVerificationResult.VerifyAsync(Func{IInteraction[], Boolean})" />
 		public async Task<bool> VerifyAsync(Func<IInteraction[], bool> predicate)
 		{
+			ThrowIfRecordingDisabled(_interactions);
 			IInteraction[] matchingInteractions = _interactions.Where(_predicate).ToArray();
 			_interactions.Verified(matchingInteractions);
 			bool result = predicate(matchingInteractions);
@@ -226,6 +238,7 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 	/// <inheritdoc cref="IVerificationResult.Verify(Func{IInteraction[], Boolean})" />
 	bool IVerificationResult.Verify(Func<IInteraction[], bool> predicate)
 	{
+		ThrowIfRecordingDisabled(_interactions);
 		IInteraction[] matchingInteractions = _interactions.Where(_predicate).ToArray();
 		_interactions.Verified(matchingInteractions);
 		return predicate(matchingInteractions);

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -60,12 +60,13 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 
 	private static void ThrowIfRecordingDisabled(MockInteractions interactions)
 	{
-		if (!interactions.RecordingEnabled)
+		if (interactions.SkipInteractionRecording)
 		{
 			throw new MockException(
-				"Cannot verify interactions because interaction recording is disabled. " +
-				"To re-enable verifications, set MockBehavior.SkipInteractionRecording to false " +
-				"(for example, via `MockBehavior.Default.SkippingInteractionRecording(false)`).");
+				"""
+				Cannot verify interactions because interaction recording is disabled. To re-enable verifications, set MockBehavior.SkipInteractionRecording to false."
+				"""
+			);
 		}
 	}
 

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -63,8 +63,9 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 		if (!interactions.RecordingEnabled)
 		{
 			throw new MockException(
-				"Cannot verify interactions because MockBehavior.SkipInteractionRecording is true. " +
-				"Remove SkippingInteractionRecording from the mock's MockBehavior to use verifications.");
+				"Cannot verify interactions because interaction recording is disabled. " +
+				"To re-enable verifications, set MockBehavior.SkipInteractionRecording to false " +
+				"(for example, via `MockBehavior.Default.SkippingInteractionRecording(false)`).");
 		}
 	}
 

--- a/Tests/Mockolate.Api.Tests/ApiAcceptance.cs
+++ b/Tests/Mockolate.Api.Tests/ApiAcceptance.cs
@@ -5,7 +5,7 @@ public sealed class ApiAcceptance
 	/// <summary>
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
-	[Fact(Explicit = true)]
+	[Fact()]
 	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =

--- a/Tests/Mockolate.Api.Tests/ApiAcceptance.cs
+++ b/Tests/Mockolate.Api.Tests/ApiAcceptance.cs
@@ -5,7 +5,7 @@ public sealed class ApiAcceptance
 	/// <summary>
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
-	[Fact()]
+	[Fact(Explicit = true)]
 	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -726,7 +726,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public struct MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
+    public class MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
     {
         public MethodInvocation(string name, string parameterName1, T1 parameter1) { }
         public string Name { get; }
@@ -778,7 +778,6 @@ namespace Mockolate.Interactions
     {
         public MockInteractions() { }
         public int Count { get; }
-        public bool RecordingEnabled { get; init; }
         public System.Collections.Generic.IEnumerator<Mockolate.Interactions.IInteraction> GetEnumerator() { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction> GetUnverifiedInteractions() { }
     }
@@ -1235,8 +1234,8 @@ namespace Mockolate.Setup
     public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
     {
         void InitializeWith(object? value);
-        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        void InvokeSetter<T>(Mockolate.Interactions.IInteraction invocation, T value, Mockolate.MockBehavior behavior);
+        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction? invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
+        void InvokeSetter<T>(Mockolate.Interactions.IInteraction? invocation, T value, Mockolate.MockBehavior behavior);
         bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
         bool? SkipBaseClass();
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -156,6 +156,7 @@ namespace Mockolate
         public MockBehavior(Mockolate.IDefaultValueGenerator defaultValue) { }
         public Mockolate.IDefaultValueGenerator DefaultValue { get; init; }
         public bool SkipBaseClass { get; init; }
+        public bool SkipInteractionRecording { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public override string ToString() { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(System.Func<object?[]> parameters) { }
@@ -168,6 +169,7 @@ namespace Mockolate
         {
             public Mockolate.MockBehavior SkippingBaseClass(bool skipBaseClass = true) { }
             public Mockolate.MockBehavior ThrowingWhenNotSetup(bool throwWhenNotSetup = true) { }
+            public Mockolate.MockBehavior SkippingInteractionRecording(bool skipInteractionRecording = true) { }
             public Mockolate.MockBehavior WithDefaultValueFor<T>(System.Func<T> factory) { }
         }
     }
@@ -724,7 +726,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public class MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
+    public struct MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
     {
         public MethodInvocation(string name, string parameterName1, T1 parameter1) { }
         public string Name { get; }
@@ -776,6 +778,7 @@ namespace Mockolate.Interactions
     {
         public MockInteractions() { }
         public int Count { get; }
+        public bool RecordingEnabled { get; init; }
         public System.Collections.Generic.IEnumerator<Mockolate.Interactions.IInteraction> GetEnumerator() { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction> GetUnverifiedInteractions() { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -155,6 +155,7 @@ namespace Mockolate
         public MockBehavior(Mockolate.IDefaultValueGenerator defaultValue) { }
         public Mockolate.IDefaultValueGenerator DefaultValue { get; init; }
         public bool SkipBaseClass { get; init; }
+        public bool SkipInteractionRecording { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public override string ToString() { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(System.Func<object?[]> parameters) { }
@@ -167,6 +168,7 @@ namespace Mockolate
         {
             public Mockolate.MockBehavior SkippingBaseClass(bool skipBaseClass = true) { }
             public Mockolate.MockBehavior ThrowingWhenNotSetup(bool throwWhenNotSetup = true) { }
+            public Mockolate.MockBehavior SkippingInteractionRecording(bool skipInteractionRecording = true) { }
             public Mockolate.MockBehavior WithDefaultValueFor<T>(System.Func<T> factory) { }
         }
     }
@@ -723,7 +725,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public class MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
+    public struct MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
     {
         public MethodInvocation(string name, string parameterName1, T1 parameter1) { }
         public string Name { get; }
@@ -775,6 +777,7 @@ namespace Mockolate.Interactions
     {
         public MockInteractions() { }
         public int Count { get; }
+        public bool RecordingEnabled { get; init; }
         public System.Collections.Generic.IEnumerator<Mockolate.Interactions.IInteraction> GetEnumerator() { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction> GetUnverifiedInteractions() { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -725,7 +725,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public struct MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
+    public class MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
     {
         public MethodInvocation(string name, string parameterName1, T1 parameter1) { }
         public string Name { get; }
@@ -777,7 +777,6 @@ namespace Mockolate.Interactions
     {
         public MockInteractions() { }
         public int Count { get; }
-        public bool RecordingEnabled { get; init; }
         public System.Collections.Generic.IEnumerator<Mockolate.Interactions.IInteraction> GetEnumerator() { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction> GetUnverifiedInteractions() { }
     }
@@ -1234,8 +1233,8 @@ namespace Mockolate.Setup
     public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
     {
         void InitializeWith(object? value);
-        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        void InvokeSetter<T>(Mockolate.Interactions.IInteraction invocation, T value, Mockolate.MockBehavior behavior);
+        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction? invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
+        void InvokeSetter<T>(Mockolate.Interactions.IInteraction? invocation, T value, Mockolate.MockBehavior behavior);
         bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
         bool? SkipBaseClass();
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -142,6 +142,7 @@ namespace Mockolate
         public MockBehavior(Mockolate.IDefaultValueGenerator defaultValue) { }
         public Mockolate.IDefaultValueGenerator DefaultValue { get; init; }
         public bool SkipBaseClass { get; init; }
+        public bool SkipInteractionRecording { get; init; }
         public bool ThrowWhenNotSetup { get; init; }
         public override string ToString() { }
         public Mockolate.MockBehavior UseConstructorParametersFor<T>(System.Func<object?[]> parameters) { }
@@ -154,6 +155,7 @@ namespace Mockolate
         {
             public Mockolate.MockBehavior SkippingBaseClass(bool skipBaseClass = true) { }
             public Mockolate.MockBehavior ThrowingWhenNotSetup(bool throwWhenNotSetup = true) { }
+            public Mockolate.MockBehavior SkippingInteractionRecording(bool skipInteractionRecording = true) { }
             public Mockolate.MockBehavior WithDefaultValueFor<T>(System.Func<T> factory) { }
         }
     }
@@ -682,7 +684,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public class MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
+    public struct MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
     {
         public MethodInvocation(string name, string parameterName1, T1 parameter1) { }
         public string Name { get; }
@@ -734,6 +736,7 @@ namespace Mockolate.Interactions
     {
         public MockInteractions() { }
         public int Count { get; }
+        public bool RecordingEnabled { get; init; }
         public System.Collections.Generic.IEnumerator<Mockolate.Interactions.IInteraction> GetEnumerator() { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction> GetUnverifiedInteractions() { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -684,7 +684,7 @@ namespace Mockolate.Interactions
         public override string ToString() { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
-    public struct MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
+    public class MethodInvocation<T1> : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
     {
         public MethodInvocation(string name, string parameterName1, T1 parameter1) { }
         public string Name { get; }
@@ -736,7 +736,6 @@ namespace Mockolate.Interactions
     {
         public MockInteractions() { }
         public int Count { get; }
-        public bool RecordingEnabled { get; init; }
         public System.Collections.Generic.IEnumerator<Mockolate.Interactions.IInteraction> GetEnumerator() { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction> GetUnverifiedInteractions() { }
     }
@@ -1189,8 +1188,8 @@ namespace Mockolate.Setup
     public interface IInteractivePropertySetup : Mockolate.Setup.ISetup
     {
         void InitializeWith(object? value);
-        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
-        void InvokeSetter<T>(Mockolate.Interactions.IInteraction invocation, T value, Mockolate.MockBehavior behavior);
+        TResult InvokeGetter<TResult>(Mockolate.Interactions.IInteraction? invocation, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
+        void InvokeSetter<T>(Mockolate.Interactions.IInteraction? invocation, T value, Mockolate.MockBehavior behavior);
         bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
         bool? SkipBaseClass();
     }

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -802,7 +802,10 @@ public class GeneralTests
 			          				wrappedResult = wraps.MyMethod(message);
 			          				hasWrappedResult = true;
 			          			}
-			          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<string>("global::MyCode.IMyService.MyMethod", "message", message));
+			          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+			          			{
+			          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<string>("global::MyCode.IMyService.MyMethod", "message", message));
+			          			}
 			          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 			          			{
 			          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod(string)' was invoked without prior setup.");

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Mockolate.SourceGenerators.Tests;
+namespace Mockolate.SourceGenerators.Tests;
 
 public sealed partial class MockTests
 {
@@ -67,7 +67,10 @@ public sealed partial class MockTests
 					          			get
 					          			{
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int> access = new("index", index);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
@@ -79,7 +82,10 @@ public sealed partial class MockTests
 					          			set
 					          			{
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, int> access = new("index", index, value);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
@@ -96,7 +102,10 @@ public sealed partial class MockTests
 					          			get
 					          			{
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int, bool?> access = new("index", index, "isReadOnly", isReadOnly);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, bool?>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool?>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
@@ -114,7 +123,10 @@ public sealed partial class MockTests
 					          			set
 					          			{
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, string, int> access = new("index", index, "isWriteOnly", isWriteOnly, value);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
@@ -171,7 +183,10 @@ public sealed partial class MockTests
 					          			get
 					          			{
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int> access = new("index", index);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
@@ -183,7 +198,10 @@ public sealed partial class MockTests
 					          			set
 					          			{
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, int> access = new("index", index, value);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value))
 					          				{
@@ -206,7 +224,10 @@ public sealed partial class MockTests
 					          			get
 					          			{
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int, bool> access = new("index", index, "isReadOnly", isReadOnly);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, bool>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
@@ -224,7 +245,10 @@ public sealed partial class MockTests
 					          			set
 					          			{
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, string, int> access = new("index", index, "isWriteOnly", isWriteOnly, value);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value))
 					          				{
@@ -241,14 +265,20 @@ public sealed partial class MockTests
 					          			get
 					          			{
 					          				global::Mockolate.Interactions.IndexerGetterAccess<string> access = new("someAdditionalIndex", someAdditionalIndex);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
 					          			}
 					          			set
 					          			{
 					          				global::Mockolate.Interactions.IndexerSetterAccess<string, int> access = new("someAdditionalIndex", someAdditionalIndex, value);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          			}
@@ -288,7 +318,10 @@ public sealed partial class MockTests
 					          			get
 					          			{
 					          				global::Mockolate.Interactions.IndexerGetterAccess<global::Mockolate.Setup.SpanWrapper<char>> access = new("buffer", new global::Mockolate.Setup.SpanWrapper<char>(buffer));
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
@@ -300,7 +333,10 @@ public sealed partial class MockTests
 					          			set
 					          			{
 					          				global::Mockolate.Interactions.IndexerSetterAccess<global::Mockolate.Setup.SpanWrapper<char>, int> access = new("buffer", new global::Mockolate.Setup.SpanWrapper<char>(buffer), value);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
@@ -317,7 +353,10 @@ public sealed partial class MockTests
 					          			get
 					          			{
 					          				global::Mockolate.Interactions.IndexerGetterAccess<global::Mockolate.Setup.ReadOnlySpanWrapper<int>> access = new("values", new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values));
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
@@ -329,7 +368,10 @@ public sealed partial class MockTests
 					          			set
 					          			{
 					          				global::Mockolate.Interactions.IndexerSetterAccess<global::Mockolate.Setup.ReadOnlySpanWrapper<int>, int> access = new("values", new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values), value);
-					          				this.MockRegistry.RegisterInteraction(access);
+					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          				{
+					          					this.MockRegistry.RegisterInteraction(access);
+					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Mockolate.SourceGenerators.Tests;
+namespace Mockolate.SourceGenerators.Tests;
 
 public sealed partial class MockTests
 {
@@ -347,7 +347,10 @@ public sealed partial class MockTests
 					          				wrappedResult = wraps.MyMethod1(index);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyService.MyMethod1", "index", index));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyService.MyMethod1", "index", index));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod1(int)' was invoked without prior setup.");
@@ -371,7 +374,10 @@ public sealed partial class MockTests
 					          				wraps.MyMethod2(index, isReadOnly);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, bool>("global::MyCode.IMyService.MyMethod2", "index", index, "isReadOnly", isReadOnly));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, bool>("global::MyCode.IMyService.MyMethod2", "index", index, "isReadOnly", isReadOnly));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod2(int, bool)' was invoked without prior setup.");
@@ -432,7 +438,10 @@ public sealed partial class MockTests
 					          				wrappedResult = wraps.MyDirectMethod(value);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyService.MyDirectMethod", "value", value));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyService.MyDirectMethod", "value", value));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyDirectMethod(int)' was invoked without prior setup.");
@@ -457,7 +466,10 @@ public sealed partial class MockTests
 					          				wrappedResult = wraps.MyBaseMethod1(value);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyServiceBase1.MyBaseMethod1", "value", value));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyServiceBase1.MyBaseMethod1", "value", value));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyServiceBase1.MyBaseMethod1(int)' was invoked without prior setup.");
@@ -482,7 +494,10 @@ public sealed partial class MockTests
 					          				wrappedResult = wraps.MyBaseMethod2(value);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyServiceBase2.MyBaseMethod2", "value", value));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyServiceBase2.MyBaseMethod2", "value", value));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyServiceBase2.MyBaseMethod2(int)' was invoked without prior setup.");
@@ -507,7 +522,10 @@ public sealed partial class MockTests
 					          				wrappedResult = wraps.MyBaseMethod3(value);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyServiceBase3.MyBaseMethod3", "value", value));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyServiceBase3.MyBaseMethod3", "value", value));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyServiceBase3.MyBaseMethod3(int)' was invoked without prior setup.");
@@ -607,7 +625,10 @@ public sealed partial class MockTests
 					          					flag = this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!);
 					          				}
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, int, bool>("global::MyCode.MyService.MyMethod1", "index", index, "value1", value1, "flag", flag));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, int, bool>("global::MyCode.MyService.MyMethod1", "index", index, "value1", value1, "flag", flag));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.MyService.MyMethod1(int, int, bool)' was invoked without prior setup.");
@@ -647,7 +668,10 @@ public sealed partial class MockTests
 					          					flag = this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!);
 					          				}
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, bool, int, bool>("global::MyCode.MyService.MyMethod2", "index", index, "isReadOnly", isReadOnly, "value1", value1, "flag", flag));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, bool, int, bool>("global::MyCode.MyService.MyMethod2", "index", index, "isReadOnly", isReadOnly, "value1", value1, "flag", flag));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.MyService.MyMethod2(int, bool, int, bool)' was invoked without prior setup.");
@@ -668,7 +692,10 @@ public sealed partial class MockTests
 					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int>>("global::MyCode.IMyOtherService.SomeOtherMethod", m => m.Matches());
 					          			bool hasWrappedResult = false;
 					          			int wrappedResult = default!;
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation("global::MyCode.IMyOtherService.SomeOtherMethod"));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation("global::MyCode.IMyOtherService.SomeOtherMethod"));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyOtherService.SomeOtherMethod()' was invoked without prior setup.");
@@ -816,7 +843,10 @@ public sealed partial class MockTests
 					          				{
 					          				}
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyService.MyMethod1", "index", index));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.IMyService.MyMethod1", "index", index));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod1(int)' was invoked without prior setup.");
@@ -854,7 +884,10 @@ public sealed partial class MockTests
 					          					isReadOnly = this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!);
 					          				}
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, bool>("global::MyCode.IMyService.MyMethod2", "index", index, "isReadOnly", isReadOnly));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int, bool>("global::MyCode.IMyService.MyMethod2", "index", index, "isReadOnly", isReadOnly));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod2(int, bool)' was invoked without prior setup.");
@@ -879,7 +912,10 @@ public sealed partial class MockTests
 					          				wraps.MyMethod3(in p1);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<global::MyCode.MyReadonlyStruct>("global::MyCode.IMyService.MyMethod3", "p1", p1));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<global::MyCode.MyReadonlyStruct>("global::MyCode.IMyService.MyMethod3", "p1", p1));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod3(MyReadonlyStruct)' was invoked without prior setup.");
@@ -899,7 +935,10 @@ public sealed partial class MockTests
 					          				wraps.MyMethod4(in p1);
 					          				hasWrappedResult = true;
 					          			}
-					          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<global::MyCode.MyReadonlyStruct>("global::MyCode.IMyService.MyMethod4", "p1", p1));
+					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+					          			{
+					          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<global::MyCode.MyReadonlyStruct>("global::MyCode.IMyService.MyMethod4", "p1", p1));
+					          			}
 					          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 					          			{
 					          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod4(MyReadonlyStruct)' was invoked without prior setup.");

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Mockolate.SourceGenerators.Tests;
+namespace Mockolate.SourceGenerators.Tests;
 
 public sealed partial class MockTests
 {
@@ -81,7 +81,10 @@ public sealed partial class MockTests
 				          		private global::System.Span<char> Invoke(int x)
 				          		{
 				          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>>("global::MyCode.Program.DoSomething1.Invoke", m => m.Matches("x", x));
-				          			MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.Program.DoSomething1.Invoke", "x", x));
+				          			if (MockRegistry.Behavior.SkipInteractionRecording == false)
+				          			{
+				          				MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.Program.DoSomething1.Invoke", "x", x));
+				          			}
 				          			if (methodSetup is null && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 				          			{
 				          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.Program.DoSomething1.Invoke(int)' was invoked without prior setup.");
@@ -97,7 +100,10 @@ public sealed partial class MockTests
 				          		private global::System.ReadOnlySpan<char> Invoke(int x)
 				          		{
 				          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>>("global::MyCode.Program.DoSomething2.Invoke", m => m.Matches("x", x));
-				          			MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.Program.DoSomething2.Invoke", "x", x));
+				          			if (MockRegistry.Behavior.SkipInteractionRecording == false)
+				          			{
+				          				MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.Program.DoSomething2.Invoke", "x", x));
+				          			}
 				          			if (methodSetup is null && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 				          			{
 				          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.Program.DoSomething2.Invoke(int)' was invoked without prior setup.");

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Mockolate.SourceGenerators.Tests;
@@ -617,7 +617,10 @@ public sealed partial class MockTests
 			          				wraps.MyMethod(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
 			          				hasWrappedResult = true;
 			          			}
-			          			this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal>("global::MyCode.IMyService.MyMethod", "v1", v1, "v2", v2, "v3", v3, "v4", v4, "v5", v5, "v6", v6, "v7", v7, "v8", v8, "v9", v9, "v10", v10, "v11", v11, "v12", v12, "v13", v13, "v14", v14, "v15", v15));
+			          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+			          			{
+			          				this.MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal>("global::MyCode.IMyService.MyMethod", "v1", v1, "v2", v2, "v3", v3, "v4", v4, "v5", v5, "v6", v6, "v7", v7, "v8", v8, "v9", v9, "v10", v10, "v11", v11, "v12", v12, "v13", v13, "v14", v14, "v15", v15));
+			          			}
 			          			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
 			          			{
 			          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.IMyService.MyMethod(object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal)' was invoked without prior setup.");

--- a/Tests/Mockolate.Tests/MockBehaviorTests.SkipInteractionRecordingTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.SkipInteractionRecordingTests.cs
@@ -74,7 +74,6 @@ public sealed partial class MockBehaviorTests
 
 			MockInteractions interactions = ((IMock)sut).MockRegistry.Interactions;
 			await That(interactions.Count).IsEqualTo(0);
-			await That(interactions.RecordingEnabled).IsFalse();
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/MockBehaviorTests.SkipInteractionRecordingTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.SkipInteractionRecordingTests.cs
@@ -1,0 +1,132 @@
+using Mockolate.Exceptions;
+using Mockolate.Interactions;
+using Mockolate.Tests.TestHelpers;
+
+namespace Mockolate.Tests;
+
+public sealed partial class MockBehaviorTests
+{
+	public sealed class SkipInteractionRecordingTests
+	{
+		[Fact]
+		public async Task Default_ShouldBeFalse()
+		{
+			MockBehavior sut = MockBehavior.Default;
+
+			await That(sut.SkipInteractionRecording).IsFalse();
+		}
+
+		[Fact]
+		public async Task WhenSkipping_PropertyGetter_ShouldStillReturnSetupValue()
+		{
+			IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
+			sut.Mock.Setup.SomeFlag.InitializeWith(true);
+
+			bool result = sut.SomeFlag;
+
+			await That(result).IsTrue();
+		}
+
+		[Fact]
+		public async Task WhenSkipping_PropertySetter_ShouldStillStoreValue()
+		{
+			IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
+			sut.Mock.Setup.SomeFlag.InitializeWith(false);
+
+			sut.SomeFlag = true;
+			bool result = sut.SomeFlag;
+
+			await That(result).IsTrue();
+		}
+
+		[Fact]
+		public async Task WhenSkipping_Method_ShouldStillReturnSetupValue()
+		{
+			IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
+			sut.Mock.Setup.IsValid(It.IsAny<int>()).Returns(true);
+
+			bool result = sut.IsValid(42);
+
+			await That(result).IsTrue();
+		}
+
+		[Fact]
+		public async Task WhenSkipping_Indexer_ShouldStillStoreAndReturnValue()
+		{
+			IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
+			sut[7] = "hello";
+
+			string result = sut[7];
+
+			await That(result).IsEqualTo("hello");
+		}
+
+		[Fact]
+		public async Task WhenSkipping_NoInteractionsAreRecorded()
+		{
+			IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
+			sut.Mock.Setup.SomeFlag.InitializeWith(true);
+			sut.Mock.Setup.IsValid(It.IsAny<int>()).Returns(true);
+
+			_ = sut.SomeFlag;
+			sut.SomeFlag = false;
+			_ = sut.IsValid(1);
+
+			MockInteractions interactions = ((IMock)sut).MockRegistry.Interactions;
+			await That(interactions.Count).IsEqualTo(0);
+			await That(interactions.RecordingEnabled).IsFalse();
+		}
+
+		[Fact]
+		public async Task WhenSkipping_Verify_ShouldThrow()
+		{
+			IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
+			sut.Mock.Setup.SomeFlag.InitializeWith(true);
+
+			_ = sut.SomeFlag;
+
+			MockException? captured = null;
+			try
+			{
+				await That(sut.Mock.Verify.SomeFlag.Got()).Exactly(1);
+			}
+			catch (System.Exception ex) when (ex.InnerException is MockException me)
+			{
+				captured = me;
+			}
+
+			await That(captured).IsNotNull()
+				.And.For(e => e!.Message, m => m.Contains("SkipInteractionRecording"));
+		}
+
+		[Fact]
+		public async Task SkippingInteractionRecording_ShouldSupportFluentSyntax()
+		{
+			MockBehavior sut = MockBehavior.Default.SkippingInteractionRecording();
+
+			await That(sut.SkipInteractionRecording).IsTrue();
+		}
+
+		[Fact]
+		public async Task SkippingInteractionRecording_WithFalse_ShouldEnableRecording()
+		{
+			MockBehavior sut = MockBehavior.Default
+				.SkippingInteractionRecording()
+				.SkippingInteractionRecording(false);
+
+			await That(sut.SkipInteractionRecording).IsFalse();
+		}
+
+		[Fact]
+		public async Task WithRecordingEnabled_ShouldRecordAsBefore()
+		{
+			IMyService sut = IMyService.CreateMock(MockBehavior.Default);
+			sut.Mock.Setup.SomeFlag.InitializeWith(true);
+
+			_ = sut.SomeFlag;
+			_ = sut.SomeFlag;
+
+			await That(sut.Mock.Verify.SomeFlag.Got()).Exactly(2);
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockolate.Tests/Monitor/MockMonitorTests.cs
@@ -1,3 +1,4 @@
+using Mockolate.Exceptions;
 using Mockolate.Monitor;
 using Mockolate.Tests.TestHelpers;
 
@@ -5,6 +6,30 @@ namespace Mockolate.Tests.Monitor;
 
 public sealed class MockMonitorTests
 {
+	[Fact]
+	public async Task WhenSkippingInteractionRecording_Verify_ShouldThrow()
+	{
+		IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
+		MockMonitor<Mock.IMockVerifyForIMyService> monitor = sut.Mock.Monitor();
+
+		using IDisposable _ = monitor.Run();
+		sut.IsValid(1);
+
+		MockException? captured = null;
+		try
+		{
+			await That(monitor.Verify.IsValid(It.Is(1))).Once();
+		}
+		catch (System.Exception ex) when (ex.InnerException is MockException me)
+		{
+			captured = me;
+		}
+
+		await That(captured).IsNotNull()
+			.And.For(e => e!.Message, m => m.Contains("SkipInteractionRecording"));
+	}
+
+
 	[Fact]
 	public async Task ClearAllInteractions_WhenMonitorIsRunning_ShouldClearInternalCollection()
 	{


### PR DESCRIPTION
This PR introduces a new `MockBehavior` option to skip interaction recording, enabling a “no verification” mode intended to reduce per-call overhead while preserving setups/returns/callbacks/base delegation.

**Changes:**
- Add `MockBehavior.SkipInteractionRecording` plus fluent `SkippingInteractionRecording(...)` to opt out of recording (and therefore verification).
- Guard verification paths to throw when recording is disabled; propagate a `SkipInteractionRecording` flag via `MockInteractions`.
- Update source generator output/tests and documentation to reflect conditional interaction registration and the new behavior.