### PR TITLE
perf: typed indexer storage with int signature indices

### DIFF
--- a/.idea/.idea.Mockolate/.idea/.name
+++ b/.idea/.idea.Mockolate/.idea/.name
@@ -1,0 +1,1 @@
+Mockolate

--- a/.idea/.idea.Mockolate/.idea/.name
+++ b/.idea/.idea.Mockolate/.idea/.name
@@ -1,1 +1,0 @@
-Mockolate

--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -45,10 +45,11 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 	{
 		Moq.Mock<IMyIndexerInterface> mock = new();
 		mock.Setup(x => x[Moq.It.IsAny<int>()]).Returns("foo");
+		IMyIndexerInterface sut = mock.Object;
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			_ = mock.Object[42];
+			_ = sut[42];
 		}
 
 		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Exactly(InvocationCount));
@@ -96,10 +97,11 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 	{
 		IMyIndexerInterfaceImposter imposter = IMyIndexerInterface.Imposter();
 		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Returns("foo");
+		IMyIndexerInterface sut = imposter.Instance();
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			_ = imposter.Instance()[42];
+			_ = sut[42];
 		}
 
 		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(InvocationCount));

--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -13,10 +13,13 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with an indexer, setup the indexer and verify
-///     the getter was called once.
+///     the getter was called exactly <see cref="InvocationCount" /> times.
 /// </summary>
 public class CompleteIndexerBenchmarks : BenchmarksBase
 {
+	[Params(1, 10)]
+	public int InvocationCount { get; set; }
+
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
 	/// </summary>
@@ -26,9 +29,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface sut = IMyIndexerInterface.CreateMock();
 		sut.Mock.Setup[It.IsAny<int>()].Returns("foo");
 
-		_ = sut[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = sut[42];
+		}
 
-		sut.Mock.Verify[It.IsAny<int>()].Got().Once();
+		sut.Mock.Verify[It.IsAny<int>()].Got().Exactly(InvocationCount);
 	}
 
 	/// <summary>
@@ -40,9 +46,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		Moq.Mock<IMyIndexerInterface> mock = new();
 		mock.Setup(x => x[Moq.It.IsAny<int>()]).Returns("foo");
 
-		_ = mock.Object[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object[42];
+		}
 
-		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Once());
+		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -54,9 +63,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface mock = Substitute.For<IMyIndexerInterface>();
 		mock[Arg.Any<int>()].Returns("foo");
 
-		_ = mock[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock[42];
+		}
 
-		_ = mock.Received(1)[Arg.Any<int>()];
+		_ = mock.Received(InvocationCount)[Arg.Any<int>()];
 	}
 
 	/// <summary>
@@ -68,9 +80,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface mock = A.Fake<IMyIndexerInterface>();
 		A.CallTo(() => mock[A<int>.Ignored]).Returns("foo");
 
-		_ = mock[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock[42];
+		}
 
-		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(1, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -82,9 +97,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterfaceImposter imposter = IMyIndexerInterface.Imposter();
 		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Returns("foo");
 
-		_ = imposter.Instance()[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = imposter.Instance()[42];
+		}
 
-		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Once());
+		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(InvocationCount));
 	}
 
 	/* Indexers not supported on TUnit.Mocks
@@ -97,9 +115,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		TUnit.Mocks.Mock<IMyIndexerInterface> mock = TUnit.Mocks.Mock.Of<IMyIndexerInterface>();
 		mock[Any<int>()].Returns("foo");
 
-		_ = mock.Object[42];
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object[42];
+		}
 
-		mock[Any<int>()].WasCalled();
+		mock[Any<int>()].WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
 	}
 	*/
 

--- a/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
@@ -13,10 +13,13 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the simple case of an interface mock, setup a single method that gets called and
-///     verified to be called once.
+///     verified to be called exactly <see cref="InvocationCount" /> times.
 /// </summary>
 public class CompleteMethodBenchmarks : BenchmarksBase
 {
+	[Params(1, 10)]
+	public int InvocationCount { get; set; }
+
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
 	/// </summary>
@@ -26,9 +29,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface sut = IMyMethodInterface.CreateMock();
 		sut.Mock.Setup.MyFunc(It.IsAny<int>()).Returns(true);
 
-		sut.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			sut.MyFunc(42);
+		}
 
-		sut.Mock.Verify.MyFunc(It.IsAny<int>()).Once();
+		sut.Mock.Verify.MyFunc(It.IsAny<int>()).Exactly(InvocationCount);
 	}
 
 	/// <summary>
@@ -40,9 +46,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		Moq.Mock<IMyMethodInterface> mock = new();
 		mock.Setup(x => x.MyFunc(Moq.It.IsAny<int>())).Returns(true);
 
-		mock.Object.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.Object.MyFunc(42);
+		}
 
-		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Times.Once());
+		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Times.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -54,9 +63,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface mock = Substitute.For<IMyMethodInterface>();
 		mock.MyFunc(Arg.Any<int>()).Returns(true);
 
-		mock.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.MyFunc(42);
+		}
 
-		mock.Received(1).MyFunc(Arg.Any<int>());
+		mock.Received(InvocationCount).MyFunc(Arg.Any<int>());
 	}
 
 	/// <summary>
@@ -68,9 +80,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface mock = A.Fake<IMyMethodInterface>();
 		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).Returns(true);
 
-		mock.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.MyFunc(42);
+		}
 
-		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(1, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -82,9 +97,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterfaceImposter imposter = IMyMethodInterface.Imposter();
 		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Returns(true);
 
-		imposter.Instance().MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			imposter.Instance().MyFunc(42);
+		}
 
-		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Once());
+		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -96,9 +114,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		Mock<IMyMethodInterface> mock = TUnit.Mocks.Mock.Of<IMyMethodInterface>();
 		mock.MyFunc(Any<int>()).Returns(true);
 
-		mock.Object.MyFunc(42);
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			mock.Object.MyFunc(42);
+		}
 
-		mock.MyFunc(Any<int>()).WasCalled();
+		mock.MyFunc(Any<int>()).WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
 	}
 
 	public interface IMyMethodInterface

--- a/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
@@ -45,10 +45,11 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 	{
 		Moq.Mock<IMyMethodInterface> mock = new();
 		mock.Setup(x => x.MyFunc(Moq.It.IsAny<int>())).Returns(true);
+		IMyMethodInterface sut = mock.Object;
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			mock.Object.MyFunc(42);
+			sut.MyFunc(42);
 		}
 
 		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Times.Exactly(InvocationCount));
@@ -96,10 +97,11 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 	{
 		IMyMethodInterfaceImposter imposter = IMyMethodInterface.Imposter();
 		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Returns(true);
+		IMyMethodInterface sut = imposter.Instance();
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			imposter.Instance().MyFunc(42);
+			sut.MyFunc(42);
 		}
 
 		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(InvocationCount));
@@ -113,10 +115,11 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 	{
 		Mock<IMyMethodInterface> mock = TUnit.Mocks.Mock.Of<IMyMethodInterface>();
 		mock.MyFunc(Any<int>()).Returns(true);
+		IMyMethodInterface sut = mock.Object;
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			mock.Object.MyFunc(42);
+			sut.MyFunc(42);
 		}
 
 		mock.MyFunc(Any<int>()).WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -44,10 +44,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 	{
 		Moq.Mock<IMyPropertyInterface> mock = new();
 		mock.SetupGet(x => x.Counter).Returns(42);
+		IMyPropertyInterface sut = mock.Object;
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			_ = mock.Object.Counter;
+			_ = sut.Counter;
 		}
 
 		mock.VerifyGet(x => x.Counter, Times.Exactly(InvocationCount));
@@ -95,10 +96,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 	{
 		IMyPropertyInterfaceImposter imposter = IMyPropertyInterface.Imposter();
 		imposter.Counter.Getter().Returns(42);
+		IMyPropertyInterface sut = imposter.Instance();
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			_ = imposter.Instance().Counter;
+			_ = sut.Counter;
 		}
 
 		imposter.Counter.Getter().Called(Count.Exactly(InvocationCount));
@@ -112,10 +114,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 	{
 		Mock<IMyPropertyInterface> mock = TUnit.Mocks.Mock.Of<IMyPropertyInterface>();
 		mock.Counter.Returns(42);
+		IMyPropertyInterface sut = mock.Object;
 
 		for (int i = 0; i < InvocationCount; i++)
 		{
-			_ = mock.Object.Counter;
+			_ = sut.Counter;
 		}
 
 		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -12,10 +12,13 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with a property, setup the property and verify
-///     the getter was called once.
+///     the getter was called exactly <see cref="InvocationCount" /> times.
 /// </summary>
 public class CompletePropertyBenchmarks : BenchmarksBase
 {
+	[Params(1, 10)]
+	public int InvocationCount { get; set; }
+
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
 	/// </summary>
@@ -25,9 +28,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface sut = IMyPropertyInterface.CreateMock();
 		sut.Mock.Setup.Counter.InitializeWith(42);
 
-		_ = sut.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = sut.Counter;
+		}
 
-		sut.Mock.Verify.Counter.Got().Once();
+		sut.Mock.Verify.Counter.Got().Exactly(InvocationCount);
 	}
 
 	/// <summary>
