### PR TITLE
perf!: optimize indexer performance by removing capturing closures

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -198,6 +198,7 @@ internal static partial class Sources
 		string typeParams = GetGenericTypeParameters(numberOfParameters);
 		string outTypeParams = GetOutGenericTypeParameters(numberOfParameters);
 		string parameters = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"p{i}"));
+		string stateParameters = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"state.p{i}"));
 		string discards = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(_ => "_"));
 
 		sb.AppendXmlSummary($"Sets up a <typeparamref name=\"TValue\"/> indexer getter for {GetTypeParametersDescription(numberOfParameters)}.", "\t");
@@ -933,6 +934,42 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
+		// GetResult(behavior) — no-closure entry point used by the generated mock indexer body
+		sb.Append("\t\t/// <inheritdoc cref=\"global::Mockolate.Setup.IndexerSetup.GetResult{TResult}(global::Mockolate.Interactions.IndexerAccess, global::Mockolate.MockBehavior)\" />").AppendLine();
+		sb.Append("\t\tpublic override TResult GetResult<TResult>(global::Mockolate.Interactions.IndexerAccess access, global::Mockolate.MockBehavior behavior)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tif (!TryExtractParameters(access");
+		for (int i = 1; i <= numberOfParameters; i++)
+		{
+			sb.Append(", out T").Append(i).Append(" p").Append(i);
+		}
+
+		sb.Append("))").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\treturn behavior.DefaultValue.Generate(default(TResult)!);").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.AppendLine();
+		sb.Append("\t\t\tTValue currentValue;").AppendLine();
+		sb.Append("\t\t\tif (access.TryFindStoredValue(out TValue existing))").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tcurrentValue = existing;").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t\telse if (_initialization is not null)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tcurrentValue = _initialization.Invoke(").Append(parameters).Append(");").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t\telse").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tcurrentValue = TryCast(behavior.DefaultValue.Generate(default(TValue)!), out TValue casted, behavior) ? casted : default!;").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.AppendLine();
+		sb.Append("\t\t\tcurrentValue = ExecuteGetterCallbacks(").Append(parameters).Append(", currentValue);").AppendLine();
+		sb.Append("\t\t\tcurrentValue = ExecuteReturnCallbacks(").Append(parameters).Append(", currentValue, out _);").AppendLine();
+		sb.Append("\t\t\taccess.StoreValue(currentValue);").AppendLine();
+		sb.Append("\t\t\treturn TryCast(currentValue, out TResult result, behavior) ? result : behavior.DefaultValue.Generate(default(TResult)!);").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+
 		// GetResult(Func<TResult> defaultValueGenerator)
 		sb.Append("\t\t/// <inheritdoc cref=\"global::Mockolate.Setup.IndexerSetup.GetResult{TResult}(global::Mockolate.Interactions.IndexerAccess, global::Mockolate.MockBehavior, global::System.Func{TResult})\" />").AppendLine();
 		sb.Append("\t\tpublic override TResult GetResult<TResult>(global::Mockolate.Interactions.IndexerAccess access, global::Mockolate.MockBehavior behavior, global::System.Func<TResult> defaultValueGenerator)").AppendLine();
@@ -998,8 +1035,8 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>> setterCallback =").AppendLine();
 		sb.Append("\t\t\t\t\t\t_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\t\tif (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)").AppendLine();
