### PR TITLE
docs: enhance XML-doc comments

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
@@ -89,10 +89,17 @@ internal static partial class Sources
 		              	extension(global::Mockolate.Mock.IMockGenerationDidNotRun _)
 		              	{
 		              		/// <summary>
-		              		///     Add an interface <typeparamref name="TInterface" /> that the mock also implements.
+		              		///     Fallback <c>Implementing</c> that is only resolved when the Mockolate source generator did not run or when
+		              		///     <typeparamref name="TInterface" /> is not mockable. Calling it always throws a <see cref="global::Mockolate.Exceptions.MockException" />.
 		              		/// </summary>
 		              		/// <typeparam name="TInterface">Additional interface the mock should implement.</typeparam>
-		              		/// <returns>The same mock, typed so that <typeparamref name="TInterface" /> members are accessible.</returns>
+		              		/// <returns>This method never returns - it always throws.</returns>
+		              		/// <remarks>
+		              		///     The source generator emits a concrete <c>Implementing</c> overload per mockable type with the same shape.
+		              		///     If you see this fallback resolved in your IDE, the generator did not run for <typeparamref name="TInterface" />;
+		              		///     run a clean build (for example <c>dotnet clean &amp;&amp; dotnet build</c>) and verify that the type is mockable.
+		              		/// </remarks>
+		              		/// <exception cref="global::Mockolate.Exceptions.MockException">Always thrown: the source generator did not run or <typeparamref name="TInterface" /> is not mockable.</exception>
 		              		public global::Mockolate.Mock.IMockGenerationDidNotRun Implementing<TInterface>() where TInterface : class
 		              		{
 		              			throw new global::Mockolate.Exceptions.MockException($"This method should not be called directly. Either '{typeof(TInterface)}' is not mockable or the source generator did not run correctly.");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
@@ -49,22 +49,37 @@ internal static partial class Sources
 		              	extension<T>(T _)
 		              	{
 		              		/// <summary>
-		              		///     Create a new mock of <typeparamref name="T" /> with the given <paramref name="mockBehavior" />.
+		              		///     Fallback <c>CreateMock</c> that is only resolved when the Mockolate source generator did not run or when
+		              		///     <typeparamref name="T" /> is not mockable. Calling it always throws a <see cref="global::Mockolate.Exceptions.MockException" />.
 		              		/// </summary>
+		              		/// <typeparam name="T">Type to mock, which can be an interface or a class.</typeparam>
+		              		/// <param name="mockBehavior">Ignored; reserved for the generator-emitted overload.</param>
+		              		/// <returns>This method never returns - it always throws.</returns>
 		              		/// <remarks>
-		              		///     Any interface type can be used for mocking, but for classes, only abstract and virtual members can be mocked.
+		              		///     The source generator emits a concrete <c>CreateMock</c> overload per mockable type with the same shape.
+		              		///     If you see this fallback resolved in your IDE, the generator did not run for <typeparamref name="T" />;
+		              		///     run a clean build (for example <c>dotnet clean &amp;&amp; dotnet build</c>) and verify that the type is mockable.
 		              		/// </remarks>
+		              		/// <exception cref="global::Mockolate.Exceptions.MockException">Always thrown: the source generator did not run or <typeparamref name="T" /> is not mockable.</exception>
 		              		public static global::Mockolate.Mock.IMockGenerationDidNotRun CreateMock(global::Mockolate.MockBehavior? mockBehavior = null)
 		              		{
 		              			throw new global::Mockolate.Exceptions.MockException($"This method should not be called directly. Either '{typeof(T)}' is not mockable or the source generator did not run correctly.");
 		              		}
 
 		              		/// <summary>
-		              		///     Create a new mock of <typeparamref name="T" /> using the <paramref name="constructorParameters" /> with the given <paramref name="mockBehavior" />.
+		              		///     Fallback <c>CreateMock</c> that is only resolved when the Mockolate source generator did not run or when
+		              		///     <typeparamref name="T" /> is not mockable. Calling it always throws a <see cref="global::Mockolate.Exceptions.MockException" />.
 		              		/// </summary>
+		              		/// <typeparam name="T">Type to mock, which can be an interface or a class.</typeparam>
+		              		/// <param name="constructorParameters">Ignored; reserved for the generator-emitted overload.</param>
+		              		/// <param name="mockBehavior">Ignored; reserved for the generator-emitted overload.</param>
+		              		/// <returns>This method never returns - it always throws.</returns>
 		              		/// <remarks>
-		              		///     Any interface type can be used for mocking, but for classes, only abstract and virtual members can be mocked.
+		              		///     The source generator emits a concrete <c>CreateMock</c> overload per mockable type with the same shape.
+		              		///     If you see this fallback resolved in your IDE, the generator did not run for <typeparamref name="T" />;
+		              		///     run a clean build (for example <c>dotnet clean &amp;&amp; dotnet build</c>) and verify that the type is mockable.
 		              		/// </remarks>
+		              		/// <exception cref="global::Mockolate.Exceptions.MockException">Always thrown: the source generator did not run or <typeparamref name="T" /> is not mockable.</exception>
 		              		public static global::Mockolate.Mock.IMockGenerationDidNotRun CreateMock(object?[]? constructorParameters, global::Mockolate.MockBehavior? mockBehavior = null)
 		              		{
 		              			throw new global::Mockolate.Exceptions.MockException($"This method should not be called directly. Either '{typeof(T)}' is not mockable or the source generator did not run correctly.");
@@ -76,6 +91,8 @@ internal static partial class Sources
 		              		/// <summary>
 		              		///     Add an interface <typeparamref name="TInterface" /> that the mock also implements.
 		              		/// </summary>
+		              		/// <typeparam name="TInterface">Additional interface the mock should implement.</typeparam>
+		              		/// <returns>The same mock, typed so that <typeparamref name="TInterface" /> members are accessible.</returns>
 		              		public global::Mockolate.Mock.IMockGenerationDidNotRun Implementing<TInterface>() where TInterface : class
 		              		{
 		              			throw new global::Mockolate.Exceptions.MockException($"This method should not be called directly. Either '{typeof(TInterface)}' is not mockable or the source generator did not run correctly.");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -77,15 +77,21 @@ internal static partial class Sources
 
 		#region CreateMock
 
+		string createMockReturns =
+			$"A new mock instance of <see cref=\"{escapedClassName}\" />.";
+
 		sb.AppendXmlSummary(
 			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock()").AppendLine();
 		sb.Append("\t\t\t=> CreateMock(null, null, null);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
-		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock.");
+			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::System.Action<")
 			.Append(setupType).Append("> setup)").AppendLine();
 		sb.Append("\t\t\t=> CreateMock(null, null, setup);").AppendLine();
@@ -93,14 +99,19 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary(
 			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />.");
+		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior)").AppendLine();
 		sb.Append("\t\t\t=> CreateMock(null, mockBehavior, null);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />.");
-		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock.");
+			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<").Append(setupType)
 			.Append("> setup)").AppendLine();
@@ -110,14 +121,19 @@ internal static partial class Sources
 		if (!@class.IsInterface)
 		{
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the <paramref name=\"constructorParameters\" />.");
+				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> to invoke the base-class constructor.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 				.Append(" CreateMock(object?[] constructorParameters)").AppendLine();
 			sb.Append("\t\t\t=> CreateMock(constructorParameters, null, null);").AppendLine();
 			sb.AppendLine();
 
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the <paramref name=\"constructorParameters\" /> with the given <paramref name=\"mockBehavior\" />.");
+				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> and <paramref name=\"mockBehavior\" />.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 				.Append(" CreateMock(object?[] constructorParameters, global::Mockolate.MockBehavior mockBehavior)")
 				.AppendLine();
@@ -125,8 +141,11 @@ internal static partial class Sources
 			sb.AppendLine();
 
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the <paramref name=\"constructorParameters\" />.");
-			sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock.");
+				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" />, applying the given <paramref name=\"setup\" /> immediately.");
+			sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 				.Append(" CreateMock(object?[] constructorParameters, global::System.Action<").Append(setupType)
 				.Append("> setup)").AppendLine();
@@ -135,8 +154,12 @@ internal static partial class Sources
 		}
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the <paramref name=\"constructorParameters\" /> with the given <paramref name=\"mockBehavior\" />.");
-		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock.");
+			$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> and <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
+		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <see cref=\"global::Mockolate.MockBehavior.Default\" />.");
+		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
+		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\t").Append(@class.IsInterface ? "private" : "public").Append(" static ")
 			.Append(@class.ClassFullName)
 			.Append(
@@ -364,7 +387,9 @@ internal static partial class Sources
 		#endregion CreateMock
 
 		sb.AppendXmlSummary("Create a mock that wraps the given <paramref name=\"instance\" />.");
-		sb.AppendXmlRemarks("All interactions are forwarded to the <paramref name=\"instance\" />.");
+		sb.AppendXmlRemarks("Public members on the mock forward to <paramref name=\"instance\" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.");
+		sb.AppendXmlParam("instance", "The real object whose calls should be forwarded. Must not be <see langword=\"null\" />.");
+		sb.AppendXmlReturns($"A new mock of <see cref=\"{escapedClassName}\" /> that delegates to <paramref name=\"instance\" />.");
 		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Wrapping(").Append(@class.ClassFullName)
 			.Append(" instance)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -394,7 +419,10 @@ internal static partial class Sources
 		sb.AppendXmlSummary(
 			"Initialize mocks of type <typeparamref name=\"T\" /> with the given <paramref name=\"setup\" />.");
 		sb.AppendXmlRemarks(
-			"The <paramref name=\"setup\" /> is applied to the mock before the constructor is executed.");
+			"The <paramref name=\"setup\" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.");
+		sb.AppendXmlTypeParam("T", $"The mockable type derived from <see cref=\"{escapedClassName}\" /> that this setup should apply to.");
+		sb.AppendXmlParam("setup", $"Callback invoked when a new mock of <typeparamref name=\"T\" /> is created.");
+		sb.AppendXmlReturns("A new <see cref=\"global::Mockolate.MockBehavior\" /> with the registered initializer. The original instance is unchanged.");
 		sb.Append("\t\tpublic global::Mockolate.MockBehavior Initialize<T>(global::System.Action<").Append(setupType)
 			.Append("> setup)").AppendLine();
 		sb.Append("\t\t\twhere T : ").Append(@class.ClassFullName).AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2693,7 +2693,7 @@ internal static partial class Sources
 		else if (valueFlags.All(x => x))
 		{
 			text = isVerify
-				? "This overload accepts direct values for every parameter and returns a <see cref=\"global::Mockolate.Verify.VerificationResult{T}.IgnoreParameters\" /> whose <see cref=\"global::Mockolate.Verify.VerificationResult{T}.IgnoreParameters.AnyParameters()\" /> drops per-parameter matching entirely."
+				? "This overload accepts direct values for every parameter and returns a <see cref=\"global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters\" /> whose <see cref=\"global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()\" /> drops per-parameter matching entirely."
 				: "This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.";
 		}
 		else

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2670,6 +2670,57 @@ internal static partial class Sources
 		#endregion
 	}
 
+	private static void AppendOverloadDifferentiatorRemark(StringBuilder sb,
+		IReadOnlyList<string> parameterNames, bool useParameters, bool[]? valueFlags,
+		bool isVerify = false)
+	{
+		if (parameterNames.Count == 0)
+		{
+			return;
+		}
+
+		string text;
+		if (useParameters)
+		{
+			text = isVerify
+				? "This overload matches invocations via a custom <see cref=\"global::Mockolate.Match\" /> predicate (for example <see cref=\"global::Mockolate.Match.AnyParameters()\" /> or <see cref=\"global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)\" />) rather than per-parameter matchers."
+				: "This overload configures the setup via a custom <see cref=\"global::Mockolate.Match\" /> predicate (for example <see cref=\"global::Mockolate.Match.AnyParameters()\" /> or <see cref=\"global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)\" />) rather than per-parameter matchers.";
+		}
+		else if (valueFlags is null)
+		{
+			text = "This overload takes <see cref=\"global::Mockolate.It\" /> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.";
+		}
+		else if (valueFlags.All(x => x))
+		{
+			text = isVerify
+				? "This overload accepts direct values for every parameter and returns a <see cref=\"global::Mockolate.Verify.VerificationResult{T}.IgnoreParameters\" /> whose <see cref=\"global::Mockolate.Verify.VerificationResult{T}.IgnoreParameters.AnyParameters()\" /> drops per-parameter matching entirely."
+				: "This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.";
+		}
+		else
+		{
+			List<string> valueParams = [];
+			List<string> matcherParams = [];
+			for (int i = 0; i < parameterNames.Count && i < valueFlags.Length; i++)
+			{
+				if (valueFlags[i])
+				{
+					valueParams.Add($"<paramref name=\"{parameterNames[i]}\" />");
+				}
+				else
+				{
+					matcherParams.Add($"<paramref name=\"{parameterNames[i]}\" />");
+				}
+			}
+
+			string directPart = string.Join(", ", valueParams);
+			string matcherPart = string.Join(", ", matcherParams);
+			text =
+				$"This overload accepts a direct value for {directPart} (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref=\"global::Mockolate.It\" /> matcher for {matcherPart}.";
+		}
+
+		sb.AppendXmlRemarks(text);
+	}
+
 	private static void AppendMethodSetupDefinition(StringBuilder sb, Class @class, Method method,
 		bool useParameters, string? methodNameOverride = null, bool[]? valueFlags = null,
 		bool hasOverloadResolutionPriority = false)
@@ -2722,6 +2773,7 @@ internal static partial class Sources
 
 		sb.Append(".").AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
+		AppendOverloadDifferentiatorRemark(sb, method.Parameters.Select(p => p.Name).ToArray(), useParameters, valueFlags);
 		if (method.ReturnType != Type.Void)
 		{
 			if (valueFlags?.All(x => x) == true)
@@ -3337,6 +3389,9 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary(
 			$"Setup for the {indexer.Type.Fullname.EscapeForXmlDoc()} indexer <see cref=\"{indexer.ContainingType.EscapeForXmlDoc()}.this[{string.Join(", ", indexer.IndexerParameters!.Value.Select(p => p.RefKind.GetString() + p.Type.Fullname.EscapeForXmlDoc()))}]\" />");
+		string[] indexerNames = Enumerable.Range(1, indexer.IndexerParameters!.Value.Count)
+			.Select(i => $"parameter{i}").ToArray();
+		AppendOverloadDifferentiatorRemark(sb, indexerNames, useParameters: false, valueFlags);
 		if (hasOverloadResolutionPriority)
 		{
 			sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(")
@@ -3774,6 +3829,9 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary(
 			$"Verify interactions with the {indexer.Type.Fullname.EscapeForXmlDoc()} indexer <see cref=\"{indexer.ContainingType.EscapeForXmlDoc()}.this[{string.Join(", ", indexer.IndexerParameters!.Value.Select(p => p.RefKind.GetString() + p.Type.Fullname.EscapeForXmlDoc()))}]\" />.");
+		AppendOverloadDifferentiatorRemark(sb,
+			indexer.IndexerParameters!.Value.Select(p => p.Name).ToArray(),
+			useParameters: false, valueFlags, isVerify: true);
 		if (hasOverloadResolutionPriority)
 		{
 			sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(")
@@ -4218,6 +4276,7 @@ internal static partial class Sources
 
 		sb.Append(".").AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
+		AppendOverloadDifferentiatorRemark(sb, method.Parameters.Select(p => p.Name).ToArray(), useParameters, valueFlags, isVerify: true);
 		if (valueFlags?.All(x => x) == true)
 		{
 			sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<").Append(verifyName)

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -376,6 +376,26 @@ internal static partial class Sources
 			sb.Append(indent).Append("///     ").Append(remarksText).AppendLine();
 			sb.Append(indent).Append("/// </remarks>").AppendLine();
 		}
+
+		/// <summary>
+		///     Appends an XML documentation <c>&lt;param&gt;</c> tag with the given name and description.
+		/// </summary>
+		private void AppendXmlParam(string name, string description, string indent = "\t\t")
+			=> sb.Append(indent).Append("/// <param name=\"").Append(name).Append("\">")
+				.Append(description).Append("</param>").AppendLine();
+
+		/// <summary>
+		///     Appends an XML documentation <c>&lt;typeparam&gt;</c> tag with the given name and description.
+		/// </summary>
+		private void AppendXmlTypeParam(string name, string description, string indent = "\t\t")
+			=> sb.Append(indent).Append("/// <typeparam name=\"").Append(name).Append("\">")
+				.Append(description).Append("</typeparam>").AppendLine();
+
+		/// <summary>
+		///     Appends an XML documentation <c>&lt;returns&gt;</c> tag with the given text.
+		/// </summary>
+		private void AppendXmlReturns(string returnsText, string indent = "\t\t")
+			=> sb.Append(indent).Append("/// <returns>").Append(returnsText).Append("</returns>").AppendLine();
 	}
 }
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate/DefaultValueFactory.cs
+++ b/Source/Mockolate/DefaultValueFactory.cs
@@ -34,9 +34,14 @@ public class DefaultValueFactory
 		=> _predicate?.Invoke(type) ?? false;
 
 	/// <summary>
-	///     Generates a default value of the specified <paramref name="type" />, with
-	///     the <paramref name="parameters" /> for context.
+	///     Generates a default value for <paramref name="type" /> using the registered generator delegate.
 	/// </summary>
+	/// <param name="type">The runtime type to produce a default value for.</param>
+	/// <param name="parameters">
+	///     Optional context forwarded from the caller; typically empty. See
+	///     <see cref="IDefaultValueGenerator.GenerateValue(Type, object?[])" /> for details.
+	/// </param>
+	/// <returns>The generated value, or <see langword="null" /> when no generator has been configured.</returns>
 	public virtual object? GenerateValue(Type type, params object?[] parameters)
 		=> _generator?.Invoke(type, parameters);
 }

--- a/Source/Mockolate/DefaultValueFactory.cs
+++ b/Source/Mockolate/DefaultValueFactory.cs
@@ -38,7 +38,9 @@ public class DefaultValueFactory
 	/// </summary>
 	/// <param name="type">The runtime type to produce a default value for.</param>
 	/// <param name="parameters">
-	///     Optional context forwarded from the caller; typically empty. See
+	///     The runtime arguments of the mocked invocation, forwarded so the factory can vary its result by
+	///     context (for example, returning a cancelled task when a cancelled
+	///     <see cref="System.Threading.CancellationToken" /> is present). See
 	///     <see cref="IDefaultValueGenerator.GenerateValue(Type, object?[])" /> for details.
 	/// </param>
 	/// <returns>The generated value, or <see langword="null" /> when no generator has been configured.</returns>

--- a/Source/Mockolate/Exceptions/MockException.cs
+++ b/Source/Mockolate/Exceptions/MockException.cs
@@ -7,12 +7,20 @@ namespace Mockolate.Exceptions;
 /// </summary>
 public class MockException : Exception
 {
-	/// <inheritdoc cref="MockException" />
+	/// <summary>
+	///     Creates a new <see cref="MockException" /> with the given <paramref name="message" />.
+	/// </summary>
+	/// <param name="message">Human-readable description of the failure.</param>
 	public MockException(string message) : base(message)
 	{
 	}
 
-	/// <inheritdoc cref="MockException" />
+	/// <summary>
+	///     Creates a new <see cref="MockException" /> with the given <paramref name="message" /> and
+	///     <paramref name="innerException" />.
+	/// </summary>
+	/// <param name="message">Human-readable description of the failure.</param>
+	/// <param name="innerException">The underlying exception that triggered this one.</param>
 	public MockException(string message, Exception innerException) : base(message, innerException)
 	{
 	}

--- a/Source/Mockolate/Exceptions/MockNotSetupException.cs
+++ b/Source/Mockolate/Exceptions/MockNotSetupException.cs
@@ -7,12 +7,20 @@ namespace Mockolate.Exceptions;
 /// </summary>
 public class MockNotSetupException : MockException
 {
-	/// <inheritdoc cref="MockNotSetupException" />
+	/// <summary>
+	///     Creates a new <see cref="MockNotSetupException" /> with the given <paramref name="message" />.
+	/// </summary>
+	/// <param name="message">Human-readable description of the missing setup.</param>
 	public MockNotSetupException(string message) : base(message)
 	{
 	}
 
-	/// <inheritdoc cref="MockNotSetupException" />
+	/// <summary>
+	///     Creates a new <see cref="MockNotSetupException" /> with the given <paramref name="message" /> and
+	///     <paramref name="innerException" />.
+	/// </summary>
+	/// <param name="message">Human-readable description of the missing setup.</param>
+	/// <param name="innerException">The underlying exception that triggered this one.</param>
 	public MockNotSetupException(string message, Exception innerException) : base(message, innerException)
 	{
 	}

--- a/Source/Mockolate/Exceptions/MockVerificationException.cs
+++ b/Source/Mockolate/Exceptions/MockVerificationException.cs
@@ -7,12 +7,20 @@ namespace Mockolate.Exceptions;
 /// </summary>
 public class MockVerificationException : MockException
 {
-	/// <inheritdoc cref="MockVerificationException" />
+	/// <summary>
+	///     Creates a new <see cref="MockVerificationException" /> with the given <paramref name="message" />.
+	/// </summary>
+	/// <param name="message">Human-readable description of the verification failure.</param>
 	public MockVerificationException(string message) : base(message)
 	{
 	}
 
-	/// <inheritdoc cref="MockVerificationException" />
+	/// <summary>
+	///     Creates a new <see cref="MockVerificationException" /> with the given <paramref name="message" /> and
+	///     <paramref name="innerException" />.
+	/// </summary>
+	/// <param name="message">Human-readable description of the verification failure.</param>
+	/// <param name="innerException">The underlying exception that triggered this one.</param>
 	public MockVerificationException(string message, Exception innerException) : base(message, innerException)
 	{
 	}

--- a/Source/Mockolate/Exceptions/MockVerificationTimeoutException.cs
+++ b/Source/Mockolate/Exceptions/MockVerificationTimeoutException.cs
@@ -7,7 +7,12 @@ namespace Mockolate.Exceptions;
 /// </summary>
 public class MockVerificationTimeoutException : MockVerificationException
 {
-	/// <inheritdoc cref="MockVerificationException" />
+	/// <summary>
+	///     Creates a new <see cref="MockVerificationTimeoutException" /> that records the elapsed
+	///     <paramref name="timeout" /> and wraps the triggering <paramref name="innerException" />.
+	/// </summary>
+	/// <param name="timeout">The timeout that elapsed, or <see langword="null" /> when the wait was cancelled via a cancellation token.</param>
+	/// <param name="innerException">The underlying cancellation or timing exception that triggered this one.</param>
 	public MockVerificationTimeoutException(TimeSpan? timeout, Exception innerException)
 		: base(timeout is null ? "it timed out" : $"it timed out after {timeout.Value}", innerException)
 	{

--- a/Source/Mockolate/IDefaultValueGenerator.cs
+++ b/Source/Mockolate/IDefaultValueGenerator.cs
@@ -3,14 +3,26 @@
 namespace Mockolate;
 
 /// <summary>
-///     Defines a mechanism for generating default values of a specified type.
+///     Defines a mechanism for generating default values of a specified type. Populated on
+///     <see cref="MockBehavior.DefaultValue" /> and consulted whenever a mock needs a return value without a
+///     matching setup.
 /// </summary>
 public interface IDefaultValueGenerator
 {
 	/// <summary>
-	///     Generates a default value of the specified <paramref name="type" />, with
-	///     the <paramref name="parameters" /> for context.
+	///     Generates a default value for <paramref name="type" />.
 	/// </summary>
+	/// <param name="type">The runtime type to produce a default value for.</param>
+	/// <param name="parameters">
+	///     Optional context passed through from a caller of a <see cref="DefaultValueFactory" />'s
+	///     <c>Generate&lt;T&gt;(T nullValue, params object?[] parameters)</c> helper. The library itself does
+	///     not populate this array; treat it as <see langword="null" />/empty unless your factory specifically
+	///     relies on user-supplied context.
+	/// </param>
+	/// <returns>
+	///     A default value assignable to <paramref name="type" />, or <see langword="null" /> if no value can be
+	///     produced. The caller will fall back to the language default if the returned value is not assignment-compatible.
+	/// </returns>
 	object? GenerateValue(Type type, params object?[] parameters);
 }
 

--- a/Source/Mockolate/IDefaultValueGenerator.cs
+++ b/Source/Mockolate/IDefaultValueGenerator.cs
@@ -10,18 +10,22 @@ namespace Mockolate;
 public interface IDefaultValueGenerator
 {
 	/// <summary>
-	///     Generates a default value for <paramref name="type" />.
+	///     Generates a default value for <paramref name="type" />, optionally using the invocation
+	///     <paramref name="parameters" /> for context.
 	/// </summary>
 	/// <param name="type">The runtime type to produce a default value for.</param>
 	/// <param name="parameters">
-	///     Optional context passed through from a caller of a <see cref="DefaultValueFactory" />'s
-	///     <c>Generate&lt;T&gt;(T nullValue, params object?[] parameters)</c> helper. The library itself does
-	///     not populate this array; treat it as <see langword="null" />/empty unless your factory specifically
-	///     relies on user-supplied context.
+	///     The runtime arguments of the mocked invocation, in declaration order (for tuple defaults, nested
+	///     <c>Func&lt;T&gt;</c> factories for each tuple element are appended). Implementations can inspect this
+	///     array to return a more appropriate default - for example, the built-in cancellable-task factory scans it
+	///     for a cancelled <see cref="System.Threading.CancellationToken" /> and returns
+	///     <see cref="System.Threading.Tasks.Task.FromCanceled(System.Threading.CancellationToken)" /> instead of
+	///     <see cref="System.Threading.Tasks.Task.CompletedTask" />.
 	/// </param>
 	/// <returns>
 	///     A default value assignable to <paramref name="type" />, or <see langword="null" /> if no value can be
-	///     produced. The caller will fall back to the language default if the returned value is not assignment-compatible.
+	///     produced. The caller will fall back to the language default if the returned value is not
+	///     assignment-compatible.
 	/// </returns>
 	object? GenerateValue(Type type, params object?[] parameters);
 }

--- a/Source/Mockolate/IMock.cs
+++ b/Source/Mockolate/IMock.cs
@@ -1,13 +1,27 @@
 namespace Mockolate;
 
 /// <summary>
-///     The mock interface gives access to the mock registry of a mock instance.
+///     Non-generic contract exposed by every Mockolate-generated mock instance. Provides access to the
+///     <see cref="MockRegistry" /> that backs the mock.
 /// </summary>
+/// <remarks>
+///     Most users reach for the generator-emitted typed <c>Mock</c> property (for example <c>sut.Mock</c>) instead of
+///     this interface. The typed view surfaces the fluent entry points <c>Setup</c>, <c>Verify</c>, <c>Raise</c>,
+///     <c>InScenario</c>, <c>TransitionTo</c>, <c>Monitor</c>, and <c>ClearAllInteractions</c>. Use
+///     <see cref="IMock" /> directly only for framework code that needs to work against an untyped mock handle.
+/// </remarks>
 public interface IMock
 {
 	/// <summary>
-	///     The mock registry to store setups and interactions with the mock.
+	///     The <see cref="Mockolate.MockRegistry" /> that backs this mock: it owns the <see cref="MockBehavior" />,
+	///     the registered setups, and the recorded interactions.
 	/// </summary>
+	/// <remarks>
+	///     The typed <c>Mock</c> property on a generated mock exposes the fluent surface (<c>Setup</c>, <c>Verify</c>,
+	///     <c>Raise</c>, <c>InScenario</c>, <c>TransitionTo</c>, <c>Monitor</c>, <c>ClearAllInteractions</c>) and is
+	///     the preferred entry point; reach for <see cref="MockRegistry" /> directly only when you need to interact
+	///     with the underlying state (for example in custom extensions or diagnostic tooling).
+	/// </remarks>
 	MockRegistry MockRegistry { get; }
 
 	/// <summary>

--- a/Source/Mockolate/Match.AnyParameters.cs
+++ b/Source/Mockolate/Match.AnyParameters.cs
@@ -6,8 +6,16 @@ namespace Mockolate;
 public partial class Match
 {
 	/// <summary>
-	///     Matches any parameter combination.
+	///     Matches any argument combination passed to the method.
 	/// </summary>
+	/// <returns>
+	///     An <see cref="IParameters" /> usable in generator-emitted <c>Setup.Method(Match.AnyParameters())</c>
+	///     and <c>Verify.Method(Match.AnyParameters())</c> overloads.
+	/// </returns>
+	/// <remarks>
+	///     Only available on methods whose name is unique on the mocked type (no overloads). For overloaded
+	///     methods, combine per-parameter <see cref="It.IsAny{T}" /> matchers instead.
+	/// </remarks>
 	public static IParameters AnyParameters()
 		=> new AnyParametersMatch();
 

--- a/Source/Mockolate/Match.Parameters.cs
+++ b/Source/Mockolate/Match.Parameters.cs
@@ -18,7 +18,7 @@ public partial class Match
 	/// </param>
 	/// <param name="doNotPopulateThisValue">
 	///     Populated by the compiler via <see cref="CallerArgumentExpressionAttribute" /> to include the source
-	///     expression of <paramref name="predicate" /> in the setup's <see cref="object.ToString" /> and in
+	///     expression of <paramref name="predicate" /> in the setup's <see cref="object.ToString()" /> and in
 	///     verification failure messages.
 	/// </param>
 	/// <returns>

--- a/Source/Mockolate/Match.Parameters.cs
+++ b/Source/Mockolate/Match.Parameters.cs
@@ -8,8 +8,28 @@ namespace Mockolate;
 public partial class Match
 {
 	/// <summary>
-	///     Matches the parameters against the <paramref name="predicate" />.
+	///     Matches an invocation when the supplied <paramref name="predicate" /> returns <see langword="true" />
+	///     for its full argument array.
 	/// </summary>
+	/// <param name="predicate">
+	///     Receives every argument of the invocation, in declaration order, as <see langword="object" />? values.
+	///     Ref and out parameters are passed as their current values. Return <see langword="true" /> to accept the
+	///     invocation.
+	/// </param>
+	/// <param name="doNotPopulateThisValue">
+	///     Populated by the compiler via <see cref="CallerArgumentExpressionAttribute" /> to include the source
+	///     expression of <paramref name="predicate" /> in the setup's <see cref="object.ToString" /> and in
+	///     verification failure messages.
+	/// </param>
+	/// <returns>
+	///     An <see cref="IParameters" /> usable in generator-emitted <c>Setup.Method(Match.Parameters(...))</c>
+	///     and <c>Verify.Method(Match.Parameters(...))</c> overloads.
+	/// </returns>
+	/// <remarks>
+	///     The Mockolate source generator only emits <see cref="IParameters" />-based <c>Setup</c>/<c>Verify</c>
+	///     overloads for methods whose name is unique on the mocked type (no overloads). For overloaded methods,
+	///     use per-parameter <see cref="It" /> matchers instead.
+	/// </remarks>
 	public static IParameters Parameters(Func<object?[], bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -4,8 +4,18 @@ namespace Mockolate;
 
 #pragma warning disable S3453 // This class can't be instantiated; make its constructor 'public'.
 /// <summary>
-///     Specify a matching condition for a list of parameter.
+///     Specifies a matching condition across the full parameter list of a method or indexer. Complement to
+///     <see cref="It" />, which targets a single parameter at a time.
 /// </summary>
+/// <remarks>
+///     Reach for <see cref="Match" /> when you want to match by a predicate over all parameters at once, or when
+///     per-parameter matchers would be too verbose. Use <see cref="AnyParameters" /> to accept any arguments, or
+///     <c>Match.Parameters(predicate)</c> to match against a custom predicate.
+///     <para />
+///     Because the generator cannot disambiguate which overload a <see cref="Match" />-based setup targets,
+///     <see cref="Match" /> overloads are only emitted on unambiguous method names. For overloaded methods, use
+///     <see cref="It" /> matchers per parameter instead.
+/// </remarks>
 #if !DEBUG
 [System.Diagnostics.DebuggerNonUserCode]
 #endif

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -17,6 +17,8 @@ public partial class MockRegistry
 
 	/// <summary>
 	///     Registers the <paramref name="indexerSetup" /> in the mock for the given <paramref name="scenario" />.
+	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
+	///     into the default bucket.
 	/// </summary>
 	public void SetupIndexer(string scenario, IndexerSetup indexerSetup)
 		=> Setup.GetOrCreateScenario(scenario).Indexers.Add(indexerSetup);
@@ -29,6 +31,8 @@ public partial class MockRegistry
 
 	/// <summary>
 	///     Registers the <paramref name="methodSetup" /> in the mock for the given <paramref name="scenario" />.
+	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
+	///     into the default bucket.
 	/// </summary>
 	public void SetupMethod(string scenario, MethodSetup methodSetup)
 		=> Setup.GetOrCreateScenario(scenario).Methods.Add(methodSetup);
@@ -41,6 +45,8 @@ public partial class MockRegistry
 
 	/// <summary>
 	///     Registers the <paramref name="propertySetup" /> in the mock for the given <paramref name="scenario" />.
+	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
+	///     into the default bucket.
 	/// </summary>
 	public void SetupProperty(string scenario, PropertySetup propertySetup)
 		=> Setup.GetOrCreateScenario(scenario).Properties.Add(propertySetup);
@@ -53,6 +59,8 @@ public partial class MockRegistry
 
 	/// <summary>
 	///     Registers the <paramref name="eventSetup" /> in the mock for the given <paramref name="scenario" />.
+	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
+	///     into the default bucket.
 	/// </summary>
 	public void SetupEvent(string scenario, EventSetup eventSetup)
 		=> Setup.GetOrCreateScenario(scenario).Events.Add(eventSetup);

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -19,7 +19,12 @@ public partial class MockRegistry
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 	private readonly ScenarioState _scenarioState;
 
-	/// <inheritdoc cref="MockRegistry" />
+	/// <summary>
+	///     Creates a new <see cref="MockRegistry" /> with the given <paramref name="behavior" /> and, optionally,
+	///     <paramref name="constructorParameters" /> for a class mock's base-class constructor.
+	/// </summary>
+	/// <param name="behavior">The <see cref="MockBehavior" /> that governs how the mock responds without a matching setup.</param>
+	/// <param name="constructorParameters">Values forwarded to the base-class constructor, or <see langword="null" /> if no base constructor call is needed.</param>
 	public MockRegistry(MockBehavior behavior, object?[]? constructorParameters = null)
 	{
 		Behavior = behavior;
@@ -30,7 +35,12 @@ public partial class MockRegistry
 		Wraps = null;
 	}
 
-	/// <inheritdoc cref="MockRegistry" />
+	/// <summary>
+	///     Creates a <see cref="MockRegistry" /> that shares setup and scenario state with <paramref name="registry" />
+	///     but records interactions on a fresh bucket and forwards calls to <paramref name="wraps" />.
+	/// </summary>
+	/// <param name="registry">The source registry whose <see cref="Behavior" />, setups, and scenario state are reused.</param>
+	/// <param name="wraps">The real instance that the mock should delegate calls to. See <see cref="Wraps" />.</param>
 	public MockRegistry(MockRegistry registry, object wraps)
 	{
 		Behavior = registry.Behavior;
@@ -41,7 +51,12 @@ public partial class MockRegistry
 		Wraps = wraps;
 	}
 
-	/// <inheritdoc cref="MockRegistry" />
+	/// <summary>
+	///     Creates a <see cref="MockRegistry" /> that shares all state with <paramref name="registry" /> but exposes
+	///     a different set of <paramref name="constructorParameters" /> to the base-class constructor.
+	/// </summary>
+	/// <param name="registry">The source registry whose setups, interactions, scenario state, and wrapped instance are reused.</param>
+	/// <param name="constructorParameters">Values forwarded to the base-class constructor of the new mock instance.</param>
 	public MockRegistry(MockRegistry registry, object?[] constructorParameters)
 	{
 		Behavior = registry.Behavior;
@@ -52,7 +67,12 @@ public partial class MockRegistry
 		Wraps = registry.Wraps;
 	}
 
-	/// <inheritdoc cref="MockRegistry" />
+	/// <summary>
+	///     Creates a <see cref="MockRegistry" /> that shares all state with <paramref name="registry" /> but records
+	///     into the supplied <paramref name="interactions" /> collection. Used for scoped monitoring.
+	/// </summary>
+	/// <param name="registry">The source registry whose behavior, setups, constructor parameters, scenario state, and wrapped instance are reused.</param>
+	/// <param name="interactions">The interaction collection that new invocations should be appended to.</param>
 	public MockRegistry(MockRegistry registry, MockInteractions interactions)
 	{
 		Behavior = registry.Behavior;

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -84,8 +84,20 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     The current scenario of the mock. Use <see cref="TransitionTo(string)" /> to change the active scenario.
+	///     The name of the currently active scenario. Defaults to <see cref="string.Empty" />. Use
+	///     <see cref="TransitionTo(string)" /> or the generator-emitted <c>TransitionTo</c> chained onto a setup to
+	///     change it.
 	/// </summary>
+	/// <remarks>
+	///     When a member is invoked, Mockolate resolves a matching setup in this order:
+	///     <list type="number">
+	///         <item><description>the active scenario's bucket, when <see cref="Scenario" /> is not empty;</description></item>
+	///         <item><description>the default bucket (setups registered via <c>sut.Mock.Setup.*</c>);</description></item>
+	///         <item><description>the default response determined by <see cref="Behavior" />.</description></item>
+	///     </list>
+	///     Scenario setups add to, rather than replace, the default bucket - register catch-alls at the default scope
+	///     and override specific members per scenario.
+	/// </remarks>
 	public string Scenario => _scenarioState.Current;
 
 	/// <summary>
@@ -111,9 +123,15 @@ public partial class MockRegistry
 	public object? Wraps { get; }
 
 	/// <summary>
-	///     Transitions the mock to the given <paramref name="scenario" />.
+	///     Transitions the mock to the given <paramref name="scenario" />, so that subsequent member invocations
+	///     look up setups in that scenario's bucket first, and fall back to the default bucket if nothing matches.
 	/// </summary>
 	/// <param name="scenario">The name of the scenario to activate. Use <see cref="string.Empty" /> for the default scope.</param>
+	/// <remarks>
+	///     Transitioning to a scenario name for which no setups were registered via <c>InScenario(name)</c> is
+	///     legal - resolution will simply fall straight through to the default bucket. See <see cref="Scenario" />
+	///     for the full resolution order.
+	/// </remarks>
 	public void TransitionTo(string scenario)
 		=> _scenarioState.Current = scenario;
 

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -99,8 +99,15 @@ public partial class MockRegistry
 	public object?[]? ConstructorParameters { get; }
 
 	/// <summary>
-	///     The instance the mock wraps.
+	///     The real instance that public, non-protected calls are forwarded to, or <see langword="null" /> when the
+	///     mock is a plain (non-wrapping) mock.
 	/// </summary>
+	/// <remarks>
+	///     Populated by the generator-emitted <c>Wrapping(instance)</c> extension. Public members delegate to
+	///     <see cref="Wraps" /> unless a matching setup overrides them; protected members still go through the base
+	///     class implementation. All forwarded calls are recorded on <see cref="Interactions" /> and can be verified
+	///     like any other interaction.
+	/// </remarks>
 	public object? Wraps { get; }
 
 	/// <summary>

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -16,14 +16,23 @@ public static class SetupExtensions
 	extension<T>(IPropertySetupReturnWhenBuilder<T> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IPropertySetup<T> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -34,8 +43,12 @@ public static class SetupExtensions
 	extension<T>(IPropertyGetterSetupCallbackWhenBuilder<T> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IPropertySetup<T> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -46,8 +59,12 @@ public static class SetupExtensions
 	extension<T>(IPropertySetterSetupCallbackWhenBuilder<T> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IPropertySetup<T> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -58,14 +75,22 @@ public static class SetupExtensions
 	extension(IEventSubscriptionSetupCallbackWhenBuilder setup)
 	{
 		/// <summary>
-		///     Repeats the callback forever.
+		///     Terminates the callback sequence by repeating the preceding <c>Do(...)</c> entry forever instead of
+		///     cycling back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Do(...)</c> entry.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IEventSetup OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -76,14 +101,22 @@ public static class SetupExtensions
 	extension(IEventUnsubscriptionSetupCallbackWhenBuilder setup)
 	{
 		/// <summary>
-		///     Repeats the callback forever.
+		///     Terminates the callback sequence by repeating the preceding <c>Do(...)</c> entry forever instead of
+		///     cycling back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Do(...)</c> entry.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IEventSetup OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -94,14 +127,23 @@ public static class SetupExtensions
 	extension<TValue, T1>(IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -112,8 +154,12 @@ public static class SetupExtensions
 	extension<TValue, T1>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -124,8 +170,12 @@ public static class SetupExtensions
 	extension<TValue, T1>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -136,14 +186,23 @@ public static class SetupExtensions
 	extension<TValue, T1, T2>(IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -154,8 +213,12 @@ public static class SetupExtensions
 	extension<TValue, T1, T2>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -166,8 +229,12 @@ public static class SetupExtensions
 	extension<TValue, T1, T2>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -178,14 +245,23 @@ public static class SetupExtensions
 	extension<TValue, T1, T2, T3>(IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2, T3> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -196,8 +272,12 @@ public static class SetupExtensions
 	extension<TValue, T1, T2, T3>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2, T3> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -208,8 +288,12 @@ public static class SetupExtensions
 	extension<TValue, T1, T2, T3>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2, T3> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -220,14 +304,23 @@ public static class SetupExtensions
 	extension<TValue, T1, T2, T3, T4>(IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -238,8 +331,12 @@ public static class SetupExtensions
 	extension<TValue, T1, T2, T3, T4>(IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -250,8 +347,12 @@ public static class SetupExtensions
 	extension<TValue, T1, T2, T3, T4>(IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -262,14 +363,23 @@ public static class SetupExtensions
 	extension<TReturn>(IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -280,8 +390,12 @@ public static class SetupExtensions
 	extension<TReturn>(IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -292,14 +406,23 @@ public static class SetupExtensions
 	extension<TReturn, T1>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -310,8 +433,12 @@ public static class SetupExtensions
 	extension<TReturn, T1>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -322,14 +449,23 @@ public static class SetupExtensions
 	extension<TReturn, T1, T2>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1, T2> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -340,8 +476,12 @@ public static class SetupExtensions
 	extension<TReturn, T1, T2>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1, T2> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -352,14 +492,23 @@ public static class SetupExtensions
 	extension<TReturn, T1, T2, T3>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -370,8 +519,12 @@ public static class SetupExtensions
 	extension<TReturn, T1, T2, T3>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -382,14 +535,23 @@ public static class SetupExtensions
 	extension<TReturn, T1, T2, T3, T4>(IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -400,8 +562,12 @@ public static class SetupExtensions
 	extension<TReturn, T1, T2, T3, T4>(IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -412,14 +578,23 @@ public static class SetupExtensions
 	extension(IVoidMethodSetupReturnWhenBuilder setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -430,8 +605,12 @@ public static class SetupExtensions
 	extension(IVoidMethodSetupCallbackWhenBuilder setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -442,14 +621,23 @@ public static class SetupExtensions
 	extension<T1>(IVoidMethodSetupReturnWhenBuilder<T1> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -460,8 +648,12 @@ public static class SetupExtensions
 	extension<T1>(IVoidMethodSetupCallbackWhenBuilder<T1> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -472,14 +664,23 @@ public static class SetupExtensions
 	extension<T1, T2>(IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1, T2> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -490,8 +691,12 @@ public static class SetupExtensions
 	extension<T1, T2>(IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1, T2> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -502,14 +707,23 @@ public static class SetupExtensions
 	extension<T1, T2, T3>(IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1, T2, T3> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -520,8 +734,12 @@ public static class SetupExtensions
 	extension<T1, T2, T3>(IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1, T2, T3> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -532,14 +750,23 @@ public static class SetupExtensions
 	extension<T1, T2, T3, T4>(IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
 	{
 		/// <summary>
-		///     Returns/throws forever.
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
 		public void Forever()
 			=> setup.For(int.MaxValue);
 
 		/// <summary>
-		///     Uses the return value only once.
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce()
 			=> setup.Only(1);
 	}
@@ -550,8 +777,12 @@ public static class SetupExtensions
 	extension<T1, T2, T3, T4>(IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
 	{
 		/// <summary>
-		///     Executes the callback only once.
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
 		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
 		public IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce()
 			=> setup.Only(1);
 	}

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -71,16 +71,37 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 	}
 
 	/// <summary>
-	///     Makes the verification result awaitable, using the specified <paramref name="timeout" /> to wait for the expected
-	///     interactions to occur.
+	///     Returns a verification result that, when terminated with a count assertion, waits up to
+	///     <paramref name="timeout" /> for the expected interactions before throwing.
 	/// </summary>
+	/// <param name="timeout">How long to wait for interactions before reporting a timeout failure.</param>
+	/// <remarks>
+	///     The wait is synchronous: the terminating count assertion blocks the calling thread until the expectation
+	///     is satisfied, the timeout elapses, or the <see cref="WithCancellation(CancellationToken)" /> token (if any)
+	///     fires. If a non-blocking wait is needed, use the asynchronous <c>Within(TimeSpan)</c> variant provided by
+	///     the <c>aweXpect.Mockolate</c> extension package.
+	///     <para />
+	///     On timeout, a <see cref="MockVerificationTimeoutException" /> is raised internally and surfaces as a
+	///     <see cref="MockVerificationException" /> from the terminator.
+	/// </remarks>
+	/// <seealso cref="WithCancellation(CancellationToken)" />
 	public virtual VerificationResult<TVerify> Within(TimeSpan timeout)
 		=> new Awaitable(this, timeout);
 
 	/// <summary>
-	///     Makes the verification result awaitable, using the specified <paramref name="cancellationToken" /> to wait for the
-	///     expected interactions to occur.
+	///     Returns a verification result that, when terminated with a count assertion, waits for the expected
+	///     interactions until <paramref name="cancellationToken" /> is cancelled.
 	/// </summary>
+	/// <param name="cancellationToken">Token that signals when to stop waiting.</param>
+	/// <remarks>
+	///     The wait is synchronous: the terminating count assertion blocks the calling thread. Combine with
+	///     <see cref="Within(TimeSpan)" /> to apply both a timeout and an external cancellation; whichever fires
+	///     first wins.
+	///     <para />
+	///     For a non-blocking wait, use the asynchronous variant provided by the <c>aweXpect.Mockolate</c>
+	///     extension package.
+	/// </remarks>
+	/// <seealso cref="Within(TimeSpan)" />
 	public virtual VerificationResult<TVerify> WithCancellation(CancellationToken cancellationToken)
 		=> new Awaitable(this, cancellationToken);
 

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -131,7 +131,8 @@ public static class VerificationResultExtensions
 		///     Asserts that the verified interaction occurred at most <paramref name="times" /> times.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
-		///     Thrown when the verified interaction occurred more than <paramref name="times" /> times.
+		///     Thrown when the verified interaction occurred more than <paramref name="times" /> times,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
 		/// </exception>
 		public void AtMost(int times)
 		{

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -207,7 +207,8 @@ public static class VerificationResultExtensions
 		///     Asserts that the verified interaction occurred at most once.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
-		///     Thrown when the verified interaction occurred more than once.
+		///     Thrown when the verified interaction occurred more than once, or when a preceding <c>Within</c> or
+		///     <c>WithCancellation</c> causes verification to time out or be cancelled.
 		/// </exception>
 		public void AtMostOnce()
 		{

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -297,7 +297,8 @@ public static class VerificationResultExtensions
 		///     Asserts that the verified interaction never occurred.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
-		///     Thrown when the verified interaction occurred at least once.
+		///     Thrown when the verified interaction occurred at least once,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
 		/// </exception>
 		public void Never()
 		{

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -33,6 +33,10 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …at least the expected number of <paramref name="times" />.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction occurred fewer than <paramref name="times" /> times,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
 		public void AtLeast(int times)
 		{
 			IVerificationResult result = verificationResult;
@@ -59,6 +63,10 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …at least once.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction did not occur,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
 		public void AtLeastOnce()
 		{
 			IVerificationResult result = verificationResult;
@@ -85,6 +93,10 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …at least twice.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction occurred fewer than two times,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
 		public void AtLeastTwice()
 		{
 			IVerificationResult result = verificationResult;
@@ -111,6 +123,9 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …at most the expected number of <paramref name="times" />.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction occurred more than <paramref name="times" /> times.
+		/// </exception>
 		public void AtMost(int times)
 		{
 			IVerificationResult result = verificationResult;
@@ -138,6 +153,14 @@ public static class VerificationResultExtensions
 		///     Verifies that the mock was invoked between <paramref name="minimum" /> and <paramref name="maximum" /> times
 		///     (inclusive).
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction count falls outside the
+		///     <paramref name="minimum" />-<paramref name="maximum" /> range,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		///     Thrown when <paramref name="minimum" /> is negative or <paramref name="maximum" /> is less than <paramref name="minimum" />.
+		/// </exception>
 		public void Between(int minimum, int maximum)
 		{
 			if (minimum < 0)
@@ -175,6 +198,9 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …at most once.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction occurred more than once.
+		/// </exception>
 		public void AtMostOnce()
 		{
 			IVerificationResult result = verificationResult;
@@ -201,6 +227,9 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …at most twice.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction occurred more than two times.
+		/// </exception>
 		public void AtMostTwice()
 		{
 			IVerificationResult result = verificationResult;
@@ -227,6 +256,10 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …exactly the expected number of <paramref name="times" />.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction count is not equal to <paramref name="times" />,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
 		public void Exactly(int times)
 		{
 			IVerificationResult result = verificationResult;
@@ -253,6 +286,9 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …never.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction occurred at least once.
+		/// </exception>
 		public void Never()
 		{
 			IVerificationResult result = verificationResult;
@@ -279,6 +315,10 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …exactly once.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction did not occur exactly once,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
 		public void Once()
 		{
 			IVerificationResult result = verificationResult;
@@ -305,6 +345,10 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     …exactly twice.
 		/// </summary>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the verified interaction did not occur exactly two times,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
 		public void Twice()
 		{
 			IVerificationResult result = verificationResult;
@@ -331,6 +375,17 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     Verifies that the mock was invoked according to the <paramref name="predicate" />.
 		/// </summary>
+		/// <param name="predicate">
+		///     Receives the actual number of matching interactions and returns <see langword="true" /> if that count is acceptable.
+		/// </param>
+		/// <param name="doNotPopulateThisValue">
+		///     Populated by the compiler via <see cref="System.Runtime.CompilerServices.CallerArgumentExpressionAttribute" />
+		///     to include the source expression of <paramref name="predicate" /> in failure messages.
+		/// </param>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when <paramref name="predicate" /> returns <see langword="false" /> for the observed count,
+		///     or when a <see cref="VerificationResult{TVerify}.Within(TimeSpan)" /> timeout elapses first.
+		/// </exception>
 		public void Times(Func<int, bool> predicate,
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
@@ -359,6 +414,14 @@ public static class VerificationResultExtensions
 		/// <summary>
 		///     Supports fluent chaining of verifications in a given order.
 		/// </summary>
+		/// <param name="orderedChecks">
+		///     Each callback returns a follow-up <see cref="VerificationResult{TVerify}" />; that interaction must have been
+		///     recorded strictly after the previous verification in the chain for the assertion to pass.
+		/// </param>
+		/// <exception cref="MockVerificationException">
+		///     Thrown when the expected interactions did not occur in the given order
+		///     (for example, a later interaction was recorded before an earlier one, or was missing).
+		/// </exception>
 		public void Then(params Func<TMock, VerificationResult<TMock>>[] orderedChecks)
 		{
 			string? error = null;

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -31,7 +31,7 @@ public static class VerificationResultExtensions
 	extension<TMock>(VerificationResult<TMock> verificationResult)
 	{
 		/// <summary>
-		///     …at least the expected number of <paramref name="times" />.
+		///     Asserts that the verified interaction occurred at least <paramref name="times" /> times.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction occurred fewer than <paramref name="times" /> times,
@@ -61,7 +61,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …at least once.
+		///     Asserts that the verified interaction occurred at least once.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction did not occur,
@@ -91,7 +91,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …at least twice.
+		///     Asserts that the verified interaction occurred at least twice.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction occurred fewer than two times,
@@ -121,7 +121,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …at most the expected number of <paramref name="times" />.
+		///     Asserts that the verified interaction occurred at most <paramref name="times" /> times.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction occurred more than <paramref name="times" /> times.
@@ -150,8 +150,8 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     Verifies that the mock was invoked between <paramref name="minimum" /> and <paramref name="maximum" /> times
-		///     (inclusive).
+		///     Asserts that the verified interaction occurred between <paramref name="minimum" /> and
+		///     <paramref name="maximum" /> times, inclusive.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction count falls outside the
@@ -196,7 +196,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …at most once.
+		///     Asserts that the verified interaction occurred at most once.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction occurred more than once.
@@ -225,7 +225,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …at most twice.
+		///     Asserts that the verified interaction occurred at most twice.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction occurred more than two times.
@@ -254,7 +254,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …exactly the expected number of <paramref name="times" />.
+		///     Asserts that the verified interaction occurred exactly <paramref name="times" /> times.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction count is not equal to <paramref name="times" />,
@@ -284,7 +284,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …never.
+		///     Asserts that the verified interaction never occurred.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction occurred at least once.
@@ -313,7 +313,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …exactly once.
+		///     Asserts that the verified interaction occurred exactly once.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction did not occur exactly once,
@@ -343,7 +343,7 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     …exactly twice.
+		///     Asserts that the verified interaction occurred exactly twice.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
 		///     Thrown when the verified interaction did not occur exactly two times,
@@ -412,7 +412,8 @@ public static class VerificationResultExtensions
 		}
 
 		/// <summary>
-		///     Supports fluent chaining of verifications in a given order.
+		///     Asserts that the current verification and each of the <paramref name="orderedChecks" /> occurred in the
+		///     specified order.
 		/// </summary>
 		/// <param name="orderedChecks">
 		///     Each callback returns a follow-up <see cref="VerificationResult{TVerify}" />; that interaction must have been

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -237,7 +237,8 @@ public static class VerificationResultExtensions
 		///     Asserts that the verified interaction occurred at most twice.
 		/// </summary>
 		/// <exception cref="MockVerificationException">
-		///     Thrown when the verified interaction occurred more than two times.
+		///     Thrown when the verified interaction occurred more than two times, or when verification fails because a
+		///     configured wait or cancellation condition times out or is cancelled.
 		/// </exception>
 		public void AtMostTwice()
 		{

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -8,8 +8,15 @@ using Mockolate.Interactions;
 namespace Mockolate.Verify;
 
 /// <summary>
-///     The expectation contains the matching interactions for verification.
+///     Count-assertion extensions on <see cref="VerificationResult{TVerify}" /> that turn a recorded interaction set
+///     into a pass/fail check (for example <c>.Once()</c>, <c>.AtLeast(3)</c>, <c>.Then(...)</c>).
 /// </summary>
+/// <remarks>
+///     These methods are the terminators of a verification chain: each one either returns normally when the observed
+///     interactions match the expectation, or throws a <see cref="MockVerificationException" />. Use <c>Within</c> or
+///     <c>WithCancellation</c> on the <see cref="VerificationResult{TVerify}" /> before a terminator to wait for
+///     interactions produced on a background thread.
+/// </remarks>
 #if !DEBUG
 [System.Diagnostics.DebuggerNonUserCode]
 #endif


### PR DESCRIPTION
This PR improves the XML documentation across Mockolate’s public API surface (verification, setup helpers, matchers, registry, exceptions) and enhances the source generator’s emitted XML docs for generated mock types/overloads.

**Changes:**
- Expanded and clarified XML doc comments for verification terminators, wait semantics (`Within`/`WithCancellation`), setup-sequence helpers, matchers, registry/scenario behavior, and exception constructors.
- Added generator helpers to emit `<param>`, `<typeparam>`, and `<returns>` tags, and added remarks to distinguish overload shapes in generated `Setup`/`Verify` surfaces.
- Improved fallback “generator did not run” API docs in generated `Mock` helpers.