@@ -39,9 +45,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		Moq.Mock<IMyPropertyInterface> mock = new();
 		mock.SetupGet(x => x.Counter).Returns(42);
 
-		_ = mock.Object.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object.Counter;
+		}
 
-		mock.VerifyGet(x => x.Counter, Times.Once());
+		mock.VerifyGet(x => x.Counter, Times.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -53,9 +62,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface mock = Substitute.For<IMyPropertyInterface>();
 		mock.Counter.Returns(42);
 
-		_ = mock.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Counter;
+		}
 
-		_ = mock.Received(1).Counter;
+		_ = mock.Received(InvocationCount).Counter;
 	}
 
 	/// <summary>
@@ -67,9 +79,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface mock = A.Fake<IMyPropertyInterface>();
 		A.CallTo(() => mock.Counter).Returns(42);
 
-		_ = mock.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Counter;
+		}
 
-		A.CallTo(() => mock.Counter).MustHaveHappened(1, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock.Counter).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -81,9 +96,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterfaceImposter imposter = IMyPropertyInterface.Imposter();
 		imposter.Counter.Getter().Returns(42);
 
-		_ = imposter.Instance().Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = imposter.Instance().Counter;
+		}
 
-		imposter.Counter.Getter().Called(Count.Once());
+		imposter.Counter.Getter().Called(Count.Exactly(InvocationCount));
 	}
 
 	/// <summary>
@@ -95,9 +113,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		Mock<IMyPropertyInterface> mock = TUnit.Mocks.Mock.Of<IMyPropertyInterface>();
 		mock.Counter.Returns(42);
 
-		_ = mock.Object.Counter;
+		for (int i = 0; i < InvocationCount; i++)
+		{
+			_ = mock.Object.Counter;
+		}
 
-		mock.Counter.WasCalled();
+		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
 	}
 
 	public interface IMyPropertyInterface

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -191,6 +191,28 @@ internal static partial class Sources
 
 		sb.Append("\t\t\t\t_ => null,").AppendLine();
 		sb.Append("\t\t\t};").AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"global::Mockolate.Interactions.IndexerAccess.TraverseStorage(global::Mockolate.Setup.IndexerValueStorage?, bool)\" />").AppendLine();
+		sb.Append("\t\tprotected override global::Mockolate.Setup.IndexerValueStorage? TraverseStorage(global::Mockolate.Setup.IndexerValueStorage? storage, bool createMissing)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tglobal::Mockolate.Setup.IndexerValueStorage? s = storage;").AppendLine();
+		sb.Append("\t\t\tif (s is null)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\treturn null;").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		for (int i = 1; i < numberOfParameters; i++)
+		{
+			sb.Append("\t\t\ts = createMissing ? s.GetOrAddChildDispatch(Parameter").Append(i)
+				.Append(") : s.GetChildDispatch(Parameter").Append(i).Append(");").AppendLine();
+			sb.Append("\t\t\tif (s is null)").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\treturn null;").AppendLine();
+			sb.Append("\t\t\t}").AppendLine();
+		}
+
+		sb.Append("\t\t\treturn createMissing ? s.GetOrAddChildDispatch(Parameter").Append(numberOfParameters)
+			.Append(") : s.GetChildDispatch(Parameter").Append(numberOfParameters).Append(");").AppendLine();
+		sb.Append("\t\t}").AppendLine();
 	}
 
 	private static void AppendIndexerSetup(StringBuilder sb, int numberOfParameters)
@@ -934,7 +956,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		// GetResult(behavior) — no-closure entry point used by the generated mock indexer body
+		// GetResult(behavior) â€” no-closure entry point used by the generated mock indexer body
 		sb.Append("\t\t/// <inheritdoc cref=\"global::Mockolate.Setup.IndexerSetup.GetResult{TResult}(global::Mockolate.Interactions.IndexerAccess, global::Mockolate.MockBehavior)\" />").AppendLine();
 		sb.Append("\t\tpublic override TResult GetResult<TResult>(global::Mockolate.Interactions.IndexerAccess access, global::Mockolate.MockBehavior behavior)").AppendLine();
 		sb.Append("\t\t{").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -956,7 +956,7 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
-		// GetResult(behavior) â€” no-closure entry point used by the generated mock indexer body
+		// GetResult(behavior) - no-closure entry point used by the generated mock indexer body
 		sb.Append("\t\t/// <inheritdoc cref=\"global::Mockolate.Setup.IndexerSetup.GetResult{TResult}(global::Mockolate.Interactions.IndexerAccess, global::Mockolate.MockBehavior)\" />").AppendLine();
 		sb.Append("\t\tpublic override TResult GetResult<TResult>(global::Mockolate.Interactions.IndexerAccess access, global::Mockolate.MockBehavior behavior)").AppendLine();
 		sb.Append("\t\t{").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1238,7 +1238,8 @@ internal static partial class Sources
 	}
 
 	private static void AppendMockSubject_ImplementClass(StringBuilder sb, Class @class, string mockRegistryName,
-		MockClass? mockClass)
+		MockClass? mockClass, Dictionary<string, int>? signatureIndicesOverride = null,
+		int[]? nextSignatureIndexRef = null)
 	{
 		string className = @class.ClassFullName;
 		sb.Append("\t\t#region ").Append(@class.DisplayString).AppendLine();
@@ -1257,13 +1258,27 @@ internal static partial class Sources
 		}
 
 		List<Property>? mockProperties = mockClass?.AllProperties().ToList();
+		Dictionary<string, int> signatureIndices = signatureIndicesOverride ?? new Dictionary<string, int>();
+		int[] nextSignatureIndex = nextSignatureIndexRef ?? [0];
 		foreach (Property property in @class.AllProperties())
 		{
 			if (mockProperties?.All(p => !Property.EqualityComparer.Equals(property, p)) != false)
 			{
+				int signatureIndex = -1;
+				if (property is { IsIndexer: true, IndexerParameters: not null, })
+				{
+					string signatureKey = string.Join("|",
+						property.IndexerParameters.Value.Select(p => p.Type.Fullname));
+					if (!signatureIndices.TryGetValue(signatureKey, out signatureIndex))
+					{
+						signatureIndex = nextSignatureIndex[0]++;
+						signatureIndices[signatureKey] = signatureIndex;
+					}
+				}
+
 				AppendMockSubject_ImplementClass_AddProperty(sb, property, mockRegistryName, className,
 					mockClass is not null,
-					@class.IsInterface);
+					@class.IsInterface, signatureIndex);
 				sb.AppendLine();
 			}
 		}