-		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", resultValue)))").AppendLine();
+		sb.Append("\t\t\t\t\tif (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (").Append(parameters).Append(", resultValue),").AppendLine();
+		sb.Append("\t\t\t\t\t\tstatic (count, @delegate, state) => @delegate(count, ").Append(stateParameters).Append(", state.resultValue)))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();
 		sb.Append("\t\t\t\t\t}").AppendLine();
@@ -1020,8 +1057,8 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\tCallback<global::System.Action<int, ").Append(typeParams).Append(", TValue>> getterCallback =").AppendLine();
 		sb.Append("\t\t\t\t\t\t_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\t\tif (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)").AppendLine();
-		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", currentValue)))").AppendLine();
+		sb.Append("\t\t\t\t\tif (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (").Append(parameters).Append(", currentValue),").AppendLine();
+		sb.Append("\t\t\t\t\t\tstatic (count, @delegate, state) => @delegate(count, ").Append(stateParameters).Append(", state.currentValue)))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();
 		sb.Append("\t\t\t\t\t}").AppendLine();
@@ -1043,8 +1080,9 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\tCallback<global::System.Func<int, ").Append(typeParams).Append(", TValue, TValue>> returnCallback =").AppendLine();
 		sb.Append("\t\t\t\t\t\t_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\t\tif (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)").AppendLine();
-		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(parameters).Append(", currentValue), out TValue? newValue))").AppendLine();
+		sb.Append("\t\t\t\t\tif (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (").Append(parameters).Append(", currentValue),").AppendLine();
+		sb.Append("\t\t\t\t\t\tstatic (count, @delegate, state) => @delegate(count, ").Append(stateParameters).Append(", state.currentValue),").AppendLine();
+		sb.Append("\t\t\t\t\t\tout TValue? newValue))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\tmatched = true;").AppendLine();
 		sb.Append("\t\t\t\t\t\treturn newValue!;").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1469,10 +1469,14 @@ internal static partial class Sources
 					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is not ").Append(className)
 						.Append(" wraps)").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\treturn ").Append(mockRegistry).Append(".ApplyIndexerGetter(")
-						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", () => ")
-						.AppendDefaultValueGeneratorFor(property.Type, $"this.{mockRegistryName}.Behavior.DefaultValue")
-						.Append(");").AppendLine();
+					sb.Append("\t\t\t\t\treturn ").Append(setupVarName).Append(" is null")
+						.AppendLine();
+					sb.Append("\t\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
+						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(")")
+						.AppendLine();
+					sb.Append("\t\t\t\t\t\t: ").Append(mockRegistry).Append(".ApplyIndexerSetup<")
+						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
+						.Append(setupVarName).Append(");").AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
 					sb.Append("\t\t\t\t").AppendTypeOrWrapper(property.Type).Append(' ').Append(baseResultVarName)
 						.Append(" = wraps[")
@@ -1540,10 +1544,13 @@ internal static partial class Sources
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", ")
 						.Append(baseResultVarName).Append(");").AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
-					sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".ApplyIndexerGetter(")
-						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", () => ")
-						.AppendDefaultValueGeneratorFor(property.Type, $"this.{mockRegistryName}.Behavior.DefaultValue")
-						.Append(");").AppendLine();
+					sb.Append("\t\t\t\treturn ").Append(setupVarName).Append(" is null").AppendLine();
+					sb.Append("\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
+						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(")")
+						.AppendLine();
+					sb.Append("\t\t\t\t\t: ").Append(mockRegistry).Append(".ApplyIndexerSetup<")
+						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
+						.Append(setupVarName).Append(");").AppendLine();
 				}
 				else
 				{
@@ -1574,10 +1581,13 @@ internal static partial class Sources
 
 				EmitIndexerGetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 					property.Type, property.IndexerParameters.Value);
