### PR TITLE
feat: forward events to base class when not skipped

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -11,6 +11,7 @@ internal record Event
 	{
 		Accessibility = eventSymbol.DeclaredAccessibility;
 		UseOverride = eventSymbol.IsVirtual || eventSymbol.IsAbstract;
+		IsAbstract = eventSymbol.IsAbstract;
 		Name = eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name;
 		Type = new Type(eventSymbol.Type);
 		ContainingType = eventSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
@@ -41,6 +42,7 @@ internal record Event
 	public Type Type { get; }
 	public string ContainingType { get; }
 	public bool UseOverride { get; }
+	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
 	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal;
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1342,6 +1342,7 @@ internal static partial class Sources
 		sb.AppendLine("\t\t{");
 		bool supportsWrapping = @event is { IsStatic: false, IsProtected: false, ExplicitImplementation: null, } &&
 		                        !explicitInterfaceImplementation;
+		bool supportsBaseForwarding = supportsWrapping && !isClassInterface && @event.UseOverride && !@event.IsAbstract;
 		if (supportsWrapping)
 		{
 			sb.Append("\t\t\tadd").AppendLine();
@@ -1354,6 +1355,14 @@ internal static partial class Sources
 			sb.Append("\t\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\t\twraps.").Append(@event.Name).Append(" += value;").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
+			if (supportsBaseForwarding)
+			{
+				sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".Behavior.SkipBaseClass)").AppendLine();
+				sb.Append("\t\t\t\t{").AppendLine();
+				sb.Append("\t\t\t\t\tbase.").Append(@event.Name).Append(" += value;").AppendLine();
+				sb.Append("\t\t\t\t}").AppendLine();
+			}
+
 			sb.Append("\t\t\t}").AppendLine();
 			sb.Append("\t\t\tremove").AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
@@ -1365,6 +1374,14 @@ internal static partial class Sources
 			sb.Append("\t\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\t\twraps.").Append(@event.Name).Append(" -= value;").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
+			if (supportsBaseForwarding)
+			{
+				sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".Behavior.SkipBaseClass)").AppendLine();
+				sb.Append("\t\t\t\t{").AppendLine();
+				sb.Append("\t\t\t\t\tbase.").Append(@event.Name).Append(" -= value;").AppendLine();
+				sb.Append("\t\t\t\t}").AppendLine();
+			}
+
 			sb.Append("\t\t\t}").AppendLine();
 		}
 		else

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
@@ -358,6 +358,10 @@ public sealed partial class MockTests
 					          				{
 					          					wraps.SomeEvent += value;
 					          				}
+					          				if (!this.MockRegistry.Behavior.SkipBaseClass)
+					          				{
+					          					base.SomeEvent += value;
+					          				}
 					          			}
 					          			remove
 					          			{
@@ -366,6 +370,10 @@ public sealed partial class MockTests
 					          				if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
 					          				{
 					          					wraps.SomeEvent -= value;
+					          				}
+					          				if (!this.MockRegistry.Behavior.SkipBaseClass)
+					          				{
+					          					base.SomeEvent -= value;
 					          				}
 					          			}
 					          		}

--- a/Tests/Mockolate.Tests/MockEvents/InteractionsTests.ThrowingBaseTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/InteractionsTests.ThrowingBaseTests.cs
@@ -1,0 +1,147 @@
+namespace Mockolate.Tests.MockEvents;
+
+public sealed partial class InteractionsTests
+{
+	public sealed class ThrowingBaseTests
+	{
+		[Fact]
+		public async Task BaseClass_InvokesEvent_AfterUnsubscribe_ShouldNotForwardToSubscribers()
+		{
+			BroadcastingService sut = BroadcastingService.CreateMock();
+			int received = -1;
+
+			void Handler(int value)
+			{
+				received = value;
+			}
+
+			sut.Ping += Handler;
+			sut.Ping -= Handler;
+			sut.TriggerPing(42);
+
+			await That(received).IsEqualTo(-1);
+		}
+
+		[Fact]
+		public async Task BaseClass_InvokesEvent_ShouldForwardToSubscribers()
+		{
+			BroadcastingService sut = BroadcastingService.CreateMock();
+			int received = -1;
+			sut.Ping += value => received = value;
+
+			sut.TriggerPing(42);
+
+			await That(received).IsEqualTo(42);
+		}
+
+		[Fact]
+		public async Task BaseClass_InvokesEvent_WhenSkipBaseClass_ShouldNotForwardToSubscribers()
+		{
+			BroadcastingService sut = BroadcastingService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+			int received = -1;
+			sut.Ping += value => received = value;
+
+			sut.TriggerPing(42);
+
+			await That(received).IsEqualTo(-1);
+		}
+
+		[Fact]
+		public async Task
+			EventSubscribe_WhenBaseClassThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordSubscription()
+		{
+			ThrowingBaseEventService
+				sut = ThrowingBaseEventService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act()
+			{
+				sut.SomeEvent += Handler;
+			}
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify.SomeEvent.Subscribed()).Once();
+
+			static void Handler(int value)
+			{
+			}
+		}
+
+		[Fact]
+		public async Task EventSubscribe_WhenBaseClassThrows_ShouldStillRecordSubscription()
+		{
+			ThrowingBaseEventService sut = ThrowingBaseEventService.CreateMock();
+
+			void Act()
+			{
+				sut.SomeEvent += Handler;
+			}
+
+			await That(Act).Throws<InvalidOperationException>().WithMessage("base add throws");
+			await That(sut.Mock.Verify.SomeEvent.Subscribed()).Once();
+
+			static void Handler(int value)
+			{
+			}
+		}
+
+		[Fact]
+		public async Task
+			EventUnsubscribe_WhenBaseClassThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordUnsubscription()
+		{
+			ThrowingBaseEventService
+				sut = ThrowingBaseEventService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act()
+			{
+				sut.SomeEvent -= Handler;
+			}
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify.SomeEvent.Unsubscribed()).Once();
+
+			static void Handler(int value)
+			{
+			}
+		}
+
+		[Fact]
+		public async Task EventUnsubscribe_WhenBaseClassThrows_ShouldStillRecordUnsubscription()
+		{
+			ThrowingBaseEventService sut = ThrowingBaseEventService.CreateMock();
+
+			void Act()
+			{
+				sut.SomeEvent -= Handler;
+			}
+
+			await That(Act).Throws<InvalidOperationException>().WithMessage("base remove throws");
+			await That(sut.Mock.Verify.SomeEvent.Unsubscribed()).Once();
+
+			static void Handler(int value)
+			{
+			}
+		}
+
+		public delegate void ThrowingBaseEventHandler(int value);
+
+		public class ThrowingBaseEventService
+		{
+#pragma warning disable CA1070
+			public virtual event ThrowingBaseEventHandler? SomeEvent
+			{
+				add => throw new InvalidOperationException("base add throws");
+				remove => throw new InvalidOperationException("base remove throws");
+			}
+#pragma warning restore CA1070
+		}
+
+		public delegate void PingDelegate(int value);
+
+		public class BroadcastingService
+		{
+			public virtual event PingDelegate? Ping;
+
+			public void TriggerPing(int value) => Ping?.Invoke(value);
+		}
+	}
+}