@@ -1405,7 +1420,7 @@ internal static partial class Sources
 
 	private static void AppendMockSubject_ImplementClass_AddProperty(StringBuilder sb, Property property,
 		string mockRegistryName,
-		string className, bool explicitInterfaceImplementation, bool isClassInterface)
+		string className, bool explicitInterfaceImplementation, bool isClassInterface, int signatureIndex)
 	{
 		string mockRegistry = property.IsStatic ? "MockRegistryProvider.Value" : $"this.{mockRegistryName}";
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(property.ContainingType.EscapeForXmlDoc()).Append('.').Append(
@@ -1489,11 +1504,12 @@ internal static partial class Sources
 					sb.Append("\t\t\t\t\treturn ").Append(setupVarName).Append(" is null")
 						.AppendLine();
 					sb.Append("\t\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
-						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(")")
+						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
+						.Append(signatureIndex).Append(")")
 						.AppendLine();
 					sb.Append("\t\t\t\t\t\t: ").Append(mockRegistry).Append(".ApplyIndexerSetup<")
 						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
-						.Append(setupVarName).Append(");").AppendLine();
+						.Append(setupVarName).Append(", ").Append(signatureIndex).Append(");").AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
 					sb.Append("\t\t\t\t").AppendTypeOrWrapper(property.Type).Append(' ').Append(baseResultVarName)
 						.Append(" = wraps[")
@@ -1501,7 +1517,7 @@ internal static partial class Sources
 						.AppendLine();
 					sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".ApplyIndexerGetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", ")
-						.Append(baseResultVarName).Append(");").AppendLine();
+						.Append(baseResultVarName).Append(", ").Append(signatureIndex).Append(");").AppendLine();
 				}
 				else
 				{
@@ -1559,15 +1575,16 @@ internal static partial class Sources
 
 					sb.Append("\t\t\t\t\treturn ").Append(mockRegistry).Append(".ApplyIndexerGetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", ")
-						.Append(baseResultVarName).Append(");").AppendLine();
+						.Append(baseResultVarName).Append(", ").Append(signatureIndex).Append(");").AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
 					sb.Append("\t\t\t\treturn ").Append(setupVarName).Append(" is null").AppendLine();
 					sb.Append("\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
-						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(")")
+						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
+						.Append(signatureIndex).Append(")")
 						.AppendLine();
 					sb.Append("\t\t\t\t\t: ").Append(mockRegistry).Append(".ApplyIndexerSetup<")
 						.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
-						.Append(setupVarName).Append(");").AppendLine();
+						.Append(setupVarName).Append(", ").Append(signatureIndex).Append(");").AppendLine();
 				}
 				else
 				{
@@ -1600,11 +1617,12 @@ internal static partial class Sources
 					property.Type, property.IndexerParameters.Value);
 				sb.Append("\t\t\t\treturn ").Append(setupVarName).Append(" is null").AppendLine();
 				sb.Append("\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
-					.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(")")
+					.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
+					.Append(signatureIndex).Append(")")
 					.AppendLine();
 				sb.Append("\t\t\t\t\t: ").Append(mockRegistry).Append(".ApplyIndexerSetup<")
 					.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
-					.Append(setupVarName).Append(");").AppendLine();
+					.Append(setupVarName).Append(", ").Append(signatureIndex).Append(");").AppendLine();
 			}
 			else
 			{
@@ -1641,7 +1659,8 @@ internal static partial class Sources
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
-						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value);")
+						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
+						.Append(signatureIndex).Append(");")
 						.AppendLine();
 
 					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className)
@@ -1679,7 +1698,8 @@ internal static partial class Sources
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value);
 					sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".ApplyIndexerSetter(")
-						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value))").AppendLine();
+						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
+						.Append(signatureIndex).Append("))").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					if (property.Setter?.IsProtected != true)
 					{
@@ -1711,7 +1731,8 @@ internal static partial class Sources
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
-						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value);").AppendLine();
+						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
+						.Append(signatureIndex).Append(");").AppendLine();
 				}
 			}
 			else

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1267,8 +1267,11 @@ internal static partial class Sources
 				int signatureIndex = -1;
 				if (property is { IsIndexer: true, IndexerParameters: not null, })
 				{
-					string signatureKey = string.Join("|",
-						property.IndexerParameters.Value.Select(p => p.Type.Fullname));
+					string signatureKey = property.ContainingType + "::" +
+						(property.ExplicitImplementation ?? "") + "::" +
+						property.Type.Fullname + "->|" +
+						string.Join("|",
+							property.IndexerParameters.Value.Select(p => p.RefKind + " " + p.Type.Fullname));
 					if (!signatureIndices.TryGetValue(signatureKey, out signatureIndex))
 					{
 						signatureIndex = nextSignatureIndex[0]++;

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -356,11 +356,14 @@ internal static partial class Sources
 			sb.AppendLine();
 		}
 
-		AppendMockSubject_ImplementClass(sb, @class, mockRegistryName, null);
+		Dictionary<string, int> signatureIndices = new();
+		int[] nextSignatureIndex = [0];
+		AppendMockSubject_ImplementClass(sb, @class, mockRegistryName, null, signatureIndices, nextSignatureIndex);
 		foreach ((string Name, Class Class) item in additionalInterfaces)
 		{
 			sb.AppendLine();
-			AppendMockSubject_ImplementClass(sb, item.Class, mockRegistryName, @class as MockClass);
+			AppendMockSubject_ImplementClass(sb, item.Class, mockRegistryName, @class as MockClass,
+				signatureIndices, nextSignatureIndex);
 		}
 
 		sb.AppendLine();

--- a/Source/Mockolate/Interactions/IndexerAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerAccess.cs
@@ -20,35 +20,38 @@ public abstract class IndexerAccess : IInteraction
 	/// </summary>
 	public abstract object? GetParameterValueAt(int index);
 
-	internal ValueStorage? Storage { get; set; }
+	internal IndexerValueStorage? Storage { get; set; }
+
+	internal void AttachStorage(IndexerValueStorage storage)
+		=> Storage = storage;
+
+	/// <summary>
+	///     Walks the given <paramref name="storage" /> along the typed parameter path for this access,
+	///     returning the leaf node or <see langword="null" /> if no path exists (and
+	///     <paramref name="createMissing" /> is <see langword="false" />).
+	/// </summary>
+	/// <remarks>
+	///     Each concrete <see cref="IndexerAccess" /> subclass knows its parameter types and traverses
+	///     without boxing. Not intended for external implementation — the only supported subclasses are
+	///     <see cref="IndexerGetterAccess{T1}" />, <see cref="IndexerSetterAccess{T1, TValue}" />, their
+	///     multi-parameter siblings, and the source-generated 5+ parameter variants.
+	/// </remarks>
+	[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+	protected abstract IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing);
 
 	/// <summary>
 	///     Attempts to find a previously stored value for this access.
 	/// </summary>
 	public bool TryFindStoredValue<T>(out T value)
 	{
-		ValueStorage? current = Storage;
-		if (current is null)
+		if (TraverseStorage(Storage, createMissing: false) is IndexerValueStorage<T> typedLeaf && typedLeaf.HasValue)
 		{
-			value = default!;
-			return false;
-		}
-
-		int count = ParameterCount;
-		for (int i = 0; i < count; i++)
-		{
-			current = current.GetChild(GetParameterValueAt(i));
-			if (current is null)
+			T stored = typedLeaf.Value;
+			if (stored is not null)
 			{
-				value = default!;
-				return false;
+				value = stored;
+				return true;
 			}
-		}
-
-		if (current.Value is T typedValue)
-		{
-			value = typedValue;
-			return true;
 		}
 
 		value = default!;
@@ -60,18 +63,10 @@ public abstract class IndexerAccess : IInteraction
 	/// </summary>
 	public void StoreValue<T>(T value)
 	{
-		ValueStorage? current = Storage;
-		if (current is null)
+		if (TraverseStorage(Storage, createMissing: true) is IndexerValueStorage<T> typedLeaf)
 		{
-			return;
+			typedLeaf.Value = value;
+			typedLeaf.HasValue = true;
 		}
-
-		int count = ParameterCount;
-		for (int i = 0; i < count; i++)
-		{
-			current = current.GetOrAddChild(GetParameterValueAt(i)!);
-		}
-
-		current.Value = value;
 	}
 }

--- a/Source/Mockolate/Interactions/IndexerAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerAccess.cs
@@ -46,12 +46,8 @@ public abstract class IndexerAccess : IInteraction
 	{
 		if (TraverseStorage(Storage, createMissing: false) is IndexerValueStorage<T> typedLeaf && typedLeaf.HasValue)
 		{
-			T stored = typedLeaf.Value;
-			if (stored is not null)
-			{
-				value = stored;
-				return true;
-			}
+			value = typedLeaf.Value;
+			return true;
 		}
 
 		value = default!;

--- a/Source/Mockolate/Interactions/IndexerGetterAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerGetterAccess.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Mockolate.Setup;
 
 namespace Mockolate.Interactions;
 
@@ -31,6 +32,18 @@ public class IndexerGetterAccess<T1>(string parameterName1, T1 parameter1) : Ind
 			0 => Parameter1,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
@@ -81,6 +94,24 @@ public class IndexerGetterAccess<T1, T2>(
 			1 => Parameter2,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter2) : s.GetChildDispatch(Parameter2);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
@@ -144,6 +175,30 @@ public class IndexerGetterAccess<T1, T2, T3>(
 			2 => Parameter3,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter2) : s.GetChildDispatch(Parameter2);
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter3) : s.GetChildDispatch(Parameter3);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
@@ -220,6 +275,36 @@ public class IndexerGetterAccess<T1, T2, T3, T4>(
 			3 => Parameter4,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter2) : s.GetChildDispatch(Parameter2);
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter3) : s.GetChildDispatch(Parameter3);
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter4) : s.GetChildDispatch(Parameter4);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()

--- a/Source/Mockolate/Interactions/IndexerSetterAccess.cs
+++ b/Source/Mockolate/Interactions/IndexerSetterAccess.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Mockolate.Setup;
 
 namespace Mockolate.Interactions;
 
@@ -36,6 +37,18 @@ public class IndexerSetterAccess<T1, TValue>(string parameterName1, T1 parameter
 			0 => Parameter1,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
@@ -92,6 +105,24 @@ public class IndexerSetterAccess<T1, T2, TValue>(
 			1 => Parameter2,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter2) : s.GetChildDispatch(Parameter2);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
@@ -161,6 +192,30 @@ public class IndexerSetterAccess<T1, T2, T3, TValue>(
 			2 => Parameter3,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter2) : s.GetChildDispatch(Parameter2);
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter3) : s.GetChildDispatch(Parameter3);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
@@ -243,6 +298,36 @@ public class IndexerSetterAccess<T1, T2, T3, T4, TValue>(
 			3 => Parameter4,
 			_ => null,
 		};