-				sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".ApplyIndexerGetter(")
-					.Append(accessVarName).Append(", ").Append(setupVarName).Append(", () => ")
-					.AppendDefaultValueGeneratorFor(property.Type, $"this.{mockRegistryName}.Behavior.DefaultValue")
-					.Append(");").AppendLine();
+				sb.Append("\t\t\t\treturn ").Append(setupVarName).Append(" is null").AppendLine();
+				sb.Append("\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
+					.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(")")
+					.AppendLine();
+				sb.Append("\t\t\t\t\t: ").Append(mockRegistry).Append(".ApplyIndexerSetup<")
+					.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
+					.Append(setupVarName).Append(");").AppendLine();
 			}
 			else
 			{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -117,7 +117,7 @@ internal static partial class Sources
 	///     Emits variable declarations for the indexer getter access and matching setup:
 	///     <code>var access = new IndexerGetterAccess&lt;T...&gt;("p", p, ...);
 	///     mockRegistry.RegisterInteraction(access);
-	///     var setup = mockRegistry.GetIndexerSetup&lt;IndexerSetup&lt;TValue, T...&gt;&gt;(s =&gt; s.Matches(p, ...));</code>
+	///     var setup = mockRegistry.GetIndexerSetup&lt;IndexerSetup&lt;TValue, T...&gt;&gt;(access);</code>
 	/// </summary>
 	private static void EmitIndexerGetterAccessAndSetup(StringBuilder sb, string indent,
 		string mockRegistry, string accessVarName, string setupVarName,
@@ -148,8 +148,7 @@ internal static partial class Sources
 			sb.Append(", ").AppendTypeOrWrapper(p.Type);
 		}
 
-		sb.Append(">>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(")
-			.Append(accessVarName).Append("));").AppendLine();
+		sb.Append(">>(").Append(accessVarName).Append(");").AppendLine();
 	}
 
 	/// <summary>
@@ -184,8 +183,7 @@ internal static partial class Sources
 			sb.Append(", ").AppendTypeOrWrapper(p.Type);
 		}
 
-		sb.Append(">>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(")
-			.Append(accessVarName).Append("));").AppendLine();
+		sb.Append(">>(").Append(accessVarName).Append(");").AppendLine();
 	}
 
 	/// <summary>

--- a/Source/Mockolate/IDefaultValueGenerator.cs
+++ b/Source/Mockolate/IDefaultValueGenerator.cs
@@ -13,3 +13,16 @@ public interface IDefaultValueGenerator
 	/// </summary>
 	object? GenerateValue(Type type, params object?[] parameters);
 }
+
+internal static class DefaultValueGeneratorInternalExtensions
+{
+	internal static T GenerateTyped<T>(this IDefaultValueGenerator generator)
+	{
+		if (generator.GenerateValue(typeof(T)) is T value)
+		{
+			return value;
+		}
+
+		return default!;
+	}
+}

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -64,12 +64,65 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Get the latest indexer setup matching the given <paramref name="access" />,
+	///     or returns <see langword="null" /> if no matching setup is found. Scenario setups take precedence over
+	///     default-scope setups.
+	/// </summary>
+	public T? GetIndexerSetup<T>(IndexerAccess access) where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers.GetMatching<T>(access);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetMatching<T>(access);
+	}
+
+	/// <summary>
 	///     Stores the given <paramref name="value" /> for the given indexer <paramref name="access" />.
 	/// </summary>
 	public void SetIndexerValue<TResult>(IndexerAccess access, TResult value)
 	{
 		access.Storage = IndexerStorage;
 		access.StoreValue(value);
+	}
+
+	/// <summary>
+	///     Handles the no-matching-setup fallback for an indexer getter: returns any previously stored value, throws
+	///     when <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />, or otherwise stores and
+	///     returns the <see cref="MockBehavior.DefaultValue" />.
+	/// </summary>
+	public TResult GetIndexerFallback<TResult>(IndexerAccess access)
+	{
+		access.Storage = IndexerStorage;
+		if (access.TryFindStoredValue(out TResult stored))
+		{
+			return stored;
+		}
+
+		if (Behavior.ThrowWhenNotSetup)
+		{
+			throw new MockNotSetupException($"{access} was accessed without prior setup.");
+		}
+
+		TResult value = Behavior.DefaultValue.GenerateTyped<TResult>();
+		access.StoreValue(value);
+		return value;
+	}
+
+	/// <summary>
+	///     Invokes the getter flow of the given <paramref name="setup" /> for the given <paramref name="access" />,
+	///     ensuring the indexer value storage is wired up before dispatching.
+	/// </summary>
+	public TResult ApplyIndexerSetup<TResult>(IndexerAccess access, IndexerSetup setup)
+	{
+		access.Storage = IndexerStorage;
+		return setup.GetResult<TResult>(access, Behavior);
 	}
 
 	/// <summary>

