### PR TITLE
fix: callback invocations for methods with 5+ parameters

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -659,12 +659,6 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t\t\t_ => true,").AppendLine();
 		sb.Append("\t\t\t\t\t};").AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t\t/// <inheritdoc cref=\"VoidMethodSetup{").Append(typeParams).Append("}.TriggerCallbacks(").Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i}"))).Append(")\" />").AppendLine();
-		sb.Append("\t\t\tpublic override void TriggerCallbacks(").Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i} parameter{i}"))).Append(")").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t// No callbacks get triggered for IParameters").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.AppendLine();
 		sb.Append("\t\t\t/// <inheritdoc cref=\"object.ToString()\" />").AppendLine();
 		sb.Append("\t\t\tpublic override string ToString()").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallbackTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.CallbackTests.cs
@@ -1557,6 +1557,51 @@ public sealed partial class SetupMethodTests
 		public class ReturnMethodWith5Parameters
 		{
 			[Fact]
+			public async Task AnyParameters_Callback_ShouldExecuteWhenInvoked()
+			{
+				int callCount = 0;
+				IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
+
+				sut.Mock.Setup.UniqueMethodWith5Parameters(Match.AnyParameters())
+					.Do(() => { callCount++; })
+					.Returns("a");
+
+				sut.UniqueMethodWith5Parameters(1, 2, 3, 4, 5);
+
+				await That(callCount).IsEqualTo(1);
+			}
+
+			[Fact]
+			public async Task AnyParameters_CallbackWithValue_ShouldReceiveAllParameters()
+			{
+				int receivedValue1 = 0;
+				int receivedValue2 = 0;
+				int receivedValue3 = 0;
+				int receivedValue4 = 0;
+				int receivedValue5 = 0;
+				IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
+
+				sut.Mock.Setup.UniqueMethodWith5Parameters(Match.AnyParameters())
+					.Do((v1, v2, v3, v4, v5) =>
+					{
+						receivedValue1 = v1;
+						receivedValue2 = v2;
+						receivedValue3 = v3;
+						receivedValue4 = v4;
+						receivedValue5 = v5;
+					})
+					.Returns("a");
+
+				sut.UniqueMethodWith5Parameters(2, 4, 6, 8, 10);
+
+				await That(receivedValue1).IsEqualTo(2);
+				await That(receivedValue2).IsEqualTo(4);
+				await That(receivedValue3).IsEqualTo(6);
+				await That(receivedValue4).IsEqualTo(8);
+				await That(receivedValue5).IsEqualTo(10);
+			}
+
+			[Fact]
 			public async Task Callback_ShouldExecuteWhenInvoked()
 			{
 				int callCount = 0;
@@ -3412,6 +3457,49 @@ public sealed partial class SetupMethodTests
 
 		public class VoidMethodWith5Parameters
 		{
+			[Fact]
+			public async Task AnyParameters_Callback_ShouldExecuteWhenInvoked()
+			{
+				int callCount = 0;
+				IVoidMethodSetupTest sut = IVoidMethodSetupTest.CreateMock();
+
+				sut.Mock.Setup.UniqueMethodWith5Parameters(Match.AnyParameters())
+					.Do(() => { callCount++; });
+
+				sut.UniqueMethodWith5Parameters(1, 2, 3, 4, 5);
+
+				await That(callCount).IsEqualTo(1);
+			}
+
+			[Fact]
+			public async Task AnyParameters_CallbackWithValue_ShouldReceiveAllParameters()
+			{
+				int receivedValue1 = 0;
+				int receivedValue2 = 0;
+				int receivedValue3 = 0;
+				int receivedValue4 = 0;
+				int receivedValue5 = 0;
+				IVoidMethodSetupTest sut = IVoidMethodSetupTest.CreateMock();
+
+				sut.Mock.Setup.UniqueMethodWith5Parameters(Match.AnyParameters())
+					.Do((v1, v2, v3, v4, v5) =>
+					{
+						receivedValue1 = v1;
+						receivedValue2 = v2;
+						receivedValue3 = v3;
+						receivedValue4 = v4;
+						receivedValue5 = v5;
+					});
+
+				sut.UniqueMethodWith5Parameters(2, 4, 6, 8, 10);
+
+				await That(receivedValue1).IsEqualTo(2);
+				await That(receivedValue2).IsEqualTo(4);
+				await That(receivedValue3).IsEqualTo(6);
+				await That(receivedValue4).IsEqualTo(8);
+				await That(receivedValue5).IsEqualTo(10);
+			}
+
 			[Fact]
 			public async Task Callback_ShouldExecuteWhenInvoked()
 			{

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -1946,6 +1946,7 @@ public sealed partial class SetupMethodTests
 		string Method5WithOutParameter(out int p1, out int p2, out int p3, out int p4, out int p5);
 		string Method5WithRefParameter(ref int p1, ref int p2, ref int p3, ref int p4, ref int p5);
 		string UniqueMethodWithParameters(int p1, int p2);
+		string UniqueMethodWith5Parameters(int p1, int p2, int p3, int p4, int p5);
 	}
 
 	public class ReturnMethodSetupTest
@@ -1994,6 +1995,7 @@ public sealed partial class SetupMethodTests
 		void Method5WithOutParameter(out int p1, out int p2, out int p3, out int p4, out int p5);
 		void Method5WithRefParameter(ref int p1, ref int p2, ref int p3, ref int p4, ref int p5);
 		void UniqueMethodWithParameters(int p1, int p2);
+		void UniqueMethodWith5Parameters(int p1, int p2, int p3, int p4, int p5);
 	}
 
 #if DEBUG // TODO: re-enable after https://github.com/dotnet/sdk/issues/52579 is fixed


### PR DESCRIPTION
Fixes a bug where callbacks configured via `.Do(...)` were not being invoked when setting up **void methods with 5+ parameters** using `Match.AnyParameters()`.

**Changes:**
- Added regression tests ensuring `.Do(...)` callbacks execute (and receive all parameters) for both void and return methods with 5 parameters when using `Match.AnyParameters()`.
- Updated the source generator to stop emitting a `TriggerCallbacks(...)` override for `VoidMethodSetup.WithParameters` that previously prevented callbacks from running.