+
+	/// <inheritdoc cref="IndexerAccess.TraverseStorage(Mockolate.Setup.IndexerValueStorage?, bool)" />
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing)
+	{
+		IndexerValueStorage? s = storage;
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter1) : s.GetChildDispatch(Parameter1);
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter2) : s.GetChildDispatch(Parameter2);
+		if (s is null)
+		{
+			return null;
+		}
+
+		s = createMissing ? s.GetOrAddChildDispatch(Parameter3) : s.GetChildDispatch(Parameter3);
+		if (s is null)
+		{
+			return null;
+		}
+
+		return createMissing ? s.GetOrAddChildDispatch(Parameter4) : s.GetChildDispatch(Parameter4);
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -22,11 +22,22 @@ public partial class MockRegistry
 		=> Interactions.Clear();
 
 	/// <summary>
-	///     Pre-sizes the mock's internal value-storage arrays. Called once from the generated mock constructor.
-	///     Extend with further parameters (e.g. <c>methodCount</c>) as other subsystems move to fixed-size storage.
+	///     Optional pre-sizing hook for the mock's internal indexer value-storage array. When the total number
+	///     of distinct indexer signatures is known up front, calling this once avoids the lazy-grow allocation
+	///     on first access. Safe to skip — storage grows on demand otherwise.
 	/// </summary>
+	/// <param name="indexerCount">The number of distinct indexer signatures. Must be non-negative.</param>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="indexerCount" /> is negative.</exception>
 	public void InitializeStorage(int indexerCount)
-		=> Setup.Indexers.InitializeStorageCount(indexerCount);
+	{
+		if (indexerCount < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(indexerCount), indexerCount,
+				"Indexer count must be non-negative.");
+		}
+
+		Setup.Indexers.InitializeStorageCount(indexerCount);
+	}
 
 	/// <summary>
 	///     Get the latest method setup matching the given <paramref name="methodName" /> and <paramref name="predicate" />,

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -15,14 +15,18 @@ public partial class MockRegistry
 	/// </summary>
 	public MockInteractions Interactions { get; }
 
-	private ValueStorage IndexerStorage
-		=> Setup.Indexers.ValueStorage;
-
 	/// <summary>
 	///     Clears all interactions recorded by the mock object.
 	/// </summary>
 	public void ClearAllInteractions()
 		=> Interactions.Clear();
+
+	/// <summary>
+	///     Pre-sizes the mock's internal value-storage arrays. Called once from the generated mock constructor.
+	///     Extend with further parameters (e.g. <c>methodCount</c>) as other subsystems move to fixed-size storage.
+	/// </summary>
+	public void InitializeStorage(int indexerCount)
+		=> Setup.Indexers.InitializeStorageCount(indexerCount);
 
 	/// <summary>
 	///     Get the latest method setup matching the given <paramref name="methodName" /> and <paramref name="predicate" />,
@@ -87,9 +91,9 @@ public partial class MockRegistry
 	/// <summary>
 	///     Stores the given <paramref name="value" /> for the given indexer <paramref name="access" />.
 	/// </summary>
-	public void SetIndexerValue<TResult>(IndexerAccess access, TResult value)
+	public void SetIndexerValue<TResult>(IndexerAccess access, TResult value, int signatureIndex)
 	{
-		access.Storage = IndexerStorage;
+		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
 		access.StoreValue(value);
 	}
 
@@ -98,9 +102,9 @@ public partial class MockRegistry
 	///     when <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />, or otherwise stores and
 	///     returns the <see cref="MockBehavior.DefaultValue" />.
 	/// </summary>