--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -210,4 +210,85 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 		returnValue = callback(_invocationCount - 1, @delegate)!;
 		return true;
 	}
+
+#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
+	/// <summary>
+	///     Invokes the callback if the predicates are satisfied, passing the caller-supplied <paramref name="state" />
+	///     to the non-capturing <paramref name="callback" />. Equivalent in behavior to
+	///     <see cref="Invoke(bool, ref int, Action{int, TDelegate})" /> but allocation-free on the hot path.
+	/// </summary>
+	public bool Invoke<TState>(bool wasInvoked, ref int index, TState state,
+		Action<int, TDelegate, TState> callback)
+	{
+		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
+		{
+			_invocationCount++;
+			return false;
+		}
+
+		_invocationCount++;
+
+		if (RunInParallel)
+		{
+			if (!wasInvoked)
+			{
+				Interlocked.Increment(ref index);
+			}
+
+			_forIterationCount++;
+			_matchingCount++;
+			callback(_invocationCount - 1, @delegate, state);
+		}
+		else if (!wasInvoked)
+		{
+			if (!HasForSpecified || !CheckMatching(_forIterationCount + 1))
+			{
+				Interlocked.Increment(ref index);
+				_forIterationCount = 0;
+			}
+			else
+			{
+				_forIterationCount++;
+			}
+
+			_matchingCount++;
+			callback(_invocationCount - 1, @delegate, state);
+		}
+
+		return !RunInParallel;
+	}
+#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
+
+	/// <summary>
+	///     Invokes the callback if the predicates are satisfied, passing the caller-supplied <paramref name="state" />
+	///     to the non-capturing <paramref name="callback" />. Equivalent in behavior to
+	///     <see cref="Invoke{TReturn}(ref int, Func{int, TDelegate, TReturn}, out TReturn)" /> but allocation-free.
+	/// </summary>
+	public bool Invoke<TState, TReturn>(ref int index, TState state,
+		Func<int, TDelegate, TState, TReturn> callback,
+		[NotNullWhen(true)] out TReturn? returnValue)
+	{
+		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
+		{
+			_invocationCount++;
+			returnValue = default;
+			Interlocked.Increment(ref index);
+			return false;
+		}
+
+		if (!HasForSpecified || !CheckMatching(_forIterationCount + 1))
+		{
+			Interlocked.Increment(ref index);
+			_forIterationCount = 0;
+		}
+		else
+		{
+			_forIterationCount++;
+		}
+
+		_invocationCount++;
+		_matchingCount++;
+		returnValue = callback(_invocationCount - 1, @delegate, state)!;
+		return true;
+	}
 }

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -56,6 +56,12 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 	public abstract TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior, TResult baseValue);
 
 	/// <summary>
+	///     Invokes the getter flow for the given <paramref name="access" />, materializing the default value from the
+	///     <paramref name="behavior" /> inline when no stored value or initialization is present.
+	/// </summary>
+	public abstract TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior);
+
+	/// <summary>
 	///     Invokes the getter flow for the given <paramref name="access" /> using the <paramref name="defaultValueGenerator" />
 	///     when no value has been stored or initialized.
 	/// </summary>
@@ -534,6 +540,36 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 		return TryCast(currentValue, out TResult result, behavior) ? result : baseValue;
 	}
 
