### PR TITLE
refactor: rename `InvocationCount` to `N` in benchmarks

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -13,12 +13,12 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with an indexer, setup the indexer and verify
-///     the getter was called exactly <see cref="InvocationCount" /> times.
+///     the getter was called exactly <see cref="N" /> times.
 /// </summary>
 public class CompleteIndexerBenchmarks : BenchmarksBase
 {
 	[Params(1, 10)]
-	public int InvocationCount { get; set; }
+	public int N { get; set; }
 
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
@@ -29,12 +29,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface sut = IMyIndexerInterface.CreateMock();
 		sut.Mock.Setup[It.IsAny<int>()].Returns("foo");
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = sut[42];
 		}
 
-		sut.Mock.Verify[It.IsAny<int>()].Got().Exactly(InvocationCount);
+		sut.Mock.Verify[It.IsAny<int>()].Got().Exactly(N);
 	}
 
 	/// <summary>
@@ -47,12 +47,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		mock.Setup(x => x[Moq.It.IsAny<int>()]).Returns("foo");
 		IMyIndexerInterface sut = mock.Object;
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = sut[42];
 		}
 
-		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Exactly(InvocationCount));
+		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Exactly(N));
 	}
 
 	/// <summary>
@@ -64,12 +64,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface mock = Substitute.For<IMyIndexerInterface>();
 		mock[Arg.Any<int>()].Returns("foo");
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = mock[42];
 		}
 
-		_ = mock.Received(InvocationCount)[Arg.Any<int>()];
+		_ = mock.Received(N)[Arg.Any<int>()];
 	}
 
 	/// <summary>
@@ -81,12 +81,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		IMyIndexerInterface mock = A.Fake<IMyIndexerInterface>();
 		A.CallTo(() => mock[A<int>.Ignored]).Returns("foo");
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = mock[42];
 		}
 
-		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -99,12 +99,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Returns("foo");
 		IMyIndexerInterface sut = imposter.Instance();
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = sut[42];
 		}
 
-		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(InvocationCount));
+		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(N));
 	}
 
 	/* Indexers not supported on TUnit.Mocks
@@ -117,12 +117,12 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		TUnit.Mocks.Mock<IMyIndexerInterface> mock = TUnit.Mocks.Mock.Of<IMyIndexerInterface>();
 		mock[Any<int>()].Returns("foo");
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = mock.Object[42];
 		}
 
-		mock[Any<int>()].WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
+		mock[Any<int>()].WasCalled(TUnit.Mocks.Times.Exactly(N));
 	}
 	*/
 

--- a/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
@@ -13,12 +13,12 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the simple case of an interface mock, setup a single method that gets called and
-///     verified to be called exactly <see cref="InvocationCount" /> times.
+///     verified to be called exactly <see cref="N" /> times.
 /// </summary>
 public class CompleteMethodBenchmarks : BenchmarksBase
 {
 	[Params(1, 10)]
-	public int InvocationCount { get; set; }
+	public int N { get; set; }
 
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
@@ -29,12 +29,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface sut = IMyMethodInterface.CreateMock();
 		sut.Mock.Setup.MyFunc(It.IsAny<int>()).Returns(true);
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			sut.MyFunc(42);
 		}
 
-		sut.Mock.Verify.MyFunc(It.IsAny<int>()).Exactly(InvocationCount);
+		sut.Mock.Verify.MyFunc(It.IsAny<int>()).Exactly(N);
 	}
 
 	/// <summary>
@@ -47,12 +47,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		mock.Setup(x => x.MyFunc(Moq.It.IsAny<int>())).Returns(true);
 		IMyMethodInterface sut = mock.Object;
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			sut.MyFunc(42);
 		}
 
-		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Times.Exactly(InvocationCount));
+		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Times.Exactly(N));
 	}
 
 	/// <summary>
@@ -64,12 +64,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface mock = Substitute.For<IMyMethodInterface>();
 		mock.MyFunc(Arg.Any<int>()).Returns(true);
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			mock.MyFunc(42);
 		}
 