-	public TResult GetIndexerFallback<TResult>(IndexerAccess access)
+	public TResult GetIndexerFallback<TResult>(IndexerAccess access, int signatureIndex)
 	{
-		access.Storage = IndexerStorage;
+		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
 		if (access.TryFindStoredValue(out TResult stored))
 		{
 			return stored;
@@ -120,9 +124,9 @@ public partial class MockRegistry
 	///     Invokes the getter flow of the given <paramref name="setup" /> for the given <paramref name="access" />,
 	///     ensuring the indexer value storage is wired up before dispatching.
 	/// </summary>
-	public TResult ApplyIndexerSetup<TResult>(IndexerAccess access, IndexerSetup setup)
+	public TResult ApplyIndexerSetup<TResult>(IndexerAccess access, IndexerSetup setup, int signatureIndex)
 	{
-		access.Storage = IndexerStorage;
+		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
 		return setup.GetResult<TResult>(access, Behavior);
 	}
 
@@ -134,9 +138,10 @@ public partial class MockRegistry
 	///     When <paramref name="setup" /> is <see langword="null" />, returns any previously stored value or the
 	///     <paramref name="baseValue" /> (which is then stored).
 	/// </remarks>
-	public TResult ApplyIndexerGetter<TResult>(IndexerAccess access, IndexerSetup? setup, TResult baseValue)
+	public TResult ApplyIndexerGetter<TResult>(IndexerAccess access, IndexerSetup? setup, TResult baseValue,
+		int signatureIndex)
 	{
-		access.Storage = IndexerStorage;
+		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
 		if (setup is null)
 		{
 			if (access.TryFindStoredValue(out TResult stored))
@@ -162,9 +167,9 @@ public partial class MockRegistry
 	///     value.
 	/// </remarks>
 	public TResult ApplyIndexerGetter<TResult>(IndexerAccess access, IndexerSetup? setup,
-		Func<TResult> defaultValueGenerator)
+		Func<TResult> defaultValueGenerator, int signatureIndex)
 	{
-		access.Storage = IndexerStorage;
+		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
 		if (setup is null)
 		{
 			if (access.TryFindStoredValue(out TResult stored))
@@ -189,15 +194,16 @@ public partial class MockRegistry
 	///     Applies an indexer setter for the given <paramref name="access" /> with the given <paramref name="value" /> and
 	///     optional matching <paramref name="setup" />. Returns whether the base class implementation should be skipped.
 	/// </summary>
-	public bool ApplyIndexerSetter<TResult>(IndexerAccess access, IndexerSetup? setup, TResult value)
+	public bool ApplyIndexerSetter<TResult>(IndexerAccess access, IndexerSetup? setup, TResult value,
+		int signatureIndex)
 	{
+		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
 		if (setup is null)
 		{
-			SetIndexerValue(access, value);
+			access.StoreValue(value);
 			return Behavior.SkipBaseClass;
 		}
 
-		access.Storage = IndexerStorage;
 		setup.SetResult(access, Behavior, value);
 		return setup.SkipBaseClass() ?? Behavior.SkipBaseClass;
 	}

--- a/Source/Mockolate/Setup/IndexerValueStorage.cs
+++ b/Source/Mockolate/Setup/IndexerValueStorage.cs
@@ -1,0 +1,150 @@
+#pragma warning disable CS8714 // Child lookups and additions use TKey after an explicit null check; callers forward via key!.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Mockolate.Setup;
+
+/// <summary>
+///     Marker type for the typed child indexer of an <see cref="IndexerValueStorage" /> node.
+///     Concrete implementations inherit from <see cref="Dictionary{TKey, TValue}" /> for zero dispatch overhead.
+/// </summary>
+internal interface IIndexerChildIndex;
+
+/// <summary>
+///     A typed child-index dictionary for a specific key type <typeparamref name="TKey" /> and value type
+///     <typeparamref name="TValue" />. Inherits from <see cref="Dictionary{TKey, TValue}" /> so lookups go
+///     straight through without boxing.
+/// </summary>
+[DebuggerNonUserCode]
+internal sealed class IndexerChildIndex<TKey, TValue>
+	: Dictionary<TKey, IndexerValueStorage<TValue>>, IIndexerChildIndex
+	where TKey : notnull
+{
+}
+
+/// <summary>
+///     Non-generic base for an indexer value-storage tree node. Held by
+///     <see cref="Mockolate.Interactions.IndexerAccess.Storage" /> — each concrete node is a typed
+///     <see cref="IndexerValueStorage{TValue}" />. The generic parameter types (T1, T2, ...) of an
+///     <see cref="Mockolate.Interactions.IndexerAccess" /> are only known on the subclass, so tree traversal
+///     goes through these non-generic dispatch forwarders.
+/// </summary>
+/// <remarks>
+///     This type is public only because source-generated <c>IndexerGetterAccess</c> / <c>IndexerSetterAccess</c>
+///     subclasses (5+ parameters) live in the user's assembly and must override
+///     <c>IndexerAccess.TraverseStorage</c>. It is not intended to be constructed or subclassed directly.
+/// </remarks>
+[DebuggerNonUserCode]
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+public abstract class IndexerValueStorage
+{
+	/// <summary>
+	///     Non-generic dispatch to <see cref="IndexerValueStorage{TValue}.GetChild{TKey}(TKey)" /> on the
+	///     concrete typed node. Used by generated access subclasses that only know the parameter types.
+	/// </summary>
+	public abstract IndexerValueStorage? GetChildDispatch<TKey>(TKey key);
+
+	/// <summary>
+	///     Non-generic dispatch to <see cref="IndexerValueStorage{TValue}.GetOrAddChild{TKey}(TKey)" /> on the
+	///     concrete typed node. Used by generated access subclasses that only know the parameter types.
+	/// </summary>
+	public abstract IndexerValueStorage GetOrAddChildDispatch<TKey>(TKey key);
+}
+
+/// <summary>
+///     Tree node that stores indexer values by their typed parameter path. The leaf node's <see cref="Value" />
+///     holds the stored indexer result; internal nodes carry an <see cref="IIndexerChildIndex" /> that maps
+///     the next parameter to further child nodes.
+/// </summary>
+[DebuggerNonUserCode]
+internal sealed class IndexerValueStorage<TValue> : IndexerValueStorage
+{
+	/// <summary>
+	///     The value stored at this tree node. Typed to avoid boxing for value-type indexer return types.
+	///     Only meaningful when <see cref="HasValue" /> is <see langword="true" />.
+	/// </summary>
+	internal TValue Value = default!;
+
+	/// <summary>
+	///     Whether <see cref="Value" /> has been assigned. Distinguishes "never stored" from "stored default".
+	/// </summary>
+	internal bool HasValue;
+
+	private IIndexerChildIndex? _childIndex;
+	private IndexerValueStorage<TValue>? _nullChild;
+
+	/// <inheritdoc cref="IndexerValueStorage.GetChildDispatch{TKey}(TKey)" />
+	public override IndexerValueStorage? GetChildDispatch<TKey>(TKey key) => GetChild(key);
+
+	/// <inheritdoc cref="IndexerValueStorage.GetOrAddChildDispatch{TKey}(TKey)" />
+	public override IndexerValueStorage GetOrAddChildDispatch<TKey>(TKey key) => GetOrAddChild(key);
+
+	/// <summary>
+	///     Returns the child node for the given <paramref name="key" />, or <see langword="null" /> if none exists.
+	/// </summary>
+	public IndexerValueStorage<TValue>? GetChild<TKey>(TKey key)
+	{
+		if (key is null)
+		{
+			return _nullChild;
+		}
+
+		// key was null-checked above, so TKey is effectively notnull here.
+		return GetChildNonNull(key!);
+	}
+
+	/// <summary>
+	///     Returns the child node for the given <paramref name="key" />, creating one if none exists.
+	/// </summary>
+	public IndexerValueStorage<TValue> GetOrAddChild<TKey>(TKey key)
+	{
+		if (key is null)
+		{
+			if (_nullChild is null)
+			{
+				Interlocked.CompareExchange(ref _nullChild, new IndexerValueStorage<TValue>(), null);
+			}
+
+			return _nullChild!;
+		}
+
+		return GetOrAddChildNonNull(key!);
+	}
+
+#pragma warning disable CS8714 // TKey on call sites above has been null-checked; the callers pass key! to satisfy notnull.
+	private IndexerValueStorage<TValue>? GetChildNonNull<TKey>(TKey key) where TKey : notnull
+	{
+		if (_childIndex is not IndexerChildIndex<TKey, TValue> typedIndex)
+		{
+			return null;
+		}
+
+		lock (typedIndex)
+		{
+			return typedIndex.TryGetValue(key, out IndexerValueStorage<TValue>? child) ? child : null;
+		}
+	}
+
+	private IndexerValueStorage<TValue> GetOrAddChildNonNull<TKey>(TKey key) where TKey : notnull
+	{
+		if (_childIndex is not IndexerChildIndex<TKey, TValue> typedIndex)
+		{
+			Interlocked.CompareExchange(ref _childIndex, new IndexerChildIndex<TKey, TValue>(), null);
+			typedIndex = (IndexerChildIndex<TKey, TValue>)_childIndex!;
+		}
+
+		lock (typedIndex)
+		{
+			if (!typedIndex.TryGetValue(key, out IndexerValueStorage<TValue>? child))
+			{
+				child = new IndexerValueStorage<TValue>();
+				typedIndex[key] = child;
+			}
+
+			return child;
+		}
+	}
+#pragma warning restore CS8714
+}

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -77,7 +77,13 @@ internal partial class MockSetups
 				slot = Interlocked.CompareExchange(ref storages[signatureIndex], created, null) ?? created;
 			}
 
-			return (IndexerValueStorage<TValue>)slot;
+			if (slot is not IndexerValueStorage<TValue> typed)
+			{
+				throw new InvalidOperationException(
+					$"Indexer storage at signature index {signatureIndex} was created as '{slot.GetType()}' but is being accessed as 'IndexerValueStorage<{typeof(TValue)}>'. This indicates a signature-index collision between distinct indexer signatures - please report a bug against the source generator.");
+			}
+
+			return typed;
 		}
 
 		private IndexerValueStorage?[] EnsureCapacity(int signatureIndex)

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -19,6 +19,7 @@ internal partial class MockSetups
 	{
 		private List<IndexerSetup>? _storage;
 		private IndexerValueStorage?[]? _valueStorages;
+		private readonly object _valueStoragesLock = new();
 
 		public int Count
 		{
@@ -54,8 +55,15 @@ internal partial class MockSetups
 		///     Returns the root value storage for the indexer signature at the given <paramref name="signatureIndex" />,
 		///     creating one if none exists. Grows the backing array on demand when not pre-initialised.
 		/// </summary>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="signatureIndex" /> is negative.</exception>
 		internal IndexerValueStorage<TValue> GetOrCreateStorage<TValue>(int signatureIndex)
 		{
+			if (signatureIndex < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(signatureIndex), signatureIndex,
+					"Signature index must be non-negative.");
+			}
+
 			IndexerValueStorage?[]? storages = _valueStorages;
 			if (storages is null || storages.Length <= signatureIndex)
 			{
@@ -74,7 +82,7 @@ internal partial class MockSetups
 
 		private IndexerValueStorage?[] EnsureCapacity(int signatureIndex)
 		{
-			lock (this)
+			lock (_valueStoragesLock)
 			{
 				IndexerValueStorage?[]? storages = _valueStorages;
 				if (storages is null)

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -18,7 +18,7 @@ internal partial class MockSetups
 	internal sealed class IndexerSetups
 	{
 		private List<IndexerSetup>? _storage;
-		private ValueStorage? _valueStorage;
+		private IndexerValueStorage?[]? _valueStorages;
 
 		public int Count
 		{
@@ -38,18 +38,61 @@ internal partial class MockSetups
 		}
 
 		/// <summary>
-		///     The root value storage used to track stored indexer values (keyed by parameter tree).
+		///     Pre-sizes the per-signature value-storage array. Optional — <see cref="GetOrCreateStorage{TValue}(int)" />
+		///     grows lazily if unset. When the total signature count is known at mock-construction time, calling this
+		///     once avoids any reallocations.
 		/// </summary>
-		public ValueStorage ValueStorage
+		internal void InitializeStorageCount(int count)
 		{
-			get
+			if (_valueStorages is null)
 			{
-				if (_valueStorage is null)
+				Interlocked.CompareExchange(ref _valueStorages, new IndexerValueStorage?[count], null);
+			}
+		}
+
+		/// <summary>
+		///     Returns the root value storage for the indexer signature at the given <paramref name="signatureIndex" />,
+		///     creating one if none exists. Grows the backing array on demand when not pre-initialised.
+		/// </summary>
+		internal IndexerValueStorage<TValue> GetOrCreateStorage<TValue>(int signatureIndex)
+		{
+			IndexerValueStorage?[]? storages = _valueStorages;
+			if (storages is null || storages.Length <= signatureIndex)
+			{
+				storages = EnsureCapacity(signatureIndex);
+			}
+
+			IndexerValueStorage? slot = storages[signatureIndex];
+			if (slot is null)
+			{
+				IndexerValueStorage<TValue> created = new();
+				slot = Interlocked.CompareExchange(ref storages[signatureIndex], created, null) ?? created;
+			}
+
+			return (IndexerValueStorage<TValue>)slot;
+		}
+
+		private IndexerValueStorage?[] EnsureCapacity(int signatureIndex)
+		{
+			lock (this)
+			{
+				IndexerValueStorage?[]? storages = _valueStorages;
+				if (storages is null)
 				{
-					Interlocked.CompareExchange(ref _valueStorage, new ValueStorage(), null);
+					storages = new IndexerValueStorage?[signatureIndex + 1];
+					_valueStorages = storages;
+					return storages;
 				}
 
-				return _valueStorage!;
+				if (storages.Length <= signatureIndex)
+				{
+					IndexerValueStorage?[] grown = new IndexerValueStorage?[signatureIndex + 1];
+					Array.Copy(storages, grown, storages.Length);
+					_valueStorages = grown;
+					return grown;
+				}
+
+				return storages;
 			}
 		}
 
@@ -157,65 +200,5 @@ internal partial class MockSetups
 					.ToList();
 			}
 		}
-	}
-}
-
-/// <summary>
-///     Object-keyed tree used to store indexer values by their typed parameter path.
-/// </summary>
-[DebuggerNonUserCode]
-internal sealed class ValueStorage
-{
-	private readonly List<KeyValueEntry> _storage = [];
-
-	/// <summary>
-	///     The value stored at the current tree node.
-	/// </summary>
-	public object? Value { get; set; }
-
-	/// <summary>
-	///     Returns the child storage for the given <paramref name="key" />, or <see langword="null" /> if none exists.
-	/// </summary>
-	public ValueStorage? GetChild(object? key)
-	{
-		lock (_storage)
-		{
-			foreach (KeyValueEntry entry in _storage)
-			{
-				if (Equals(entry.Key, key))
-				{
-					return entry.Value;
-				}
-			}
-		}
-
-		return null;
-	}
-
-	/// <summary>
-	///     Returns the child storage for the given <paramref name="key" />, or creates one if none exists.
-	/// </summary>
-	public ValueStorage GetOrAddChild(object? key)
-	{
-		lock (_storage)
-		{
-			foreach (KeyValueEntry entry in _storage)
-			{
-				if (Equals(entry.Key, key))
-				{
-					return entry.Value;
-				}
-			}
-
-			ValueStorage newValue = new();
-			_storage.Add(new KeyValueEntry(key, newValue));
-			return newValue;
-		}
-	}
-
-	private readonly struct KeyValueEntry(object? key, ValueStorage value)
-	{
-		internal object? Key { get; } = key;
-		internal ValueStorage Value { get; } = value;
 	}
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -196,12 +196,12 @@ namespace Mockolate
         public string Scenario { get; }
         public object? Wraps { get; }
         public void AddEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
-        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator) { }
-        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue) { }
-        public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value) { }
-        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup) { }
+        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator, int signatureIndex) { }
+        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue, int signatureIndex) { }
+        public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value, int signatureIndex) { }
+        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup, int signatureIndex) { }
         public void ClearAllInteractions() { }