+	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior)" />
+	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior)
+	{
+		if (!TryExtractParameter(access, out T1 p1))
+		{
+			return behavior.DefaultValue.GenerateTyped<TResult>();
+		}
+
+		TValue currentValue;
+		if (access.TryFindStoredValue(out TValue existing))
+		{
+			currentValue = existing;
+		}
+		else if (_initialization is not null)
+		{
+			currentValue = _initialization.Invoke(p1);
+		}
+		else
+		{
+			currentValue = TryCast(behavior.DefaultValue.GenerateTyped<TValue>(), out TValue casted, behavior)
+				? casted : default!;
+		}
+
+		currentValue = ExecuteGetterCallbacks(p1, currentValue);
+		currentValue = ExecuteReturnCallbacks(p1, currentValue, out _);
+		access.StoreValue(currentValue);
+		return TryCast(currentValue, out TResult result, behavior)
+			? result : behavior.DefaultValue.GenerateTyped<TResult>();
+	}
+
 	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior, Func{TResult})" />
 	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator)
@@ -586,8 +622,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 			{
 				Callback<Action<int, T1, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, resultValue)))
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (p1, resultValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.resultValue)))
 				{
 					wasInvoked = true;
 				}
@@ -605,8 +641,8 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 			{
 				Callback<Action<int, T1, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, currentValue)))
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (p1, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.currentValue)))
 				{
 					wasInvoked = true;
 				}
@@ -625,8 +661,9 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 			{
 				Callback<Func<int, T1, TValue, TValue>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, currentValue), out TValue? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (p1, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.currentValue),
+					    out TValue? newValue))
 				{
 					matched = true;
 					return newValue!;
@@ -1101,6 +1138,36 @@ public class IndexerSetup<TValue, T1, T2>(
 		return TryCast(currentValue, out TResult result, behavior) ? result : baseValue;
 	}
 
+	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior)" />
+	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior)
+	{
+		if (!TryExtractParameters(access, out T1 p1, out T2 p2))
+		{
+			return behavior.DefaultValue.GenerateTyped<TResult>();
+		}
+
+		TValue currentValue;
+		if (access.TryFindStoredValue(out TValue existing))
+		{
+			currentValue = existing;
+		}
+		else if (_initialization is not null)
+		{
+			currentValue = _initialization.Invoke(p1, p2);
+		}
+		else
+		{
+			currentValue = TryCast(behavior.DefaultValue.GenerateTyped<TValue>(), out TValue casted, behavior)
+				? casted : default!;
+		}
+
+		currentValue = ExecuteGetterCallbacks(p1, p2, currentValue);
+		currentValue = ExecuteReturnCallbacks(p1, p2, currentValue, out _);
+		access.StoreValue(currentValue);
+		return TryCast(currentValue, out TResult result, behavior)
+			? result : behavior.DefaultValue.GenerateTyped<TResult>();
+	}
+
 	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior, Func{TResult})" />
 	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator)
@@ -1153,8 +1220,8 @@ public class IndexerSetup<TValue, T1, T2>(
 			{
 				Callback<Action<int, T1, T2, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, resultValue)))
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (p1, p2, resultValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.resultValue)))
 				{
 					wasInvoked = true;
 				}
@@ -1172,8 +1239,8 @@ public class IndexerSetup<TValue, T1, T2>(
 			{
 				Callback<Action<int, T1, T2, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, currentValue)))
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (p1, p2, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.currentValue)))
 				{
 					wasInvoked = true;
 				}
@@ -1192,8 +1259,9 @@ public class IndexerSetup<TValue, T1, T2>(
 			{
 				Callback<Func<int, T1, T2, TValue, TValue>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, currentValue), out TValue? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (p1, p2, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.currentValue),
+					    out TValue? newValue))
 				{
 					matched = true;
 					return newValue!;
@@ -1685,6 +1753,36 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		return TryCast(currentValue, out TResult result, behavior) ? result : baseValue;
 	}
 