--- a/Tests/Mockolate.Tests/MockEvents/InteractionsTests.ThrowingBaseTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/InteractionsTests.ThrowingBaseTests.cs
@@ -139,7 +139,9 @@ public sealed partial class InteractionsTests
 
 		public class BroadcastingService
 		{
+			#pragma warning disable CA1070
 			public virtual event PingDelegate? Ping;
+			#pragma warning restore CA1070
 
 			public void TriggerPing(int value) => Ping?.Invoke(value);
 		}

--- a/Tests/Mockolate.Tests/MockIndexers/InteractionsTests.ThrowingBaseTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/InteractionsTests.ThrowingBaseTests.cs
@@ -292,6 +292,28 @@ public sealed partial class InteractionsTests
 			await That(v5.Values).HasSingle().Which.IsEqualTo(5);
 		}
 
+		[Fact]
+		public async Task IndexerGetter_WhenBaseThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordAccess()
+		{
+			ThrowingBaseIndexerService sut = ThrowingBaseIndexerService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act() => _ = sut[1];
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify[1].Got()).Once();
+		}
+
+		[Fact]
+		public async Task IndexerSetter_WhenBaseThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordAccess()
+		{
+			ThrowingBaseIndexerService sut = ThrowingBaseIndexerService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act() => sut[1] = "value";
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify[1].Set("value")).Once();
+		}
+
 		public class ThrowingBaseIndexerService
 		{
 			public virtual string this[int p1]

--- a/Tests/Mockolate.Tests/MockMethods/InteractionsTests.ThrowingBaseTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/InteractionsTests.ThrowingBaseTests.cs
@@ -316,6 +316,28 @@ public sealed partial class InteractionsTests
 			await That(v5.Values).HasSingle().Which.IsEqualTo(5);
 		}
 
+		[Fact]
+		public async Task VoidMethod_WhenBaseThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordInvocation()
+		{
+			ThrowingBaseService sut = ThrowingBaseService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act() => sut.VoidMethodWith0Parameters();
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify.VoidMethodWith0Parameters()).Once();
+		}
+
+		[Fact]
+		public async Task ReturnMethod_WhenBaseThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordInvocation()
+		{
+			ThrowingBaseService sut = ThrowingBaseService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act() => sut.ReturnMethodWith0Parameters();
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify.ReturnMethodWith0Parameters()).Once();
+		}
+
 		public class ThrowingBaseService
 		{
 			public virtual void VoidMethodWith0Parameters()

--- a/Tests/Mockolate.Tests/MockProperties/InteractionsTests.ThrowingBaseTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/InteractionsTests.ThrowingBaseTests.cs
@@ -52,6 +52,28 @@ public sealed partial class InteractionsTests
 			await That(receivedValue).IsEqualTo(42);
 		}
 
+		[Fact]
+		public async Task VirtualPropertyGetter_WhenBaseThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordAccess()
+		{
+			ThrowingBaseService sut = ThrowingBaseService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act() => _ = sut.Value;
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify.Value.Got()).Once();
+		}
+
+		[Fact]
+		public async Task VirtualPropertySetter_WhenBaseThrows_AndSkipBaseClass_ShouldNotThrow_AndShouldRecordAccess()
+		{
+			ThrowingBaseService sut = ThrowingBaseService.CreateMock(MockBehavior.Default.SkippingBaseClass());
+
+			void Act() => sut.Value = 42;
+
+			await That(Act).DoesNotThrow();
+			await That(sut.Mock.Verify.Value.Set(It.Is(42))).Once();
+		}
+
 		public class ThrowingBaseService
 		{
 			public virtual int Value


### PR DESCRIPTION
This PR updates Mockolate’s class-mock event generation so that virtual events forward subscriptions/unsubscriptions to the base class when base calls are not being skipped, ensuring base-class event invocations reach subscribers (consistent with non-skipped base behavior for other member types).

**Changes:**
- Update the source generator to forward virtual, non-abstract class event `add/remove` to `base` when `SkipBaseClass` is false.
- Extend the generator’s `Event` entity model with an `IsAbstract` flag to support the forwarding condition.
- Add/extend tests across events/methods/properties/indexers and update generator baseline expectations to cover the new behavior and SkipBaseClass scenarios.