-        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access) { }
+        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access, int signatureIndex) { }
         public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
@@ -212,10 +212,11 @@ namespace Mockolate
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSet<T, TValue>(T subject, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TValue>, bool> setPredicate, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
+        public void InitializeStorage(int indexerCount) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public void RegisterInteraction(Mockolate.Interactions.IInteraction interaction) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
-        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value) { }
+        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupEvent(string scenario, Mockolate.Setup.EventSetup eventSetup) { }
@@ -622,6 +623,7 @@ namespace Mockolate.Interactions
         public abstract int ParameterCount { get; }
         public abstract object? GetParameterValueAt(int index);
         public void StoreValue<T>(T value) { }
+        protected abstract Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing);
         public bool TryFindStoredValue<T>(out T value) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
@@ -633,6 +635,7 @@ namespace Mockolate.Interactions
         public string ParameterName1 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2> : Mockolate.Interactions.IndexerAccess
@@ -645,6 +648,7 @@ namespace Mockolate.Interactions
         public string ParameterName2 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2, T3> : Mockolate.Interactions.IndexerAccess
@@ -659,6 +663,7 @@ namespace Mockolate.Interactions
         public string ParameterName3 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2, T3, T4> : Mockolate.Interactions.IndexerAccess
@@ -675,6 +680,7 @@ namespace Mockolate.Interactions
         public string ParameterName4 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, TValue> : Mockolate.Interactions.IndexerAccess
@@ -686,6 +692,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, TValue> : Mockolate.Interactions.IndexerAccess
@@ -699,6 +706,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, T3, TValue> : Mockolate.Interactions.IndexerAccess
@@ -714,6 +722,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, T3, T4, TValue> : Mockolate.Interactions.IndexerAccess
@@ -731,6 +740,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MethodInvocation : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
@@ -1855,6 +1865,12 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
+    }
+    public abstract class IndexerValueStorage
+    {
+        protected IndexerValueStorage() { }
+        public abstract Mockolate.Setup.IndexerValueStorage? GetChildDispatch<TKey>(TKey key);
+        public abstract Mockolate.Setup.IndexerValueStorage GetOrAddChildDispatch<TKey>(TKey key);
     }
     public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVerifiableMethodSetup
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -195,12 +195,12 @@ namespace Mockolate
         public string Scenario { get; }
         public object? Wraps { get; }
         public void AddEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
-        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator) { }
-        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue) { }
-        public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value) { }
-        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup) { }
+        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator, int signatureIndex) { }
+        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue, int signatureIndex) { }
+        public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value, int signatureIndex) { }
+        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup, int signatureIndex) { }
         public void ClearAllInteractions() { }
-        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access) { }
+        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access, int signatureIndex) { }
         public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
@@ -211,10 +211,11 @@ namespace Mockolate
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSet<T, TValue>(T subject, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TValue>, bool> setPredicate, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
+        public void InitializeStorage(int indexerCount) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public void RegisterInteraction(Mockolate.Interactions.IInteraction interaction) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
-        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value) { }
+        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupEvent(string scenario, Mockolate.Setup.EventSetup eventSetup) { }
@@ -621,6 +622,7 @@ namespace Mockolate.Interactions
         public abstract int ParameterCount { get; }
         public abstract object? GetParameterValueAt(int index);
         public void StoreValue<T>(T value) { }
+        protected abstract Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing);
         public bool TryFindStoredValue<T>(out T value) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
@@ -632,6 +634,7 @@ namespace Mockolate.Interactions
         public string ParameterName1 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2> : Mockolate.Interactions.IndexerAccess
@@ -644,6 +647,7 @@ namespace Mockolate.Interactions
         public string ParameterName2 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2, T3> : Mockolate.Interactions.IndexerAccess
@@ -658,6 +662,7 @@ namespace Mockolate.Interactions
         public string ParameterName3 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2, T3, T4> : Mockolate.Interactions.IndexerAccess
@@ -674,6 +679,7 @@ namespace Mockolate.Interactions
         public string ParameterName4 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, TValue> : Mockolate.Interactions.IndexerAccess
@@ -685,6 +691,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, TValue> : Mockolate.Interactions.IndexerAccess
@@ -698,6 +705,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, T3, TValue> : Mockolate.Interactions.IndexerAccess
@@ -713,6 +721,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, T3, T4, TValue> : Mockolate.Interactions.IndexerAccess
@@ -730,6 +739,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MethodInvocation : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
@@ -1854,6 +1864,12 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
+    }
+    public abstract class IndexerValueStorage
+    {
+        protected IndexerValueStorage() { }
+        public abstract Mockolate.Setup.IndexerValueStorage? GetChildDispatch<TKey>(TKey key);
+        public abstract Mockolate.Setup.IndexerValueStorage GetOrAddChildDispatch<TKey>(TKey key);
     }
     public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVerifiableMethodSetup
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -182,12 +182,12 @@ namespace Mockolate
         public string Scenario { get; }
         public object? Wraps { get; }
         public void AddEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
-        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator) { }
-        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue) { }
-        public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value) { }
-        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup) { }
+        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, System.Func<TResult> defaultValueGenerator, int signatureIndex) { }
+        public TResult ApplyIndexerGetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult baseValue, int signatureIndex) { }
+        public bool ApplyIndexerSetter<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup? setup, TResult value, int signatureIndex) { }
+        public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup, int signatureIndex) { }
         public void ClearAllInteractions() { }
-        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access) { }
+        public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access, int signatureIndex) { }
         public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
@@ -198,10 +198,11 @@ namespace Mockolate
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSet<T, TValue>(T subject, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TValue>, bool> setPredicate, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
+        public void InitializeStorage(int indexerCount) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public void RegisterInteraction(Mockolate.Interactions.IInteraction interaction) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
-        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value) { }
+        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupEvent(string scenario, Mockolate.Setup.EventSetup eventSetup) { }
@@ -580,6 +581,7 @@ namespace Mockolate.Interactions
         public abstract int ParameterCount { get; }
         public abstract object? GetParameterValueAt(int index);
         public void StoreValue<T>(T value) { }
+        protected abstract Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing);
         public bool TryFindStoredValue<T>(out T value) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
@@ -591,6 +593,7 @@ namespace Mockolate.Interactions
         public string ParameterName1 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2> : Mockolate.Interactions.IndexerAccess
@@ -603,6 +606,7 @@ namespace Mockolate.Interactions
         public string ParameterName2 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2, T3> : Mockolate.Interactions.IndexerAccess
@@ -617,6 +621,7 @@ namespace Mockolate.Interactions
         public string ParameterName3 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerGetterAccess<T1, T2, T3, T4> : Mockolate.Interactions.IndexerAccess