+	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior)" />
+	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior)
+	{
+		if (!TryExtractParameters(access, out T1 p1, out T2 p2, out T3 p3))
+		{
+			return behavior.DefaultValue.GenerateTyped<TResult>();
+		}
+
+		TValue currentValue;
+		if (access.TryFindStoredValue(out TValue existing))
+		{
+			currentValue = existing;
+		}
+		else if (_initialization is not null)
+		{
+			currentValue = _initialization.Invoke(p1, p2, p3);
+		}
+		else
+		{
+			currentValue = TryCast(behavior.DefaultValue.GenerateTyped<TValue>(), out TValue casted, behavior)
+				? casted : default!;
+		}
+
+		currentValue = ExecuteGetterCallbacks(p1, p2, p3, currentValue);
+		currentValue = ExecuteReturnCallbacks(p1, p2, p3, currentValue, out _);
+		access.StoreValue(currentValue);
+		return TryCast(currentValue, out TResult result, behavior)
+			? result : behavior.DefaultValue.GenerateTyped<TResult>();
+	}
+
 	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior, Func{TResult})" />
 	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator)
@@ -1737,8 +1835,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 			{
 				Callback<Action<int, T1, T2, T3, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3, resultValue)))
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (p1, p2, p3, resultValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3, state.resultValue)))
 				{
 					wasInvoked = true;
 				}
@@ -1756,8 +1854,8 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 			{
 				Callback<Action<int, T1, T2, T3, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3, currentValue)))
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (p1, p2, p3, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3, state.currentValue)))
 				{
 					wasInvoked = true;
 				}
@@ -1776,8 +1874,9 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 			{
 				Callback<Func<int, T1, T2, T3, TValue, TValue>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3, currentValue), out TValue? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (p1, p2, p3, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3, state.currentValue),
+					    out TValue? newValue))
 				{
 					matched = true;
 					return newValue!;
@@ -2278,6 +2377,36 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		return TryCast(currentValue, out TResult result, behavior) ? result : baseValue;
 	}
 
+	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior)" />
+	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior)
+	{
+		if (!TryExtractParameters(access, out T1 p1, out T2 p2, out T3 p3, out T4 p4))
+		{
+			return behavior.DefaultValue.GenerateTyped<TResult>();
+		}
+
+		TValue currentValue;
+		if (access.TryFindStoredValue(out TValue existing))
+		{
+			currentValue = existing;
+		}
+		else if (_initialization is not null)
+		{
+			currentValue = _initialization.Invoke(p1, p2, p3, p4);
+		}
+		else
+		{
+			currentValue = TryCast(behavior.DefaultValue.GenerateTyped<TValue>(), out TValue casted, behavior)
+				? casted : default!;
+		}
+
+		currentValue = ExecuteGetterCallbacks(p1, p2, p3, p4, currentValue);
+		currentValue = ExecuteReturnCallbacks(p1, p2, p3, p4, currentValue, out _);
+		access.StoreValue(currentValue);
+		return TryCast(currentValue, out TResult result, behavior)
+			? result : behavior.DefaultValue.GenerateTyped<TResult>();
+	}
+
 	/// <inheritdoc cref="IndexerSetup.GetResult{TResult}(IndexerAccess, MockBehavior, Func{TResult})" />
 	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator)
@@ -2330,8 +2459,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 			{
 				Callback<Action<int, T1, T2, T3, T4, TValue>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3, p4, resultValue)))
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, (p1, p2, p3, p4, resultValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3, state.p4, state.resultValue)))
 				{
 					wasInvoked = true;
 				}
@@ -2349,8 +2478,8 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 			{
 				Callback<Action<int, T1, T2, T3, T4, TValue>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3, p4, currentValue)))
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, (p1, p2, p3, p4, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3, state.p4, state.currentValue)))
 				{
 					wasInvoked = true;
 				}
@@ -2369,8 +2498,9 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 			{
 				Callback<Func<int, T1, T2, T3, T4, TValue, TValue>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)