-		mock.Received(InvocationCount).MyFunc(Arg.Any<int>());
+		mock.Received(N).MyFunc(Arg.Any<int>());
 	}
 
 	/// <summary>
@@ -81,12 +81,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		IMyMethodInterface mock = A.Fake<IMyMethodInterface>();
 		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).Returns(true);
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			mock.MyFunc(42);
 		}
 
-		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -99,12 +99,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Returns(true);
 		IMyMethodInterface sut = imposter.Instance();
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			sut.MyFunc(42);
 		}
 
-		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(InvocationCount));
+		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(N));
 	}
 
 	/// <summary>
@@ -117,12 +117,12 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		mock.MyFunc(Any<int>()).Returns(true);
 		IMyMethodInterface sut = mock.Object;
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			sut.MyFunc(42);
 		}
 
-		mock.MyFunc(Any<int>()).WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
+		mock.MyFunc(Any<int>()).WasCalled(TUnit.Mocks.Times.Exactly(N));
 	}
 
 	public interface IMyMethodInterface

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -12,12 +12,12 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with a property, setup the property and verify
-///     the getter was called exactly <see cref="InvocationCount" /> times.
+///     the getter was called exactly <see cref="N" /> times.
 /// </summary>
 public class CompletePropertyBenchmarks : BenchmarksBase
 {
 	[Params(1, 10)]
-	public int InvocationCount { get; set; }
+	public int N { get; set; }
 
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
@@ -28,12 +28,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface sut = IMyPropertyInterface.CreateMock();
 		sut.Mock.Setup.Counter.InitializeWith(42);
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
 		}
 
-		sut.Mock.Verify.Counter.Got().Exactly(InvocationCount);
+		sut.Mock.Verify.Counter.Got().Exactly(N);
 	}
 
 	/// <summary>
@@ -46,12 +46,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		mock.SetupGet(x => x.Counter).Returns(42);
 		IMyPropertyInterface sut = mock.Object;
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
 		}
 
-		mock.VerifyGet(x => x.Counter, Times.Exactly(InvocationCount));
+		mock.VerifyGet(x => x.Counter, Times.Exactly(N));
 	}
 
 	/// <summary>
@@ -63,12 +63,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface mock = Substitute.For<IMyPropertyInterface>();
 		mock.Counter.Returns(42);
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = mock.Counter;
 		}
 
-		_ = mock.Received(InvocationCount).Counter;
+		_ = mock.Received(N).Counter;
 	}
 
 	/// <summary>
@@ -80,12 +80,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		IMyPropertyInterface mock = A.Fake<IMyPropertyInterface>();
 		A.CallTo(() => mock.Counter).Returns(42);
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = mock.Counter;
 		}
 
-		A.CallTo(() => mock.Counter).MustHaveHappened(InvocationCount, FakeItEasy.Times.Exactly);
+		A.CallTo(() => mock.Counter).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -98,12 +98,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		imposter.Counter.Getter().Returns(42);
 		IMyPropertyInterface sut = imposter.Instance();
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
 		}
 
-		imposter.Counter.Getter().Called(Count.Exactly(InvocationCount));
+		imposter.Counter.Getter().Called(Count.Exactly(N));
 	}
 
 	/// <summary>
@@ -116,12 +116,12 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		mock.Counter.Returns(42);
 		IMyPropertyInterface sut = mock.Object;
 
-		for (int i = 0; i < InvocationCount; i++)
+		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
 		}
 
-		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(InvocationCount));
+		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(N));
 	}
 
 	public interface IMyPropertyInterface


### PR DESCRIPTION
This PR refactors the BenchmarkDotNet parameter name used in the “complete” benchmarks to improve the readability of benchmark tables in GitHub-rendered output (by renaming `InvocationCount` to the conventional `N`).

**Changes:**
- Renamed the `[Params]` property `InvocationCount` → `N` in complete property/method/indexer benchmarks.
- Updated loops, verification calls, and XML docs (`<see cref=.../>`) to reference `N`.