@@ -633,6 +638,7 @@ namespace Mockolate.Interactions
         public string ParameterName4 { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, TValue> : Mockolate.Interactions.IndexerAccess
@@ -644,6 +650,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, TValue> : Mockolate.Interactions.IndexerAccess
@@ -657,6 +664,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, T3, TValue> : Mockolate.Interactions.IndexerAccess
@@ -672,6 +680,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class IndexerSetterAccess<T1, T2, T3, T4, TValue> : Mockolate.Interactions.IndexerAccess
@@ -689,6 +698,7 @@ namespace Mockolate.Interactions
         public TValue TypedValue { get; }
         public override object? GetParameterValueAt(int index) { }
         public override string ToString() { }
+        protected override Mockolate.Setup.IndexerValueStorage? TraverseStorage(Mockolate.Setup.IndexerValueStorage? storage, bool createMissing) { }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString()}")]
     public class MethodInvocation : Mockolate.Interactions.IInteraction, Mockolate.Interactions.IMethodInteraction
@@ -1809,6 +1819,12 @@ namespace Mockolate.Setup
         public Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
             where TException : System.Exception, new () { }
         public override string ToString() { }
+    }
+    public abstract class IndexerValueStorage
+    {
+        protected IndexerValueStorage() { }
+        public abstract Mockolate.Setup.IndexerValueStorage? GetChildDispatch<TKey>(TKey key);
+        public abstract Mockolate.Setup.IndexerValueStorage GetOrAddChildDispatch<TKey>(TKey key);
     }
     public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVerifiableMethodSetup
     {

--- a/Tests/Mockolate.Internal.Tests/IndexerSetupWhiteBoxTests.cs
+++ b/Tests/Mockolate.Internal.Tests/IndexerSetupWhiteBoxTests.cs
@@ -228,7 +228,7 @@ public sealed class IndexerSetupWhiteBoxTests
 				(IParameterMatch<T1>)It.IsAny<T1>(),
 				(IParameterMatch<T2>)It.IsAny<T2>())
 		{
-			private readonly ValueStorage _storage = new();
+			private readonly IndexerValueStorage<string> _storage = new();
 
 			public T DoGetResult<T>(
 				IndexerAccess indexerAccess, T value, MockBehavior? behavior = null)
@@ -362,7 +362,7 @@ public sealed class IndexerSetupWhiteBoxTests
 				(IParameterMatch<T2>)It.IsAny<T2>(),
 				(IParameterMatch<T3>)It.IsAny<T3>())
 		{
-			private readonly ValueStorage _storage = new();
+			private readonly IndexerValueStorage<string> _storage = new();
 
 			public T DoGetResult<T>(
 				IndexerAccess indexerAccess, T value, MockBehavior? behavior = null)
@@ -504,7 +504,7 @@ public sealed class IndexerSetupWhiteBoxTests
 				(IParameterMatch<T3>)It.IsAny<T3>(),
 				(IParameterMatch<T4>)It.IsAny<T4>())
 		{
-			private readonly ValueStorage _storage = new();
+			private readonly IndexerValueStorage<string> _storage = new();
 
 			public T DoGetResult<T>(
 				IndexerAccess indexerAccess, T value, MockBehavior? behavior = null)
@@ -656,7 +656,7 @@ public sealed class IndexerSetupWhiteBoxTests
 				(IParameterMatch<T4>)It.IsAny<T4>(),
 				(IParameterMatch<T5>)It.IsAny<T5>())
 		{
-			private readonly ValueStorage _storage = new();
+			private readonly IndexerValueStorage<string> _storage = new();
 
 			public T DoGetResult<T>(
 				IndexerAccess indexerAccess, T value, MockBehavior? behavior = null)
@@ -679,7 +679,7 @@ public sealed class IndexerSetupWhiteBoxTests
 			new MockRegistry(MockBehavior.Default),
 			(IParameterMatch<T1>)It.IsAny<T1>())
 	{
-		private readonly ValueStorage _storage = new();
+		private readonly IndexerValueStorage<string> _storage = new();
 
 		public T DoGetResult<T>(
 			IndexerAccess indexerAccess, T value, MockBehavior? behavior = null)

--- a/Tests/Mockolate.Internal.Tests/TestHelpers/FakeIndexerAccess.cs
+++ b/Tests/Mockolate.Internal.Tests/TestHelpers/FakeIndexerAccess.cs
@@ -1,4 +1,5 @@
 using Mockolate.Interactions;
+using Mockolate.Setup;
 
 namespace Mockolate.Internal.Tests.TestHelpers;
 
@@ -7,4 +8,6 @@ internal sealed class FakeIndexerAccess : IndexerAccess
 	public override int ParameterCount => 0;
 
 	public override object? GetParameterValueAt(int index) => null;
+
+	protected override IndexerValueStorage? TraverseStorage(IndexerValueStorage? storage, bool createMissing) => Storage;
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -75,11 +75,11 @@ public sealed partial class MockTests
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
-					          						? this.MockRegistry.GetIndexerFallback<int>(access)
-					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
+					          						? this.MockRegistry.GetIndexerFallback<int>(access, 0)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 0);
 					          				}
 					          				int baseResult = wraps[index];
-					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
+					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 0);
 					          			}
 					          			set
 					          			{
@@ -89,7 +89,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
-					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
+					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 0);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps[index] = value;
@@ -112,11 +112,11 @@ public sealed partial class MockTests
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
-					          						? this.MockRegistry.GetIndexerFallback<int>(access)
-					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
+					          						? this.MockRegistry.GetIndexerFallback<int>(access, 1)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 1);
 					          				}
 					          				int baseResult = wraps[index, isReadOnly];
-					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
+					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 1);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -132,7 +132,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(access);
-					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
+					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 2);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps[index, isWriteOnly] = value;
@@ -195,11 +195,11 @@ public sealed partial class MockTests
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
 					          					int baseResult = this.MockRegistry.Wraps is global::MyCode.MyService wraps ? wraps[index] : base[index];
-					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
+					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 0);
 					          				}
 					          				return setup is null
-					          					? this.MockRegistry.GetIndexerFallback<int>(access)
-					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
+					          					? this.MockRegistry.GetIndexerFallback<int>(access, 0)
+					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 0);
 					          			}
 					          			set
 					          			{
@@ -209,7 +209,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
-					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value))
+					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value, 0))
 					          				{
 					          					if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
 					          					{
@@ -238,11 +238,11 @@ public sealed partial class MockTests
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
 					          					int baseResult = base[index, isReadOnly];
-					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
+					          					return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 1);
 					          				}
 					          				return setup is null
-					          					? this.MockRegistry.GetIndexerFallback<int>(access)
-					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
+					          					? this.MockRegistry.GetIndexerFallback<int>(access, 1)
+					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 1);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -258,7 +258,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(access);
-					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value))
+					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value, 2))
 					          				{
 					          					base[index, isWriteOnly] = value;
 					          				}
@@ -279,8 +279,8 @@ public sealed partial class MockTests
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(access);
 					          				return setup is null
-					          					? this.MockRegistry.GetIndexerFallback<int>(access)
-					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
+					          					? this.MockRegistry.GetIndexerFallback<int>(access, 3)
+					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 3);
 					          			}
 					          			set
 					          			{
@@ -290,7 +290,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(access);
-					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
+					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 3);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle();
@@ -336,11 +336,11 @@ public sealed partial class MockTests
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
-					          						? this.MockRegistry.GetIndexerFallback<int>(access)
-					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
+					          						? this.MockRegistry.GetIndexerFallback<int>(access, 0)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 0);
 					          				}
 					          				int baseResult = wraps[buffer];
-					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
+					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 0);
 					          			}
 					          			set
 					          			{
@@ -350,7 +350,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(access);
-					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
+					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 0);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps[buffer] = value;
@@ -373,11 +373,11 @@ public sealed partial class MockTests
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
-					          						? this.MockRegistry.GetIndexerFallback<int>(access)
-					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup);
+					          						? this.MockRegistry.GetIndexerFallback<int>(access, 1)
+					          						: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 1);
 					          				}
 					          				int baseResult = wraps[values];