-					    => @delegate(invocationCount, p1, p2, p3, p4, currentValue), out TValue? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (p1, p2, p3, p4, currentValue),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3, state.p4, state.currentValue),
+					    out TValue? newValue))
 				{
 					matched = true;
 					return newValue!;

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -85,6 +85,29 @@ internal partial class MockSetups
 			return null;
 		}
 
+		public T? GetMatching<T>(IndexerAccess access) where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					if (storage[i] is T typedSetup &&
+					    ((IInteractiveIndexerSetup)typedSetup).Matches(access))
+					{
+						return typedSetup;
+					}
+				}
+			}
+
+			return null;
+		}
+
 		/// <inheritdoc cref="object.ToString()" />
 		[ExcludeFromCodeCoverage]
 		public override string ToString()

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -199,7 +199,11 @@ namespace Mockolate
         public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator) { }
         public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue) { }
         public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value) { }
+        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup) { }
         public void ClearAllInteractions() { }
+        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access) { }
+        public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
+            where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetMethodSetup<T>(string methodName, System.Func<T, bool> predicate)
@@ -895,6 +899,8 @@ namespace Mockolate.Setup
         public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
+        public bool Invoke<TState>(bool wasInvoked, ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
+        public bool Invoke<TState, TReturn>(ref int index, TState state, System.Func<int, TDelegate, TState, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }
     public static class CallbacksExtensions
     {
@@ -1728,6 +1734,7 @@ namespace Mockolate.Setup
     public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup(Mockolate.MockRegistry mockRegistry) { }
+        public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue);
         protected abstract bool MatchesAccess(Mockolate.Interactions.IndexerAccess access);
@@ -1742,6 +1749,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
@@ -1769,6 +1777,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
@@ -1796,6 +1805,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
@@ -1823,6 +1833,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -198,7 +198,11 @@ namespace Mockolate
         public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator) { }
         public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue) { }
         public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value) { }
+        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup) { }
         public void ClearAllInteractions() { }
+        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access) { }
+        public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
+            where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetMethodSetup<T>(string methodName, System.Func<T, bool> predicate)
@@ -894,6 +898,8 @@ namespace Mockolate.Setup
         public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
+        public bool Invoke<TState>(bool wasInvoked, ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
+        public bool Invoke<TState, TReturn>(ref int index, TState state, System.Func<int, TDelegate, TState, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }
     public static class CallbacksExtensions
     {
@@ -1727,6 +1733,7 @@ namespace Mockolate.Setup
     public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup(Mockolate.MockRegistry mockRegistry) { }
+        public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue);
         protected abstract bool MatchesAccess(Mockolate.Interactions.IndexerAccess access);
@@ -1741,6 +1748,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
@@ -1768,6 +1776,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
@@ -1795,6 +1804,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
@@ -1822,6 +1832,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -185,7 +185,11 @@ namespace Mockolate
         public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator) { }
         public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue) { }
         public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value) { }
+        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup) { }
         public void ClearAllInteractions() { }
+        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access) { }
+        public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
+            where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetMethodSetup<T>(string methodName, System.Func<T, bool> predicate)
@@ -849,6 +853,8 @@ namespace Mockolate.Setup
         public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
         public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
+        public bool Invoke<TState>(bool wasInvoked, ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
+        public bool Invoke<TState, TReturn>(ref int index, TState state, System.Func<int, TDelegate, TState, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }
     public static class CallbacksExtensions
     {
@@ -1682,6 +1688,7 @@ namespace Mockolate.Setup
     public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup(Mockolate.MockRegistry mockRegistry) { }
+        public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue);
         protected abstract bool MatchesAccess(Mockolate.Interactions.IndexerAccess access);
@@ -1696,6 +1703,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator) { }
@@ -1723,6 +1731,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator) { }
@@ -1750,6 +1759,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator) { }
@@ -1777,6 +1787,7 @@ namespace Mockolate.Setup
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+        public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator) { }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue) { }
         public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator) { }