-					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult);
+					          				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 1);
 					          			}
 					          			set
 					          			{
@@ -387,7 +387,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(access);
-					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value);
+					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 1);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps[values] = value;

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.CombinedMockTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.CombinedMockTests.cs
@@ -1,0 +1,65 @@
+namespace Mockolate.Tests.MockIndexers;
+
+public sealed partial class SetupIndexerTests
+{
+	public sealed class CombinedMockTests
+	{
+		[Fact]
+		public async Task DistinctReturnTypes_SameParameterTypes_ShouldNotCollide()
+		{
+			IFooIndexer sut = IFooIndexer.CreateMock().Implementing<IBarIndexer>().Implementing<IBazIndexer>();
+			IBarIndexer barView = (IBarIndexer)sut;
+			IBazIndexer bazView = (IBazIndexer)sut;
+
+			sut[1] = "foo";
+			barView[1] = 42;
+			bazView[1] = 43;
+
+			await That(sut[1]).IsEqualTo("foo");
+			await That(barView[1]).IsEqualTo(42);
+			await That(bazView[1]).IsEqualTo(43);
+		}
+
+		[Fact]
+		public async Task VirtualClassIndexer_AndExplicitInterfaceImplWithSameSignature_ShouldNotCollide()
+		{
+			BaseWithVirtualIndexer sut = BaseWithVirtualIndexer.CreateMock().Implementing<IExplicitIndexer>();
+			IExplicitIndexer explicitView = (IExplicitIndexer)sut;
+
+			sut[1] = 100;
+			explicitView[1] = 200;
+
+			await That(sut[1]).IsEqualTo(100);
+			await That(explicitView[1]).IsEqualTo(200);
+		}
+
+		public class BaseWithVirtualIndexer
+		{
+			public virtual int this[int x]
+			{
+				get => 0;
+				set { }
+			}
+		}
+
+		public interface IExplicitIndexer
+		{
+			int this[int x] { get; set; }
+		}
+
+		public interface IFooIndexer
+		{
+			string this[int x] { get; set; }
+		}
+
+		public interface IBarIndexer
+		{
+			int this[int x] { get; set; }
+		}
+		
+		public interface IBazIndexer
+		{
+			int this[int x] { get; set; }
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -148,16 +148,9 @@ public sealed partial class SetupIndexerTests
 	public async Task ThreeLevels_WithoutSetup_ShouldStoreLastValue()
 	{
 		IIndexerService sut = IIndexerService.CreateMock();
-		MockRegistry registry = ((IMock)sut).MockRegistry;
 
 		int? result0 = sut["foo", 1, 2];
-		registry.SetIndexerValue<int?>(
-			new IndexerSetterAccess<string?, int, int, int?>(
-				"index1", "foo",
-				"index2", 1,
-				"index3", 2,
-				42),
-			42);
+		sut["foo", 1, 2] = 42;
 		int? result1 = sut["foo", 1, 2];
 		int? result2 = sut["bar", 1, 2];
 		int? result3 = sut["foo", 2, 2];
@@ -208,8 +201,10 @@ public sealed partial class SetupIndexerTests
 		IndexerSetup? stringSetup = registry.GetIndexerSetup<IndexerSetup>(s => true);
 		IndexerGetterAccess<int> access1 = new("index", 1);
 		IndexerGetterAccess<int> access2 = new("index", 1);
-		string result1 = registry.ApplyIndexerGetter<string>(access1, stringSetup, () => "");
-		int result2 = registry.ApplyIndexerGetter<int>(access2, stringSetup, () => 0);
+		string result1 = registry.ApplyIndexerGetter<string>(access1, stringSetup, () => "", 0);
+		// Use a different signature index for the int-typed access to avoid colliding with the
+		// string-typed storage slot created above: per-signature storage is now TValue-invariant.
+		int result2 = registry.ApplyIndexerGetter<int>(access2, stringSetup, () => 0, 100);
 
 		await That(result1).IsEqualTo("foo");
 		await That(result2).IsEqualTo(0);

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -215,8 +215,9 @@ public sealed partial class SetupIndexerTests
 		IndexerGetterAccess<int> access1 = new("index", 1);
 		IndexerGetterAccess<int> access2 = new("index", 1);
 		string result1 = registry.ApplyIndexerGetter<string>(access1, stringSetup, () => "", 0);
-		// Use a different signature index for the int-typed access to avoid colliding with the
-		// string-typed storage slot created above: per-signature storage is now TValue-invariant.
+		// Use a different signature index for the int-typed access: each per-signature storage slot
+		// is bound to a single TValue on first access (it is an IndexerValueStorage<TValue>), so
+		// reusing index 0 with TValue=int would now throw an InvalidOperationException.
 		int result2 = registry.ApplyIndexerGetter<int>(access2, stringSetup, () => 0, 100);
 
 		await That(result1).IsEqualTo("foo");

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -106,6 +106,19 @@ public sealed partial class SetupIndexerTests
 	}
 
 	[Fact]
+	public async Task StoredNullValue_ShouldNotFallBackToDefault()
+	{
+		IIndexerService sut = IIndexerService.CreateMock();
+
+		string resultBefore = sut[1];
+		sut[1] = null!;
+		string resultAfter = sut[1];
+
+		await That(resultBefore).IsNotNull();
+		await That(resultAfter).IsNull();
+	}
+
+	[Fact]
 	public async Task ShouldSupportNullAsParameter()
 	{
 		IIndexerService sut = IIndexerService.CreateMock();
@@ -419,6 +432,109 @@ public sealed partial class SetupIndexerTests
 
 			ISetup setup = await That(result).HasSingle();
 			await That(setup.ToString()).IsEqualTo("string this[1, 2, 3, 4, 5]");
+		}
+	}
+
+
+	public class NegativeArgumentValidation
+	{
+		[Fact]
+		public async Task InitializeStorage_WithNegativeCount_ShouldThrow()
+		{
+			IIndexerService sut = IIndexerService.CreateMock();
+			MockRegistry registry = ((IMock)sut).MockRegistry;
+
+			void Act()
+				=> registry.InitializeStorage(-1);
+
+			await That(Act).Throws<ArgumentOutOfRangeException>()
+				.WithParamName("indexerCount");
+		}
+
+		[Fact]
+		public async Task SetIndexerValue_WithNegativeSignatureIndex_ShouldThrow()
+		{
+			IIndexerService sut = IIndexerService.CreateMock();
+			MockRegistry registry = ((IMock)sut).MockRegistry;
+			IndexerGetterAccess<int> access = new("index", 1);
+
+			void Act()
+				=> registry.SetIndexerValue(access, "foo", -1);
+
+			await That(Act).Throws<ArgumentOutOfRangeException>()
+				.WithParamName("signatureIndex");
+		}
+
+		[Fact]
+		public async Task GetIndexerFallback_WithNegativeSignatureIndex_ShouldThrow()
+		{
+			IIndexerService sut = IIndexerService.CreateMock();
+			MockRegistry registry = ((IMock)sut).MockRegistry;
+			IndexerGetterAccess<int> access = new("index", 1);
+
+			void Act()
+				=> registry.GetIndexerFallback<string>(access, -1);
+
+			await That(Act).Throws<ArgumentOutOfRangeException>()
+				.WithParamName("signatureIndex");
+		}
+
+		[Fact]
+		public async Task ApplyIndexerSetup_WithNegativeSignatureIndex_ShouldThrow()
+		{
+			IIndexerService sut = IIndexerService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()].Returns("foo");
+			MockRegistry registry = ((IMock)sut).MockRegistry;
+			IndexerSetup setup = registry.GetIndexerSetup<IndexerSetup>(s => true)!;
+			IndexerGetterAccess<int> access = new("index", 1);
+
+			void Act()
+				=> registry.ApplyIndexerSetup<string>(access, setup, -1);
+
+			await That(Act).Throws<ArgumentOutOfRangeException>()
+				.WithParamName("signatureIndex");
+		}
+
+		[Fact]
+		public async Task ApplyIndexerGetter_WithBaseValue_WithNegativeSignatureIndex_ShouldThrow()
+		{
+			IIndexerService sut = IIndexerService.CreateMock();
+			MockRegistry registry = ((IMock)sut).MockRegistry;
+			IndexerGetterAccess<int> access = new("index", 1);
+
+			void Act()
+				=> registry.ApplyIndexerGetter<string>(access, null, "base", -1);
+
+			await That(Act).Throws<ArgumentOutOfRangeException>()
+				.WithParamName("signatureIndex");
+		}
+
+		[Fact]
+		public async Task ApplyIndexerGetter_WithGenerator_WithNegativeSignatureIndex_ShouldThrow()
+		{
+			IIndexerService sut = IIndexerService.CreateMock();
+			MockRegistry registry = ((IMock)sut).MockRegistry;
+			IndexerGetterAccess<int> access = new("index", 1);
+
+			void Act()
+				=> registry.ApplyIndexerGetter<string>(access, null, () => "base", -1);
+
+			await That(Act).Throws<ArgumentOutOfRangeException>()
+				.WithParamName("signatureIndex");
+		}
+
+		[Fact]
+		public async Task ApplyIndexerSetter_WithNegativeSignatureIndex_ShouldThrow()
+		{
+			IIndexerService sut = IIndexerService.CreateMock();
+			MockRegistry registry = ((IMock)sut).MockRegistry;
+			IndexerSetterAccess<int, string> access = new("index", 1, "foo");
+
+			void Act()
+				=> registry.ApplyIndexerSetter<string>(access, null, "foo", -1);
+
+			await That(Act).Throws<ArgumentOutOfRangeException>()
+				.WithParamName("signatureIndex");
 		}
 	}
 


### PR DESCRIPTION
This PR refactors indexer value storage to use typed, per-signature storage slots (indexed by an `int` signature index) to improve performance and reduce boxing, and updates generators/tests accordingly.

**Changes:**
- Replace the old object-keyed `ValueStorage` tree with a typed `IndexerValueStorage<TValue>` implementation and per-signature storage array.
- Update `MockRegistry` indexer APIs and source-generated indexer bodies to thread a `signatureIndex` through getter/setter/fallback flows.
- Refresh affected unit tests, generator snapshot tests, API baselines, and benchmarks.