--- a/Tests/Mockolate.Internal.Tests/TestHelpers/FakeIndexerSetup.cs
+++ b/Tests/Mockolate.Internal.Tests/TestHelpers/FakeIndexerSetup.cs
@@ -19,6 +19,9 @@ internal sealed class FakeIndexerSetup : IndexerSetup
 	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior, TResult baseValue)
 		=> baseValue;
 
+	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior)
+		=> default!;
+
 	public override TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior, Func<TResult> defaultValueGenerator)
 		=> defaultValueGenerator();
 

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -71,10 +71,12 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
-					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          					return setup is null
+					          						? this.MockRegistry.GetIndexerFallback<int>(access)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
 					          				}
 					          				int baseResult = wraps[index];
 					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
@@ -86,7 +88,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
@@ -106,10 +108,12 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, bool?>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool?>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int, bool?>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool?>>(access);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
-					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          					return setup is null
+					          						? this.MockRegistry.GetIndexerFallback<int>(access)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
 					          				}
 					          				int baseResult = wraps[index, isReadOnly];
 					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
@@ -127,7 +131,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(access);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
@@ -187,13 +191,15 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
 					          					int baseResult = this.MockRegistry.Wraps is global::MyCode.MyService wraps ? wraps[index] : base[index];
 					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
 					          				}
-					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          				return setup is null
+					          					? this.MockRegistry.GetIndexerFallback<int>(access)
+					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
 					          			}
 					          			set
 					          			{
@@ -202,7 +208,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
 					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value))
 					          				{
 					          					if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
@@ -228,13 +234,15 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, bool>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int, bool>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool>>(access);
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
 					          					int baseResult = base[index, isReadOnly];
 					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
 					          				}
-					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          				return setup is null
+					          					? this.MockRegistry.GetIndexerFallback<int>(access)
+					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -249,7 +257,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(access);
 					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value))
 					          				{
 					          					base[index, isWriteOnly] = value;
@@ -269,8 +277,10 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
-					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(access);
+					          				return setup is null
+					          					? this.MockRegistry.GetIndexerFallback<int>(access)
+					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
 					          			}
 					          			set
 					          			{
@@ -279,7 +289,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(access);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          			}
 					          		}
@@ -322,10 +332,12 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(access);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
-					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          					return setup is null
+					          						? this.MockRegistry.GetIndexerFallback<int>(access)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
 					          				}
 					          				int baseResult = wraps[buffer];
 					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
@@ -337,7 +349,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(access);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
@@ -357,10 +369,12 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(access);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
-					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!));
+					          					return setup is null
+					          						? this.MockRegistry.GetIndexerFallback<int>(access)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
 					          				}
 					          				int baseResult = wraps[values];
 					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
@@ -372,7 +386,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(s => ((global::Mockolate.Setup.IInteractiveIndexerSetup)s).Matches(access));
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(access);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{


### PR DESCRIPTION
This PR optimizes generated indexer getter paths by removing capturing closures, adding allocation-free callback invocation overloads and new indexer setup resolution/fallback APIs to support the updated generated code.

**Changes:**
- Update generated mock indexer getters to avoid capturing closures by using `GetIndexerSetup(access)` plus `GetIndexerFallback`/`ApplyIndexerSetup`.
- Add access-based indexer setup lookup in `MockSetups.IndexerSetups` and `MockRegistry`, plus new indexer fallback/setup helper methods.
- Add allocation-free `Callback.Invoke` overloads that accept caller state, and extend `IndexerSetup` with a new getter entry point used by the new flow.

**Benchmarks**

| Variant   | Mean       | Allocated |
| --------- | ----------:| ---------:|
| Baseline  | 1,026 ns   | 2.56 KB   |
| Step 1    | 1,000 ns   | 2.47 KB   |
| Step 2    |   892 ns   | 2.41 KB   |
| Step 3    |   845 ns   | 2.27 KB   |

---

- *Part of #518*