### PR TITLE
docs: improve XML docs

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -313,7 +313,7 @@ internal static partial class Sources
 			.Append("> OnSet { get; }").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary("Specifies if calling the base class implementation should be skipped.");
+		sb.AppendXmlSummary("Overrides <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" /> for this indexer only.");
 		sb.AppendXmlRemarks("If not specified, use <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" />.");
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetup<TValue, ").Append(typeParams)
 			.Append("> SkippingBaseClass(bool skipBaseClass = true);").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -161,7 +161,7 @@ internal static partial class Sources
 			"\t");
 		sb.Append("\tinternal interface IVoidMethodSetup<").Append(typeParams).Append("> : IMethodSetup").AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary("Specifies if calling the base class implementation should be skipped.");
+		sb.AppendXmlSummary("Overrides <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" /> for this method only.");
 		sb.AppendXmlRemarks("If not specified, use <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" />.");
 		sb.Append("\t\tglobal::Mockolate.Setup.IVoidMethodSetup<").Append(typeParams).Append("> SkippingBaseClass(bool skipBaseClass = true);")
 			.AppendLine();
@@ -353,7 +353,7 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		// SkippingBaseClass
-		sb.AppendXmlSummary("Specifies if calling the base class implementation should be skipped.");
+		sb.AppendXmlSummary("Overrides <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" /> for this method only.");
 		sb.AppendXmlRemarks("If not specified, use <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" />.");
 		sb.Append("\t\tglobal::Mockolate.Setup.IVoidMethodSetup<").Append(typeParams)
 			.Append("> global::Mockolate.Setup.IVoidMethodSetup<").Append(typeParams)
@@ -789,7 +789,7 @@ internal static partial class Sources
 		sb.Append("\tinternal interface IReturnMethodSetup<TReturn, ").Append(typeParams).Append("> : global::Mockolate.Setup.IMethodSetup")
 			.AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary("Specifies if calling the base class implementation should be skipped.");
+		sb.AppendXmlSummary("Overrides <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" /> for this method only.");
 		sb.AppendXmlRemarks("If not specified, use <see cref=\"global::Mockolate.MockBehavior.SkipBaseClass\" />.");
 		sb.Append("\t\tglobal::Mockolate.Setup.IReturnMethodSetup<TReturn, ").Append(typeParams)
 			.Append("> SkippingBaseClass(bool skipBaseClass = true);").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
@@ -32,8 +32,18 @@ internal static partial class Sources
 		          	extension(global::Mockolate.MockBehavior)
 		          	{
 		          		/// <summary>
-		          		///     The default mock behavior settings.
+		          		///     The default <see cref="global::Mockolate.MockBehavior" /> - the starting point for configuring a mock.
 		          		/// </summary>
+		          		/// <remarks>
+		          		///     Un-configured members return the generator-provided default value (empty strings/collections, completed
+		          		///     <see cref="global::System.Threading.Tasks.Task" />s, <see langword="null" /> otherwise), base-class
+		          		///     implementations run for class mocks, and every invocation is recorded for later verification.
+		          		///     <para />
+		          		///     Chain <c>SkippingBaseClass()</c>, <c>ThrowingWhenNotSetup()</c>, <c>SkippingInteractionRecording()</c>,
+		          		///     <c>WithDefaultValueFor&lt;T&gt;(...)</c> or <c>UseConstructorParametersFor&lt;T&gt;(...)</c> to derive
+		          		///     a customized <see cref="global::Mockolate.MockBehavior" />; because it is a <see langword="record" />,
+		          		///     each call returns a new instance and this shared default stays unchanged.
+		          		/// </remarks>
 		          		public static global::Mockolate.MockBehavior Default => _default;
 		          	}
 		          	

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -885,14 +885,6 @@ internal static partial class Sources
 			"Each mocked member is available as a strongly-typed entry on this surface. Chain <c>Returns</c>, <c>ReturnsAsync</c>, <c>Throws</c>, <c>ThrowsAsync</c> or <c>Do</c> to control the response; chain <c>InitializeWith</c>/<c>Register</c> to initialize properties and indexers; chain multiple returns/throws to define a sequence; use <c>.For(n)</c>, <c>.Only(n)</c>, <c>.Forever()</c>, <c>.When(predicate)</c> to control when a callback runs.",
 			"When two setups overlap, the most recently defined one wins.",
 		]);
-		sb.AppendXmlExample([
-			"sut.Mock.Setup.MyMethod(It.IsAny&lt;int&gt;()).Returns(42);",
-			"sut.Mock.Setup.MyProperty.InitializeWith(10);",
-			"sut.Mock.Setup.MyMethod(It.IsAny&lt;int&gt;())",
-			"    .Returns(1).For(2)     // first two calls return 1",
-			"    .Throws&lt;InvalidOperationException&gt;() // third call throws",
-			"    .Returns(0).Forever(); // remaining calls return 0",
-		]);
 		sb.Append("\t\tIMockSetupFor").Append(name).Append(" Setup { get; }").AppendLine();
 		sb.AppendLine();
 		if (hasProtectedMembers)
@@ -900,10 +892,6 @@ internal static partial class Sources
 			sb.AppendXmlSummary($"Configures how <see langword=\"protected\" /> virtual members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
 			sb.AppendXmlRemarks([
 				"Only members declared as <see langword=\"protected\" /> (or <see langword=\"protected\" /> <see langword=\"internal\" />) on the mocked class appear here. All setup chain operators (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, sequences, <c>.For</c>/<c>.Only</c>/<c>.Forever</c>, ...) work identically to <see cref=\"Setup\" />.",
-			]);
-			sb.AppendXmlExample([
-				"sut.Mock.SetupProtected.DispenseInternal(It.Is(\"Dark\"), It.IsAny&lt;int&gt;())",
-				"    .Returns(true);",
 			]);
 			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" SetupProtected { get; }").AppendLine();
 			sb.AppendLine();
@@ -954,10 +942,6 @@ internal static partial class Sources
 			sb.AppendXmlRemarks([
 				"One entry per event is generated; the signature matches the event's delegate. Only handlers that are subscribed at the moment of the <c>Raise</c> call are invoked - handlers subscribed later (or already removed) are skipped.",
 			]);
-			sb.AppendXmlExample([
-				"sut.MyEvent += (sender, args) => { /* ... */ };",
-				"sut.Mock.Raise.MyEvent(sut, EventArgs.Empty);",
-			]);
 			sb.Append("\t\tIMockRaiseOn").Append(name).Append(" Raise { get; }").AppendLine();
 			sb.AppendLine();
 		}
@@ -988,13 +972,6 @@ internal static partial class Sources
 			"Use <c>Within(TimeSpan)</c> / <c>WithCancellation(CancellationToken)</c> before the terminator to wait for expected interactions that happen on background threads.",
 			"Chain <c>Then(...)</c> to assert an ordered sequence of calls. A failing assertion throws a <see cref=\"global::Mockolate.Exceptions.MockVerificationException\" />.",
 		]);
-		sb.AppendXmlExample([
-			"sut.Mock.Verify.MyMethod(It.IsAny&lt;int&gt;()).Once();",
-			"sut.Mock.Verify.MyProperty.Got().AtLeastOnce();",
-			"sut.Mock.Verify.MyProperty.Set(It.Is(42)).Never();",
-			"sut.Mock.Verify.MyMethod(It.Is(1)).Then(",
-			"    m =&gt; m.MyMethod(It.Is(2)));",
-		]);
 		sb.Append("\t\tIMockVerifyFor").Append(name).Append(" Verify { get; }").AppendLine();
 		sb.AppendLine();
 		if (hasProtectedMembers || hasProtectedEvents)
@@ -1023,11 +1000,6 @@ internal static partial class Sources
 		]);
 		sb.AppendXmlParam("setup", "The setup previously registered through <see cref=\"Setup\" /> (typically returned from a <c>Returns(...)</c>/<c>Throws(...)</c> call).");
 		sb.AppendXmlReturns("A <c>VerificationResult</c> that counts invocations matching the given setup.");
-		sb.AppendXmlExample([
-			"IMockSetup setup = sut.Mock.Setup.MyMethod(It.Is(1)).Returns(true);",
-			"// ... exercise the subject ...",
-			"sut.Mock.VerifySetup(setup).AtLeastOnce();",
-		]);
 		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name)
 			.Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
 		sb.AppendLine();
@@ -1048,12 +1020,6 @@ internal static partial class Sources
 		sb.AppendXmlSummary("Removes every recorded interaction from this mock while keeping all registered setups intact.");
 		sb.AppendXmlRemarks([
 			"Handy when a single test exercises multiple logical phases and you only want to verify the interactions of the latest phase.",
-		]);
-		sb.AppendXmlExample([
-			"sut.DoSomething();",
-			"sut.Mock.ClearAllInteractions();",
-			"sut.DoSomethingElse();",
-			"sut.Mock.Verify.DoSomethingElse(Match.AnyParameters()).Once();",
 		]);
 		sb.Append("\t\tvoid ClearAllInteractions();").AppendLine();
 		sb.AppendLine();
@@ -1445,6 +1411,46 @@ internal static partial class Sources
 		}
 	}
 
+	/// <summary>
+	///     Builds an XML-doc cref string for the given <paramref name="constructor" /> on
+	///     <paramref name="class" />, in the form <c>{class-cref}.{simple-name}({param-types})</c>,
+	///     or returns <see langword="null" /> when no valid cref can be produced.
+	/// </summary>
+	/// <remarks>
+	///     Generic classes are skipped because the cref type-parameter-list syntax (e.g. <c>{T}</c>)
+	///     expects identifier tokens, not the concrete type arguments that closed generics carry —
+	///     emitting <c>MyClass{int}.MyClass(int)</c> would surface CS1584/CS1658 on the consumer side.
+	/// </remarks>
+	private static string? BuildConstructorCref(Class @class, Method constructor)
+	{
+		string fullName = @class.ClassFullName;
+
+		if (fullName.IndexOf('<') >= 0)
+		{
+			return null;
+		}
+
+		int lastDot = fullName.LastIndexOf('.');
+		string simpleName = lastDot >= 0 ? fullName.Substring(lastDot + 1) : fullName;
+
+		StringBuilder cref = new();
+		cref.Append(fullName).Append('.').Append(simpleName).Append('(');
+		bool first = true;
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			if (!first)
+			{
+				cref.Append(", ");
+			}
+
+			first = false;
+			cref.Append(parameter.Type.Fullname.EscapeForXmlDoc());
+		}
+
+		cref.Append(')');
+		return cref.ToString();
+	}
+
 #pragma warning disable S107 // Methods should not have too many parameters
 	private static void TryEmitTypedCreateMockOverload(StringBuilder sb, Class @class, Method constructor,
 		string setupType, string escapedClassName, string createMockReturns,
@@ -1470,22 +1476,34 @@ internal static partial class Sources
 			return;
 		}
 
-		if (includeSetup)
+		string? constructorCref = BuildConstructorCref(@class, constructor);
+		string ctorPhrase = constructorCref is null
+			? "the base-class constructor"
+			: $"the <see cref=\"{constructorCref}\" /> constructor";
+
+		if (includeMockBehavior && includeSetup)
 		{
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given constructor parameters, applying the given <paramref name=\"{setupName}\" /> immediately.");
+				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"{mockBehaviorName}\" />, applying the given <paramref name=\"{setupName}\" /> immediately, using the given constructor parameters to invoke {ctorPhrase}.");
+			sb.AppendXmlRemarks(
+				$"The provided <paramref name=\"{setupName}\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		}
+		else if (includeMockBehavior)
+		{
+			sb.AppendXmlSummary(
+				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"{mockBehaviorName}\" /> and the given constructor parameters to invoke {ctorPhrase}.");
+		}
+		else if (includeSetup)
+		{
+			sb.AppendXmlSummary(
+				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"{setupName}\" /> immediately, using the given constructor parameters to invoke {ctorPhrase}.");
 			sb.AppendXmlRemarks(
 				$"The provided <paramref name=\"{setupName}\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
 		}
 		else
 		{
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given constructor parameters to invoke the base-class constructor.");
-		}
-
-		foreach (MethodParameter parameter in constructor.Parameters)
-		{
-			sb.AppendXmlParam(parameter.Name, "Value forwarded to the base-class constructor.");
+				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given constructor parameters to invoke {ctorPhrase}.");
 		}
 
 		if (includeMockBehavior)
@@ -1498,6 +1516,11 @@ internal static partial class Sources
 		{
 			sb.AppendXmlParam(setupName,
 				"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		}
+
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			sb.AppendXmlParam(parameter.Name, "Value forwarded to the base-class constructor.");
 		}
 
 		sb.AppendXmlReturns(createMockReturns);

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -85,12 +85,6 @@ internal static partial class Sources
 		sb.AppendXmlRemarks(mockPropertyRemarks.ToArray());
 		sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
 			$"The instance is not a Mockolate-generated mock of <see cref=\"{escapedClassName}\" />.");
-		string displayForCode = @class.DisplayString.EscapeForXmlText();
-		sb.AppendXmlExample([
-			"sut.Mock.Setup.MemberName(It.IsAny&lt;int&gt;()).Returns(42);",
-			"// ... exercise the subject ...",
-			"sut.Mock.Verify.MemberName(It.IsAny&lt;int&gt;()).Once();",
-		]);
 		sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(name).Append(' ').Append(mockPropertyName)
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -133,12 +127,6 @@ internal static partial class Sources
 			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
 		sb.AppendXmlRemarks(createMockRemarks.ToArray());
 		sb.AppendXmlReturns(createMockReturns);
-		sb.AppendXmlExample([
-			$"{displayForCode} sut = {displayForCode}.CreateMock();",
-			"sut.Mock.Setup.MemberName(It.IsAny&lt;int&gt;()).Returns(42);",
-			"// ... exercise the subject ...",
-			"sut.Mock.Verify.MemberName(It.IsAny&lt;int&gt;()).Once();",
-		]);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock()").AppendLine();
 		sb.Append("\t\t\t=> CreateMock(null, null, (object?[]?)null);").AppendLine();
 		sb.AppendLine();
@@ -932,7 +920,7 @@ internal static partial class Sources
 			"After the transition, setups registered via <see cref=\"InScenario(string)\" /> under that scenario take effect. Scenarios that have no matching setup for a given member fall back to the default (un-scoped) setups.",
 		]);
 		sb.AppendXmlParam("scenario", "Name of the scenario to transition to.");
-		sb.AppendXmlReturns("This accessor, to allow chaining further operations.");
+		sb.AppendXmlReturns("This accessor, to allow chaining.");
 		sb.Append("\t\tIMockFor").Append(name).Append(" TransitionTo(string scenario);").AppendLine();
 		sb.AppendLine();
 
@@ -1024,20 +1012,11 @@ internal static partial class Sources
 		sb.Append("\t\tvoid ClearAllInteractions();").AppendLine();
 		sb.AppendLine();
 		sb.AppendXmlSummary(
-			"Creates a scoped monitor that records interactions only while its <see cref=\"global::System.IDisposable\" /> scope is active.");
+			"Creates a monitor whose <c>Verify</c> surface is scoped to interactions produced between <c>monitor.Run()</c> and the disposal of its <see cref=\"global::System.IDisposable\" /> scope.");
 		sb.AppendXmlRemarks([
-			"Interactions recorded on the mock outside <c>monitor.Run()</c> are not visible through the monitor. Useful to verify only the interactions produced by a specific block of test code without resetting the mock.",
+			"The underlying mock keeps recording all interactions as usual - only the monitor's <c>Verify</c> view is scoped. Useful to verify only the interactions produced by a specific block of test code without resetting the mock.",
 		]);
 		sb.AppendXmlReturns("A <see cref=\"global::Mockolate.Monitor.MockMonitor{T}\" /> that exposes <c>Verify</c> over the monitored interactions and a <c>Run()</c> method that opens the recording scope.");
-		sb.AppendXmlExample([
-			"var monitor = sut.Mock.Monitor();",
-			"using (monitor.Run())",
-			"{",
-			"    sut.DoSomething(); // recorded",
-			"}",
-			"sut.DoSomething();     // not recorded",
-			"monitor.Verify.DoSomething(Match.AnyParameters()).Once();",
-		]);
 		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();")
 			.AppendLine();
 		sb.Append("\t}").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -56,25 +56,37 @@ internal static partial class Sources
 
 		string mockPropertyName = CreateUniquePropertyName(@class, "Mock");
 
-		sb.AppendXmlSummary($"Gets the mock accessor for <see cref=\"{escapedClassName}\" /> - the entry point for configuring setups, verifying interactions and raising events.");
-		sb.AppendXmlRemarks([
+		List<string> mockPropertyRemarks = new()
+		{
 			$"The accessor is the bridge between the strongly-typed instance of <see cref=\"{escapedClassName}\" /> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.",
 			"Through it you can:",
 			"<list type=\"bullet\">",
 			"  <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item>",
 			"  <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item>",
-			"  <item><description><c>Raise</c> - trigger events declared on the mocked type (only available if the type has events).</description></item>",
-			"  <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword=\"protected\" /> members on class mocks.</description></item>",
-			"  <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword=\"static\" /> members on interface mocks.</description></item>",
-			"  <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item>",
-			"  <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item>",
-			"  <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item>",
-			"</list>",
-			$"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the instance is not a Mockolate-generated mock of <see cref=\"{escapedClassName}\" />.",
-		]);
+		};
+		if (hasEvents)
+		{
+			mockPropertyRemarks.Add("  <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item>");
+		}
+		if (hasProtectedMembers || hasProtectedEvents)
+		{
+			mockPropertyRemarks.Add("  <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword=\"protected\" /> members on class mocks.</description></item>");
+		}
+		if (hasStaticMembers || hasStaticEvents)
+		{
+			mockPropertyRemarks.Add("  <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword=\"static\" /> members on interface mocks.</description></item>");
+		}
+		mockPropertyRemarks.Add("  <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item>");
+		mockPropertyRemarks.Add("  <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item>");
+		mockPropertyRemarks.Add("  <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item>");
+		mockPropertyRemarks.Add("</list>");
+
+		sb.AppendXmlSummary($"Gets the mock accessor for <see cref=\"{escapedClassName}\" /> - the entry point for configuring setups, verifying interactions and raising events.");
+		sb.AppendXmlRemarks(mockPropertyRemarks.ToArray());
+		sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
+			$"The instance is not a Mockolate-generated mock of <see cref=\"{escapedClassName}\" />.");
 		string displayForCode = @class.DisplayString.EscapeForXmlText();
 		sb.AppendXmlExample([
-			$"{displayForCode} sut = {displayForCode}.CreateMock();",
 			"sut.Mock.Setup.MemberName(It.IsAny&lt;int&gt;()).Returns(42);",
 			"// ... exercise the subject ...",
 			"sut.Mock.Verify.MemberName(It.IsAny&lt;int&gt;()).Once();",
@@ -102,18 +114,24 @@ internal static partial class Sources
 		string createMockReturns =
 			$"A new mock instance of <see cref=\"{escapedClassName}\" />.";
 
-		sb.AppendXmlSummary(
-			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
-		sb.AppendXmlRemarks([
+		List<string> createMockRemarks = new()
+		{
 			$"The returned instance is a strongly-typed mock generated at compile time - it implements <see cref=\"{escapedClassName}\" /> and exposes the Mockolate surface through <c>.Mock</c>:",
 			"<list type=\"bullet\">",
 			"  <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item>",
 			"  <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item>",
-			"  <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item>",
-			"</list>",
-			"With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword=\"null\" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref=\"global::Mockolate.MockBehavior\" /> to customize this (for example to make un-configured calls throw or to skip the base class).",
-			"Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.",
-		]);
+		};
+		if (hasEvents)
+		{
+			createMockRemarks.Add("  <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item>");
+		}
+		createMockRemarks.Add("</list>");
+		createMockRemarks.Add("With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword=\"null\" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref=\"global::Mockolate.MockBehavior\" /> to customize this (for example to make un-configured calls throw or to skip the base class).");
+		createMockRemarks.Add("Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.");
+
+		sb.AppendXmlSummary(
+			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlRemarks(createMockRemarks.ToArray());
 		sb.AppendXmlReturns(createMockReturns);
 		sb.AppendXmlExample([
 			$"{displayForCode} sut = {displayForCode}.CreateMock();",
@@ -126,7 +144,7 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
 		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
 		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
 		sb.AppendXmlReturns(createMockReturns);
@@ -136,7 +154,7 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />.");
+			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />.");
 		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
@@ -145,7 +163,7 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
 		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
 		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
 		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
@@ -159,7 +177,7 @@ internal static partial class Sources
 		if (!@class.IsInterface)
 		{
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> to invoke the base-class constructor.");
+				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> to invoke the base-class constructor.");
 			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
@@ -168,7 +186,7 @@ internal static partial class Sources
 			sb.AppendLine();
 
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" /> and <paramref name=\"constructorParameters\" />.");
+				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" /> and <paramref name=\"constructorParameters\" />.");
 			sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
 			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlReturns(createMockReturns);
@@ -179,7 +197,7 @@ internal static partial class Sources
 			sb.AppendLine();
 
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
+				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
 			sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
 			sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
 			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
@@ -194,7 +212,7 @@ internal static partial class Sources
 		}
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
+			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
 		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
 		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <see cref=\"global::Mockolate.MockBehavior.Default\" />.");
 		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
@@ -425,7 +443,7 @@ internal static partial class Sources
 
 		#endregion CreateMock
 
-		sb.AppendXmlSummary("Create a mock that wraps the given <paramref name=\"instance\" />.");
+		sb.AppendXmlSummary("Creates a mock that wraps the given <paramref name=\"instance\" />.");
 		sb.AppendXmlRemarks("Public members on the mock forward to <paramref name=\"instance\" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.");
 		sb.AppendXmlParam("instance", "The real object whose calls should be forwarded. Must not be <see langword=\"null\" />.");
 		sb.AppendXmlReturns($"A new mock of <see cref=\"{escapedClassName}\" /> that delegates to <paramref name=\"instance\" />.");
@@ -456,7 +474,7 @@ internal static partial class Sources
 		sb.Append("\t{").AppendLine();
 
 		sb.AppendXmlSummary(
-			"Initialize mocks of type <typeparamref name=\"T\" /> with the given <paramref name=\"setup\" />.");
+			"Initializes mocks of type <typeparamref name=\"T\" /> with the given <paramref name=\"setup\" />.");
 		sb.AppendXmlRemarks(
 			"The <paramref name=\"setup\" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.");
 		sb.AppendXmlTypeParam("T", $"The mockable type derived from <see cref=\"{escapedClassName}\" /> that this setup should apply to.");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -56,7 +56,29 @@ internal static partial class Sources
 
 		string mockPropertyName = CreateUniquePropertyName(@class, "Mock");
 
-		sb.AppendXmlSummary($"Get access to the mock of <see cref=\"{escapedClassName}\" />.");
+		sb.AppendXmlSummary($"Gets the mock accessor for <see cref=\"{escapedClassName}\" /> - the entry point for configuring setups, verifying interactions and raising events.");
+		sb.AppendXmlRemarks([
+			$"The accessor is the bridge between the strongly-typed instance of <see cref=\"{escapedClassName}\" /> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.",
+			"Through it you can:",
+			"<list type=\"bullet\">",
+			"  <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item>",
+			"  <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item>",
+			"  <item><description><c>Raise</c> - trigger events declared on the mocked type (only available if the type has events).</description></item>",
+			"  <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword=\"protected\" /> members on class mocks.</description></item>",
+			"  <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword=\"static\" /> members on interface mocks.</description></item>",
+			"  <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item>",
+			"  <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item>",
+			"  <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item>",
+			"</list>",
+			$"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the instance is not a Mockolate-generated mock of <see cref=\"{escapedClassName}\" />.",
+		]);
+		string displayForCode = @class.DisplayString.EscapeForXmlText();
+		sb.AppendXmlExample([
+			$"{displayForCode} sut = {displayForCode}.CreateMock();",
+			"sut.Mock.Setup.MemberName(It.IsAny&lt;int&gt;()).Returns(42);",
+			"// ... exercise the subject ...",
+			"sut.Mock.Verify.MemberName(It.IsAny&lt;int&gt;()).Once();",
+		]);
 		sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(name).Append(' ').Append(mockPropertyName)
 			.AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -81,8 +103,24 @@ internal static partial class Sources
 			$"A new mock instance of <see cref=\"{escapedClassName}\" />.";
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
+			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlRemarks([
+			$"The returned instance is a strongly-typed mock generated at compile time - it implements <see cref=\"{escapedClassName}\" /> and exposes the Mockolate surface through <c>.Mock</c>:",
+			"<list type=\"bullet\">",
+			"  <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item>",
+			"  <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item>",
+			"  <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item>",
+			"</list>",
+			"With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword=\"null\" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref=\"global::Mockolate.MockBehavior\" /> to customize this (for example to make un-configured calls throw or to skip the base class).",
+			"Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.",
+		]);
 		sb.AppendXmlReturns(createMockReturns);
+		sb.AppendXmlExample([
+			$"{displayForCode} sut = {displayForCode}.CreateMock();",
+			"sut.Mock.Setup.MemberName(It.IsAny&lt;int&gt;()).Returns(42);",
+			"// ... exercise the subject ...",
+			"sut.Mock.Verify.MemberName(It.IsAny&lt;int&gt;()).Once();",
+		]);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock()").AppendLine();
 		sb.Append("\t\t\t=> CreateMock(null, null, (object?[]?)null);").AppendLine();
 		sb.AppendLine();
@@ -818,92 +856,204 @@ internal static partial class Sources
 
 		#region IMockForXXX
 
-		sb.AppendXmlSummary($"Accesses the mock of <see cref=\"{escapedClassName}\" />.", "\t");
+		sb.AppendXmlSummary($"The Mockolate accessor for a mock of <see cref=\"{escapedClassName}\" />, reached through <c>.Mock</c> on the mocked instance.", "\t");
+		sb.AppendXmlRemarks([
+			"Groups every operation that acts on the mock rather than on the mocked subject: setups, verifications, event raising, scenarios and monitoring.",
+		], "\t");
 		sb.Append("\tinternal interface IMockFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary($"Set up the mock of <see cref=\"{escapedClassName}\" />.");
+		sb.AppendXmlSummary($"Configures how members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
+		sb.AppendXmlRemarks([
+			"Each mocked member is available as a strongly-typed entry on this surface. Chain <c>Returns</c>, <c>ReturnsAsync</c>, <c>Throws</c>, <c>ThrowsAsync</c> or <c>Do</c> to control the response; chain <c>InitializeWith</c>/<c>Register</c> to initialize properties and indexers; chain multiple returns/throws to define a sequence; use <c>.For(n)</c>, <c>.Only(n)</c>, <c>.Forever()</c>, <c>.When(predicate)</c> to control when a callback runs.",
+			"When two setups overlap, the most recently defined one wins.",
+		]);
+		sb.AppendXmlExample([
+			"sut.Mock.Setup.MyMethod(It.IsAny&lt;int&gt;()).Returns(42);",
+			"sut.Mock.Setup.MyProperty.InitializeWith(10);",
+			"sut.Mock.Setup.MyMethod(It.IsAny&lt;int&gt;())",
+			"    .Returns(1).For(2)     // first two calls return 1",
+			"    .Throws&lt;InvalidOperationException&gt;() // third call throws",
+			"    .Returns(0).Forever(); // remaining calls return 0",
+		]);
 		sb.Append("\t\tIMockSetupFor").Append(name).Append(" Setup { get; }").AppendLine();
 		sb.AppendLine();
 		if (hasProtectedMembers)
 		{
-			sb.AppendXmlSummary($"Set up protected members on the mock of <see cref=\"{escapedClassName}\" />.");
+			sb.AppendXmlSummary($"Configures how <see langword=\"protected\" /> virtual members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
+			sb.AppendXmlRemarks([
+				"Only members declared as <see langword=\"protected\" /> (or <see langword=\"protected\" /> <see langword=\"internal\" />) on the mocked class appear here. All setup chain operators (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, sequences, <c>.For</c>/<c>.Only</c>/<c>.Forever</c>, ...) work identically to <see cref=\"Setup\" />.",
+			]);
+			sb.AppendXmlExample([
+				"sut.Mock.SetupProtected.DispenseInternal(It.Is(\"Dark\"), It.IsAny&lt;int&gt;())",
+				"    .Returns(true);",
+			]);
 			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" SetupProtected { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasStaticMembers)
 		{
-			sb.AppendXmlSummary($"Set up static members on the mock of <see cref=\"{escapedClassName}\" />.");
+			sb.AppendXmlSummary($"Configures how <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> respond when invoked.");
+			sb.AppendXmlRemarks([
+				"Static members are scoped per async/execution flow while the mock is alive; invocations from other flows are not intercepted.",
+			]);
 			sb.Append("\t\tIMockStaticSetupFor").Append(name).Append(" SetupStatic { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
-		sb.AppendXmlSummary($"Enter a scenario scope on the mock of <see cref=\"{escapedClassName}\" />.");
+		sb.AppendXmlSummary($"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> so that additional setups can be registered for that scenario.");
+		sb.AppendXmlRemarks([
+			"Scenarios let you define per-state behavior. Setups registered inside the returned <c>IMockInScenarioFor...</c> scope only apply while the mock's current scenario matches <paramref name=\"scenario\" />; switch scenarios with <see cref=\"TransitionTo\" />.",
+		]);
+		sb.AppendXmlParam("scenario", "Name of the scenario to enter. Any non-null string acts as a key; the mock starts in an unnamed default scenario.");
+		sb.AppendXmlReturns("A scoped accessor whose <c>Setup</c> (and <c>SetupProtected</c>, where applicable) register scenario-specific setups.");
 		sb.Append("\t\tIMockInScenarioFor").Append(name).Append(" InScenario(string scenario);").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary($"Enter a scenario scope on the mock of <see cref=\"{escapedClassName}\" /> and invoke the <paramref name=\"setup\" />.");
+		sb.AppendXmlSummary($"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> and immediately invokes <paramref name=\"setup\" /> to register scenario-specific setups.");
+		sb.AppendXmlRemarks([
+			"Equivalent to <c>InScenario(scenario)</c> followed by the setup callback, but returns the original <c>IMockFor...</c> accessor so it chains nicely at mock-creation time.",
+		]);
+		sb.AppendXmlParam("scenario", "Name of the scenario to enter.");
+		sb.AppendXmlParam("setup", "Callback that receives the scenario-scoped setup surface and registers scenario-specific setups.");
+		sb.AppendXmlReturns("This accessor, to allow chaining.");
 		sb.Append("\t\tIMockFor").Append(name).Append(" InScenario(string scenario, global::System.Action<IMockInScenarioFor")
 			.Append(name).Append("> setup);").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary($"Transitions the mock of <see cref=\"{escapedClassName}\" /> to the given <paramref name=\"scenario\" />.");
+		sb.AppendXmlSummary($"Switches the active scenario of the mock of <see cref=\"{escapedClassName}\" /> to <paramref name=\"scenario\" />.");
+		sb.AppendXmlRemarks([
+			"After the transition, setups registered via <see cref=\"InScenario(string)\" /> under that scenario take effect. Scenarios that have no matching setup for a given member fall back to the default (un-scoped) setups.",
+		]);
+		sb.AppendXmlParam("scenario", "Name of the scenario to transition to.");
+		sb.AppendXmlReturns("This accessor, to allow chaining further operations.");
 		sb.Append("\t\tIMockFor").Append(name).Append(" TransitionTo(string scenario);").AppendLine();
 		sb.AppendLine();
 
 		if (hasEvents)
 		{
-			sb.AppendXmlSummary($"Raise events on the mock of <see cref=\"{escapedClassName}\" />.");
+			sb.AppendXmlSummary($"Triggers events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlRemarks([
+				"One entry per event is generated; the signature matches the event's delegate. Only handlers that are subscribed at the moment of the <c>Raise</c> call are invoked - handlers subscribed later (or already removed) are skipped.",
+			]);
+			sb.AppendXmlExample([
+				"sut.MyEvent += (sender, args) => { /* ... */ };",
+				"sut.Mock.Raise.MyEvent(sut, EventArgs.Empty);",
+			]);
 			sb.Append("\t\tIMockRaiseOn").Append(name).Append(" Raise { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasProtectedEvents)
 		{
-			sb.AppendXmlSummary($"Raise protected events on the mock of <see cref=\"{escapedClassName}\" />.");
+			sb.AppendXmlSummary($"Triggers <see langword=\"protected\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlRemarks([
+				"Same semantics as <see cref=\"Raise\" /> but for events whose accessibility prevents external subscription from outside the class. Useful when testing code that subclasses the mocked type.",
+			]);
 			sb.Append("\t\tIMockProtectedRaiseOn").Append(name).Append(" RaiseProtected { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasStaticEvents)
 		{
-			sb.AppendXmlSummary($"Raise static events on the mock of <see cref=\"{escapedClassName}\" />.");
+			sb.AppendXmlSummary($"Triggers <see langword=\"static\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlRemarks([
+				"Static events are scoped per async/execution flow while the mock is alive.",
+			]);
 			sb.Append("\t\tIMockStaticRaiseOn").Append(name).Append(" RaiseStatic { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
-		sb.AppendXmlSummary($"Verify interactions with the mock of <see cref=\"{escapedClassName}\" />.");
+		sb.AppendXmlSummary($"Asserts how often, and in which order, members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
+		sb.AppendXmlRemarks([
+			"Each call to a member here returns a <c>VerificationResult</c> that you terminate with a count assertion: <c>Never</c>, <c>Once</c>, <c>Twice</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>/<c>AtLeastOnce</c>/<c>AtLeastTwice</c>, <c>AtMost(n)</c>/<c>AtMostOnce</c>/<c>AtMostTwice</c>, <c>Between(min, max)</c> or <c>Times(predicate)</c>.",
+			"Use <c>Within(TimeSpan)</c> / <c>WithCancellation(CancellationToken)</c> before the terminator to wait for expected interactions that happen on background threads.",
+			"Chain <c>Then(...)</c> to assert an ordered sequence of calls. A failing assertion throws a <see cref=\"global::Mockolate.Exceptions.MockVerificationException\" />.",
+		]);
+		sb.AppendXmlExample([
+			"sut.Mock.Verify.MyMethod(It.IsAny&lt;int&gt;()).Once();",
+			"sut.Mock.Verify.MyProperty.Got().AtLeastOnce();",
+			"sut.Mock.Verify.MyProperty.Set(It.Is(42)).Never();",
+			"sut.Mock.Verify.MyMethod(It.Is(1)).Then(",
+			"    m =&gt; m.MyMethod(It.Is(2)));",
+		]);
 		sb.Append("\t\tIMockVerifyFor").Append(name).Append(" Verify { get; }").AppendLine();
 		sb.AppendLine();
 		if (hasProtectedMembers || hasProtectedEvents)
 		{
-			sb.AppendXmlSummary($"Verify protected interactions with the mock of <see cref=\"{escapedClassName}\" />.");
+			sb.AppendXmlSummary($"Asserts how often, and in which order, <see langword=\"protected\" /> members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
+			sb.AppendXmlRemarks([
+				"Same terminators and modifiers as <see cref=\"Verify\" /> (<c>Once</c>, <c>Exactly</c>, <c>Within</c>, <c>Then</c>, ...); applies to <see langword=\"protected\" /> members and events instead of public ones.",
+			]);
 			sb.Append("\t\tIMockProtectedVerifyFor").Append(name).Append(" VerifyProtected { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasStaticMembers || hasStaticEvents)
 		{
-			sb.AppendXmlSummary($"Verify static interactions with the mock of <see cref=\"{escapedClassName}\" />.");
+			sb.AppendXmlSummary($"Asserts how often, and in which order, <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> were invoked.");
+			sb.AppendXmlRemarks([
+				"Same terminators and modifiers as <see cref=\"Verify\" />; scoped per async/execution flow in the same way as <see cref=\"SetupStatic\" />.",
+			]);
 			sb.Append("\t\tIMockStaticVerifyFor").Append(name).Append(" VerifyStatic { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
-		sb.AppendXmlSummary("Verifies the method invocations for the <paramref name=\"setup\" /> on the mock.");
+		sb.AppendXmlSummary("Verifies how often a specific method setup was matched by actual invocations.");
+		sb.AppendXmlRemarks([
+			"Useful when you want to verify &quot;this <em>particular</em> setup was hit N times&quot; without re-stating the matchers. Chain the usual count terminators (<c>Once</c>, <c>AtLeastOnce</c>, <c>Exactly</c>, ...) on the returned result.",
+		]);
+		sb.AppendXmlParam("setup", "The setup previously registered through <see cref=\"Setup\" /> (typically returned from a <c>Returns(...)</c>/<c>Throws(...)</c> call).");
+		sb.AppendXmlReturns("A <c>VerificationResult</c> that counts invocations matching the given setup.");
+		sb.AppendXmlExample([
+			"IMockSetup setup = sut.Mock.Setup.MyMethod(It.Is(1)).Returns(true);",
+			"// ... exercise the subject ...",
+			"sut.Mock.VerifySetup(setup).AtLeastOnce();",
+		]);
 		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name)
 			.Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary("Gets a value indicating whether all expected interactions have been verified.");
+		sb.AppendXmlSummary("Checks whether every recorded interaction on this mock has been observed by at least one <c>Verify</c> call.");
+		sb.AppendXmlRemarks([
+			"Useful in test teardown to catch unexpected interactions (&quot;strict verification&quot;): if any recorded call has never been matched by a verification, the method returns <see langword=\"false\" />.",
+		]);
+		sb.AppendXmlReturns("<see langword=\"true\" /> if every recorded interaction was verified at least once; otherwise <see langword=\"false\" />.");
 		sb.Append("\t\tbool VerifyThatAllInteractionsAreVerified();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary("Gets a value indicating whether all registered setups were used.");
+		sb.AppendXmlSummary("Checks whether every registered setup on this mock was matched by at least one actual invocation.");
+		sb.AppendXmlRemarks([
+			"Useful to catch unused setups that silently rot as the test subject evolves.",
+		]);
+		sb.AppendXmlReturns("<see langword=\"true\" /> if every registered setup was used at least once; otherwise <see langword=\"false\" />.");
 		sb.Append("\t\tbool VerifyThatAllSetupsAreUsed();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary("Clears all interactions recorded by the mock object.");
+		sb.AppendXmlSummary("Removes every recorded interaction from this mock while keeping all registered setups intact.");
+		sb.AppendXmlRemarks([
+			"Handy when a single test exercises multiple logical phases and you only want to verify the interactions of the latest phase.",
+		]);
+		sb.AppendXmlExample([
+			"sut.DoSomething();",
+			"sut.Mock.ClearAllInteractions();",
+			"sut.DoSomethingElse();",
+			"sut.Mock.Verify.DoSomethingElse(Match.AnyParameters()).Once();",
+		]);
 		sb.Append("\t\tvoid ClearAllInteractions();").AppendLine();
 		sb.AppendLine();
 		sb.AppendXmlSummary(
-			"Provides monitoring capabilities for a mocked instance of the specified type, allowing inspection of accessed properties, invoked methods, and event subscriptions.");
+			"Creates a scoped monitor that records interactions only while its <see cref=\"global::System.IDisposable\" /> scope is active.");
+		sb.AppendXmlRemarks([
+			"Interactions recorded on the mock outside <c>monitor.Run()</c> are not visible through the monitor. Useful to verify only the interactions produced by a specific block of test code without resetting the mock.",
+		]);
+		sb.AppendXmlReturns("A <see cref=\"global::Mockolate.Monitor.MockMonitor{T}\" /> that exposes <c>Verify</c> over the monitored interactions and a <c>Run()</c> method that opens the recording scope.");
+		sb.AppendXmlExample([
+			"var monitor = sut.Mock.Monitor();",
+			"using (monitor.Run())",
+			"{",
+			"    sut.DoSomething(); // recorded",
+			"}",
+			"sut.DoSomething();     // not recorded",
+			"monitor.Verify.DoSomething(Match.AnyParameters()).Once();",
+		]);
 		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();")
 			.AppendLine();
 		sb.Append("\t}").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -956,7 +956,7 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary($"Asserts how often, and in which order, members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
 		sb.AppendXmlRemarks([
-			"Each call to a member here returns a <c>VerificationResult</c> that you terminate with a count assertion: <c>Never</c>, <c>Once</c>, <c>Twice</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>/<c>AtLeastOnce</c>/<c>AtLeastTwice</c>, <c>AtMost(n)</c>/<c>AtMostOnce</c>/<c>AtMostTwice</c>, <c>Between(min, max)</c> or <c>Times(predicate)</c>.",
+			"Each call to a member here returns a <c>VerificationResult</c> that you terminate with a count assertion: <c>Never()</c>, <c>Once()</c>, <c>Twice()</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>/<c>AtLeastOnce()</c>/<c>AtLeastTwice()</c>, <c>AtMost(n)</c>/<c>AtMostOnce()</c>/<c>AtMostTwice()</c>, <c>Between(min, max)</c> or <c>Times(predicate)</c>.",
 			"Use <c>Within(TimeSpan)</c> / <c>WithCancellation(CancellationToken)</c> before the terminator to wait for expected interactions that happen on background threads.",
 			"Chain <c>Then(...)</c> to assert an ordered sequence of calls. A failing assertion throws a <see cref=\"global::Mockolate.Exceptions.MockVerificationException\" />.",
 		]);
@@ -966,7 +966,7 @@ internal static partial class Sources
 		{
 			sb.AppendXmlSummary($"Asserts how often, and in which order, <see langword=\"protected\" /> members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
 			sb.AppendXmlRemarks([
-				"Same terminators and modifiers as <see cref=\"Verify\" /> (<c>Once</c>, <c>Exactly</c>, <c>Within</c>, <c>Then</c>, ...); applies to <see langword=\"protected\" /> members and events instead of public ones.",
+				"Same terminators and modifiers as <see cref=\"Verify\" /> (<c>Once()</c>, <c>Exactly(n)</c>, <c>Within(...)</c>, <c>Then(...)</c>, ...); applies to <see langword=\"protected\" /> members and events instead of public ones.",
 			]);
 			sb.Append("\t\tIMockProtectedVerifyFor").Append(name).Append(" VerifyProtected { get; }").AppendLine();
 			sb.AppendLine();
@@ -984,7 +984,7 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary("Verifies how often a specific method setup was matched by actual invocations.");
 		sb.AppendXmlRemarks([
-			"Useful when you want to verify &quot;this <em>particular</em> setup was hit N times&quot; without re-stating the matchers. Chain the usual count terminators (<c>Once</c>, <c>AtLeastOnce</c>, <c>Exactly</c>, ...) on the returned result.",
+			"Useful when you want to verify &quot;this <em>particular</em> setup was hit N times&quot; without re-stating the matchers. Chain the usual count terminators (<c>Once()</c>, <c>AtLeastOnce()</c>, <c>Exactly(n)</c>, ...) on the returned result.",
 		]);
 		sb.AppendXmlParam("setup", "The setup previously registered through <see cref=\"Setup\" /> (typically returned from a <c>Returns(...)</c>/<c>Throws(...)</c> call).");
 		sb.AppendXmlReturns("A <c>VerificationResult</c> that counts invocations matching the given setup.");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -49,7 +49,14 @@ internal static partial class Sources
 		#region Implementing
 
 		(string Name, Class Class) lastInterface = additionalInterfaces[additionalInterfaces.Length - 1];
-		sb.AppendXmlSummary($"Create a mock that also implements <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+		sb.AppendXmlSummary($"Extends this mock so the returned instance also implements <typeparamref name=\"TInterface\" /> (here resolved to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />).");
+		sb.AppendXmlRemarks([
+			$"The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <typeparamref name=\"TInterface\" /> to exercise the extra surface; use <c>.Mock.As&lt;TInterface&gt;()</c> to reach the Setup/Verify surface of the additional interface.",
+			"<paramref name=\"setups\" /> is applied immediately to the new mock - use it to register initial setups for members of <typeparamref name=\"TInterface\" /> before the mock is returned (important for constructor-time interactions).",
+		]);
+		sb.AppendXmlTypeParam("TInterface", $"An additional interface to implement. Must derive from <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+		sb.AppendXmlParam("setups", "Optional setup callbacks registered on the additional interface before the mock is returned.");
+		sb.AppendXmlReturns("A mock of the original type that additionally implements <typeparamref name=\"TInterface\" />.");
 		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Implementing<TInterface>(params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[] setups)").AppendLine();
 		sb.Append("\t\t\twhere TInterface : ").Append(lastInterface.Class.ClassFullName).AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -213,8 +220,13 @@ internal static partial class Sources
 			sb.Append("{").AppendLine();
 			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" mock)").AppendLine();
 			sb.Append("\t{").AppendLine();
-			sb.AppendXmlSummary($"Interprets the mock as a mock of <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-			sb.AppendXmlRemarks($"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the subject does not implement <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <typeparamref name=\"T\" /> (here constrained to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />) to reach its Setup/Verify/Raise surface.");
+			sb.AppendXmlRemarks([
+				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.",
+				$"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the subject does not implement <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.",
+			]);
+			sb.AppendXmlTypeParam("T", $"The additional interface to reinterpret the mock as. Must derive from <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" As<T>() where T : ").Append(lastInterface.Class.ClassFullName).AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" typed)").AppendLine();
@@ -230,8 +242,13 @@ internal static partial class Sources
 			sb.Append("{").AppendLine();
 			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" mock)").AppendLine();
 			sb.Append("\t{").AppendLine();
-			sb.AppendXmlSummary($"Interprets the mock as a mock of <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-			sb.AppendXmlRemarks($"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the subject does not implement <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <typeparamref name=\"T\" /> (here constrained to <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />) to reach its Setup/Verify/Raise surface.");
+			sb.AppendXmlRemarks([
+				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.",
+				$"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the subject does not implement <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.",
+			]);
+			sb.AppendXmlTypeParam("T", $"The additional interface to reinterpret the mock as. Must derive from <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" As<T>() where T : ").Append(source.Class.ClassFullName).AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" typed)").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -49,14 +49,12 @@ internal static partial class Sources
 		#region Implementing
 
 		(string Name, Class Class) lastInterface = additionalInterfaces[additionalInterfaces.Length - 1];
-		sb.AppendXmlSummary($"Extends this mock so the returned instance also implements <typeparamref name=\"TInterface\" /> (here resolved to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />).");
+		sb.AppendXmlSummary($"Extends this mock so the returned instance also implements <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 		sb.AppendXmlRemarks([
-			$"The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <typeparamref name=\"TInterface\" /> to exercise the extra surface; use <c>.Mock.As&lt;TInterface&gt;()</c> to reach the Setup/Verify surface of the additional interface.",
-			"<paramref name=\"setups\" /> is applied immediately to the new mock - use it to register initial setups for members of <typeparamref name=\"TInterface\" /> before the mock is returned (important for constructor-time interactions).",
+			$"The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" /> to exercise the extra surface or use <c>.Mock.As&lt;{lastInterface.Class.ClassName}&gt;()</c> to reach the Setup/Verify surface of the additional interface.",
 		]);
-		sb.AppendXmlTypeParam("TInterface", $"An additional interface to implement. Must derive from <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 		sb.AppendXmlParam("setups", "Optional setup callbacks registered on the additional interface before the mock is returned.");
-		sb.AppendXmlReturns("A mock of the original type that additionally implements <typeparamref name=\"TInterface\" />.");
+		sb.AppendXmlReturns($"A mock of the original type that additionally implements <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Implementing<TInterface>(params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[] setups)").AppendLine();
 		sb.Append("\t\t\twhere TInterface : ").Append(lastInterface.Class.ClassFullName).AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -220,10 +218,9 @@ internal static partial class Sources
 			sb.Append("{").AppendLine();
 			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" mock)").AppendLine();
 			sb.Append("\t{").AppendLine();
-			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <typeparamref name=\"T\" /> (here constrained to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />) to reach its Setup/Verify/Raise surface.");
+			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" /> to reach its Setup/Verify/Raise surface.");
 			sb.AppendXmlRemarks(
 				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.");
-			sb.AppendXmlTypeParam("T", $"The additional interface to reinterpret the mock as. Must derive from <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
 				$"The subject does not implement <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -221,12 +221,12 @@ internal static partial class Sources
 			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" mock)").AppendLine();
 			sb.Append("\t{").AppendLine();
 			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <typeparamref name=\"T\" /> (here constrained to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />) to reach its Setup/Verify/Raise surface.");
-			sb.AppendXmlRemarks([
-				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.",
-				$"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the subject does not implement <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.",
-			]);
+			sb.AppendXmlRemarks(
+				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.");
 			sb.AppendXmlTypeParam("T", $"The additional interface to reinterpret the mock as. Must derive from <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+			sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
+				$"The subject does not implement <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" As<T>() where T : ").Append(lastInterface.Class.ClassFullName).AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" typed)").AppendLine();
@@ -243,12 +243,12 @@ internal static partial class Sources
 			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" mock)").AppendLine();
 			sb.Append("\t{").AppendLine();
 			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <typeparamref name=\"T\" /> (here constrained to <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />) to reach its Setup/Verify/Raise surface.");
-			sb.AppendXmlRemarks([
-				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.",
-				$"Throws a <see cref=\"global::Mockolate.Exceptions.MockException\" /> if the subject does not implement <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.",
-			]);
+			sb.AppendXmlRemarks(
+				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.");
 			sb.AppendXmlTypeParam("T", $"The additional interface to reinterpret the mock as. Must derive from <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+			sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
+				$"The subject does not implement <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" As<T>() where T : ").Append(source.Class.ClassFullName).AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" typed)").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -239,10 +239,9 @@ internal static partial class Sources
 			sb.Append("{").AppendLine();
 			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" mock)").AppendLine();
 			sb.Append("\t{").AppendLine();
-			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <typeparamref name=\"T\" /> (here constrained to <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />) to reach its Setup/Verify/Raise surface.");
+			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" /> to reach its Setup/Verify/Raise surface.");
 			sb.AppendXmlRemarks(
 				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.");
-			sb.AppendXmlTypeParam("T", $"The additional interface to reinterpret the mock as. Must derive from <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
 			sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
 				$"The subject does not implement <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
@@ -6,6 +6,10 @@ internal static partial class Sources
 {
 	public static string ReturnsThrowsAsyncExtensions(int[] numberOfParameters)
 	{
+		const string SequenceRemark =
+			"\t///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles\n" +
+			"\t///     back to the first entry unless the last one is followed by <c>.Forever()</c>.";
+
 		StringBuilder sb = InitializeBuilder();
 
 		sb.Append("""
@@ -30,9 +34,15 @@ internal static partial class Sources
 			string variables = string.Join(", ", Enumerable.Range(1, number).Select(i => $"v{i}"));
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers the <see langword=\"async\" /> <paramref name=\"returnValue\" /> for this method.")
+					"\t///     Appends <paramref name=\"returnValue\" /> to the sequence - the next matching invocation returns a completed")
+				.AppendLine();
+			sb.Append(
+					"\t///     <see cref=\"global::System.Threading.Tasks.Task{TReturn}\" /> carrying this value.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
 				.Append(types).Append("> setup, TReturn returnValue)").AppendLine();
@@ -41,9 +51,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers an <see langword=\"async\" /> <paramref name=\"callback\" /> to setup the return value for this method.")
+					"\t///     Appends a lazy async return to the sequence; <paramref name=\"callback\" /> is invoked on each matching")
+				.AppendLine();
+			sb.Append(
+					"\t///     invocation and its result is wrapped in a completed <see cref=\"global::System.Threading.Tasks.Task{TReturn}\" />.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
 				.Append(types).Append("> setup, global::System.Func<TReturn> callback)").AppendLine();
@@ -52,9 +68,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers an <see langword=\"async\" /> <paramref name=\"callback\" /> to setup the return value for this method.")
+					"\t///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a")
+				.AppendLine();
+			sb.Append(
+					"\t///     completed <see cref=\"global::System.Threading.Tasks.Task{TReturn}\" />.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<TReturn>, ")
 				.Append(types).Append("> setup, global::System.Func<").Append(types).Append(", TReturn> callback)").AppendLine();
@@ -64,9 +86,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers an <paramref name=\"exception\" /> to throw when the <see langword=\"async\" /> method is awaited.")
+					"\t///     Appends an entry that faults the returned <see cref=\"global::System.Threading.Tasks.Task{TReturn}\" /> with")
+				.AppendLine();
+			sb.Append(
+					"\t///     <paramref name=\"exception\" /> so awaiting it throws.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
 				.Append(types).Append("> setup, global::System.Exception exception)").AppendLine();
@@ -75,9 +103,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers a <paramref name=\"callback\" /> that calculates the exception to throw when the <see langword=\"async\" /> method is awaited.")
+					"\t///     Appends an entry that invokes <paramref name=\"callback\" /> to build the exception the returned")
+				.AppendLine();
+			sb.Append(
+					"\t///     <see cref=\"global::System.Threading.Tasks.Task{TReturn}\" /> is faulted with.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
 				.Append(types).Append("> setup, global::System.Func<global::System.Exception> callback)").AppendLine();
@@ -86,9 +120,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers a <paramref name=\"callback\" /> that calculates the exception to throw when the <see langword=\"async\" /> method is awaited.")
+					"\t///     Appends an entry that invokes <paramref name=\"callback\" /> with the method's arguments to build the")
+				.AppendLine();
+			sb.Append(
+					"\t///     exception the returned <see cref=\"global::System.Threading.Tasks.Task{TReturn}\" /> is faulted with.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<TReturn>, ")
 				.Append(types).Append("> setup, global::System.Func<").Append(types).Append(", global::System.Exception> callback)").AppendLine();
@@ -105,9 +145,15 @@ internal static partial class Sources
 			string variables = string.Join(", ", Enumerable.Range(1, number).Select(i => $"v{i}"));
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers the <see langword=\"async\" /> <paramref name=\"returnValue\" /> for this method.")
+					"\t///     Appends <paramref name=\"returnValue\" /> to the sequence - the next matching invocation returns a completed")
+				.AppendLine();
+			sb.Append(
+					"\t///     <see cref=\"global::System.Threading.Tasks.ValueTask{TReturn}\" /> carrying this value.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types)
 				.Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
@@ -117,9 +163,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers an <see langword=\"async\" /> <paramref name=\"callback\" /> to setup the return value for this method.")
+					"\t///     Appends a lazy async return to the sequence; <paramref name=\"callback\" /> is invoked on each matching")
+				.AppendLine();
+			sb.Append(
+					"\t///     invocation and its result is wrapped in a completed <see cref=\"global::System.Threading.Tasks.ValueTask{TReturn}\" />.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types)
 				.Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
@@ -129,9 +181,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers an <see langword=\"async\" /> <paramref name=\"callback\" /> to setup the return value for this method.")
+					"\t///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a")
+				.AppendLine();
+			sb.Append(
+					"\t///     completed <see cref=\"global::System.Threading.Tasks.ValueTask{TReturn}\" />.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types)
 				.Append(">(this global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types).Append("> setup, global::System.Func<")
@@ -142,9 +200,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers an <paramref name=\"exception\" /> to throw when the <see langword=\"async\" /> method is awaited.")
+					"\t///     Appends an entry that faults the returned <see cref=\"global::System.Threading.Tasks.ValueTask{TReturn}\" /> with")
+				.AppendLine();
+			sb.Append(
+					"\t///     <paramref name=\"exception\" /> so awaiting it throws.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types)
 				.Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
@@ -154,9 +218,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers a <paramref name=\"callback\" /> that calculates the exception to throw when the <see langword=\"async\" /> method is awaited.")
+					"\t///     Appends an entry that invokes <paramref name=\"callback\" /> to build the exception the returned")
+				.AppendLine();
+			sb.Append(
+					"\t///     <see cref=\"global::System.Threading.Tasks.ValueTask{TReturn}\" /> is faulted with.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types)
 				.Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
@@ -166,9 +236,15 @@ internal static partial class Sources
 
 			sb.Append("\t/// <summary>").AppendLine();
 			sb.Append(
-					"\t///     Registers a <paramref name=\"callback\" /> that calculates the exception to throw when the <see langword=\"async\" /> method is awaited.")
+					"\t///     Appends an entry that invokes <paramref name=\"callback\" /> with the method's arguments to build the")
+				.AppendLine();
+			sb.Append(
+					"\t///     exception the returned <see cref=\"global::System.Threading.Tasks.ValueTask{TReturn}\" /> is faulted with.")
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
+			sb.Append("\t/// <remarks>").AppendLine();
+			sb.Append(SequenceRemark).AppendLine();
+			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types)
 				.Append(">(this global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types).Append("> setup, global::System.Func<")

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.ReturnsAsyncExtensions.cs
@@ -6,9 +6,11 @@ internal static partial class Sources
 {
 	public static string ReturnsThrowsAsyncExtensions(int[] numberOfParameters)
 	{
-		const string SequenceRemark =
-			"\t///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles\n" +
-			"\t///     back to the first entry unless the last one is followed by <c>.Forever()</c>.";
+		static void AppendSequenceRemark(StringBuilder sb)
+		{
+			sb.Append("\t///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles").AppendLine();
+			sb.Append("\t///     back to the first entry unless the last one is followed by <c>.Forever()</c>.").AppendLine();
+		}
 
 		StringBuilder sb = InitializeBuilder();
 
@@ -41,7 +43,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
@@ -58,7 +60,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
@@ -75,7 +77,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<TReturn>, ")
@@ -93,7 +95,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
@@ -110,7 +112,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task<TReturn>, ")
@@ -127,7 +129,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.Task<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types).Append(">(this global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<TReturn>, ")
@@ -152,7 +154,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types)
@@ -170,7 +172,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types)
@@ -188,7 +190,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ReturnsAsync<TReturn, ").Append(types)
@@ -207,7 +209,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types)
@@ -225,7 +227,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types)
@@ -243,7 +245,7 @@ internal static partial class Sources
 				.AppendLine();
 			sb.Append("\t/// </summary>").AppendLine();
 			sb.Append("\t/// <remarks>").AppendLine();
-			sb.Append(SequenceRemark).AppendLine();
+			AppendSequenceRemark(sb);
 			sb.Append("\t/// </remarks>").AppendLine();
 			sb.Append("\tpublic static global::Mockolate.Setup.IReturnMethodSetupReturnBuilder<global::System.Threading.Tasks.ValueTask<TReturn>, ").Append(types)
 				.Append("> ThrowsAsync<TReturn, ").Append(types)

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -431,6 +431,13 @@ internal static partial class Sources
 		/// </summary>
 		private void AppendXmlReturns(string returnsText, string indent = "\t\t")
 			=> sb.Append(indent).Append("/// <returns>").Append(returnsText).Append("</returns>").AppendLine();
+
+		/// <summary>
+		///     Appends an XML documentation <c>&lt;exception&gt;</c> tag with the given <paramref name="cref" /> and text.
+		/// </summary>
+		private void AppendXmlException(string cref, string text, string indent = "\t\t")
+			=> sb.Append(indent).Append("/// <exception cref=\"").Append(cref).Append("\">")
+				.Append(text).Append("</exception>").AppendLine();
 	}
 }
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -353,13 +353,6 @@ internal static partial class Sources
 	{
 		private string EscapeForXmlDoc()
 			=> value.Replace('<', '{').Replace('>', '}');
-
-		/// <summary>
-		///     Escapes <c>&lt;</c>, <c>&gt;</c> and <c>&amp;</c> for use inside an XML-doc text or <c>&lt;code&gt;</c> block,
-		///     so that types like <c>List&lt;T&gt;</c> don't break the surrounding XML.
-		/// </summary>
-		private string EscapeForXmlText()
-			=> value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
 	}
 
 	extension(StringBuilder sb)
@@ -395,32 +388,16 @@ internal static partial class Sources
 			}
 
 			sb.Append(indent).Append("/// <remarks>").AppendLine();
-			int i = 0;
-			foreach (string line in lines)
+			for (int i = 0; i < lines.Length; i++)
 			{
-				sb.Append(indent).Append("///     ").Append(line);
-				if (i++ < lines.Length)
+				sb.Append(indent).Append("///     ").Append(lines[i]);
+				if (i < lines.Length - 1)
 				{
 					sb.Append("<br />");
 				}
 				sb.AppendLine();
 			}
 			sb.Append(indent).Append("/// </remarks>").AppendLine();
-		}
-
-		/// <summary>
-		///     Appends an XML documentation <c>&lt;example&gt;</c> block containing a <c>&lt;code&gt;</c> snippet.
-		/// </summary>
-		private void AppendXmlExample(string[] codeLines, string indent = "\t\t")
-		{
-			sb.Append(indent).Append("/// <example>").AppendLine();
-			sb.Append(indent).Append("///     <code>").AppendLine();
-			foreach (string line in codeLines)
-			{
-				sb.Append(indent).Append("///     ").Append(line).AppendLine();
-			}
-			sb.Append(indent).Append("///     </code>").AppendLine();
-			sb.Append(indent).Append("/// </example>").AppendLine();
 		}
 
 		/// <summary>

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -389,10 +389,21 @@ internal static partial class Sources
 		/// </summary>
 		private void AppendXmlRemarks(string[] lines, string indent = "\t\t")
 		{
+			if (lines.Length == 0)
+			{
+				return;
+			}
+
 			sb.Append(indent).Append("/// <remarks>").AppendLine();
+			int i = 0;
 			foreach (string line in lines)
 			{
-				sb.Append(indent).Append("///     ").Append(line).AppendLine();
+				sb.Append(indent).Append("///     ").Append(line);
+				if (i++ < lines.Length)
+				{
+					sb.Append("<br />");
+				}
+				sb.AppendLine();
 			}
 			sb.Append(indent).Append("/// </remarks>").AppendLine();
 		}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -353,6 +353,13 @@ internal static partial class Sources
 	{
 		private string EscapeForXmlDoc()
 			=> value.Replace('<', '{').Replace('>', '}');
+
+		/// <summary>
+		///     Escapes <c>&lt;</c>, <c>&gt;</c> and <c>&amp;</c> for use inside an XML-doc text or <c>&lt;code&gt;</c> block,
+		///     so that types like <c>List&lt;T&gt;</c> don't break the surrounding XML.
+		/// </summary>
+		private string EscapeForXmlText()
+			=> value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
 	}
 
 	extension(StringBuilder sb)
@@ -375,6 +382,34 @@ internal static partial class Sources
 			sb.Append(indent).Append("/// <remarks>").AppendLine();
 			sb.Append(indent).Append("///     ").Append(remarksText).AppendLine();
 			sb.Append(indent).Append("/// </remarks>").AppendLine();
+		}
+
+		/// <summary>
+		///     Appends an XML documentation <c>&lt;remarks&gt;</c> block consisting of several pre-formatted lines.
+		/// </summary>
+		private void AppendXmlRemarks(string[] lines, string indent = "\t\t")
+		{
+			sb.Append(indent).Append("/// <remarks>").AppendLine();
+			foreach (string line in lines)
+			{
+				sb.Append(indent).Append("///     ").Append(line).AppendLine();
+			}
+			sb.Append(indent).Append("/// </remarks>").AppendLine();
+		}
+
+		/// <summary>
+		///     Appends an XML documentation <c>&lt;example&gt;</c> block containing a <c>&lt;code&gt;</c> snippet.
+		/// </summary>
+		private void AppendXmlExample(string[] codeLines, string indent = "\t\t")
+		{
+			sb.Append(indent).Append("/// <example>").AppendLine();
+			sb.Append(indent).Append("///     <code>").AppendLine();
+			foreach (string line in codeLines)
+			{
+				sb.Append(indent).Append("///     ").Append(line).AppendLine();
+			}
+			sb.Append(indent).Append("///     </code>").AppendLine();
+			sb.Append(indent).Append("/// </example>").AppendLine();
 		}
 
 		/// <summary>

--- a/Source/Mockolate/IMockBehaviorAccess.cs
+++ b/Source/Mockolate/IMockBehaviorAccess.cs
@@ -8,20 +8,27 @@ namespace Mockolate;
 public interface IMockBehaviorAccess
 {
 	/// <summary>
-	///     Stores the given <paramref name="value" /> in the <see cref="MockBehavior" />.
+	///     Returns a new <see cref="MockBehavior" /> with <paramref name="value" /> stored under the key
+	///     <typeparamref name="T" />. Any existing entry for <typeparamref name="T" /> is replaced.
 	/// </summary>
+	/// <typeparam name="T">The storage key &#8212; typically the runtime type of <paramref name="value" />.</typeparam>
+	/// <param name="value">The value to store.</param>
+	/// <returns>A new <see cref="MockBehavior" /> with the value attached; the current instance is unchanged.</returns>
 	MockBehavior Set<T>(T value);
 
 	/// <summary>
-	///     Retrieves the <paramref name="value" /> from the <see cref="MockBehavior" />.
+	///     Retrieves the value previously stored under key <typeparamref name="T" />.
 	/// </summary>
+	/// <typeparam name="T">The storage key to look up.</typeparam>
+	/// <param name="value">When this method returns <see langword="true" />, contains the stored value; otherwise <see langword="default" />.</param>
+	/// <returns><see langword="true" /> when a value is found; <see langword="false" /> otherwise.</returns>
 	bool TryGet<T>([NotNullWhen(true)] out T value);
 
 	/// <summary>
-	///     Tries to get the constructor parameters for a mock of type <typeparamref name="T" />.
+	///     Tries to get the constructor parameters configured for a mock of type <typeparamref name="T" />.
 	/// </summary>
-	/// <remarks>
-	///     Returns <see langword="false" />, when no matching constructor parameters are found.
-	/// </remarks>
+	/// <typeparam name="T">The mocked type whose constructor parameters are being looked up.</typeparam>
+	/// <param name="parameters">When this method returns <see langword="true" />, contains the configured parameter array; otherwise <see langword="null" />.</param>
+	/// <returns><see langword="false" /> when no matching constructor parameters are found; <see langword="true" /> otherwise.</returns>
 	bool TryGetConstructorParameters<T>([NotNullWhen(true)] out object?[]? parameters);
 }

--- a/Source/Mockolate/It.Contains.cs
+++ b/Source/Mockolate/It.Contains.cs
@@ -24,12 +24,7 @@ public partial class It
 	/// <typeparam name="T">The collection element type.</typeparam>
 	/// <param name="item">The item that must appear in the collection.</param>
 	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Process(It.Contains(5)).Returns(true);
-	///     sut.Mock.Verify.Process(It.Contains("HELLO").Using(StringComparer.OrdinalIgnoreCase)).Once();
-	///     </code>
-	/// </example>
+	/// <returns>A parameter matcher that accepts any supported collection containing <paramref name="item" />.</returns>
 	public static IContainsParameter<T> Contains<T>(T item,
 		[CallerArgumentExpression(nameof(item))]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.Contains.cs
+++ b/Source/Mockolate/It.Contains.cs
@@ -10,15 +10,15 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a collection parameter that contains <paramref name="item" /> (according to
-	///     <see cref="EqualityComparer{T}.Default" /> or a custom comparer via
-	///     <see cref="IContainsParameter{T}.Using" />).
+	///     Matches a collection parameter that contains <paramref name="item" />.
 	/// </summary>
 	/// <remarks>
-	///     Supports method parameters declared as <see cref="IEnumerable{T}" />, <see cref="ICollection{T}" />,
-	///     <see cref="IList{T}" />, <see cref="IReadOnlyCollection{T}" />, <see cref="IReadOnlyList{T}" />,
-	///     <see cref="ISet{T}" />, <typeparamref name="T" /> arrays, <see cref="List{T}" />,
-	///     <see cref="HashSet{T}" />, <see cref="Queue{T}" /> or <see cref="Stack{T}" />. Use
+	///     Equality uses <see cref="EqualityComparer{T}.Default" /> unless
+	///     <see cref="IContainsParameter{T}.Using" /> supplies a custom comparer. Supports method parameters declared
+	///     as <see cref="IEnumerable{T}" />, <see cref="ICollection{T}" />, <see cref="IList{T}" />,
+	///     <see cref="IReadOnlyCollection{T}" />, <see cref="IReadOnlyList{T}" />, <see cref="ISet{T}" />,
+	///     <typeparamref name="T" /> arrays, <see cref="List{T}" />, <see cref="HashSet{T}" />,
+	///     <see cref="Queue{T}" /> or <see cref="Stack{T}" />. Use
 	///     <see cref="SequenceEquals{T}(IEnumerable{T})" /> when order and length must match.
 	/// </remarks>
 	/// <typeparam name="T">The collection element type.</typeparam>

--- a/Source/Mockolate/It.Contains.cs
+++ b/Source/Mockolate/It.Contains.cs
@@ -10,14 +10,26 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a collection parameter that contains <paramref name="item" />.
+	///     Matches a collection parameter that contains <paramref name="item" /> (according to
+	///     <see cref="EqualityComparer{T}.Default" /> or a custom comparer via
+	///     <see cref="IContainsParameter{T}.Using" />).
 	/// </summary>
 	/// <remarks>
 	///     Supports method parameters declared as <see cref="IEnumerable{T}" />, <see cref="ICollection{T}" />,
 	///     <see cref="IList{T}" />, <see cref="IReadOnlyCollection{T}" />, <see cref="IReadOnlyList{T}" />,
 	///     <see cref="ISet{T}" />, <typeparamref name="T" /> arrays, <see cref="List{T}" />,
-	///     <see cref="HashSet{T}" />, <see cref="Queue{T}" /> or <see cref="Stack{T}" />.
+	///     <see cref="HashSet{T}" />, <see cref="Queue{T}" /> or <see cref="Stack{T}" />. Use
+	///     <see cref="SequenceEquals{T}(IEnumerable{T})" /> when order and length must match.
 	/// </remarks>
+	/// <typeparam name="T">The collection element type.</typeparam>
+	/// <param name="item">The item that must appear in the collection.</param>
+	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Process(It.Contains(5)).Returns(true);
+	///     sut.Mock.Verify.Process(It.Contains("HELLO").Using(StringComparer.OrdinalIgnoreCase)).Once();
+	///     </code>
+	/// </example>
 	public static IContainsParameter<T> Contains<T>(T item,
 		[CallerArgumentExpression(nameof(item))]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.Is.cs
+++ b/Source/Mockolate/It.Is.cs
@@ -9,14 +9,14 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a parameter that equals <paramref name="value" /> according to <see cref="EqualityComparer{T}.Default" />
-	///     (overridable via <see cref="IIsParameter{T}.Using" />).
+	///     Matches a parameter that equals <paramref name="value" />.
 	/// </summary>
 	/// <remarks>
-	///     For methods and indexers with up to four parameters you can also pass the raw value directly - Mockolate
-	///     treats it as if it were wrapped in <c>It.Is(value)</c>. Prefer an explicit <c>It.Is(...)</c> when the call
-	///     site would otherwise be ambiguous (e.g. when mixing matchers and raw values), or when you need
-	///     <see cref="IIsParameter{T}.Using"/> for a custom comparer.
+	///     Equality uses <see cref="EqualityComparer{T}.Default" /> unless overridden via
+	///     <see cref="IIsParameter{T}.Using" />. For methods and indexers with up to four parameters you can also pass
+	///     the raw value directly &#8212; Mockolate treats it as if it were wrapped in <c>It.Is(value)</c>. Prefer an
+	///     explicit <c>It.Is(...)</c> when the call site would otherwise be ambiguous (e.g. when mixing matchers and
+	///     raw values), or when you need <see cref="IIsParameter{T}.Using"/> for a custom comparer.
 	///     <para />
 	///     The expression passed as <paramref name="value" /> is captured by the compiler (via
 	///     <see cref="CallerArgumentExpressionAttribute" />) and appears verbatim in failure messages, so keep

--- a/Source/Mockolate/It.Is.cs
+++ b/Source/Mockolate/It.Is.cs
@@ -26,12 +26,6 @@ public partial class It
 	/// <param name="value">The expected value.</param>
 	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
 	/// <returns>A parameter matcher that only accepts arguments equal to <paramref name="value" />.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Dispense(It.Is("Dark"), It.Is(5)).Returns(true);
-	///     sut.Mock.Verify.Lookup(It.Is("hello").Using(StringComparer.OrdinalIgnoreCase)).Once();
-	///     </code>
-	/// </example>
 	public static IIsParameter<T> Is<T>(T value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.Is.cs
+++ b/Source/Mockolate/It.Is.cs
@@ -9,21 +9,47 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a parameter that is equal to <paramref name="value" />.
+	///     Matches a parameter that equals <paramref name="value" /> according to <see cref="EqualityComparer{T}.Default" />
+	///     (overridable via <see cref="IIsParameter{T}.Using" />).
 	/// </summary>
+	/// <remarks>
+	///     For methods and indexers with up to four parameters you can also pass the raw value directly - Mockolate
+	///     treats it as if it were wrapped in <c>It.Is(value)</c>. Prefer an explicit <c>It.Is(...)</c> when the call
+	///     site would otherwise be ambiguous (e.g. when mixing matchers and raw values), or when you need
+	///     <see cref="IIsParameter{T}.Using"/> for a custom comparer.
+	///     <para />
+	///     The expression passed as <paramref name="value" /> is captured by the compiler (via
+	///     <see cref="CallerArgumentExpressionAttribute" />) and appears verbatim in failure messages, so keep
+	///     expressions short to get readable diagnostics.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <param name="value">The expected value.</param>
+	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
+	/// <returns>A parameter matcher that only accepts arguments equal to <paramref name="value" />.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Dispense(It.Is("Dark"), It.Is(5)).Returns(true);
+	///     sut.Mock.Verify.Lookup(It.Is("hello").Using(StringComparer.OrdinalIgnoreCase)).Once();
+	///     </code>
+	/// </example>
 	public static IIsParameter<T> Is<T>(T value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
 		=> new ParameterEqualsMatch<T>(value, doNotPopulateThisValue);
 
 	/// <summary>
-	///     An <see cref="IParameter{T}" /> used for equality comparison.
+	///     An <see cref="IParameter{T}" /> used for equality comparison, with an opt-in custom comparer.
 	/// </summary>
 	public interface IIsParameter<out T> : IParameterWithCallback<T>
 	{
 		/// <summary>
-		///     Use the specified comparer to determine equality.
+		///     Switches equality comparison to use <paramref name="comparer" /> instead of
+		///     <see cref="EqualityComparer{T}.Default" />.
 		/// </summary>
+		/// <remarks>
+		///     Useful for case-insensitive string comparison or structural comparisons on types that don't override
+		///     <see cref="object.Equals(object)" />.
+		/// </remarks>
 		IIsParameter<T> Using(IEqualityComparer<T> comparer,
 			[CallerArgumentExpression(nameof(comparer))]
 			string doNotPopulateThisValue = "");

--- a/Source/Mockolate/It.IsAny.cs
+++ b/Source/Mockolate/It.IsAny.cs
@@ -8,9 +8,25 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any parameter of type <typeparamref name="T" />.
+	///     Matches any value passed for a parameter of type <typeparamref name="T" /> (including <see langword="null" />).
 	/// </summary>
-	/// <remarks>Also matches, if the method parameter is <see langword="null" />.</remarks>
+	/// <remarks>
+	///     The workhorse matcher when a setup or verification shouldn't care about the exact argument value. For
+	///     reference-typed and nullable parameters <see langword="null" /> also matches. For <see langword="ref" />,
+	///     <see langword="out" />, span or ref-struct parameters, use the dedicated <c>It.IsAnyRef</c>,
+	///     <c>It.IsAnyOut</c>, <c>It.IsAnySpan</c>, <c>It.IsAnyRefStruct</c> counterparts instead.
+	///     <para />
+	///     Chain <c>.Monitor(out var monitor)</c> (see <see cref="ParameterExtensions" />) to observe the actual values that
+	///     flow through the matcher at runtime.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <returns>A parameter matcher that accepts every value of type <typeparamref name="T" />.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Dispense(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;()).Returns(true);
+	///     sut.Mock.Verify.Dispense(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;()).AtLeastOnce();
+	///     </code>
+	/// </example>
 	public static IParameterWithCallback<T> IsAny<T>()
 		=> new AnyParameterMatch<T>();
 

--- a/Source/Mockolate/It.IsAny.cs
+++ b/Source/Mockolate/It.IsAny.cs
@@ -21,12 +21,6 @@ public partial class It
 	/// </remarks>
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>
 	/// <returns>A parameter matcher that accepts every value of type <typeparamref name="T" />.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Dispense(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;()).Returns(true);
-	///     sut.Mock.Verify.Dispense(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;()).AtLeastOnce();
-	///     </code>
-	/// </example>
 	public static IParameterWithCallback<T> IsAny<T>()
 		=> new AnyParameterMatch<T>();
 

--- a/Source/Mockolate/It.IsFalse.cs
+++ b/Source/Mockolate/It.IsFalse.cs
@@ -7,8 +7,17 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any boolean parameter that is <see langword="false" />.
+	///     Matches any <see langword="bool" /> parameter whose value is <see langword="false" />.
 	/// </summary>
+	/// <remarks>
+	///     Shorthand for <c>It.Is(false)</c> with a nicer failure-message rendering. Use <see cref="IsTrue" /> for the
+	///     opposite.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Verify.Toggle(It.IsFalse()).Never();
+	///     </code>
+	/// </example>
 	public static IParameterWithCallback<bool> IsFalse()
 		=> new FalseParameterMatch();
 

--- a/Source/Mockolate/It.IsFalse.cs
+++ b/Source/Mockolate/It.IsFalse.cs
@@ -13,11 +13,6 @@ public partial class It
 	///     Shorthand for <c>It.Is(false)</c> with a nicer failure-message rendering. Use <see cref="IsTrue" /> for the
 	///     opposite.
 	/// </remarks>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Verify.Toggle(It.IsFalse()).Never();
-	///     </code>
-	/// </example>
 	public static IParameterWithCallback<bool> IsFalse()
 		=> new FalseParameterMatch();
 

--- a/Source/Mockolate/It.IsInRange.cs
+++ b/Source/Mockolate/It.IsInRange.cs
@@ -9,8 +9,29 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any parameter that is within the specified range.
+	///     Matches any parameter whose value lies between <paramref name="minimum" /> and <paramref name="maximum" />
+	///     according to <see cref="IComparable{T}.CompareTo" />.
 	/// </summary>
+	/// <remarks>
+	///     Bounds are inclusive by default (<see cref="IInRangeParameter{T}.Inclusive" />); chain
+	///     <see cref="IInRangeParameter{T}.Exclusive" /> to exclude them.
+	///     Works on any type that implements <see cref="IComparable{T}" /> - numerics,
+	///     <see cref="System.DateTime" />, <see cref="TimeSpan" />, etc.
+	///     Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="maximum" /> is less than
+	///     <paramref name="minimum" />.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <param name="minimum">Lower bound of the accepted range.</param>
+	/// <param name="maximum">Upper bound of the accepted range.</param>
+	/// <param name="doNotPopulateThisValue1">Do not populate - captured automatically by the compiler.</param>
+	/// <param name="doNotPopulateThisValue2">Do not populate - captured automatically by the compiler.</param>
+	/// <returns>A parameter matcher that accepts values in the specified range.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Dispense(It.IsAny&lt;string&gt;(), It.IsInRange(1, 10)).Returns(true);
+	///     sut.Mock.Setup.Dispense(It.IsAny&lt;string&gt;(), It.IsInRange(1, 10).Exclusive()).Returns(false);
+	///     </code>
+	/// </example>
 	public static IInRangeParameter<T> IsInRange<T>(T minimum, T maximum,
 		[CallerArgumentExpression("minimum")] string doNotPopulateThisValue1 = "",
 		[CallerArgumentExpression("maximum")] string doNotPopulateThisValue2 = "")
@@ -18,20 +39,21 @@ public partial class It
 		=> new InRangeMatch<T>(minimum, maximum, doNotPopulateThisValue1, doNotPopulateThisValue2);
 
 	/// <summary>
-	///     Matches a method parameter of type <typeparamref name="T" /> to be in a given range.
+	///     A parameter matcher for an in-range constraint on values of type <typeparamref name="T" />.
 	/// </summary>
 	public interface IInRangeParameter<out T> : IParameterWithCallback<T>
 	{
 		/// <summary>
-		///     Exclude the minimum and maximum of the range.
+		///     Switches to exclusive bounds: values equal to the minimum or maximum are rejected.
 		/// </summary>
 		IParameterWithCallback<T> Exclusive();
 
 		/// <summary>
-		///     Include the minimum and maximum of the range.
+		///     Switches to inclusive bounds: values equal to the minimum or maximum are accepted.
 		/// </summary>
 		/// <remarks>
-		///     This is the default behavior.
+		///     This is the default behavior; calling <see cref="Inclusive" /> explicitly is only needed to revert a
+		///     previous <see cref="Exclusive" /> call.
 		/// </remarks>
 		IParameterWithCallback<T> Inclusive();
 	}

--- a/Source/Mockolate/It.IsInRange.cs
+++ b/Source/Mockolate/It.IsInRange.cs
@@ -17,8 +17,6 @@ public partial class It
 	///     <see cref="IInRangeParameter{T}.Exclusive" /> to exclude them.
 	///     Works on any type that implements <see cref="IComparable{T}" /> - numerics,
 	///     <see cref="System.DateTime" />, <see cref="TimeSpan" />, etc.
-	///     Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="maximum" /> is less than
-	///     <paramref name="minimum" />.
 	/// </remarks>
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>
 	/// <param name="minimum">Lower bound of the accepted range.</param>
@@ -26,12 +24,7 @@ public partial class It
 	/// <param name="doNotPopulateThisValue1">Do not populate - captured automatically by the compiler.</param>
 	/// <param name="doNotPopulateThisValue2">Do not populate - captured automatically by the compiler.</param>
 	/// <returns>A parameter matcher that accepts values in the specified range.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Dispense(It.IsAny&lt;string&gt;(), It.IsInRange(1, 10)).Returns(true);
-	///     sut.Mock.Setup.Dispense(It.IsAny&lt;string&gt;(), It.IsInRange(1, 10).Exclusive()).Returns(false);
-	///     </code>
-	/// </example>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="maximum" /> is less than <paramref name="minimum" />.</exception>
 	public static IInRangeParameter<T> IsInRange<T>(T minimum, T maximum,
 		[CallerArgumentExpression("minimum")] string doNotPopulateThisValue1 = "",
 		[CallerArgumentExpression("maximum")] string doNotPopulateThisValue2 = "")

--- a/Source/Mockolate/It.IsInRange.cs
+++ b/Source/Mockolate/It.IsInRange.cs
@@ -9,13 +9,13 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any parameter whose value lies between <paramref name="minimum" /> and <paramref name="maximum" />
-	///     according to <see cref="IComparable{T}.CompareTo" />.
+	///     Matches any parameter whose value is inclusively between <paramref name="minimum" /> and
+	///     <paramref name="maximum" />.
 	/// </summary>
 	/// <remarks>
-	///     Bounds are inclusive by default (<see cref="IInRangeParameter{T}.Inclusive" />); chain
-	///     <see cref="IInRangeParameter{T}.Exclusive" /> to exclude them.
-	///     Works on any type that implements <see cref="IComparable{T}" /> - numerics,
+	///     Comparison is performed via <see cref="IComparable{T}.CompareTo" />. Bounds are inclusive by default
+	///     (<see cref="IInRangeParameter{T}.Inclusive" />); chain <see cref="IInRangeParameter{T}.Exclusive" /> to
+	///     exclude them. Works on any type that implements <see cref="IComparable{T}" /> &#8212; numerics,
 	///     <see cref="System.DateTime" />, <see cref="TimeSpan" />, etc.
 	/// </remarks>
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>

--- a/Source/Mockolate/It.IsNot.cs
+++ b/Source/Mockolate/It.IsNot.cs
@@ -20,11 +20,6 @@ public partial class It
 	/// <param name="value">The value to reject.</param>
 	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
 	/// <returns>A parameter matcher that accepts any value not equal to <paramref name="value" />.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Dispense(It.IsNot("White"), It.IsAny&lt;int&gt;()).Returns(true);
-	///     </code>
-	/// </example>
 	public static IIsNotParameter<T> IsNot<T>(T value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.IsNot.cs
+++ b/Source/Mockolate/It.IsNot.cs
@@ -12,9 +12,9 @@ public partial class It
 	///     Matches a parameter whose value is <em>not</em> equal to <paramref name="value" />.
 	/// </summary>
 	/// <remarks>
-	///     The inverse of <see cref="Is{T}(T, string)" />. Unlike <c>Is</c>, this matcher also accepts arguments of
-	///     runtime types that are incompatible with <typeparamref name="T" /> (reached via covariant widening), since
-	///     such values cannot equal a <typeparamref name="T" />-typed expectation.
+	///     The inverse of <see cref="Is{T}(T, string)" />. Unlike <c>Is</c>, this matcher also accepts arguments
+	///     whose runtime type is not <typeparamref name="T" />, since such values cannot equal a
+	///     <typeparamref name="T" />-typed expectation.
 	/// </remarks>
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>
 	/// <param name="value">The value to reject.</param>

--- a/Source/Mockolate/It.IsNot.cs
+++ b/Source/Mockolate/It.IsNot.cs
@@ -9,20 +9,35 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a parameter that is not equal to <paramref name="value" />.
+	///     Matches a parameter whose value is <em>not</em> equal to <paramref name="value" />.
 	/// </summary>
+	/// <remarks>
+	///     The inverse of <see cref="Is{T}(T, string)" />. Unlike <c>Is</c>, this matcher also accepts arguments of
+	///     runtime types that are incompatible with <typeparamref name="T" /> (reached via covariant widening), since
+	///     such values cannot equal a <typeparamref name="T" />-typed expectation.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <param name="value">The value to reject.</param>
+	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
+	/// <returns>A parameter matcher that accepts any value not equal to <paramref name="value" />.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Dispense(It.IsNot("White"), It.IsAny&lt;int&gt;()).Returns(true);
+	///     </code>
+	/// </example>
 	public static IIsNotParameter<T> IsNot<T>(T value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
 		=> new ParameterEqualsNotMatch<T>(value, doNotPopulateThisValue);
 
 	/// <summary>
-	///     An <see cref="IParameter{T}" /> used for equality comparison.
+	///     An <see cref="IParameter{T}" /> used for inequality comparison, with an opt-in custom comparer.
 	/// </summary>
 	public interface IIsNotParameter<out T> : IParameterWithCallback<T>
 	{
 		/// <summary>
-		///     Use the specified comparer to determine equality.
+		///     Switches equality comparison to use <paramref name="comparer" /> instead of
+		///     <see cref="EqualityComparer{T}.Default" />.
 		/// </summary>
 		IIsNotParameter<T> Using(IEqualityComparer<T> comparer,
 			[CallerArgumentExpression(nameof(comparer))]

--- a/Source/Mockolate/It.IsNotNull.cs
+++ b/Source/Mockolate/It.IsNotNull.cs
@@ -8,8 +8,20 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any parameter that is not <see langword="null" />.
+	///     Matches any parameter whose value is not <see langword="null" />.
 	/// </summary>
+	/// <remarks>
+	///     The inverse of <see cref="IsNull{T}(string)" />. Arguments of a different runtime type than
+	///     <typeparamref name="T" /> also match - their very presence proves they aren't <see langword="null" />.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <param name="toString">Optional override for the matcher's <see cref="object.ToString" /> rendering, used in failure messages.</param>
+	/// <returns>A parameter matcher that accepts every non-<see langword="null" /> argument.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Verify.Process(It.IsNotNull&lt;byte[]&gt;()).AtLeastOnce();
+	///     </code>
+	/// </example>
 	public static IParameterWithCallback<T> IsNotNull<T>(string? toString = null)
 		=> new NotNullParameterMatch<T>(toString);
 

--- a/Source/Mockolate/It.IsNotNull.cs
+++ b/Source/Mockolate/It.IsNotNull.cs
@@ -17,11 +17,6 @@ public partial class It
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>
 	/// <param name="toString">Optional override for the matcher's <see cref="object.ToString" /> rendering, used in failure messages.</param>
 	/// <returns>A parameter matcher that accepts every non-<see langword="null" /> argument.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Verify.Process(It.IsNotNull&lt;byte[]&gt;()).AtLeastOnce();
-	///     </code>
-	/// </example>
 	public static IParameterWithCallback<T> IsNotNull<T>(string? toString = null)
 		=> new NotNullParameterMatch<T>(toString);
 

--- a/Source/Mockolate/It.IsNotOneOf.cs
+++ b/Source/Mockolate/It.IsNotOneOf.cs
@@ -20,11 +20,6 @@ public partial class It
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>
 	/// <param name="values">The values to reject.</param>
 	/// <returns>A parameter matcher that rejects every value equal to one of <paramref name="values" />.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Dispense(It.IsNotOneOf("Green", "White"), It.IsAny&lt;int&gt;()).Returns(true);
-	///     </code>
-	/// </example>
 	public static IIsNotOneOfParameter<T> IsNotOneOf<T>(params IEnumerable<T> values)
 		=> new ParameterIsNotOneOfMatch<T>(values.ToArray());
 

--- a/Source/Mockolate/It.IsNotOneOf.cs
+++ b/Source/Mockolate/It.IsNotOneOf.cs
@@ -10,18 +10,33 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a parameter that is not equal to one of the <paramref name="values" />.
+	///     Matches a parameter whose value is <em>not</em> equal to any of the supplied <paramref name="values" />.
 	/// </summary>
+	/// <remarks>
+	///     The inverse of <see cref="IsOneOf{T}(IEnumerable{T})" />. Values whose runtime type is incompatible with
+	///     <typeparamref name="T" /> also match, since they cannot equal any <typeparamref name="T" />-typed
+	///     alternative.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <param name="values">The values to reject.</param>
+	/// <returns>A parameter matcher that rejects every value equal to one of <paramref name="values" />.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Dispense(It.IsNotOneOf("Green", "White"), It.IsAny&lt;int&gt;()).Returns(true);
+	///     </code>
+	/// </example>
 	public static IIsNotOneOfParameter<T> IsNotOneOf<T>(params IEnumerable<T> values)
 		=> new ParameterIsNotOneOfMatch<T>(values.ToArray());
 
 	/// <summary>
-	///     An <see cref="IParameter{T}" /> used for equality comparison of a collection of alternatives.
+	///     An <see cref="IParameter{T}" /> used to reject values matching any of a set of alternatives, with an opt-in
+	///     custom comparer.
 	/// </summary>
 	public interface IIsNotOneOfParameter<out T> : IParameterWithCallback<T>
 	{
 		/// <summary>
-		///     Use the specified comparer to determine equality.
+		///     Switches equality comparison to use <paramref name="comparer" /> instead of
+		///     <see cref="EqualityComparer{T}.Default" />.
 		/// </summary>
 		IIsNotOneOfParameter<T> Using(IEqualityComparer<T> comparer,
 			[CallerArgumentExpression(nameof(comparer))]

--- a/Source/Mockolate/It.IsNull.cs
+++ b/Source/Mockolate/It.IsNull.cs
@@ -10,6 +10,18 @@ public partial class It
 	/// <summary>
 	///     Matches any parameter that is <see langword="null" />.
 	/// </summary>
+	/// <remarks>
+	///     Useful to assert explicit-null arguments in setups or verifications; for non-null values use
+	///     <see cref="IsNotNull{T}(string)" />.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter. Must be a reference type or a <see cref="System.Nullable{T}" />.</typeparam>
+	/// <param name="toString">Optional override for the matcher's <see cref="object.ToString" /> rendering, used in failure messages.</param>
+	/// <returns>A parameter matcher that only accepts <see langword="null" />.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Lookup(It.IsNull&lt;string&gt;()).Throws&lt;ArgumentNullException&gt;();
+	///     </code>
+	/// </example>
 	public static IParameterWithCallback<T> IsNull<T>(string? toString = null)
 		=> new NullParameterMatch<T>(toString);
 

--- a/Source/Mockolate/It.IsNull.cs
+++ b/Source/Mockolate/It.IsNull.cs
@@ -14,14 +14,9 @@ public partial class It
 	///     Useful to assert explicit-null arguments in setups or verifications; for non-null values use
 	///     <see cref="IsNotNull{T}(string)" />.
 	/// </remarks>
-	/// <typeparam name="T">The declared type of the parameter. Must be a reference type or a <see cref="System.Nullable{T}" />.</typeparam>
+	/// <typeparam name="T">The declared type of the parameter. Should be a reference type or a <see cref="System.Nullable{T}" />; for other value types this matcher never matches.</typeparam>
 	/// <param name="toString">Optional override for the matcher's <see cref="object.ToString" /> rendering, used in failure messages.</param>
 	/// <returns>A parameter matcher that only accepts <see langword="null" />.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Lookup(It.IsNull&lt;string&gt;()).Throws&lt;ArgumentNullException&gt;();
-	///     </code>
-	/// </example>
 	public static IParameterWithCallback<T> IsNull<T>(string? toString = null)
 		=> new NullParameterMatch<T>(toString);
 

--- a/Source/Mockolate/It.IsOneOf.cs
+++ b/Source/Mockolate/It.IsOneOf.cs
@@ -10,18 +10,32 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a parameter that is equal to one of the <paramref name="values" />.
+	///     Matches a parameter that equals any one of the supplied <paramref name="values" />.
 	/// </summary>
+	/// <remarks>
+	///     Equality uses <see cref="EqualityComparer{T}.Default" /> unless <see cref="IIsOneOfParameter{T}.Using" /> is
+	///     called. Pass the allowed values either as a comma-separated list or as any <see cref="IEnumerable{T}" />.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <param name="values">The accepted values.</param>
+	/// <returns>A parameter matcher that accepts any value equal to one of <paramref name="values" />.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Dispense(It.IsOneOf("Dark", "Milk"), It.IsAny&lt;int&gt;()).Returns(true);
+	///     </code>
+	/// </example>
 	public static IIsOneOfParameter<T> IsOneOf<T>(params IEnumerable<T> values)
 		=> new ParameterIsOneOfMatch<T>(values.ToArray());
 
 	/// <summary>
-	///     An <see cref="IParameter{T}" /> used for equality comparison of a collection of alternatives.
+	///     An <see cref="IParameter{T}" /> used for equality comparison against a set of alternatives, with an opt-in
+	///     custom comparer.
 	/// </summary>
 	public interface IIsOneOfParameter<out T> : IParameterWithCallback<T>
 	{
 		/// <summary>
-		///     Use the specified comparer to determine equality.
+		///     Switches equality comparison to use <paramref name="comparer" /> instead of
+		///     <see cref="EqualityComparer{T}.Default" />.
 		/// </summary>
 		IIsOneOfParameter<T> Using(IEqualityComparer<T> comparer,
 			[CallerArgumentExpression(nameof(comparer))]

--- a/Source/Mockolate/It.IsOneOf.cs
+++ b/Source/Mockolate/It.IsOneOf.cs
@@ -19,11 +19,6 @@ public partial class It
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>
 	/// <param name="values">The accepted values.</param>
 	/// <returns>A parameter matcher that accepts any value equal to one of <paramref name="values" />.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Dispense(It.IsOneOf("Dark", "Milk"), It.IsAny&lt;int&gt;()).Returns(true);
-	///     </code>
-	/// </example>
 	public static IIsOneOfParameter<T> IsOneOf<T>(params IEnumerable<T> values)
 		=> new ParameterIsOneOfMatch<T>(values.ToArray());
 

--- a/Source/Mockolate/It.IsOut.cs
+++ b/Source/Mockolate/It.IsOut.cs
@@ -20,11 +20,7 @@ public partial class It
 	///     <see cref="IsAnyOut{T}" /> to assign <see langword="default" /> to the caller's variable.
 	/// </remarks>
 	/// <typeparam name="T">The out-parameter's type.</typeparam>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Verify.TryDelete(It.Is(id), It.IsOut&lt;User?&gt;()).Once();
-	///     </code>
-	/// </example>
+	/// <returns>An <see cref="IVerifyOutParameter{T}" /> that matches any out-argument.</returns>
 	public static IVerifyOutParameter<T> IsOut<T>()
 		=> new InvokedOutParameterMatch<T>();
 
@@ -41,24 +37,23 @@ public partial class It
 	/// <typeparam name="T">The out-parameter's type.</typeparam>
 	/// <param name="setter">Factory that produces the value to assign to the caller's out-variable.</param>
 	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.TryDelete(It.Is(id), It.IsOut(() =&gt; new User(id, "Alice"))).Returns(true);
-	///     </code>
-	/// </example>
+	/// <returns>An <see cref="IOutParameter{T}" /> that produces a value via <paramref name="setter" />.</returns>
 	public static IOutParameter<T> IsOut<T>(Func<T> setter,
 		[CallerArgumentExpression("setter")] string doNotPopulateThisValue = "")
 		=> new OutParameterMatch<T>(setter, doNotPopulateThisValue);
 
 	/// <summary>
 	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" /> in a <c>Setup</c> and assigns
-	///     <see langword="default" /> to the caller's variable.
+	///     the value produced by the mock's <see cref="MockBehavior.DefaultValue" /> generator to the caller's variable.
 	/// </summary>
 	/// <remarks>
-	///     Shorthand for <c>It.IsOut(() =&gt; default)</c>. Use this when the caller's out value is irrelevant to the
-	///     test and you just need the method call to return.
+	///     Use this when the caller's out value is irrelevant to the test and you just need the method call to return.
+	///     The produced value equals <see langword="default" /><c>(T)</c> unless a custom
+	///     <see cref="MockBehaviorExtensions.WithDefaultValueFor" /> factory is registered; in that case the factory's
+	///     value is used.
 	/// </remarks>
 	/// <typeparam name="T">The out-parameter's type.</typeparam>
+	/// <returns>An <see cref="IOutParameter{T}" /> that produces a default value for the caller's out-variable.</returns>
 	public static IOutParameter<T> IsAnyOut<T>()
 		=> new AnyOutParameterMatch<T>();
 

--- a/Source/Mockolate/It.IsOut.cs
+++ b/Source/Mockolate/It.IsOut.cs
@@ -11,22 +11,54 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" />.
+	///     Placeholder matcher for an <see langword="out" /> parameter of type <typeparamref name="T" />, intended
+	///     for use in <c>Verify</c>.
 	/// </summary>
+	/// <remarks>
+	///     Use this overload when you only want to assert that a method was invoked (with any out-argument).
+	///     For <c>Setup</c>, use <see cref="IsOut{T}(Func{T}, string)" /> to actually produce an out-value, or
+	///     <see cref="IsAnyOut{T}" /> to assign <see langword="default" /> to the caller's variable.
+	/// </remarks>
+	/// <typeparam name="T">The out-parameter's type.</typeparam>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Verify.TryDelete(It.Is(id), It.IsOut&lt;User?&gt;()).Once();
+	///     </code>
+	/// </example>
 	public static IVerifyOutParameter<T> IsOut<T>()
 		=> new InvokedOutParameterMatch<T>();
 
 	/// <summary>
-	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" /> and
-	///     uses the <paramref name="setter" /> to set the value when the method is invoked.
+	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" /> in a <c>Setup</c> and uses
+	///     <paramref name="setter" /> to produce the value assigned to the caller's variable when the method is
+	///     invoked.
 	/// </summary>
+	/// <remarks>
+	///     <paramref name="setter" /> runs on every matching invocation, so you can return a fresh value per call
+	///     (e.g. a new <see cref="System.Guid" /> or an incrementing counter). Pair with
+	///     <see cref="IOutParameter{T}.Do" /> to observe each produced value.
+	/// </remarks>
+	/// <typeparam name="T">The out-parameter's type.</typeparam>
+	/// <param name="setter">Factory that produces the value to assign to the caller's out-variable.</param>
+	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.TryDelete(It.Is(id), It.IsOut(() =&gt; new User(id, "Alice"))).Returns(true);
+	///     </code>
+	/// </example>
 	public static IOutParameter<T> IsOut<T>(Func<T> setter,
 		[CallerArgumentExpression("setter")] string doNotPopulateThisValue = "")
 		=> new OutParameterMatch<T>(setter, doNotPopulateThisValue);
 
 	/// <summary>
-	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" />.
+	///     Matches any <see langword="out" /> parameter of type <typeparamref name="T" /> in a <c>Setup</c> and assigns
+	///     <see langword="default" /> to the caller's variable.
 	/// </summary>
+	/// <remarks>
+	///     Shorthand for <c>It.IsOut(() =&gt; default)</c>. Use this when the caller's out value is irrelevant to the
+	///     test and you just need the method call to return.
+	/// </remarks>
+	/// <typeparam name="T">The out-parameter's type.</typeparam>
 	public static IOutParameter<T> IsAnyOut<T>()
 		=> new AnyOutParameterMatch<T>();
 

--- a/Source/Mockolate/It.IsReadOnlySpan.cs
+++ b/Source/Mockolate/It.IsReadOnlySpan.cs
@@ -13,15 +13,24 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any parameter of type <see cref="System.ReadOnlySpan{T}" /> of <typeparamref name="T" />.
+	///     Matches any parameter of type <see cref="ReadOnlySpan{T}" /> of <typeparamref name="T" />.
 	/// </summary>
+	/// <remarks>
+	///     Because <see cref="ReadOnlySpan{T}" /> is a ref struct and cannot be stored, Mockolate copies its contents
+	///     into a <typeparamref name="T" />-array before dispatch. The predicate-based overload
+	///     <see cref="IsReadOnlySpan{T}(Func{T[], bool}, string)" /> receives this array.
+	/// </remarks>
 	public static IVerifyReadOnlySpanParameter<T> IsAnyReadOnlySpan<T>()
 		=> new ReadOnlySpanParameterMatch<T>(null);
 
 	/// <summary>
-	///     Matches any parameter of type <see cref="System.ReadOnlySpan{T}" /> of <typeparamref name="T" /> that matches the
-	///     <paramref name="predicate" />.
+	///     Matches a <see cref="ReadOnlySpan{T}" /> of <typeparamref name="T" /> parameter whose contents (copied to a
+	///     <typeparamref name="T" />-array) satisfy <paramref name="predicate" />.
 	/// </summary>
+	/// <remarks>
+	///     The span is copied to an array before <paramref name="predicate" /> is invoked, because ref structs cannot
+	///     be stored. If you only need to match any span, use <see cref="IsAnyReadOnlySpan{T}" />.
+	/// </remarks>
 	public static IVerifyReadOnlySpanParameter<T> IsReadOnlySpan<T>(Func<T[], bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.IsRef.cs
+++ b/Source/Mockolate/It.IsRef.cs
@@ -19,13 +19,10 @@ public partial class It
 	///     Mockolate mocks a method that mutates a ref argument. Use <see cref="IsRef{T}(Func{T, bool}, string)" />
 	///     when you only want to match (without mutating), or <see cref="IsRef{T}()" /> for verification.
 	/// </remarks>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Increment(It.IsRef&lt;int&gt;(v =&gt; v + 1)).Returns(true);
-	///     int value = 5;
-	///     sut.Increment(ref value); // value == 6 after the call
-	///     </code>
-	/// </example>
+	/// <typeparam name="T">The ref-parameter's type.</typeparam>
+	/// <param name="setter">Factory that takes the caller's current value and returns the replacement value.</param>
+	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
+	/// <returns>An <see cref="IRefParameter{T}" /> that mutates the caller's ref-variable via <paramref name="setter" />.</returns>
 	public static IRefParameter<T> IsRef<T>(Func<T, T> setter,
 		[CallerArgumentExpression("setter")] string doNotPopulateThisValue = "")
 		=> new RefParameterMatch<T>(_ => true, setter, null, doNotPopulateThisValue);
@@ -38,6 +35,12 @@ public partial class It
 	///     Combine a predicate gate with a value mutation. Both source expressions are captured by the compiler and
 	///     appear in failure messages.
 	/// </remarks>
+	/// <typeparam name="T">The ref-parameter's type.</typeparam>
+	/// <param name="predicate">The predicate evaluated against the caller's current value.</param>
+	/// <param name="setter">Factory that takes the caller's current value and returns the replacement value.</param>
+	/// <param name="doNotPopulateThisValue1">Do not populate - captured automatically by the compiler.</param>
+	/// <param name="doNotPopulateThisValue2">Do not populate - captured automatically by the compiler.</param>
+	/// <returns>An <see cref="IRefParameter{T}" /> that matches when <paramref name="predicate" /> is satisfied and mutates via <paramref name="setter" />.</returns>
 	public static IRefParameter<T> IsRef<T>(Func<T, bool> predicate, Func<T, T> setter,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue1 = "",
@@ -51,6 +54,10 @@ public partial class It
 	/// <remarks>
 	///     Useful when you want to assert on the in-value of a ref argument (via <c>Verify</c>) without mutating it.
 	/// </remarks>
+	/// <typeparam name="T">The ref-parameter's type.</typeparam>
+	/// <param name="predicate">The predicate evaluated against the caller's current value.</param>
+	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
+	/// <returns>An <see cref="IRefParameter{T}" /> that matches when <paramref name="predicate" /> is satisfied and does not mutate the ref-variable.</returns>
 	public static IRefParameter<T> IsRef<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
@@ -64,6 +71,8 @@ public partial class It
 	///     Accepts any ref-argument without constraint. For <c>Setup</c>, use one of the overloads that accept a
 	///     <c>setter</c> to mutate the caller's value.
 	/// </remarks>
+	/// <typeparam name="T">The ref-parameter's type.</typeparam>
+	/// <returns>An <see cref="IVerifyRefParameter{T}" /> that matches any ref-argument.</returns>
 	public static IVerifyRefParameter<T> IsRef<T>()
 		=> new InvokedRefParameterMatch<T>();
 
@@ -75,6 +84,8 @@ public partial class It
 	///     <see cref="IRefParameter{T}" /> usable in <c>Setup</c>. Use it when the method has a <see langword="ref" />
 	///     argument you don't care to inspect or mutate.
 	/// </remarks>
+	/// <typeparam name="T">The ref-parameter's type.</typeparam>
+	/// <returns>An <see cref="IRefParameter{T}" /> that matches any ref-argument and leaves it unchanged.</returns>
 	public static IRefParameter<T> IsAnyRef<T>()
 		=> new AnyRefParameterMatch<T>();
 

--- a/Source/Mockolate/It.IsRef.cs
+++ b/Source/Mockolate/It.IsRef.cs
@@ -64,12 +64,12 @@ public partial class It
 		=> new RefParameterMatch<T>(predicate, null, doNotPopulateThisValue, null);
 
 	/// <summary>
-	///     Placeholder matcher for a <see langword="ref" /> parameter of type <typeparamref name="T" />, intended
-	///     for use in <c>Verify</c>.
+	///     Matches any <see langword="ref" /> argument of type <typeparamref name="T" /> &#8212; for <c>Verify</c> only;
+	///     use <see cref="IsAnyRef{T}" /> in <c>Setup</c>.
 	/// </summary>
 	/// <remarks>
 	///     Accepts any ref-argument without constraint. For <c>Setup</c>, use one of the overloads that accept a
-	///     <c>setter</c> to mutate the caller's value.
+	///     <c>setter</c> to mutate the caller's value, or <see cref="IsAnyRef{T}" /> when you don't care about the value.
 	/// </remarks>
 	/// <typeparam name="T">The ref-parameter's type.</typeparam>
 	/// <returns>An <see cref="IVerifyRefParameter{T}" /> that matches any ref-argument.</returns>

--- a/Source/Mockolate/It.IsRef.cs
+++ b/Source/Mockolate/It.IsRef.cs
@@ -11,18 +11,33 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any <see langword="ref" /> parameter of type <typeparamref name="T" /> and
-	///     uses the <paramref name="setter" /> to set the value when the method is invoked.
+	///     Matches any <see langword="ref" /> parameter of type <typeparamref name="T" /> and replaces its value with
+	///     the result of <paramref name="setter" /> when the method is invoked.
 	/// </summary>
+	/// <remarks>
+	///     <paramref name="setter" /> receives the caller's current value and returns the new one; this is how
+	///     Mockolate mocks a method that mutates a ref argument. Use <see cref="IsRef{T}(Func{T, bool}, string)" />
+	///     when you only want to match (without mutating), or <see cref="IsRef{T}()" /> for verification.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Increment(It.IsRef&lt;int&gt;(v =&gt; v + 1)).Returns(true);
+	///     int value = 5;
+	///     sut.Increment(ref value); // value == 6 after the call
+	///     </code>
+	/// </example>
 	public static IRefParameter<T> IsRef<T>(Func<T, T> setter,
 		[CallerArgumentExpression("setter")] string doNotPopulateThisValue = "")
 		=> new RefParameterMatch<T>(_ => true, setter, null, doNotPopulateThisValue);
 
 	/// <summary>
-	///     Matches a <see langword="ref" /> parameter of type <typeparamref name="T" /> that satisfies the
-	///     <paramref name="predicate" /> and
-	///     uses the <paramref name="setter" /> to set the value when the method is invoked.
+	///     Matches a <see langword="ref" /> parameter of type <typeparamref name="T" /> whose current value satisfies
+	///     <paramref name="predicate" />, and replaces its value with the result of <paramref name="setter" />.
 	/// </summary>
+	/// <remarks>
+	///     Combine a predicate gate with a value mutation. Both source expressions are captured by the compiler and
+	///     appear in failure messages.
+	/// </remarks>
 	public static IRefParameter<T> IsRef<T>(Func<T, bool> predicate, Func<T, T> setter,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue1 = "",
@@ -30,23 +45,36 @@ public partial class It
 		=> new RefParameterMatch<T>(predicate, setter, doNotPopulateThisValue1, doNotPopulateThisValue2);
 
 	/// <summary>
-	///     Matches a <see langword="ref" /> parameter of type <typeparamref name="T" /> that satisfies the
-	///     <paramref name="predicate" />.
+	///     Matches a <see langword="ref" /> parameter of type <typeparamref name="T" /> whose current value satisfies
+	///     <paramref name="predicate" />, without replacing it.
 	/// </summary>
+	/// <remarks>
+	///     Useful when you want to assert on the in-value of a ref argument (via <c>Verify</c>) without mutating it.
+	/// </remarks>
 	public static IRefParameter<T> IsRef<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		=> new RefParameterMatch<T>(predicate, null, doNotPopulateThisValue, null);
 
 	/// <summary>
-	///     Matches any <see langword="ref" /> parameter of type <typeparamref name="T" />.
+	///     Placeholder matcher for a <see langword="ref" /> parameter of type <typeparamref name="T" />, intended
+	///     for use in <c>Verify</c>.
 	/// </summary>
+	/// <remarks>
+	///     Accepts any ref-argument without constraint. For <c>Setup</c>, use one of the overloads that accept a
+	///     <c>setter</c> to mutate the caller's value.
+	/// </remarks>
 	public static IVerifyRefParameter<T> IsRef<T>()
 		=> new InvokedRefParameterMatch<T>();
 
 	/// <summary>
-	///     Matches any <see langword="ref" /> parameter of type <typeparamref name="T" />.
+	///     Matches any <see langword="ref" /> parameter of type <typeparamref name="T" /> without replacing its value.
 	/// </summary>
+	/// <remarks>
+	///     Unlike <see cref="IsRef{T}()" /> (which is only for verification), <see cref="IsAnyRef{T}" /> returns an
+	///     <see cref="IRefParameter{T}" /> usable in <c>Setup</c>. Use it when the method has a <see langword="ref" />
+	///     argument you don't care to inspect or mutate.
+	/// </remarks>
 	public static IRefParameter<T> IsAnyRef<T>()
 		=> new AnyRefParameterMatch<T>();
 

--- a/Source/Mockolate/It.IsSpan.cs
+++ b/Source/Mockolate/It.IsSpan.cs
@@ -31,11 +31,6 @@ public partial class It
 	///     The span is copied to an array before <paramref name="predicate" /> is invoked, because ref structs cannot
 	///     be stored. If you only need to match any span, use <see cref="IsAnySpan{T}" />.
 	/// </remarks>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Process(It.IsSpan&lt;byte&gt;(data =&gt; data.Length &gt; 0)).Returns(true);
-	///     </code>
-	/// </example>
 	public static IVerifySpanParameter<T> IsSpan<T>(Func<T[], bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.IsSpan.cs
+++ b/Source/Mockolate/It.IsSpan.cs
@@ -13,15 +13,29 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any parameter of type <see cref="System.Span{T}" /> of <typeparamref name="T" />.
+	///     Matches any parameter of type <see cref="Span{T}" /> of <typeparamref name="T" />.
 	/// </summary>
+	/// <remarks>
+	///     Because <see cref="Span{T}" /> is a ref struct and cannot be stored, Mockolate copies its contents into a
+	///     <typeparamref name="T" />-array before dispatch. The predicate-based overload
+	///     <see cref="IsSpan{T}(Func{T[], bool}, string)" /> receives this array.
+	/// </remarks>
 	public static IVerifySpanParameter<T> IsAnySpan<T>()
 		=> new SpanParameterMatch<T>(null);
 
 	/// <summary>
-	///     Matches any parameter of type <see cref="System.Span{T}" /> of <typeparamref name="T" /> that matches the
-	///     <paramref name="predicate" />.
+	///     Matches a <see cref="Span{T}" /> of <typeparamref name="T" /> parameter whose contents (copied to a
+	///     <typeparamref name="T" />-array) satisfy <paramref name="predicate" />.
 	/// </summary>
+	/// <remarks>
+	///     The span is copied to an array before <paramref name="predicate" /> is invoked, because ref structs cannot
+	///     be stored. If you only need to match any span, use <see cref="IsAnySpan{T}" />.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Process(It.IsSpan&lt;byte&gt;(data =&gt; data.Length &gt; 0)).Returns(true);
+	///     </code>
+	/// </example>
 	public static IVerifySpanParameter<T> IsSpan<T>(Func<T[], bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.IsTrue.cs
+++ b/Source/Mockolate/It.IsTrue.cs
@@ -7,8 +7,17 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches any boolean parameter that is <see langword="true" />.
+	///     Matches any <see langword="bool" /> parameter whose value is <see langword="true" />.
 	/// </summary>
+	/// <remarks>
+	///     Shorthand for <c>It.Is(true)</c> with a nicer failure-message rendering. Use
+	///     <see cref="IsFalse" /> for the opposite.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Verify.Toggle(It.IsTrue()).Once();
+	///     </code>
+	/// </example>
 	public static IParameterWithCallback<bool> IsTrue()
 		=> new TrueParameterMatch();
 

--- a/Source/Mockolate/It.IsTrue.cs
+++ b/Source/Mockolate/It.IsTrue.cs
@@ -13,11 +13,6 @@ public partial class It
 	///     Shorthand for <c>It.Is(true)</c> with a nicer failure-message rendering. Use
 	///     <see cref="IsFalse" /> for the opposite.
 	/// </remarks>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Verify.Toggle(It.IsTrue()).Once();
-	///     </code>
-	/// </example>
 	public static IParameterWithCallback<bool> IsTrue()
 		=> new TrueParameterMatch();
 

--- a/Source/Mockolate/It.Matches.cs
+++ b/Source/Mockolate/It.Matches.cs
@@ -11,28 +11,44 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a <see langword="string" /> parameter against the given wildcard <paramref name="pattern" />.
+	///     Matches a <see langword="string" /> parameter against the given wildcard <paramref name="pattern" />
+	///     (<c>*</c> for any sequence, <c>?</c> for a single character).
 	/// </summary>
 	/// <remarks>
-	///     Default comparison is case-insensitive.
-	///     Use <see cref="IParameterMatches.CaseSensitive(bool)" /> to change this behavior.
+	///     Default comparison is case-insensitive; use <see cref="IParameterMatches.CaseSensitive(bool)" /> to change
+	///     that, or <see cref="IParameterMatches.AsRegex" /> to treat <paramref name="pattern" /> as a
+	///     <see cref="Regex" /> instead of a wildcard expression.
 	/// </remarks>
+	/// <param name="pattern">The wildcard (or, with <c>.AsRegex()</c>, regular-expression) pattern to match against.</param>
+	/// <returns>A string parameter matcher, fluently configurable with <c>.CaseSensitive()</c> / <c>.AsRegex()</c>.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Post(It.Matches("*example.com*"), It.IsAny&lt;HttpContent&gt;())
+	///         .Returns(new HttpResponseMessage(HttpStatusCode.OK));
+	///     sut.Mock.Setup.ValidateEmail(It.Matches(@"^\w+@\w+\.\w+$").AsRegex())
+	///         .Returns(true);
+	///     </code>
+	/// </example>
 	public static IParameterMatches Matches(string pattern)
 		=> new MatchesAsWildcardMatch(pattern);
 
 	/// <summary>
-	///     A string parameter that matches against a pattern.
+	///     A <see langword="string" /> parameter matcher driven by a wildcard or regular-expression pattern.
 	/// </summary>
 	public interface IParameterMatches : IParameterWithCallback<string>
 	{
 		/// <summary>
-		///     Enables case-sensitive matching of the pattern when specified.
+		///     Switches the pattern comparison to be case-sensitive (default: case-insensitive).
 		/// </summary>
 		IParameterMatches CaseSensitive(bool caseSensitive = true);
 
 		/// <summary>
-		///     Matches the pattern directly as a regular expression.
+		///     Interprets the pattern as a <see cref="Regex" /> rather than a wildcard expression.
 		/// </summary>
+		/// <param name="options">Regex options forwarded to <see cref="Regex" />.</param>
+		/// <param name="timeout">Optional match timeout; defaults to <see cref="Regex.InfiniteMatchTimeout" />.</param>
+		/// <param name="doNotPopulateThisValue1">Do not populate - captured automatically by the compiler.</param>
+		/// <param name="doNotPopulateThisValue2">Do not populate - captured automatically by the compiler.</param>
 		IParameterMatches AsRegex(
 			RegexOptions options = RegexOptions.None,
 			TimeSpan? timeout = null,

--- a/Source/Mockolate/It.Matches.cs
+++ b/Source/Mockolate/It.Matches.cs
@@ -21,14 +21,6 @@ public partial class It
 	/// </remarks>
 	/// <param name="pattern">The wildcard (or, with <c>.AsRegex()</c>, regular-expression) pattern to match against.</param>
 	/// <returns>A string parameter matcher, fluently configurable with <c>.CaseSensitive()</c> / <c>.AsRegex()</c>.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Post(It.Matches("*example.com*"), It.IsAny&lt;HttpContent&gt;())
-	///         .Returns(new HttpResponseMessage(HttpStatusCode.OK));
-	///     sut.Mock.Setup.ValidateEmail(It.Matches(@"^\w+@\w+\.\w+$").AsRegex())
-	///         .Returns(true);
-	///     </code>
-	/// </example>
 	public static IParameterMatches Matches(string pattern)
 		=> new MatchesAsWildcardMatch(pattern);
 

--- a/Source/Mockolate/It.Satisfies.cs
+++ b/Source/Mockolate/It.Satisfies.cs
@@ -22,12 +22,6 @@ public partial class It
 	/// <param name="predicate">The predicate that decides whether an argument matches.</param>
 	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
 	/// <returns>A parameter matcher that delegates to <paramref name="predicate" />.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.AddUser(It.Satisfies&lt;string&gt;(name =&gt; name.StartsWith("A")))
-	///         .Returns(new User(id, "Alice"));
-	///     </code>
-	/// </example>
 	public static IParameterWithCallback<T> Satisfies<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.Satisfies.cs
+++ b/Source/Mockolate/It.Satisfies.cs
@@ -10,8 +10,24 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a parameter of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
+	///     Matches a parameter of type <typeparamref name="T" /> whose value makes <paramref name="predicate" /> return
+	///     <see langword="true" />.
 	/// </summary>
+	/// <remarks>
+	///     Use this when the built-in matchers aren't expressive enough (e.g. &quot;a <see cref="System.DateTime" /> in
+	///     the past&quot; or &quot;a string that contains a substring&quot;). The predicate source expression is captured
+	///     by the compiler and shown in failure messages, so keep lambdas short for readable diagnostics.
+	/// </remarks>
+	/// <typeparam name="T">The declared type of the parameter.</typeparam>
+	/// <param name="predicate">The predicate that decides whether an argument matches.</param>
+	/// <param name="doNotPopulateThisValue">Do not populate - captured automatically by the compiler.</param>
+	/// <returns>A parameter matcher that delegates to <paramref name="predicate" />.</returns>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.AddUser(It.Satisfies&lt;string&gt;(name =&gt; name.StartsWith("A")))
+	///         .Returns(new User(id, "Alice"));
+	///     </code>
+	/// </example>
 	public static IParameterWithCallback<T> Satisfies<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/Mockolate/It.SequenceEquals.cs
+++ b/Source/Mockolate/It.SequenceEquals.cs
@@ -24,11 +24,7 @@ public partial class It
 	/// </remarks>
 	/// <typeparam name="T">The collection element type.</typeparam>
 	/// <param name="values">The expected sequence, in order.</param>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Process(It.SequenceEquals("a", "b", "c")).Returns(true);
-	///     </code>
-	/// </example>
+	/// <returns>A parameter matcher that accepts any supported ordered collection whose elements equal <paramref name="values" /> in order.</returns>
 	public static ISequenceEqualsParameter<T> SequenceEquals<T>(params IEnumerable<T> values)
 		=> new ParameterSequenceEqualsMatch<T>(values.ToArray());
 

--- a/Source/Mockolate/It.SequenceEquals.cs
+++ b/Source/Mockolate/It.SequenceEquals.cs
@@ -10,7 +10,8 @@ namespace Mockolate;
 public partial class It
 {
 	/// <summary>
-	///     Matches a collection parameter whose elements equal <paramref name="values" /> in order.
+	///     Matches a collection parameter whose elements equal <paramref name="values" /> in the same order (and
+	///     have the same length).
 	/// </summary>
 	/// <remarks>
 	///     Supports method parameters declared as <see cref="IEnumerable{T}" />, <see cref="ICollection{T}" />,
@@ -18,8 +19,16 @@ public partial class It
 	///     <typeparamref name="T" /> arrays, <see cref="List{T}" />, <see cref="Queue{T}" /> or
 	///     <see cref="Stack{T}" />. Unordered shapes such as <see cref="ISet{T}" /> and
 	///     <see cref="HashSet{T}" /> are intentionally not supported, as their enumeration order
-	///     is not guaranteed.
+	///     is not guaranteed. Use <see cref="Contains{T}(T, string)" /> when you only care about containment rather
+	///     than order.
 	/// </remarks>
+	/// <typeparam name="T">The collection element type.</typeparam>
+	/// <param name="values">The expected sequence, in order.</param>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Process(It.SequenceEquals("a", "b", "c")).Returns(true);
+	///     </code>
+	/// </example>
 	public static ISequenceEqualsParameter<T> SequenceEquals<T>(params IEnumerable<T> values)
 		=> new ParameterSequenceEqualsMatch<T>(values.ToArray());
 

--- a/Source/Mockolate/It.cs
+++ b/Source/Mockolate/It.cs
@@ -8,8 +8,24 @@ namespace Mockolate;
 #pragma warning disable S3453 // This class can't be instantiated; make its constructor 'public'.
 #pragma warning disable S3218 // Inner class members should not shadow outer class "static" or type members
 /// <summary>
-///     Specify a matching condition for a parameter.
+///     Specifies a matching condition for a single method or indexer parameter. Complement to
+///     <see cref="Match" />, which targets the full parameter list at once.
 /// </summary>
+/// <remarks>
+///     Use <see cref="It" /> matchers to describe expectations parameter-by-parameter inside a <c>Setup</c> or
+///     <c>Verify</c> call. Commonly used matchers:
+///     <list type="bullet">
+///       <item><description><c>It.IsAny&lt;T&gt;()</c> / <c>It.Is(value)</c> - accept any value / accept a specific value (equality check, overridable comparer via <c>.Using(...)</c>).</description></item>
+///       <item><description><c>It.IsNot(value)</c> / <c>It.IsNull&lt;T&gt;()</c> / <c>It.IsNotNull&lt;T&gt;()</c> / <c>It.IsTrue()</c> / <c>It.IsFalse()</c> - negative, null and boolean matchers.</description></item>
+///       <item><description><c>It.IsOneOf(values)</c> / <c>It.IsNotOneOf(values)</c> / <c>It.IsInRange(min, max)</c> - set and range matchers.</description></item>
+///       <item><description><c>It.Satisfies&lt;T&gt;(predicate)</c> / <c>It.Matches(pattern)</c> / <c>It.Contains(item)</c> / <c>It.SequenceEquals(values)</c> - predicate, wildcard and collection matchers.</description></item>
+///       <item><description><c>It.IsOut&lt;T&gt;(...)</c> / <c>It.IsRef&lt;T&gt;(...)</c> / <c>It.IsSpan&lt;T&gt;(...)</c> / <c>It.IsReadOnlySpan&lt;T&gt;(...)</c> / <c>It.IsRefStruct&lt;T&gt;(...)</c> - <see langword="out" /> / <see langword="ref" /> / span / <see langword="ref struct" /> parameters.</description></item>
+///     </list>
+///     <para />
+///     For methods and indexers with up to four parameters, a raw value can be passed directly in place of
+///     <c>It.Is(value)</c>. Reach for <see cref="Match" /> when you want to match the full argument tuple with a
+///     single predicate or to express "any arguments" via <c>Match.AnyParameters()</c>.
+/// </remarks>
 #if !DEBUG
 [System.Diagnostics.DebuggerNonUserCode]
 #endif

--- a/Source/Mockolate/Match.WithDefaultParameters.cs
+++ b/Source/Mockolate/Match.WithDefaultParameters.cs
@@ -6,8 +6,18 @@ namespace Mockolate;
 public partial class Match
 {
 	/// <summary>
-	///     Use default event parameters when raising events.
+	///     Signals the <c>Raise</c> surface to synthesize default values for every parameter of the event's delegate,
+	///     instead of requiring them to be passed explicitly.
 	/// </summary>
+	/// <remarks>
+	///     Useful when subscribers don't care about the event payload and you just need the signal to fire. The
+	///     generated values follow the mock's <see cref="MockBehavior.DefaultValue" />.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Raise.UsersChanged(Match.WithDefaultParameters());
+	///     </code>
+	/// </example>
 	public static IDefaultEventParameters WithDefaultParameters()
 		=> new DefaultEventParameters();
 

--- a/Source/Mockolate/Match.WithDefaultParameters.cs
+++ b/Source/Mockolate/Match.WithDefaultParameters.cs
@@ -13,11 +13,6 @@ public partial class Match
 	///     Useful when subscribers don't care about the event payload and you just need the signal to fire. The
 	///     generated values follow the mock's <see cref="MockBehavior.DefaultValue" />.
 	/// </remarks>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Raise.UsersChanged(Match.WithDefaultParameters());
-	///     </code>
-	/// </example>
 	public static IDefaultEventParameters WithDefaultParameters()
 		=> new DefaultEventParameters();
 

--- a/Source/Mockolate/Match.cs
+++ b/Source/Mockolate/Match.cs
@@ -4,13 +4,17 @@ namespace Mockolate;
 
 #pragma warning disable S3453 // This class can't be instantiated; make its constructor 'public'.
 /// <summary>
-///     Specifies a matching condition across the full parameter list of a method or indexer. Complement to
+///     Specifies a matching condition across the full parameter list of a method, indexer or event. Complement to
 ///     <see cref="It" />, which targets a single parameter at a time.
 /// </summary>
 /// <remarks>
-///     Reach for <see cref="Match" /> when you want to match by a predicate over all parameters at once, or when
-///     per-parameter matchers would be too verbose. Use <see cref="AnyParameters" /> to accept any arguments, or
-///     <c>Match.Parameters(predicate)</c> to match against a custom predicate.
+///     Reach for <see cref="Match" /> when you want to match the full argument tuple with a single predicate, or
+///     when per-parameter matchers would be too verbose. Available helpers:
+///     <list type="bullet">
+///       <item><description><see cref="AnyParameters" /> - accept any argument list (equivalent to <c>It.IsAny&lt;T&gt;()</c> on every parameter).</description></item>
+///       <item><description><c>Match.Parameters(predicate)</c> - match when the predicate applied to the raw <see langword="object" /><c>?[]</c> argument array returns <see langword="true" />.</description></item>
+///       <item><description><c>Match.WithDefaultParameters()</c> - match an event invocation with the default <c>EventArgs</c>-like payload.</description></item>
+///     </list>
 ///     <para />
 ///     Because the generator cannot disambiguate which overload a <see cref="Match" />-based setup targets,
 ///     <see cref="Match" /> overloads are only emitted on unambiguous method names. For overloaded methods, use

--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -7,8 +7,21 @@ using System.Linq;
 namespace Mockolate;
 
 /// <summary>
-///     The behavior of the mock.
+///     Controls how a Mockolate mock responds when a member is invoked without a matching setup.
 /// </summary>
+/// <remarks>
+///     An instance is an immutable <see langword="record" /> - every configuration method returns a modified copy,
+///     leaving the original untouched so behaviors can be shared safely across tests. Pass a <see cref="MockBehavior" />
+///     to <c>CreateMock(...)</c> to customize how un-configured members are handled:
+///     <list type="bullet">
+///       <item><description><see cref="ThrowWhenNotSetup" /> (see <see cref="MockBehaviorExtensions.ThrowingWhenNotSetup" />) - throw <see cref="Mockolate.Exceptions.MockNotSetupException" /> instead of returning a default value.</description></item>
+///       <item><description><see cref="SkipBaseClass" /> (see <see cref="MockBehaviorExtensions.SkippingBaseClass" />) - for class mocks, bypass the base-class implementation entirely.</description></item>
+///       <item><description><see cref="SkipInteractionRecording" /> (see <see cref="MockBehaviorExtensions.SkippingInteractionRecording" />) - trade verifiability for performance by not recording invocations.</description></item>
+///       <item><description><see cref="DefaultValue" /> (tune via <see cref="WithDefaultValueFor(DefaultValueFactory[])" /> or <c>MockBehaviorExtensions.WithDefaultValueFor&lt;T&gt;(factory)</c>) - supplies the default return values for un-configured members.</description></item>
+///       <item><description><c>UseConstructorParametersFor&lt;T&gt;(...)</c> - pre-register constructor parameters applied whenever a mock of <c>T</c> is created without explicit ones.</description></item>
+///     </list>
+///     Start from <c>MockBehavior.Default</c> (generator-emitted) and chain the fluent extension methods.
+/// </remarks>
 #if !DEBUG
 [System.Diagnostics.DebuggerNonUserCode]
 #endif

--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -7,7 +7,9 @@ using System.Linq;
 namespace Mockolate;
 
 /// <summary>
-///     Controls how a Mockolate mock responds when a member is invoked without a matching setup.
+///     Configures the runtime behavior of a Mockolate mock: default return values for un-configured members,
+///     base-class delegation, interaction recording, pre-registered constructor parameters, and whether
+///     un-configured invocations throw.
 /// </summary>
 /// <remarks>
 ///     An instance is an immutable <see langword="record" /> - every configuration method returns a modified copy,
@@ -30,7 +32,11 @@ public record MockBehavior : IMockBehaviorAccess
 	private ConcurrentStack<IConstructorParameters>? _constructorParameters;
 	private ConcurrentStack<object?>? _values;
 
-	/// <inheritdoc cref="MockBehavior" />
+	/// <summary>
+	///     Initializes a new <see cref="MockBehavior" /> with the given <paramref name="defaultValue" /> generator and
+	///     all other flags at their defaults.
+	/// </summary>
+	/// <param name="defaultValue">The generator used to produce default return values for un-configured members.</param>
 	public MockBehavior(IDefaultValueGenerator defaultValue)
 	{
 		DefaultValue = defaultValue;
@@ -115,11 +121,14 @@ public record MockBehavior : IMockBehaviorAccess
 	}
 
 	/// <summary>
-	///     Initialize all mocks of type <typeparamref name="T" /> to use the given constructor <paramref name="parameters" />.
+	///     Initializes all mocks of type <typeparamref name="T" /> to use the given constructor <paramref name="parameters" />.
 	/// </summary>
 	/// <remarks>
 	///     These parameters are only used when no explicit constructor parameters are provided when creating the mock.
 	/// </remarks>
+	/// <typeparam name="T">The mocked type whose constructor parameters are being pre-registered.</typeparam>
+	/// <param name="parameters">A factory that produces a fresh parameter array on each mock creation.</param>
+	/// <returns>A new <see cref="MockBehavior" /> with the pre-registered parameters.</returns>
 	public MockBehavior UseConstructorParametersFor<T>(Func<object?[]> parameters)
 	{
 		MockBehavior behavior = this with
@@ -131,11 +140,14 @@ public record MockBehavior : IMockBehaviorAccess
 	}
 
 	/// <summary>
-	///     Initialize all mocks of type <typeparamref name="T" /> to use the given constructor <paramref name="parameters" />.
+	///     Initializes all mocks of type <typeparamref name="T" /> to use the given constructor <paramref name="parameters" />.
 	/// </summary>
 	/// <remarks>
 	///     These parameters are only used when no explicit constructor parameters are provided when creating the mock.
 	/// </remarks>
+	/// <typeparam name="T">The mocked type whose constructor parameters are being pre-registered.</typeparam>
+	/// <param name="parameters">The parameter array shared across every mock creation.</param>
+	/// <returns>A new <see cref="MockBehavior" /> with the pre-registered parameters.</returns>
 	public MockBehavior UseConstructorParametersFor<T>(params object?[] parameters)
 	{
 		MockBehavior behavior = this with
@@ -149,6 +161,8 @@ public record MockBehavior : IMockBehaviorAccess
 	/// <summary>
 	///     Uses the given <paramref name="defaultValueFactories" /> to create default values for supported types.
 	/// </summary>
+	/// <param name="defaultValueFactories">Factories consulted in order; the first one whose <see cref="DefaultValueFactory.CanGenerateValue" /> returns <see langword="true" /> wins, otherwise the previously configured <see cref="DefaultValue" /> generator is used.</param>
+	/// <returns>A new <see cref="MockBehavior" /> that layers <paramref name="defaultValueFactories" /> on top of the existing default-value generator.</returns>
 	public MockBehavior WithDefaultValueFor(params DefaultValueFactory[] defaultValueFactories)
 	{
 		MockBehavior behavior = this with

--- a/Source/Mockolate/MockBehavior.cs
+++ b/Source/Mockolate/MockBehavior.cs
@@ -79,7 +79,8 @@ public record MockBehavior : IMockBehaviorAccess
 	///     The generator for default values when not specified by a setup.
 	/// </summary>
 	/// <remarks>
-	///     If <see cref="ThrowWhenNotSetup" /> is not set to <see langword="false" />, an exception is thrown in such cases.
+	///     When <see cref="ThrowWhenNotSetup" /> is <see langword="true" />, a
+	///     <see cref="Mockolate.Exceptions.MockNotSetupException" /> is thrown instead of consulting this generator.
 	/// </remarks>
 	public IDefaultValueGenerator DefaultValue { get; init; }
 

--- a/Source/Mockolate/MockBehaviorExtensions.cs
+++ b/Source/Mockolate/MockBehaviorExtensions.cs
@@ -62,8 +62,12 @@ public static class MockBehaviorExtensions
 			};
 
 		/// <summary>
-		///     Uses the given <paramref name="factory" /> to create default values for <typeparamref name="T" />.
+		///     Returns a <see cref="MockBehavior" /> that uses <paramref name="factory" /> to produce the default value
+		///     whenever a mocked member of type <typeparamref name="T" /> falls back to a default.
 		/// </summary>
+		/// <typeparam name="T">The target type the factory supplies defaults for. Matched by exact type equality &#8212; subtypes are not covered.</typeparam>
+		/// <param name="factory">Lazy producer of the default value; invoked once per fallback.</param>
+		/// <returns>A new <see cref="MockBehavior" /> with the factory registered; the original behavior is unchanged.</returns>
 		public MockBehavior WithDefaultValueFor<T>(Func<T> factory)
 			=> mockBehavior.WithDefaultValueFor(new DefaultValueFactory(
 				t => t == typeof(T),

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -40,10 +40,14 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Get the latest method setup matching the given <paramref name="methodName" /> and <paramref name="predicate" />,
-	///     or returns <see langword="null" /> if no matching setup is found. Scenario setups take precedence over
-	///     default-scope setups.
+	///     Returns the latest registered method setup of type <typeparamref name="T" /> whose name equals
+	///     <paramref name="methodName" /> and that satisfies <paramref name="predicate" />, or <see langword="null" />
+	///     when no setup matches. Scenario-scoped setups take precedence over default-scope setups.
 	/// </summary>
+	/// <typeparam name="T">The concrete <see cref="MethodSetup" /> subtype to return.</typeparam>
+	/// <param name="methodName">The simple method name.</param>
+	/// <param name="predicate">Argument matcher applied to each candidate setup.</param>
+	/// <returns>The matching setup, or <see langword="null" /> when none was found.</returns>
 	public T? GetMethodSetup<T>(string methodName, Func<T, bool> predicate) where T : MethodSetup
 	{
 		if (!string.IsNullOrEmpty(Scenario) &&
@@ -76,6 +80,9 @@ public partial class MockRegistry
 	///         <see cref="GetMethodSetup{T}(string, Func{T, bool})" />'s precedence.
 	///     </para>
 	/// </remarks>
+	/// <typeparam name="T">The concrete <see cref="MethodSetup" /> subtype to return.</typeparam>
+	/// <param name="methodName">The simple method name.</param>
+	/// <returns>A lazy stream of matching setups, scenario-scoped first.</returns>
 	public IEnumerable<T> GetMethodSetups<T>(string methodName) where T : MethodSetup
 	{
 		if (!string.IsNullOrEmpty(Scenario) &&
@@ -94,10 +101,13 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Get the latest indexer setup matching the given <paramref name="predicate" />,
-	///     or returns <see langword="null" /> if no matching setup is found. Scenario setups take precedence over
-	///     default-scope setups.
+	///     Returns the latest registered indexer setup of type <typeparamref name="T" /> that satisfies
+	///     <paramref name="predicate" />, or <see langword="null" /> when no setup matches. Scenario-scoped setups
+	///     take precedence over default-scope setups.
 	/// </summary>
+	/// <typeparam name="T">The concrete <see cref="IndexerSetup" /> subtype to return.</typeparam>
+	/// <param name="predicate">Argument matcher applied to each candidate setup.</param>
+	/// <returns>The matching setup, or <see langword="null" /> when none was found.</returns>
 	public T? GetIndexerSetup<T>(Func<T, bool> predicate) where T : IndexerSetup
 	{
 		if (!string.IsNullOrEmpty(Scenario) &&
@@ -114,10 +124,13 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Get the latest indexer setup matching the given <paramref name="access" />,
-	///     or returns <see langword="null" /> if no matching setup is found. Scenario setups take precedence over
-	///     default-scope setups.
+	///     Returns the latest registered indexer setup of type <typeparamref name="T" /> that matches the
+	///     <paramref name="access" />, or <see langword="null" /> when no setup matches. Scenario-scoped setups take
+	///     precedence over default-scope setups.
 	/// </summary>
+	/// <typeparam name="T">The concrete <see cref="IndexerSetup" /> subtype to return.</typeparam>
+	/// <param name="access">The indexer access whose argument values must be matched.</param>
+	/// <returns>The matching setup, or <see langword="null" /> when none was found.</returns>
 	public T? GetIndexerSetup<T>(IndexerAccess access) where T : IndexerSetup
 	{
 		if (!string.IsNullOrEmpty(Scenario) &&
@@ -134,8 +147,12 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Stores the given <paramref name="value" /> for the given indexer <paramref name="access" />.
+	///     Stores <paramref name="value" /> in the indexer value slot identified by <paramref name="access" />.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The indexer access whose arguments identify the slot.</param>
+	/// <param name="value">The value to store.</param>
+	/// <param name="signatureIndex">Index into the mock's indexer-signature table (emitted by the source generator).</param>
 	public void SetIndexerValue<TResult>(IndexerAccess access, TResult value, int signatureIndex)
 	{
 		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
@@ -147,6 +164,11 @@ public partial class MockRegistry
 	///     when <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />, or otherwise stores and
 	///     returns the <see cref="MockBehavior.DefaultValue" />.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The indexer access whose arguments identify the slot.</param>
+	/// <param name="signatureIndex">Index into the mock's indexer-signature table (emitted by the source generator).</param>
+	/// <returns>The stored value, or the freshly generated default.</returns>
+	/// <exception cref="MockNotSetupException"><see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" /> and no value was previously stored for this access.</exception>
 	public TResult GetIndexerFallback<TResult>(IndexerAccess access, int signatureIndex)
 	{
 		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
@@ -169,6 +191,11 @@ public partial class MockRegistry
 	///     Invokes the getter flow of the given <paramref name="setup" /> for the given <paramref name="access" />,
 	///     ensuring the indexer value storage is wired up before dispatching.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The indexer access whose arguments identify the slot.</param>
+	/// <param name="setup">The previously matched indexer setup.</param>
+	/// <param name="signatureIndex">Index into the mock's indexer-signature table (emitted by the source generator).</param>
+	/// <returns>The value produced by the setup.</returns>
 	public TResult ApplyIndexerSetup<TResult>(IndexerAccess access, IndexerSetup setup, int signatureIndex)
 	{
 		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
@@ -183,6 +210,12 @@ public partial class MockRegistry
 	///     When <paramref name="setup" /> is <see langword="null" />, returns any previously stored value or the
 	///     <paramref name="baseValue" /> (which is then stored).
 	/// </remarks>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The indexer access whose arguments identify the slot.</param>
+	/// <param name="setup">The matching indexer setup, or <see langword="null" /> to fall through to stored/base value.</param>
+	/// <param name="baseValue">Value returned by the base-class indexer (or a caller-supplied default).</param>
+	/// <param name="signatureIndex">Index into the mock's indexer-signature table (emitted by the source generator).</param>
+	/// <returns>The final getter result.</returns>
 	public TResult ApplyIndexerGetter<TResult>(IndexerAccess access, IndexerSetup? setup, TResult baseValue,
 		int signatureIndex)
 	{
@@ -211,6 +244,13 @@ public partial class MockRegistry
 	///     <see cref="MockNotSetupException" />, otherwise stores and returns the <paramref name="defaultValueGenerator" />'s
 	///     value.
 	/// </remarks>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The indexer access whose arguments identify the slot.</param>
+	/// <param name="setup">The matching indexer setup, or <see langword="null" /> to fall through to stored/default value.</param>
+	/// <param name="defaultValueGenerator">Lazy producer of the default value &#8212; only invoked when a default is actually needed.</param>
+	/// <param name="signatureIndex">Index into the mock's indexer-signature table (emitted by the source generator).</param>
+	/// <returns>The final getter result.</returns>
+	/// <exception cref="MockNotSetupException"><paramref name="setup" /> is <see langword="null" />, <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />, and no value was previously stored.</exception>
 	public TResult ApplyIndexerGetter<TResult>(IndexerAccess access, IndexerSetup? setup,
 		Func<TResult> defaultValueGenerator, int signatureIndex)
 	{
@@ -236,9 +276,15 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Applies an indexer setter for the given <paramref name="access" /> with the given <paramref name="value" /> and
-	///     optional matching <paramref name="setup" />. Returns whether the base class implementation should be skipped.
+	///     Applies an indexer setter for the given <paramref name="access" /> with the given <paramref name="value" />
+	///     and optional matching <paramref name="setup" />.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The indexer access whose arguments identify the slot.</param>
+	/// <param name="setup">The matching indexer setup, or <see langword="null" /> to simply store the value.</param>
+	/// <param name="value">The value being assigned.</param>
+	/// <param name="signatureIndex">Index into the mock's indexer-signature table (emitted by the source generator).</param>
+	/// <returns><see langword="true" /> when the base-class setter should be skipped.</returns>
 	public bool ApplyIndexerSetter<TResult>(IndexerAccess access, IndexerSetup? setup, TResult value,
 		int signatureIndex)
 	{
@@ -254,11 +300,12 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Register an <paramref name="interaction" /> with the mock.
+	///     Appends <paramref name="interaction" /> to the mock's recorded interactions.
 	/// </summary>
 	/// <remarks>
 	///     Has no effect when <see cref="MockBehavior.SkipInteractionRecording" /> is <see langword="true" />.
 	/// </remarks>
+	/// <param name="interaction">The recorded interaction to append.</param>
 	public void RegisterInteraction(IInteraction interaction)
 	{
 		if (!Behavior.SkipInteractionRecording)
@@ -292,8 +339,15 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Accesses the getter of the property with <paramref name="propertyName" />.
+	///     Executes the getter flow for the property named <paramref name="propertyName" />, honoring configured
+	///     setups and the active <see cref="MockBehavior" />.
 	/// </summary>
+	/// <typeparam name="TResult">The property's value type.</typeparam>
+	/// <param name="propertyName">The simple property name.</param>
+	/// <param name="defaultValueGenerator">Producer of the default value when no setup supplies one.</param>
+	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered.</param>
+	/// <returns>The resolved getter value.</returns>
+	/// <exception cref="MockNotSetupException">No setup exists for the property and <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />.</exception>
 	public TResult GetProperty<TResult>(string propertyName, Func<TResult> defaultValueGenerator,
 		Func<TResult>? baseValueAccessor)
 	{
@@ -337,12 +391,16 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Accesses the setter of the property with <paramref name="propertyName" /> and the matching
-	///     <paramref name="value" />.
+	///     Executes the setter flow for the property named <paramref name="propertyName" />, honoring configured
+	///     setups and the active <see cref="MockBehavior" />.
 	/// </summary>
 	/// <remarks>
-	///     Returns a flag, indicating whether the base class implementation should be skipped.
+	///     Returns a flag indicating whether the base-class setter should be skipped.
 	/// </remarks>
+	/// <typeparam name="T">The property's value type.</typeparam>
+	/// <param name="propertyName">The simple property name.</param>
+	/// <param name="value">The value being assigned.</param>
+	/// <returns><see langword="true" /> when the base-class setter should be skipped.</returns>
 	public bool SetProperty<T>(string propertyName, T value)
 	{
 		IInteraction? interaction = null;
@@ -422,9 +480,13 @@ public partial class MockRegistry
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
 	/// <summary>
-	///     Associates the specified event <paramref name="method" /> on the <paramref name="target" /> with the event
-	///     identified by the given <paramref name="name" />.
+	///     Records a subscription to the event named <paramref name="name" /> and fires registered
+	///     <c>OnSubscribed</c> callbacks.
 	/// </summary>
+	/// <param name="name">The simple event name.</param>
+	/// <param name="target">The subscribing handler's target (<see langword="null" /> for static methods).</param>
+	/// <param name="method">The subscribing handler's method.</param>
+	/// <exception cref="MockException"><paramref name="method" /> is <see langword="null" />.</exception>
 	public void AddEvent(string name, object? target, MethodInfo? method)
 	{
 		if (method is null)
@@ -444,9 +506,13 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Removes the specified event <paramref name="method" /> on the <paramref name="target" /> from the event identified
-	///     by the given <paramref name="name" />.
+	///     Records an unsubscription from the event named <paramref name="name" /> and fires registered
+	///     <c>OnUnsubscribed</c> callbacks.
 	/// </summary>
+	/// <param name="name">The simple event name.</param>
+	/// <param name="target">The unsubscribing handler's target (<see langword="null" /> for static methods).</param>
+	/// <param name="method">The unsubscribing handler's method.</param>
+	/// <exception cref="MockException"><paramref name="method" /> is <see langword="null" />.</exception>
 	public void RemoveEvent(string name, object? target, MethodInfo? method)
 	{
 		if (method is null)

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -10,58 +10,62 @@ public partial class MockRegistry
 	internal MockSetups Setup { get; }
 
 	/// <summary>
-	///     Registers the <paramref name="indexerSetup" /> in the mock.
+	///     Registers <paramref name="indexerSetup" /> for the default scenario.
 	/// </summary>
+	/// <param name="indexerSetup">The indexer setup produced by the fluent <c>Setup[...]</c> API.</param>
 	public void SetupIndexer(IndexerSetup indexerSetup)
 		=> SetupIndexer("", indexerSetup);
 
 	/// <summary>
-	///     Registers the <paramref name="indexerSetup" /> in the mock for the given <paramref name="scenario" />.
-	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
-	///     into the default bucket.
+	///     Registers <paramref name="indexerSetup" /> for the given <paramref name="scenario" />.
 	/// </summary>
+	/// <param name="scenario">The scenario name the setup applies to. The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" /> and does not leak into the default bucket.</param>
+	/// <param name="indexerSetup">The indexer setup produced by the fluent <c>Setup[...]</c> API.</param>
 	public void SetupIndexer(string scenario, IndexerSetup indexerSetup)
 		=> Setup.GetOrCreateScenario(scenario).Indexers.Add(indexerSetup);
 
 	/// <summary>
-	///     Registers the <paramref name="methodSetup" /> in the mock.
+	///     Registers <paramref name="methodSetup" /> for the default scenario.
 	/// </summary>
+	/// <param name="methodSetup">The method setup produced by the fluent <c>Setup.MethodName(...)</c> API.</param>
 	public void SetupMethod(MethodSetup methodSetup)
 		=> SetupMethod("", methodSetup);
 
 	/// <summary>
-	///     Registers the <paramref name="methodSetup" /> in the mock for the given <paramref name="scenario" />.
-	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
-	///     into the default bucket.
+	///     Registers <paramref name="methodSetup" /> for the given <paramref name="scenario" />.
 	/// </summary>
+	/// <param name="scenario">The scenario name the setup applies to. The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" /> and does not leak into the default bucket.</param>
+	/// <param name="methodSetup">The method setup produced by the fluent <c>Setup.MethodName(...)</c> API.</param>
 	public void SetupMethod(string scenario, MethodSetup methodSetup)
 		=> Setup.GetOrCreateScenario(scenario).Methods.Add(methodSetup);
 
 	/// <summary>
-	///     Registers the <paramref name="propertySetup" /> in the mock.
+	///     Registers <paramref name="propertySetup" /> for the default scenario.
 	/// </summary>
+	/// <param name="propertySetup">The property setup produced by the fluent <c>Setup.PropertyName</c> API.</param>
 	public void SetupProperty(PropertySetup propertySetup)
 		=> SetupProperty("", propertySetup);
 
 	/// <summary>
-	///     Registers the <paramref name="propertySetup" /> in the mock for the given <paramref name="scenario" />.
-	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
-	///     into the default bucket.
+	///     Registers <paramref name="propertySetup" /> for the given <paramref name="scenario" />.
 	/// </summary>
+	/// <param name="scenario">The scenario name the setup applies to. The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" /> and does not leak into the default bucket.</param>
+	/// <param name="propertySetup">The property setup produced by the fluent <c>Setup.PropertyName</c> API.</param>
 	public void SetupProperty(string scenario, PropertySetup propertySetup)
 		=> Setup.GetOrCreateScenario(scenario).Properties.Add(propertySetup);
 
 	/// <summary>
-	///     Registers the <paramref name="eventSetup" /> in the mock.
+	///     Registers <paramref name="eventSetup" /> for the default scenario.
 	/// </summary>
+	/// <param name="eventSetup">The event setup produced by the fluent <c>Setup.EventName</c> API.</param>
 	public void SetupEvent(EventSetup eventSetup)
 		=> SetupEvent("", eventSetup);
 
 	/// <summary>
-	///     Registers the <paramref name="eventSetup" /> in the mock for the given <paramref name="scenario" />.
-	///     The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" />; it does not leak
-	///     into the default bucket.
+	///     Registers <paramref name="eventSetup" /> for the given <paramref name="scenario" />.
 	/// </summary>
+	/// <param name="scenario">The scenario name the setup applies to. The setup only applies while <see cref="Scenario" /> equals <paramref name="scenario" /> and does not leak into the default bucket.</param>
+	/// <param name="eventSetup">The event setup produced by the fluent <c>Setup.EventName</c> API.</param>
 	public void SetupEvent(string scenario, EventSetup eventSetup)
 		=> Setup.GetOrCreateScenario(scenario).Events.Add(eventSetup);
 }

--- a/Source/Mockolate/MockRegistry.Verify.cs
+++ b/Source/Mockolate/MockRegistry.Verify.cs
@@ -13,8 +13,16 @@ namespace Mockolate;
 public partial class MockRegistry
 {
 	/// <summary>
-	///     Counts the invocations of methods with <paramref name="methodName" /> matching the <paramref name="predicate" /> on the <paramref name="subject" />.
+	///     Counts invocations of the method named <paramref name="methodName" /> on <paramref name="subject" /> whose
+	///     recorded interaction satisfies <paramref name="predicate" />.
 	/// </summary>
+	/// <typeparam name="T">The verification facade type; returned to the caller so chaining can continue.</typeparam>
+	/// <typeparam name="TMethod">The concrete <see cref="IMethodInteraction" /> subtype to filter on.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="methodName">The simple method name (e.g. <c>"Greet"</c>).</param>
+	/// <param name="predicate">Argument predicate applied to each matching interaction.</param>
+	/// <param name="expectation">Factory producing the expectation description used in failure messages.</param>
+	/// <returns>A verification result exposing <c>AnyParameters()</c> in addition to the usual terminators.</returns>
 	public VerificationResult<T>.IgnoreParameters VerifyMethod<T, TMethod>(T subject, string methodName, Func<TMethod, bool> predicate, Func<string> expectation) where TMethod : IMethodInteraction
 	{
 		return new VerificationResult<T>.IgnoreParameters(
@@ -32,8 +40,12 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Counts the getter accesses of property <paramref name="propertyName" /> on the <paramref name="subject" />.
+	///     Counts getter accesses of the property named <paramref name="propertyName" /> on <paramref name="subject" />.
 	/// </summary>
+	/// <typeparam name="T">The verification facade type.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="propertyName">The simple property name.</param>
+	/// <returns>A verification result pending a count terminator (e.g. <c>.Once()</c>).</returns>
 	public VerificationResult<T> VerifyProperty<T>(T subject, string propertyName)
 	{
 		return new VerificationResult<T>(subject,
@@ -50,9 +62,15 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Counts the setter accesses of property <paramref name="propertyName" />
-	///     with the matching <paramref name="value" /> on the <paramref name="subject" />.
+	///     Counts setter accesses of the property named <paramref name="propertyName" /> on <paramref name="subject" />
+	///     where the assigned value matches <paramref name="value" />.
 	/// </summary>
+	/// <typeparam name="TSubject">The verification facade type.</typeparam>
+	/// <typeparam name="TValue">The property's type.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="propertyName">The simple property name.</param>
+	/// <param name="value">Parameter matcher evaluated against the assigned value.</param>
+	/// <returns>A verification result pending a count terminator.</returns>
 	public VerificationResult<TSubject> VerifyProperty<TSubject, TValue>(TSubject subject, string propertyName,
 		IParameterMatch<TValue> value)
 	{
@@ -71,8 +89,13 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Counts the invocations of methods matching the <paramref name="methodSetup" /> on the <paramref name="subject" />.
+	///     Counts invocations on <paramref name="subject" /> that match the <paramref name="methodSetup" />.
 	/// </summary>
+	/// <typeparam name="T">The verification facade type.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="methodSetup">An existing method setup. Must also implement <see cref="IVerifiableMethodSetup" />.</param>
+	/// <returns>A verification result pending a count terminator.</returns>
+	/// <exception cref="MockException"><paramref name="methodSetup" /> does not implement <see cref="IVerifiableMethodSetup" />.</exception>
 	public VerificationResult<T> Method<T>(T subject, IMethodSetup methodSetup)
 	{
 		if (methodSetup is not IVerifiableMethodSetup verifiableMethodSetup)
@@ -96,9 +119,14 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Counts the getter accesses of the indexer matching <paramref name="gotPredicate" /> on the
-	///     <paramref name="subject" />.
+	///     Counts indexer getter accesses on <paramref name="subject" /> whose recorded interaction satisfies
+	///     <paramref name="gotPredicate" />.
 	/// </summary>
+	/// <typeparam name="T">The verification facade type.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="gotPredicate">Predicate evaluated against each recorded interaction.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	/// <returns>A verification result pending a count terminator.</returns>
 	public VerificationResult<T> IndexerGot<T>(T subject,
 		Func<IInteraction, bool> gotPredicate,
 		Func<string> parametersDescription)
@@ -108,9 +136,16 @@ public partial class MockRegistry
 			() => $"got indexer {parametersDescription()}");
 
 	/// <summary>
-	///     Counts the setter accesses of the indexer matching <paramref name="setPredicate" /> to the given
-	///     <paramref name="value" /> on the <paramref name="subject" />.
+	///     Counts indexer setter accesses on <paramref name="subject" /> where the recorded interaction matches
+	///     <paramref name="setPredicate" /> and the assigned value matches <paramref name="value" />.
 	/// </summary>
+	/// <typeparam name="T">The verification facade type.</typeparam>
+	/// <typeparam name="TValue">The indexer's value type.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="setPredicate">Predicate evaluated against each recorded interaction and the expected value matcher.</param>
+	/// <param name="value">Parameter matcher evaluated against the assigned value.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	/// <returns>A verification result pending a count terminator.</returns>
 	public VerificationResult<T> IndexerSet<T, TValue>(T subject,
 		Func<IInteraction, IParameterMatch<TValue>, bool> setPredicate,
 		IParameterMatch<TValue> value,
@@ -129,8 +164,12 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Counts the subscriptions to the event <paramref name="eventName" /> on the <paramref name="subject" />.
+	///     Counts subscriptions (<c>+=</c>) to the event named <paramref name="eventName" /> on <paramref name="subject" />.
 	/// </summary>
+	/// <typeparam name="T">The verification facade type.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="eventName">The simple event name.</param>
+	/// <returns>A verification result pending a count terminator.</returns>
 	public VerificationResult<T> SubscribedTo<T>(T subject, string eventName)
 	{
 		return new VerificationResult<T>(subject, Interactions,
@@ -146,8 +185,12 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Counts the unsubscriptions from the event <paramref name="eventName" /> on the <paramref name="subject" />.
+	///     Counts unsubscriptions (<c>-=</c>) from the event named <paramref name="eventName" /> on <paramref name="subject" />.
 	/// </summary>
+	/// <typeparam name="T">The verification facade type.</typeparam>
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="eventName">The simple event name.</param>
+	/// <returns>A verification result pending a count terminator.</returns>
 	public VerificationResult<T> UnsubscribedFrom<T>(T subject, string eventName)
 	{
 		return new VerificationResult<T>(subject, Interactions,
@@ -163,8 +206,11 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Returns the setups that have not been used by the given <paramref name="interactions" />.
+	///     Returns every registered setup (indexer, property, method) that was not hit by any of the given
+	///     <paramref name="interactions" />.
 	/// </summary>
+	/// <param name="interactions">The interactions to check against.</param>
+	/// <returns>The unused setups; empty when every setup was exercised.</returns>
 	public IReadOnlyCollection<ISetup> GetUnusedSetups(MockInteractions interactions)
 	{
 		List<ISetup> unusedSetups =

--- a/Source/Mockolate/ParameterExtensions.cs
+++ b/Source/Mockolate/ParameterExtensions.cs
@@ -12,8 +12,12 @@ namespace Mockolate;
 public static class ParameterExtensions
 {
 	/// <summary>
-	///     Create a <paramref name="monitor" /> to collect the matched values of the <paramref name="parameter" />.
+	///     Attaches a <paramref name="monitor" /> that records every argument value matched by this parameter.
 	/// </summary>
+	/// <typeparam name="T">The parameter's value type.</typeparam>
+	/// <param name="parameter">The parameter matcher to observe.</param>
+	/// <param name="monitor">An out-parameter receiving the monitor; its <see cref="IParameterMonitor{T}.Values" /> list grows as the mock is invoked.</param>
+	/// <returns>The same <paramref name="parameter" />, allowing further fluent calls.</returns>
 	public static IParameterWithCallback<T> Monitor<T>(this IParameterWithCallback<T> parameter,
 		out IParameterMonitor<T> monitor)
 	{
@@ -24,8 +28,12 @@ public static class ParameterExtensions
 	}
 
 	/// <summary>
-	///     Create a <paramref name="monitor" /> to collect the matched values of the <paramref name="parameter" />.
+	///     Attaches a <paramref name="monitor" /> that records every argument value matched by this ref-parameter.
 	/// </summary>
+	/// <typeparam name="T">The ref-parameter's value type.</typeparam>
+	/// <param name="parameter">The ref-parameter matcher to observe.</param>
+	/// <param name="monitor">An out-parameter receiving the monitor; its <see cref="IParameterMonitor{T}.Values" /> list grows as the mock is invoked.</param>
+	/// <returns>The same <paramref name="parameter" />, allowing further fluent calls.</returns>
 	public static IRefParameter<T> Monitor<T>(this IRefParameter<T> parameter,
 		out IParameterMonitor<T> monitor)
 	{
@@ -36,8 +44,12 @@ public static class ParameterExtensions
 	}
 
 	/// <summary>
-	///     Create a <paramref name="monitor" /> to collect the matched values of the <paramref name="parameter" />.
+	///     Attaches a <paramref name="monitor" /> that records every argument value matched by this out-parameter.
 	/// </summary>
+	/// <typeparam name="T">The out-parameter's value type.</typeparam>
+	/// <param name="parameter">The out-parameter matcher to observe.</param>
+	/// <param name="monitor">An out-parameter receiving the monitor; its <see cref="IParameterMonitor{T}.Values" /> list grows as the mock is invoked.</param>
+	/// <returns>The same <paramref name="parameter" />, allowing further fluent calls.</returns>
 	public static IOutParameter<T> Monitor<T>(this IOutParameter<T> parameter,
 		out IParameterMonitor<T> monitor)
 	{

--- a/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
+++ b/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
@@ -14,101 +14,171 @@ namespace Mockolate;
 public static class ReturnsThrowsAsyncExtensions
 {
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="Task{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="Task{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's argument and produces the value wrapped in a
+	///     completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1> setup, Func<T1, TReturn> callback)
 		=> setup.Returns(v1 => Task.FromResult(callback(v1)));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="Task{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a
+	///     completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2> setup, Func<T1, T2, TReturn> callback)
 		=> setup.Returns((v1, v2) => Task.FromResult(callback(v1, v2)));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="Task{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a
+	///     completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3> setup, Func<T1, T2, T3, TReturn> callback)
 		=> setup.Returns((v1, v2, v3) => Task.FromResult(callback(v1, v2, v3)));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="Task{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a
+	///     completed <see cref="Task{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3, T4> setup, Func<T1, T2, T3, T4, TReturn> callback)
 		=> setup.Returns((v1, v2, v3, v4) => Task.FromResult(callback(v1, v2, v3, v4)));
@@ -116,101 +186,171 @@ public static class ReturnsThrowsAsyncExtensions
 #if NET8_0_OR_GREATER
 #pragma warning disable CA2012 // Use ValueTasks correctly
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="ValueTask{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="ValueTask{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's argument and produces the value wrapped in a
+	///     completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1> setup, Func<T1, TReturn> callback)
 		=> setup.Returns(v1 => ValueTask.FromResult(callback(v1)));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="ValueTask{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a
+	///     completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2> setup, Func<T1, T2, TReturn> callback)
 		=> setup.Returns((v1, v2) => ValueTask.FromResult(callback(v1, v2)));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="ValueTask{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a
+	///     completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3> setup, Func<T1, T2, T3, TReturn> callback)
 		=> setup.Returns((v1, v2, v3) => ValueTask.FromResult(callback(v1, v2, v3)));
 
 	/// <summary>
-	///     Registers the <see langword="async" /> <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns a completed
+	///     <see cref="ValueTask{TReturn}" /> carrying this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
 		T4>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return to the sequence; <paramref name="callback" /> is invoked on each matching
+	///     invocation and its result is wrapped in a completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
 		T4>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
 
 	/// <summary>
-	///     Registers an <see langword="async" /> <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy async return that receives the method's arguments and produces the value wrapped in a
+	///     completed <see cref="ValueTask{TReturn}" />.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
 		T4>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<T1, T2, T3, T4, TReturn> callback)
@@ -219,121 +359,182 @@ public static class ReturnsThrowsAsyncExtensions
 #endif
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="Task{TReturn}" /> with <paramref name="exception" />
+	///     so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		Exception exception)
 		=> setup.Returns(Task.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => Task.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="Task{TReturn}" /> with <paramref name="exception" />
+	///     so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup,
 		Exception exception)
 		=> setup.Returns(Task.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => Task.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's argument to build the
+	///     exception the returned <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1> setup,
 		Func<T1, Exception> callback)
 		=> setup.Returns(p1 => Task.FromException<TReturn>(callback(p1)));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="Task{TReturn}" /> with <paramref name="exception" />
+	///     so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup,
 		Exception exception)
 		=> setup.Returns(Task.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => Task.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception the returned <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2> setup,
 		Func<T1, T2, Exception> callback)
 		=> setup.Returns((p1, p2) => Task.FromException<TReturn>(callback(p1, p2)));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="Task{TReturn}" /> with <paramref name="exception" />
+	///     so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup,
 		Exception exception)
 		=> setup.Returns(Task.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => Task.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception the returned <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3> setup,
 		Func<T1, T2, T3, Exception> callback)
 		=> setup.Returns((p1, p2, p3) => Task.FromException<TReturn>(callback(p1, p2, p3)));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="Task{TReturn}" /> with <paramref name="exception" />
+	///     so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ThrowsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup,
 		Exception exception)
 		=> setup.Returns(Task.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ThrowsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => Task.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception the returned <see cref="Task{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ThrowsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3, T4> setup,
 		Func<T1, T2, T3, T4, Exception> callback)
@@ -342,121 +543,182 @@ public static class ReturnsThrowsAsyncExtensions
 #if NET8_0_OR_GREATER
 #pragma warning disable CA2012 // Use ValueTasks correctly
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="ValueTask{TReturn}" /> with
+	///     <paramref name="exception" /> so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup,
 		Exception exception)
 		=> setup.Returns(ValueTask.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => ValueTask.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="ValueTask{TReturn}" /> with
+	///     <paramref name="exception" /> so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup,
 		Exception exception)
 		=> setup.Returns(ValueTask.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => ValueTask.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's argument to build the
+	///     exception the returned <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1> setup,
 		Func<T1, Exception> callback)
 		=> setup.Returns(p1 => ValueTask.FromException<TReturn>(callback(p1)));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="ValueTask{TReturn}" /> with
+	///     <paramref name="exception" /> so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup,
 		Exception exception)
 		=> setup.Returns(ValueTask.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => ValueTask.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception the returned <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2> setup,
 		Func<T1, T2, Exception> callback)
 		=> setup.Returns((p1, p2) => ValueTask.FromException<TReturn>(callback(p1, p2)));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="ValueTask{TReturn}" /> with
+	///     <paramref name="exception" /> so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup,
 		Exception exception)
 		=> setup.Returns(ValueTask.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup,
 		Func<Exception> callback)
 		=> setup.Returns(() => ValueTask.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception the returned <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3> setup,
 		Func<T1, T2, T3, Exception> callback)
 		=> setup.Returns((p1, p2, p3) => ValueTask.FromException<TReturn>(callback(p1, p2, p3)));
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the <see langword="async" /> method is awaited.
+	///     Appends an entry that faults the returned <see cref="ValueTask{TReturn}" /> with
+	///     <paramref name="exception" /> so awaiting it throws.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4>
 		ThrowsAsync<TReturn, T1, T2, T3, T4>(this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup,
 			Exception exception)
 		=> setup.Returns(ValueTask.FromException<TReturn>(exception));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception the returned
+	///     <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4>
 		ThrowsAsync<TReturn, T1, T2, T3, T4>(this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup,
 			Func<Exception> callback)
 		=> setup.Returns(() => ValueTask.FromException<TReturn>(callback()));
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that calculates the exception to throw when the <see langword="async" />
-	///     method is awaited.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception the returned <see cref="ValueTask{TReturn}" /> is faulted with.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
+	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4>
 		ThrowsAsync<TReturn, T1, T2, T3, T4>(this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3, T4> setup,
 			Func<T1, T2, T3, T4, Exception> callback)

--- a/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
+++ b/Source/Mockolate/ReturnsThrowsAsyncExtensions.cs
@@ -21,6 +21,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		TReturn returnValue)
@@ -34,6 +38,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		Func<TReturn> callback)
@@ -47,6 +55,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
@@ -59,6 +72,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
@@ -71,6 +89,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1> setup, Func<T1, TReturn> callback)
 		=> setup.Returns(v1 => Task.FromResult(callback(v1)));
@@ -83,6 +106,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
@@ -95,6 +124,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
@@ -107,6 +142,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2> setup, Func<T1, T2, TReturn> callback)
 		=> setup.Returns((v1, v2) => Task.FromResult(callback(v1, v2)));
@@ -119,6 +160,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
@@ -131,6 +179,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
@@ -143,6 +198,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3> setup, Func<T1, T2, T3, TReturn> callback)
 		=> setup.Returns((v1, v2, v3) => Task.FromResult(callback(v1, v2, v3)));
@@ -155,6 +217,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup, TReturn returnValue)
 		=> setup.Returns(Task.FromResult(returnValue));
@@ -167,6 +237,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup, Func<TReturn> callback)
 		=> setup.Returns(() => Task.FromResult(callback()));
@@ -179,6 +257,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3, T4> setup, Func<T1, T2, T3, T4, TReturn> callback)
 		=> setup.Returns((v1, v2, v3, v4) => Task.FromResult(callback(v1, v2, v3, v4)));
@@ -193,6 +279,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
@@ -205,6 +295,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ReturnsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
@@ -217,6 +311,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
@@ -229,6 +328,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
@@ -241,6 +345,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ReturnsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1> setup, Func<T1, TReturn> callback)
 		=> setup.Returns(v1 => ValueTask.FromResult(callback(v1)));
@@ -253,6 +362,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
@@ -265,6 +380,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
@@ -277,6 +398,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ReturnsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2> setup, Func<T1, T2, TReturn> callback)
 		=> setup.Returns((v1, v2) => ValueTask.FromResult(callback(v1, v2)));
@@ -289,6 +416,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, TReturn returnValue)
 		=> setup.Returns(ValueTask.FromResult(returnValue));
@@ -301,6 +435,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup, Func<TReturn> callback)
 		=> setup.Returns(() => ValueTask.FromResult(callback()));
@@ -313,6 +454,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ReturnsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3> setup, Func<T1, T2, T3, TReturn> callback)
 		=> setup.Returns((v1, v2, v3) => ValueTask.FromResult(callback(v1, v2, v3)));
@@ -325,6 +473,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
 		T4>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, TReturn returnValue)
@@ -338,6 +494,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
 		T4>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<TReturn> callback)
@@ -351,6 +515,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4> ReturnsAsync<TReturn, T1, T2, T3,
 		T4>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3, T4> setup, Func<T1, T2, T3, T4, TReturn> callback)
@@ -366,6 +538,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		Exception exception)
@@ -379,6 +555,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<Task<TReturn>> setup,
 		Func<Exception> callback)
@@ -392,6 +572,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup,
 		Exception exception)
@@ -405,6 +590,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<Task<TReturn>, T1> setup,
 		Func<Exception> callback)
@@ -418,6 +608,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1> setup,
 		Func<T1, Exception> callback)
@@ -431,6 +626,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup,
 		Exception exception)
@@ -444,6 +645,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2> setup,
 		Func<Exception> callback)
@@ -457,6 +664,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2> setup,
 		Func<T1, T2, Exception> callback)
@@ -470,6 +683,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup,
 		Exception exception)
@@ -483,6 +703,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3> setup,
 		Func<Exception> callback)
@@ -496,6 +723,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3> setup,
 		Func<T1, T2, T3, Exception> callback)
@@ -509,6 +743,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ThrowsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup,
 		Exception exception)
@@ -522,6 +764,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ThrowsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetup<Task<TReturn>, T1, T2, T3, T4> setup,
 		Func<Exception> callback)
@@ -535,6 +785,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<Task<TReturn>, T1, T2, T3, T4> ThrowsAsync<TReturn, T1, T2, T3, T4>(
 		this IReturnMethodSetupWithCallback<Task<TReturn>, T1, T2, T3, T4> setup,
 		Func<T1, T2, T3, T4, Exception> callback)
@@ -550,6 +808,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup,
 		Exception exception)
@@ -563,6 +825,10 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>> ThrowsAsync<TReturn>(
 		this IReturnMethodSetup<ValueTask<TReturn>> setup,
 		Func<Exception> callback)
@@ -576,6 +842,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup,
 		Exception exception)
@@ -589,6 +860,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1> setup,
 		Func<Exception> callback)
@@ -602,6 +878,11 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1> ThrowsAsync<TReturn, T1>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1> setup,
 		Func<T1, Exception> callback)
@@ -615,6 +896,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup,
 		Exception exception)
@@ -628,6 +915,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2> setup,
 		Func<Exception> callback)
@@ -641,6 +934,12 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2> ThrowsAsync<TReturn, T1, T2>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2> setup,
 		Func<T1, T2, Exception> callback)
@@ -654,6 +953,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup,
 		Exception exception)
@@ -667,6 +973,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3> setup,
 		Func<Exception> callback)
@@ -680,6 +993,13 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3> ThrowsAsync<TReturn, T1, T2, T3>(
 		this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3> setup,
 		Func<T1, T2, T3, Exception> callback)
@@ -693,6 +1013,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4>
 		ThrowsAsync<TReturn, T1, T2, T3, T4>(this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup,
 			Exception exception)
@@ -706,6 +1034,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4>
 		ThrowsAsync<TReturn, T1, T2, T3, T4>(this IReturnMethodSetup<ValueTask<TReturn>, T1, T2, T3, T4> setup,
 			Func<Exception> callback)
@@ -719,6 +1055,14 @@ public static class ReturnsThrowsAsyncExtensions
 	///     Call <c>ReturnsAsync</c>/<c>ThrowsAsync</c> multiple times to build a sequence; once exhausted it cycles
 	///     back to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TReturn">The value-task result type produced by the asynchronous method.</typeparam>
+	/// <typeparam name="T1">The type of the first method argument.</typeparam>
+	/// <typeparam name="T2">The type of the second method argument.</typeparam>
+	/// <typeparam name="T3">The type of the third method argument.</typeparam>
+	/// <typeparam name="T4">The type of the fourth method argument.</typeparam>
+	/// <param name="setup">The method setup to extend.</param>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	public static IReturnMethodSetupReturnBuilder<ValueTask<TReturn>, T1, T2, T3, T4>
 		ThrowsAsync<TReturn, T1, T2, T3, T4>(this IReturnMethodSetupWithCallback<ValueTask<TReturn>, T1, T2, T3, T4> setup,
 			Func<T1, T2, T3, T4, Exception> callback)

--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -110,8 +110,13 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	/// <summary>
-	///     Invokes the callback if the predicates are satisfied, providing the invocation count.
+	///     Invokes the wrapped delegate when all gating predicates (<c>.When</c>/<c>.For</c>/<c>.Only</c>) are
+	///     satisfied, feeding the zero-based invocation count to <paramref name="callback" />.
 	/// </summary>
+	/// <param name="wasInvoked">Whether an earlier callback in the same sequence has already run for this interaction (serial-mode gating).</param>
+	/// <param name="index">Shared sequence index; advanced by this call when the sequence moves on to the next entry.</param>
+	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count.</param>
+	/// <returns><see langword="true" /> when the callback ran exclusively (serial mode) &#8212; signalling that no later serial callback should fire.</returns>
 	public bool Invoke(bool wasInvoked, ref int index, Action<int, TDelegate> callback)
 	{
 		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
@@ -154,8 +159,12 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
 	/// <summary>
-	///     Invokes the callback if the predicates are satisfied, providing the invocation count.
+	///     Invokes the wrapped delegate when all gating predicates are satisfied, always advancing the shared
+	///     sequence index.
 	/// </summary>
+	/// <param name="index">Shared sequence index; always advanced by this call.</param>
+	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count.</param>
+	/// <returns><see langword="true" /> when the callback ran; <see langword="false" /> when gating skipped it.</returns>
 	public bool Invoke(ref int index, Action<int, TDelegate> callback)
 	{
 		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
@@ -182,8 +191,13 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 	}
 
 	/// <summary>
-	///     Invokes the callback if the predicates are satisfied, providing the invocation count.
+	///     Invokes the wrapped delegate when all gating predicates are satisfied and captures its return value.
 	/// </summary>
+	/// <typeparam name="TReturn">The wrapped delegate's return type.</typeparam>
+	/// <param name="index">Shared sequence index; always advanced by this call.</param>
+	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count and produces the return value.</param>
+	/// <param name="returnValue">When this method returns <see langword="true" />, contains the value produced by <paramref name="callback" />; otherwise <see langword="default" />.</param>
+	/// <returns><see langword="true" /> when the callback ran; <see langword="false" /> when gating skipped it.</returns>
 	public bool Invoke<TReturn>(ref int index, Func<int, TDelegate, TReturn> callback,
 		[NotNullWhen(true)] out TReturn? returnValue)
 	{
@@ -213,10 +227,16 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	/// <summary>
-	///     Invokes the callback if the predicates are satisfied, passing the caller-supplied <paramref name="state" />
-	///     to the non-capturing <paramref name="callback" />. Equivalent in behavior to
-	///     <see cref="Invoke(bool, ref int, Action{int, TDelegate})" /> but allocation-free on the hot path.
+	///     State-passing variant of <see cref="Invoke(bool, ref int, Action{int, TDelegate})" /> &#8212; identical
+	///     semantics, but <paramref name="state" /> is forwarded verbatim so <paramref name="callback" /> does not need
+	///     to capture it in a closure.
 	/// </summary>
+	/// <typeparam name="TState">The caller-supplied state type.</typeparam>
+	/// <param name="wasInvoked">Whether an earlier callback in the same sequence has already run for this interaction.</param>
+	/// <param name="index">Shared sequence index; advanced when the sequence moves on.</param>
+	/// <param name="state">Arbitrary caller state forwarded to <paramref name="callback" />.</param>
+	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count and <paramref name="state" />.</param>
+	/// <returns><see langword="true" /> when the callback ran exclusively in serial mode.</returns>
 	public bool Invoke<TState>(bool wasInvoked, ref int index, TState state,
 		Action<int, TDelegate, TState> callback)
 	{
@@ -260,10 +280,18 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
 	/// <summary>
-	///     Invokes the callback if the predicates are satisfied, passing the caller-supplied <paramref name="state" />
-	///     to the non-capturing <paramref name="callback" />. Equivalent in behavior to
-	///     <see cref="Invoke{TReturn}(ref int, Func{int, TDelegate, TReturn}, out TReturn)" /> but allocation-free.
+	///     State-passing variant of
+	///     <see cref="Invoke{TReturn}(ref int, Func{int, TDelegate, TReturn}, out TReturn)" /> &#8212; identical
+	///     semantics, but <paramref name="state" /> is forwarded verbatim so <paramref name="callback" /> does not need
+	///     to capture it in a closure.
 	/// </summary>
+	/// <typeparam name="TState">The caller-supplied state type.</typeparam>
+	/// <typeparam name="TReturn">The wrapped delegate's return type.</typeparam>
+	/// <param name="index">Shared sequence index; always advanced by this call.</param>
+	/// <param name="state">Arbitrary caller state forwarded to <paramref name="callback" />.</param>
+	/// <param name="callback">Invoker that produces the return value using <typeparamref name="TDelegate" /> and <paramref name="state" />.</param>
+	/// <param name="returnValue">When this method returns <see langword="true" />, contains the produced value.</param>
+	/// <returns><see langword="true" /> when the callback ran; <see langword="false" /> when gating skipped it.</returns>
 	public bool Invoke<TState, TReturn>(ref int index, TState state,
 		Func<int, TDelegate, TState, TReturn> callback,
 		[NotNullWhen(true)] out TReturn? returnValue)

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -42,35 +42,56 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 	/// <summary>
 	///     Transitions the associated mock registry to the given <paramref name="scenario" />.
 	/// </summary>
+	/// <param name="scenario">The scenario name to switch to.</param>
 	protected void TransitionScenario(string scenario)
 		=> _mockRegistry.TransitionTo(scenario);
 
 	/// <summary>
-	///     Checks if the <paramref name="access" /> matches the setup.
+	///     Returns whether this setup applies to the given <paramref name="access" />.
 	/// </summary>
+	/// <param name="access">The recorded access being matched.</param>
+	/// <returns><see langword="true" /> when this setup should handle the access.</returns>
 	protected abstract bool MatchesAccess(IndexerAccess access);
 
 	/// <summary>
-	///     Invokes the getter flow for the given <paramref name="access" /> using <paramref name="baseValue" /> as the seed.
+	///     Runs the getter flow for <paramref name="access" /> using <paramref name="baseValue" /> as the seed.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The recorded access whose arguments identify the slot.</param>
+	/// <param name="behavior">The mock's active behavior.</param>
+	/// <param name="baseValue">The value produced by the base-class indexer (or a caller-supplied default).</param>
+	/// <returns>The resolved getter value.</returns>
 	public abstract TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior, TResult baseValue);
 
 	/// <summary>
-	///     Invokes the getter flow for the given <paramref name="access" />, materializing the default value from the
+	///     Runs the getter flow for <paramref name="access" />, materializing the default value from
 	///     <paramref name="behavior" /> inline when no stored value or initialization is present.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The recorded access whose arguments identify the slot.</param>
+	/// <param name="behavior">The mock's active behavior (also provides the default value factory).</param>
+	/// <returns>The resolved getter value.</returns>
 	public abstract TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior);
 
 	/// <summary>
-	///     Invokes the getter flow for the given <paramref name="access" /> using the <paramref name="defaultValueGenerator" />
-	///     when no value has been stored or initialized.
+	///     Runs the getter flow for <paramref name="access" /> using <paramref name="defaultValueGenerator" /> as the
+	///     fallback when no value has been stored or initialized.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The recorded access whose arguments identify the slot.</param>
+	/// <param name="behavior">The mock's active behavior.</param>
+	/// <param name="defaultValueGenerator">Lazy producer of the default value; only invoked when a default is actually needed.</param>
+	/// <returns>The resolved getter value.</returns>
 	public abstract TResult GetResult<TResult>(IndexerAccess access, MockBehavior behavior,
 		Func<TResult> defaultValueGenerator);
 
 	/// <summary>
-	///     Invokes the setter flow for the given <paramref name="access" /> with the given <paramref name="value" />.
+	///     Runs the setter flow for <paramref name="access" /> with the given <paramref name="value" />.
 	/// </summary>
+	/// <typeparam name="TResult">The indexer's value type.</typeparam>
+	/// <param name="access">The recorded access whose arguments identify the slot.</param>
+	/// <param name="behavior">The mock's active behavior.</param>
+	/// <param name="value">The value being assigned.</param>
 	public abstract void SetResult<TResult>(IndexerAccess access, MockBehavior behavior, TResult value);
 
 	/// <summary>

--- a/Source/Mockolate/Setup/Interfaces.EventSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.EventSetup.cs
@@ -41,11 +41,6 @@ public interface IEventSubscriptionSetup
 	/// </summary>
 	/// <param name="callback">The action to invoke on every matching subscription.</param>
 	/// <returns>A builder for chaining repetition/gating operators such as <c>.For(n)</c> or <c>.When(...)</c>.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.UsersChanged.OnSubscribed.Do(() =&gt; Console.WriteLine("subscribed!"));
-	///     </code>
-	/// </example>
 	IEventSubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>

--- a/Source/Mockolate/Setup/Interfaces.EventSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.EventSetup.cs
@@ -4,69 +4,88 @@ using System.Reflection;
 namespace Mockolate.Setup;
 
 /// <summary>
-///     Interface for setting up an event with fluent syntax.
+///     Fluent surface for observing subscription lifecycle of a mocked event.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.EventName</c>. Use <see cref="OnSubscribed" /> to attach callbacks that fire
+///     when a handler is added via <c>+=</c>, and <see cref="OnUnsubscribed" /> for handlers removed via <c>-=</c>.
+///     To actually trigger the event on subscribers, use <c>sut.Mock.Raise.EventName(...)</c> instead.
+/// </remarks>
 public interface IEventSetup
 {
 	/// <summary>
-	///     Sets up callbacks on the event subscription (add accessor).
+	///     Attaches callbacks that fire whenever a handler is subscribed to the event (the <c>add</c> accessor).
 	/// </summary>
 	IEventSubscriptionSetup OnSubscribed { get; }
 
 	/// <summary>
-	///     Sets up callbacks on the event unsubscription (remove accessor).
+	///     Attaches callbacks that fire whenever a handler is unsubscribed from the event (the <c>remove</c>
+	///     accessor).
 	/// </summary>
 	IEventUnsubscriptionSetup OnUnsubscribed { get; }
 }
 
 /// <summary>
-///     Interface for setting up an event subscription with fluent syntax.
+///     Fluent surface for attaching side-effects to an event's <c>add</c> accessor.
 /// </summary>
+/// <remarks>
+///     Each <c>Do</c> registers a callback that fires on every handler subscription. Chain multiple <c>Do</c> calls
+///     to form a sequence; chain <c>.InParallel()</c>, <c>.When(predicate)</c>, <c>.For(n)</c>, <c>.Only(n)</c>,
+///     <c>.OnlyOnce()</c>, <c>.Forever()</c> on the returned builders to control repetition and gating.
+/// </remarks>
 public interface IEventSubscriptionSetup
 {
 	/// <summary>
-	///     Registers a callback to be invoked whenever a handler is subscribed to the event.
+	///     Fires <paramref name="callback" /> whenever a handler subscribes to the event.
 	/// </summary>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.UsersChanged.OnSubscribed.Do(() =&gt; Console.WriteLine("subscribed!"));
+	///     </code>
+	/// </example>
 	IEventSubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever a handler is subscribed to the event.
+	///     Fires <paramref name="callback" /> whenever a handler subscribes, passing the subscriber's target object
+	///     (<see langword="null" /> for static methods) and <see cref="MethodInfo" />.
 	/// </summary>
 	/// <remarks>
-	///     The callback receives the target object and method of the subscribed handler.
+	///     Useful for diagnostics or for asserting which specific method on which target was wired up.
 	/// </remarks>
 	IEventSubscriptionSetupCallbackBuilder Do(Action<object?, MethodInfo> callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> whenever a handler is subscribed to the event.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever a handler subscribes.
 	/// </summary>
-	/// <param name="scenario">The name of the new scenario.</param>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
 	IEventSubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
 }
 
 /// <summary>
-///     Interface for setting up an event unsubscription with fluent syntax.
+///     Fluent surface for attaching side-effects to an event's <c>remove</c> accessor.
 /// </summary>
+/// <remarks>
+///     Mirror of <see cref="IEventSubscriptionSetup" /> for unsubscriptions: each <c>Do</c> registers a callback that
+///     fires when a handler is removed via <c>-=</c>; the same builder operators (<c>.InParallel()</c>,
+///     <c>.When(predicate)</c>, <c>.For(n)</c>, <c>.Only(n)</c>, <c>.OnlyOnce()</c>, <c>.Forever()</c>) apply.
+/// </remarks>
 public interface IEventUnsubscriptionSetup
 {
 	/// <summary>
-	///     Registers a callback to be invoked whenever a handler is unsubscribed from the event.
+	///     Fires <paramref name="callback" /> whenever a handler unsubscribes from the event.
 	/// </summary>
 	IEventUnsubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever a handler is unsubscribed from the event.
+	///     Fires <paramref name="callback" /> whenever a handler unsubscribes, passing the handler's target object
+	///     (<see langword="null" /> for static methods) and <see cref="MethodInfo" />.
 	/// </summary>
-	/// <remarks>
-	///     The callback receives the target object and method of the unsubscribed handler.
-	/// </remarks>
 	IEventUnsubscriptionSetupCallbackBuilder Do(Action<object?, MethodInfo> callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> whenever a handler is unsubscribed from the
-	///     event.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever a handler unsubscribes.
 	/// </summary>
-	/// <param name="scenario">The name of the new scenario.</param>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
 	IEventUnsubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
 }
 

--- a/Source/Mockolate/Setup/Interfaces.EventSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.EventSetup.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 namespace Mockolate.Setup;
 
 /// <summary>
-///     Fluent surface for observing subscription lifecycle of a mocked event.
+///     Setup for observing subscription lifecycle of a mocked event.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.EventName</c>. Use <see cref="OnSubscribed" /> to attach callbacks that fire
@@ -27,7 +27,7 @@ public interface IEventSetup
 }
 
 /// <summary>
-///     Fluent surface for attaching side-effects to an event's <c>add</c> accessor.
+///     Setup for attaching side-effects to an event's <c>add</c> accessor.
 /// </summary>
 /// <remarks>
 ///     Each <c>Do</c> registers a callback that fires on every handler subscription. Chain multiple <c>Do</c> calls
@@ -40,7 +40,7 @@ public interface IEventSubscriptionSetup
 	///     Fires <paramref name="callback" /> whenever a handler subscribes to the event.
 	/// </summary>
 	/// <param name="callback">The action to invoke on every matching subscription.</param>
-	/// <returns>A builder for chaining repetition/gating operators such as <c>.For(n)</c> or <c>.When(...)</c>.</returns>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IEventSubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
@@ -63,7 +63,7 @@ public interface IEventSubscriptionSetup
 }
 
 /// <summary>
-///     Fluent surface for attaching side-effects to an event's <c>remove</c> accessor.
+///     Setup for attaching side-effects to an event's <c>remove</c> accessor.
 /// </summary>
 /// <remarks>
 ///     Mirror of <see cref="IEventSubscriptionSetup" /> for unsubscriptions: each <c>Do</c> registers a callback that
@@ -80,10 +80,10 @@ public interface IEventUnsubscriptionSetup
 	IEventUnsubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
-	///     Fires <paramref name="callback" /> whenever a handler unsubscribes, passing the handler's target object
+	///     Fires <paramref name="callback" /> whenever a handler unsubscribes, passing the subscriber's target object
 	///     (<see langword="null" /> for static methods) and <see cref="MethodInfo" />.
 	/// </summary>
-	/// <param name="callback">The action to invoke on every matching unsubscription, receiving the handler's target and <see cref="MethodInfo" />.</param>
+	/// <param name="callback">The action to invoke on every matching unsubscription, receiving the subscriber's target and <see cref="MethodInfo" />.</param>
 	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	/// <remarks>
 	///     Useful for diagnostics or for asserting which specific method on which target was unwired.

--- a/Source/Mockolate/Setup/Interfaces.EventSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.EventSetup.cs
@@ -14,13 +14,14 @@ namespace Mockolate.Setup;
 public interface IEventSetup
 {
 	/// <summary>
-	///     Attaches callbacks that fire whenever a handler is subscribed to the event (the <c>add</c> accessor).
+	///     Gets the fluent surface for attaching callbacks that fire whenever a handler is subscribed to the event
+	///     (the <c>add</c> accessor).
 	/// </summary>
 	IEventSubscriptionSetup OnSubscribed { get; }
 
 	/// <summary>
-	///     Attaches callbacks that fire whenever a handler is unsubscribed from the event (the <c>remove</c>
-	///     accessor).
+	///     Gets the fluent surface for attaching callbacks that fire whenever a handler is unsubscribed from the event
+	///     (the <c>remove</c> accessor).
 	/// </summary>
 	IEventUnsubscriptionSetup OnUnsubscribed { get; }
 }
@@ -38,6 +39,8 @@ public interface IEventSubscriptionSetup
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever a handler subscribes to the event.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching subscription.</param>
+	/// <returns>A builder for chaining repetition/gating operators such as <c>.For(n)</c> or <c>.When(...)</c>.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.UsersChanged.OnSubscribed.Do(() =&gt; Console.WriteLine("subscribed!"));
@@ -49,6 +52,8 @@ public interface IEventSubscriptionSetup
 	///     Fires <paramref name="callback" /> whenever a handler subscribes, passing the subscriber's target object
 	///     (<see langword="null" /> for static methods) and <see cref="MethodInfo" />.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching subscription, receiving the handler's target and <see cref="MethodInfo" />.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	/// <remarks>
 	///     Useful for diagnostics or for asserting which specific method on which target was wired up.
 	/// </remarks>
@@ -58,6 +63,7 @@ public interface IEventSubscriptionSetup
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever a handler subscribes.
 	/// </summary>
 	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IEventSubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
 }
 
@@ -74,18 +80,26 @@ public interface IEventUnsubscriptionSetup
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever a handler unsubscribes from the event.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching unsubscription.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IEventUnsubscriptionSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever a handler unsubscribes, passing the handler's target object
 	///     (<see langword="null" /> for static methods) and <see cref="MethodInfo" />.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching unsubscription, receiving the handler's target and <see cref="MethodInfo" />.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
+	/// <remarks>
+	///     Useful for diagnostics or for asserting which specific method on which target was unwired.
+	/// </remarks>
 	IEventUnsubscriptionSetupCallbackBuilder Do(Action<object?, MethodInfo> callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever a handler unsubscribes.
 	/// </summary>
 	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IEventUnsubscriptionSetupParallelCallbackBuilder TransitionTo(string scenario);
 }
 
@@ -95,11 +109,10 @@ public interface IEventUnsubscriptionSetup
 public interface IEventSubscriptionSetupParallelCallbackBuilder : IEventSubscriptionSetupCallbackWhenBuilder
 {
 	/// <summary>
-	///     Limits the callback to only execute for event interactions where the predicate returns true.
+	///     Limits the callback to only execute for event interactions where <paramref name="predicate" /> returns <see langword="true" />.
 	/// </summary>
-	/// <remarks>
-	///     Provides a zero-based counter indicating how many times the event has been interacted with so far.
-	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the event has been interacted with so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IEventSubscriptionSetupCallbackWhenBuilder When(Func<int, bool> predicate);
 }
 
@@ -111,6 +124,7 @@ public interface IEventSubscriptionSetupCallbackBuilder : IEventSubscriptionSetu
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IEventSubscriptionSetupParallelCallbackBuilder InParallel();
 }
 
@@ -122,6 +136,8 @@ public interface IEventSubscriptionSetupCallbackWhenBuilder : IEventSetup
 	/// <summary>
 	///     Repeats the callback for the given number of <paramref name="times" />.
 	/// </summary>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining further <c>.For(n)</c> / <c>.Only(n)</c> calls on additional callbacks.</returns>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IEventSubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
@@ -131,6 +147,8 @@ public interface IEventSubscriptionSetupCallbackWhenBuilder : IEventSetup
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer <see cref="IEventSetup" /> for chaining additional event setups.</returns>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IEventSubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
@@ -144,11 +162,10 @@ public interface IEventSubscriptionSetupCallbackWhenBuilder : IEventSetup
 public interface IEventUnsubscriptionSetupParallelCallbackBuilder : IEventUnsubscriptionSetupCallbackWhenBuilder
 {
 	/// <summary>
-	///     Limits the callback to only execute for event interactions where the predicate returns true.
+	///     Limits the callback to only execute for event interactions where <paramref name="predicate" /> returns <see langword="true" />.
 	/// </summary>
-	/// <remarks>
-	///     Provides a zero-based counter indicating how many times the event has been interacted with so far.
-	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the event has been interacted with so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IEventUnsubscriptionSetupCallbackWhenBuilder When(Func<int, bool> predicate);
 }
 
@@ -160,6 +177,7 @@ public interface IEventUnsubscriptionSetupCallbackBuilder : IEventUnsubscription
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IEventUnsubscriptionSetupParallelCallbackBuilder InParallel();
 }
 
@@ -171,6 +189,8 @@ public interface IEventUnsubscriptionSetupCallbackWhenBuilder : IEventSetup
 	/// <summary>
 	///     Repeats the callback for the given number of <paramref name="times" />.
 	/// </summary>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining further <c>.For(n)</c> / <c>.Only(n)</c> calls on additional callbacks.</returns>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IEventUnsubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).
@@ -180,6 +200,8 @@ public interface IEventUnsubscriptionSetupCallbackWhenBuilder : IEventSetup
 	/// <summary>
 	///     Deactivates the callback after the given number of <paramref name="times" />.
 	/// </summary>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer <see cref="IEventSetup" /> for chaining additional event setups.</returns>
 	/// <remarks>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IEventUnsubscriptionSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to <see langword="true" />).

--- a/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
@@ -49,12 +49,15 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.Ping().Do(() =&gt; Console.WriteLine("ping!")).Returns(true);
@@ -65,12 +68,16 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn> Do(Action<int> callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn> TransitionTo(string scenario);
 
 	/// <summary>
@@ -81,6 +88,8 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn> Returns(Func<TReturn> callback);
 
 	/// <summary>
@@ -90,6 +99,8 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.Ping()
@@ -107,6 +118,8 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws<TException>()
 		where TException : Exception, new();
 
@@ -117,6 +130,8 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws(Exception exception);
 
 	/// <summary>
@@ -127,6 +142,8 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws(Func<Exception> callback);
 }
 
@@ -139,6 +156,7 @@ public interface IReturnMethodSetupCallbackBuilder<in TReturn>
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn> InParallel();
 }
 
@@ -154,6 +172,8 @@ public interface IReturnMethodSetupParallelCallbackBuilder<in TReturn>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn> When(Func<int, bool> predicate);
 }
 
@@ -172,6 +192,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn> For(int times);
 
 	/// <summary>
@@ -183,6 +205,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn> Only(int times);
 }
 
@@ -198,6 +222,8 @@ public interface IReturnMethodSetupReturnBuilder<in TReturn>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn> When(Func<int, bool> predicate);
 }
 
@@ -216,6 +242,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn> For(int times);
 
 	/// <summary>
@@ -227,6 +255,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn> Only(int times);
 }
 
@@ -254,18 +284,23 @@ public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1> TransitionTo(string scenario);
 
 	/// <summary>
@@ -276,6 +311,8 @@ public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Returns(Func<TReturn> callback);
 
 	/// <summary>
@@ -285,6 +322,8 @@ public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.CanHandle(It.IsAny&lt;string&gt;())
@@ -302,6 +341,8 @@ public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws<TException>()
 		where TException : Exception, new();
 
@@ -312,6 +353,8 @@ public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws(Exception exception);
 
 	/// <summary>
@@ -322,6 +365,8 @@ public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws(Func<Exception> callback);
 }
 
@@ -334,11 +379,15 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1> : IReturnMet
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's argument whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> Do(Action<T1> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's argument.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> Do(Action<int, T1> callback);
 
 	/// <summary>
@@ -348,6 +397,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1> : IReturnMet
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Returns(Func<T1, TReturn> callback);
 
 	/// <summary>
@@ -358,6 +409,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1> : IReturnMet
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws(Func<T1, Exception> callback);
 }
 
@@ -370,6 +423,7 @@ public interface IReturnMethodSetupCallbackBuilder<in TReturn, out T1>
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1> InParallel();
 }
 
@@ -385,6 +439,8 @@ public interface IReturnMethodSetupParallelCallbackBuilder<in TReturn, out T1>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> When(Func<int, bool> predicate);
 }
 
@@ -403,6 +459,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> For(int times);
 
 	/// <summary>
@@ -414,6 +472,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1> Only(int times);
 }
 
@@ -429,6 +489,8 @@ public interface IReturnMethodSetupReturnBuilder<in TReturn, out T1>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1> When(Func<int, bool> predicate);
 }
 
@@ -447,6 +509,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1> For(int times);
 
 	/// <summary>
@@ -458,6 +522,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1> Only(int times);
 }
 
@@ -470,6 +536,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1>
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1> AnyParameters();
 }
 
@@ -497,18 +564,23 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2> TransitionTo(string scenario);
 
 	/// <summary>
@@ -519,6 +591,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Returns(Func<TReturn> callback);
 
 	/// <summary>
@@ -528,6 +602,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.IsMatch(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;())
@@ -545,6 +621,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws<TException>()
 		where TException : Exception, new();
 
@@ -555,6 +633,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws(Exception exception);
 
 	/// <summary>
@@ -565,6 +645,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws(Func<Exception> callback);
 }
 
@@ -577,11 +659,15 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2> : IR
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> Do(Action<T1, T2> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> Do(Action<int, T1, T2> callback);
 
 	/// <summary>
@@ -591,6 +677,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2> : IR
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Returns(Func<T1, T2, TReturn> callback);
 
 	/// <summary>
@@ -601,6 +689,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2> : IR
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws(Func<T1, T2, Exception> callback);
 }
 
@@ -613,6 +703,7 @@ public interface IReturnMethodSetupCallbackBuilder<in TReturn, out T1, out T2>
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2> InParallel();
 }
 
@@ -628,6 +719,8 @@ public interface IReturnMethodSetupParallelCallbackBuilder<in TReturn, out T1, o
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> When(Func<int, bool> predicate);
 }
 
@@ -646,6 +739,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1, out T
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> For(int times);
 
 	/// <summary>
@@ -657,6 +752,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1, out T
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1, T2> Only(int times);
 }
 
@@ -672,6 +769,8 @@ public interface IReturnMethodSetupReturnBuilder<in TReturn, out T1, out T2>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> When(Func<int, bool> predicate);
 }
 
@@ -690,6 +789,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1, out T2>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> For(int times);
 
 	/// <summary>
@@ -701,6 +802,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1, out T2>
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1, T2> Only(int times);
 }
 
@@ -713,6 +816,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2>
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1, T2> AnyParameters();
 }
 
@@ -741,18 +845,23 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMetho
 	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3> TransitionTo(string scenario);
 
 	/// <summary>
@@ -763,6 +872,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMetho
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Returns(Func<TReturn> callback);
 
 	/// <summary>
@@ -772,6 +883,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMetho
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.Accepts(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;(), It.IsAny&lt;bool&gt;())
@@ -789,6 +902,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMetho
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws<TException>()
 		where TException : Exception, new();
 
@@ -799,6 +914,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMetho
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws(Exception exception);
 
 	/// <summary>
@@ -809,6 +926,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMetho
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws(Func<Exception> callback);
 }
 
@@ -821,11 +940,15 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out 
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> Do(Action<T1, T2, T3> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> Do(Action<int, T1, T2, T3> callback);
 
 	/// <summary>
@@ -835,6 +958,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Returns(Func<T1, T2, T3, TReturn> callback);
 
 	/// <summary>
@@ -845,6 +970,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback);
 }
 
@@ -857,6 +984,7 @@ public interface IReturnMethodSetupCallbackBuilder<in TReturn, out T1, out T2, o
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3> InParallel();
 }
 
@@ -872,6 +1000,8 @@ public interface IReturnMethodSetupParallelCallbackBuilder<in TReturn, out T1, o
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> When(Func<int, bool> predicate);
 }
 
@@ -890,6 +1020,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1, out T
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> For(int times);
 
 	/// <summary>
@@ -901,6 +1033,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1, out T
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3> Only(int times);
 }
 
@@ -916,6 +1050,8 @@ public interface IReturnMethodSetupReturnBuilder<in TReturn, out T1, out T2, out
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> When(Func<int, bool> predicate);
 }
 
@@ -934,6 +1070,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1, out T2,
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> For(int times);
 
 	/// <summary>
@@ -945,6 +1083,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1, out T2,
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3> Only(int times);
 }
 
@@ -957,6 +1097,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2, 
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3> AnyParameters();
 }
 
@@ -986,18 +1127,23 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> 
 	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4> TransitionTo(string scenario);
 
 	/// <summary>
@@ -1008,6 +1154,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Returns(Func<TReturn> callback);
 
 	/// <summary>
@@ -1017,6 +1165,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.Validate(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;(), It.IsAny&lt;bool&gt;(), It.IsAny&lt;double&gt;())
@@ -1034,6 +1184,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws<TException>()
 		where TException : Exception, new();
 
@@ -1044,6 +1196,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws(Exception exception);
 
 	/// <summary>
@@ -1054,6 +1208,8 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws(Func<Exception> callback);
 }
 
@@ -1066,11 +1222,15 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out 
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4> callback);
 
 	/// <summary>
@@ -1080,6 +1240,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TReturn> callback);
 
 	/// <summary>
@@ -1090,6 +1252,8 @@ public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out 
 	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
 	///     first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback);
 }
 
@@ -1102,6 +1266,7 @@ public interface IReturnMethodSetupCallbackBuilder<in TReturn, out T1, out T2, o
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4> InParallel();
 }
 
@@ -1117,6 +1282,8 @@ public interface IReturnMethodSetupParallelCallbackBuilder<in TReturn, out T1, o
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> When(Func<int, bool> predicate);
 }
 
@@ -1135,6 +1302,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1, out T
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> For(int times);
 
 	/// <summary>
@@ -1146,6 +1315,8 @@ public interface IReturnMethodSetupCallbackWhenBuilder<in TReturn, out T1, out T
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3, T4> Only(int times);
 }
 
@@ -1161,6 +1332,8 @@ public interface IReturnMethodSetupReturnBuilder<in TReturn, out T1, out T2, out
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> When(Func<int, bool> predicate);
 }
 
@@ -1179,6 +1352,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1, out T2,
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> For(int times);
 
 	/// <summary>
@@ -1190,6 +1365,8 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn, out T1, out T2,
 	///     <see langword="true" />
 	///     ).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3, T4> Only(int times);
 }
 
@@ -1202,6 +1379,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2, 
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IReturnMethodSetup<TReturn, T1, T2, T3, T4> AnyParameters();
 }
 #pragma warning restore S2436 // Types and methods should not have too many generic parameters
@@ -1222,27 +1400,34 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
-	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs as part of the invocation; when <see langword="true" /> it is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder Do(Action<int> callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder TransitionTo(string scenario);
 
 	/// <summary>
@@ -1253,6 +1438,7 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.DoWork()
@@ -1271,6 +1457,8 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder Throws<TException>()
 		where TException : Exception, new();
 
@@ -1281,6 +1469,8 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder Throws(Exception exception);
 
 	/// <summary>
@@ -1291,6 +1481,8 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder Throws(Func<Exception> callback);
 }
 
@@ -1302,6 +1494,7 @@ public interface IVoidMethodSetupCallbackBuilder : IVoidMethodSetupParallelCallb
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder InParallel();
 }
 
@@ -1316,6 +1509,8 @@ public interface IVoidMethodSetupParallelCallbackBuilder : IVoidMethodSetupCallb
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder When(Func<int, bool> predicate);
 }
 
@@ -1332,6 +1527,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder : IVoidMethodSetup
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder For(int times);
 
 	/// <summary>
@@ -1342,6 +1539,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder : IVoidMethodSetup
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup Only(int times);
 }
 
@@ -1356,6 +1555,8 @@ public interface IVoidMethodSetupReturnBuilder : IVoidMethodSetupReturnWhenBuild
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder When(Func<int, bool> predicate);
 }
 
@@ -1372,6 +1573,8 @@ public interface IVoidMethodSetupReturnWhenBuilder : IVoidMethodSetup
 	///     <see cref="IVoidMethodSetupReturnBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder For(int times);
 
 	/// <summary>
@@ -1382,6 +1585,8 @@ public interface IVoidMethodSetupReturnWhenBuilder : IVoidMethodSetup
 	///     <see cref="IVoidMethodSetupReturnBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup Only(int times);
 }
 
@@ -1401,22 +1606,27 @@ public interface IVoidMethodSetup<out T1> : IMethodSetup
 	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
-	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs as part of the invocation; when <see langword="true" /> it is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1> TransitionTo(string scenario);
 
 	/// <summary>
@@ -1427,6 +1637,7 @@ public interface IVoidMethodSetup<out T1> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1> DoesNotThrow();
 
 	/// <summary>
@@ -1437,6 +1648,8 @@ public interface IVoidMethodSetup<out T1> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1> Throws<TException>()
 		where TException : Exception, new();
 
@@ -1447,6 +1660,8 @@ public interface IVoidMethodSetup<out T1> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1> Throws(Exception exception);
 
 	/// <summary>
@@ -1457,6 +1672,8 @@ public interface IVoidMethodSetup<out T1> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1> Throws(Func<Exception> callback);
 }
 
@@ -1469,11 +1686,15 @@ public interface IVoidMethodSetupWithCallback<out T1> : IVoidMethodSetup<T1>
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's argument whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1> Do(Action<T1> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's argument.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1> Do(Action<int, T1> callback);
 
 	/// <summary>
@@ -1484,6 +1705,8 @@ public interface IVoidMethodSetupWithCallback<out T1> : IVoidMethodSetup<T1>
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1> Throws(Func<T1, Exception> callback);
 }
 
@@ -1496,6 +1719,7 @@ public interface IVoidMethodSetupCallbackBuilder<out T1>
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1> InParallel();
 }
 
@@ -1511,6 +1735,8 @@ public interface IVoidMethodSetupParallelCallbackBuilder<out T1>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1> When(Func<int, bool> predicate);
 }
 
@@ -1528,6 +1754,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1>
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1> For(int times);
 
 	/// <summary>
@@ -1538,6 +1766,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1>
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1> Only(int times);
 }
 
@@ -1553,6 +1783,8 @@ public interface IVoidMethodSetupReturnBuilder<out T1>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1> When(Func<int, bool> predicate);
 }
 
@@ -1570,6 +1802,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1>
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1> For(int times);
 
 	/// <summary>
@@ -1580,6 +1814,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1>
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1> Only(int times);
 }
 
@@ -1592,6 +1828,7 @@ public interface IVoidMethodSetupParameterIgnorer<out T1>
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1> AnyParameters();
 }
 
@@ -1611,22 +1848,27 @@ public interface IVoidMethodSetup<out T1, out T2> : IMethodSetup
 	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
-	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs as part of the invocation; when <see langword="true" /> it is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2> TransitionTo(string scenario);
 
 	/// <summary>
@@ -1637,6 +1879,7 @@ public interface IVoidMethodSetup<out T1, out T2> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2> DoesNotThrow();
 
 	/// <summary>
@@ -1647,6 +1890,8 @@ public interface IVoidMethodSetup<out T1, out T2> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws<TException>()
 		where TException : Exception, new();
 
@@ -1657,6 +1902,8 @@ public interface IVoidMethodSetup<out T1, out T2> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws(Exception exception);
 
 	/// <summary>
@@ -1667,6 +1914,8 @@ public interface IVoidMethodSetup<out T1, out T2> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws(Func<Exception> callback);
 }
 
@@ -1679,11 +1928,15 @@ public interface IVoidMethodSetupWithCallback<out T1, out T2> : IVoidMethodSetup
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2> Do(Action<T1, T2> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2> Do(Action<int, T1, T2> callback);
 
 	/// <summary>
@@ -1694,6 +1947,8 @@ public interface IVoidMethodSetupWithCallback<out T1, out T2> : IVoidMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws(Func<T1, T2, Exception> callback);
 }
 
@@ -1706,6 +1961,7 @@ public interface IVoidMethodSetupCallbackBuilder<out T1, out T2>
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2> InParallel();
 }
 
@@ -1721,6 +1977,8 @@ public interface IVoidMethodSetupParallelCallbackBuilder<out T1, out T2>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1, T2> When(Func<int, bool> predicate);
 }
 
@@ -1738,6 +1996,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1, out T2>
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1, T2> For(int times);
 
 	/// <summary>
@@ -1748,6 +2008,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1, out T2>
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1, T2> Only(int times);
 }
 
@@ -1763,6 +2025,8 @@ public interface IVoidMethodSetupReturnBuilder<out T1, out T2>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1, T2> When(Func<int, bool> predicate);
 }
 
@@ -1780,6 +2044,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1, out T2>
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1, T2}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1, T2> For(int times);
 
 	/// <summary>
@@ -1790,6 +2056,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1, out T2>
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1, T2}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1, T2> Only(int times);
 }
 
@@ -1802,6 +2070,7 @@ public interface IVoidMethodSetupParameterIgnorer<out T1, out T2>
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2> AnyParameters();
 }
 
@@ -1821,22 +2090,27 @@ public interface IVoidMethodSetup<out T1, out T2, out T3> : IMethodSetup
 	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
-	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs as part of the invocation; when <see langword="true" /> it is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3> TransitionTo(string scenario);
 
 	/// <summary>
@@ -1847,6 +2121,7 @@ public interface IVoidMethodSetup<out T1, out T2, out T3> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2, T3> DoesNotThrow();
 
 	/// <summary>
@@ -1857,6 +2132,8 @@ public interface IVoidMethodSetup<out T1, out T2, out T3> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws<TException>()
 		where TException : Exception, new();
 
@@ -1867,6 +2144,8 @@ public interface IVoidMethodSetup<out T1, out T2, out T3> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws(Exception exception);
 
 	/// <summary>
@@ -1877,6 +2156,8 @@ public interface IVoidMethodSetup<out T1, out T2, out T3> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws(Func<Exception> callback);
 }
 
@@ -1889,11 +2170,15 @@ public interface IVoidMethodSetupWithCallback<out T1, out T2, out T3> : IVoidMet
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> Do(Action<T1, T2, T3> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> Do(Action<int, T1, T2, T3> callback);
 
 	/// <summary>
@@ -1904,6 +2189,8 @@ public interface IVoidMethodSetupWithCallback<out T1, out T2, out T3> : IVoidMet
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback);
 }
 
@@ -1916,6 +2203,7 @@ public interface IVoidMethodSetupCallbackBuilder<out T1, out T2, out T3>
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3> InParallel();
 }
 
@@ -1931,6 +2219,8 @@ public interface IVoidMethodSetupParallelCallbackBuilder<out T1, out T2, out T3>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> When(Func<int, bool> predicate);
 }
 
@@ -1948,6 +2238,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1, out T2, out T3>
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> For(int times);
 
 	/// <summary>
@@ -1958,6 +2250,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1, out T2, out T3>
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1, T2, T3> Only(int times);
 }
 
@@ -1973,6 +2267,8 @@ public interface IVoidMethodSetupReturnBuilder<out T1, out T2, out T3>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> When(Func<int, bool> predicate);
 }
 
@@ -1990,6 +2286,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1, out T2, out T3>
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1, T2, T3}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> For(int times);
 
 	/// <summary>
@@ -2000,6 +2298,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1, out T2, out T3>
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1, T2, T3}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1, T2, T3> Only(int times);
 }
 
@@ -2012,6 +2312,7 @@ public interface IVoidMethodSetupParameterIgnorer<out T1, out T2, out T3>
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2, T3> AnyParameters();
 }
 
@@ -2031,22 +2332,27 @@ public interface IVoidMethodSetup<out T1, out T2, out T3, out T4> : IMethodSetup
 	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
-	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs as part of the invocation; when <see langword="true" /> it is skipped entirely.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
 	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
 	///     invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> Do(Action callback);
 
 	/// <summary>
 	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
 	///     to model state transitions.
 	/// </summary>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4> TransitionTo(string scenario);
 
 	/// <summary>
@@ -2057,6 +2363,7 @@ public interface IVoidMethodSetup<out T1, out T2, out T3, out T4> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2, T3, T4> DoesNotThrow();
 
 	/// <summary>
@@ -2067,6 +2374,8 @@ public interface IVoidMethodSetup<out T1, out T2, out T3, out T4> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
 		where TException : Exception, new();
 
@@ -2077,6 +2386,8 @@ public interface IVoidMethodSetup<out T1, out T2, out T3, out T4> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws(Exception exception);
 
 	/// <summary>
@@ -2087,6 +2398,8 @@ public interface IVoidMethodSetup<out T1, out T2, out T3, out T4> : IMethodSetup
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws(Func<Exception> callback);
 }
 
@@ -2099,11 +2412,15 @@ public interface IVoidMethodSetupWithCallback<out T1, out T2, out T3, out T4> : 
 	/// <summary>
 	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
 
 	/// <summary>
 	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4> callback);
 
 	/// <summary>
@@ -2114,6 +2431,8 @@ public interface IVoidMethodSetupWithCallback<out T1, out T2, out T3, out T4> : 
 	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback);
 }
 
@@ -2126,6 +2445,7 @@ public interface IVoidMethodSetupCallbackBuilder<out T1, out T2, out T3, out T4>
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4> InParallel();
 }
 
@@ -2141,6 +2461,8 @@ public interface IVoidMethodSetupParallelCallbackBuilder<out T1, out T2, out T3,
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> When(Func<int, bool> predicate);
 }
 
@@ -2158,6 +2480,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1, out T2, out T3, out
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> For(int times);
 
 	/// <summary>
@@ -2168,6 +2492,8 @@ public interface IVoidMethodSetupCallbackWhenBuilder<out T1, out T2, out T3, out
 	///     <see cref="IVoidMethodSetupParallelCallbackBuilder.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1, T2, T3, T4> Only(int times);
 }
 
@@ -2183,6 +2509,8 @@ public interface IVoidMethodSetupReturnBuilder<out T1, out T2, out T3, out T4>
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the method has been invoked so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> When(Func<int, bool> predicate);
 }
 
@@ -2200,6 +2528,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1, out T2, out T3, out T
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> For(int times);
 
 	/// <summary>
@@ -2210,6 +2540,8 @@ public interface IVoidMethodSetupReturnWhenBuilder<out T1, out T2, out T3, out T
 	///     <see cref="IVoidMethodSetupReturnBuilder{T1, T2, T3, T4}.When(Func{int, bool})" /> evaluates to
 	///     <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IVoidMethodSetup<T1, T2, T3, T4> Only(int times);
 }
 
@@ -2222,5 +2554,6 @@ public interface IVoidMethodSetupParameterIgnorer<out T1, out T2, out T3, out T4
 	/// <summary>
 	///     Replaces the explicit parameter matcher with <see cref="Match.AnyParameters()" />.
 	/// </summary>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IVoidMethodSetup<T1, T2, T3, T4> AnyParameters();
 }

--- a/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
@@ -26,59 +26,90 @@ public interface IVerifiableMethodSetup
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" />.
+///     Fluent surface for configuring a parameterless mocked method that returns <typeparamref name="TReturn" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName()</c>. Chain <see cref="Returns(TReturn)" /> /
+///     <see cref="Throws{TException}" /> to define a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive <c>Returns</c>/<c>Throws</c>/<c>Do</c> calls build a sequence that cycles once
+///     exhausted - terminate with <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c>
+///     / <c>.When(predicate)</c> on the builders to control repetition and gating.
+///     <para />
+///     For async methods, use the generator-emitted <c>.ReturnsAsync(...)</c> / <c>.ThrowsAsync(...)</c> overloads
+///     instead of wrapping a <see cref="System.Threading.Tasks.Task" /> in <c>.Returns(...)</c>.
+/// </remarks>
 public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs and its return value is used as the default value for un-configured invocations; when
+	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IReturnMethodSetup<TReturn> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Ping().Do(() =&gt; Console.WriteLine("ping!")).Returns(true);
+	///     </code>
+	/// </example>
 	IReturnMethodSetupCallbackBuilder<TReturn> Do(Action callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn> Do(Action<int> callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return to the sequence; <paramref name="callback" /> is invoked on each matching invocation
+	///     and its result is returned.
 	/// </summary>
 	IReturnMethodSetupReturnBuilder<TReturn> Returns(Func<TReturn> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Ping()
+	///         .Returns(true).For(2)   // first two calls return true
+	///         .Returns(false).Forever(); // remaining calls return false
+	///     </code>
+	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn> Returns(TReturn returnValue);
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws(Func<Exception> callback);
 }
@@ -950,54 +981,70 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2, 
 #pragma warning restore S2436 // Types and methods should not have too many generic parameters
 
 /// <summary>
-///     Sets up a method returning <see langword="void" />.
+///     Fluent surface for configuring a parameterless mocked method that returns <see langword="void" />.
 /// </summary>
+/// <remarks>
+///     Same pattern as <see cref="IReturnMethodSetup{TReturn}" /> minus the return-value overloads:
+///     chain <see cref="Do(Action)" /> for side-effects and <see cref="Throws{TException}" /> /
+///     <see cref="DoesNotThrow" /> to build a throw sequence. Consecutive entries form a sequence that cycles once
+///     exhausted - use <c>.Forever()</c>, <c>.For(n)</c>, <c>.Only(n)</c>, <c>.When(predicate)</c> on the returned
+///     builders to control repetition.
+/// </remarks>
 public interface IVoidMethodSetup : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
+	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
 	/// </remarks>
 	IVoidMethodSetup SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback; <paramref name="callback" /> runs whenever the method is invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder Do(Action callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder Do(Action<int> callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked.
 	/// </summary>
 	IVoidMethodSetupParallelCallbackBuilder TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers an iteration in the sequence of method invocations, that does not throw.
+	///     Appends a &quot;does-nothing&quot; entry to the sequence - useful between <see cref="Throws{TException}" />
+	///     entries to model &quot;throw, succeed, throw&quot; patterns.
 	/// </summary>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.DoWork()
+	///         .Throws&lt;TimeoutException&gt;()
+	///         .DoesNotThrow()
+	///         .Throws(new InvalidOperationException());
+	///     </code>
+	/// </example>
 	IVoidMethodSetup DoesNotThrow();
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
 	IVoidMethodSetupReturnBuilder Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
 	IVoidMethodSetupReturnBuilder Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
 	IVoidMethodSetupReturnBuilder Throws(Func<Exception> callback);
 }

--- a/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
@@ -58,11 +58,6 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	/// </summary>
 	/// <param name="callback">The action to invoke on every matching invocation.</param>
 	/// <returns>A builder for chaining repetition/gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Ping().Do(() =&gt; Console.WriteLine("ping!")).Returns(true);
-	///     </code>
-	/// </example>
 	IReturnMethodSetupCallbackBuilder<TReturn> Do(Action callback);
 
 	/// <summary>
@@ -101,13 +96,6 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	/// </remarks>
 	/// <param name="returnValue">The value returned on the next matching invocation.</param>
 	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Ping()
-	///         .Returns(true).For(2)   // first two calls return true
-	///         .Returns(false).Forever(); // remaining calls return false
-	///     </code>
-	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn> Returns(TReturn returnValue);
 
 	/// <summary>
@@ -324,13 +312,6 @@ public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 	/// </remarks>
 	/// <param name="returnValue">The value returned on the next matching invocation.</param>
 	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.CanHandle(It.IsAny&lt;string&gt;())
-	///         .Returns(true).For(2)   // first two calls return true
-	///         .Returns(false).Forever(); // remaining calls return false
-	///     </code>
-	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Returns(TReturn returnValue);
 
 	/// <summary>
@@ -604,13 +585,6 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 	/// </remarks>
 	/// <param name="returnValue">The value returned on the next matching invocation.</param>
 	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.IsMatch(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;())
-	///         .Returns(true).For(2)   // first two calls return true
-	///         .Returns(false).Forever(); // remaining calls return false
-	///     </code>
-	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Returns(TReturn returnValue);
 
 	/// <summary>
@@ -885,13 +859,6 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMetho
 	/// </remarks>
 	/// <param name="returnValue">The value returned on the next matching invocation.</param>
 	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Accepts(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;(), It.IsAny&lt;bool&gt;())
-	///         .Returns(true).For(2)   // first two calls return true
-	///         .Returns(false).Forever(); // remaining calls return false
-	///     </code>
-	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Returns(TReturn returnValue);
 
 	/// <summary>
@@ -1167,13 +1134,6 @@ public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> 
 	/// </remarks>
 	/// <param name="returnValue">The value returned on the next matching invocation.</param>
 	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.Validate(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;(), It.IsAny&lt;bool&gt;(), It.IsAny&lt;double&gt;())
-	///         .Returns(true).For(2)   // first two calls return true
-	///         .Returns(false).Forever(); // remaining calls return false
-	///     </code>
-	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Returns(TReturn returnValue);
 
 	/// <summary>
@@ -1439,14 +1399,6 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
 	/// </remarks>
 	/// <returns>The same setup instance, to allow chaining.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.DoWork()
-	///         .Throws&lt;TimeoutException&gt;()
-	///         .DoesNotThrow()
-	///         .Throws(new InvalidOperationException());
-	///     </code>
-	/// </example>
 	IVoidMethodSetup DoesNotThrow();
 
 	/// <summary>

--- a/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
@@ -77,6 +77,10 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     Appends a lazy return to the sequence; <paramref name="callback" /> is invoked on each matching invocation
 	///     and its result is returned.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn> Returns(Func<TReturn> callback);
 
 	/// <summary>
@@ -99,18 +103,30 @@ public interface IReturnMethodSetup<in TReturn> : IMethodSetup
 	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
 	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
 	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws(Exception exception);
 
 	/// <summary>
 	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
 	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn> Throws(Func<Exception> callback);
 }
 
@@ -215,81 +231,133 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn>
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" />.
+///     Fluent surface for configuring a mocked method with one parameter that returns <typeparamref name="TReturn" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Returns(TReturn)" /> /
+///     <see cref="Throws{TException}" /> to define a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive <c>Returns</c>/<c>Throws</c>/<c>Do</c> calls build a sequence that cycles once
+///     exhausted - terminate with <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c>
+///     / <c>.When(predicate)</c> on the builders to control repetition and gating.
+///     <para />
+///     For async methods, use the generator-emitted <c>.ReturnsAsync(...)</c> / <c>.ThrowsAsync(...)</c> overloads
+///     instead of wrapping a <see cref="System.Threading.Tasks.Task" /> in <c>.Returns(...)</c>.
+/// </remarks>
 public interface IReturnMethodSetup<in TReturn, out T1> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs and its return value is used as the default value for un-configured invocations; when
+	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IReturnMethodSetup<TReturn, T1> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return to the sequence; <paramref name="callback" /> is invoked on each matching invocation
+	///     and its result is returned.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Returns(Func<TReturn> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.CanHandle(It.IsAny&lt;string&gt;())
+	///         .Returns(true).For(2)   // first two calls return true
+	///         .Returns(false).Forever(); // remaining calls return false
+	///     </code>
+	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Returns(TReturn returnValue);
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" /> with callback support for the parameter.
+///     Parameter-aware overloads for <see cref="IReturnMethodSetup{TReturn, T1}" /> - <c>Do</c>, <c>Returns</c>
+///     and <c>Throws</c> variants whose callbacks receive the method's argument.
 /// </summary>
 public interface IReturnMethodSetupWithCallback<in TReturn, out T1> : IReturnMethodSetup<TReturn, T1>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's argument whenever the method is invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> Do(Action<T1> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's argument.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1> Do(Action<int, T1> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return that receives the method's argument and produces the value to return.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Returns(Func<T1, TReturn> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's argument to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1> Throws(Func<T1, Exception> callback);
 }
 
@@ -406,81 +474,133 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1>
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" />.
+///     Fluent surface for configuring a mocked method with two parameters that returns <typeparamref name="TReturn" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Returns(TReturn)" /> /
+///     <see cref="Throws{TException}" /> to define a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive <c>Returns</c>/<c>Throws</c>/<c>Do</c> calls build a sequence that cycles once
+///     exhausted - terminate with <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c>
+///     / <c>.When(predicate)</c> on the builders to control repetition and gating.
+///     <para />
+///     For async methods, use the generator-emitted <c>.ReturnsAsync(...)</c> / <c>.ThrowsAsync(...)</c> overloads
+///     instead of wrapping a <see cref="System.Threading.Tasks.Task" /> in <c>.Returns(...)</c>.
+/// </remarks>
 public interface IReturnMethodSetup<in TReturn, out T1, out T2> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs and its return value is used as the default value for un-configured invocations; when
+	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IReturnMethodSetup<TReturn, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return to the sequence; <paramref name="callback" /> is invoked on each matching invocation
+	///     and its result is returned.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Returns(Func<TReturn> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.IsMatch(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;())
+	///         .Returns(true).For(2)   // first two calls return true
+	///         .Returns(false).Forever(); // remaining calls return false
+	///     </code>
+	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Returns(TReturn returnValue);
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" /> with callback support for the parameters.
+///     Parameter-aware overloads for <see cref="IReturnMethodSetup{TReturn, T1, T2}" /> - <c>Do</c>, <c>Returns</c>
+///     and <c>Throws</c> variants whose callbacks receive the method's arguments.
 /// </summary>
 public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2> : IReturnMethodSetup<TReturn, T1, T2>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> Do(Action<T1, T2> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2> Do(Action<int, T1, T2> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return that receives the method's arguments and produces the value to return.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Returns(Func<T1, T2, TReturn> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2> Throws(Func<T1, T2, Exception> callback);
 }
 
@@ -597,81 +717,134 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2>
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" />.
+///     Fluent surface for configuring a mocked method with three parameters that returns
+///     <typeparamref name="TReturn" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Returns(TReturn)" /> /
+///     <see cref="Throws{TException}" /> to define a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive <c>Returns</c>/<c>Throws</c>/<c>Do</c> calls build a sequence that cycles once
+///     exhausted - terminate with <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c>
+///     / <c>.When(predicate)</c> on the builders to control repetition and gating.
+///     <para />
+///     For async methods, use the generator-emitted <c>.ReturnsAsync(...)</c> / <c>.ThrowsAsync(...)</c> overloads
+///     instead of wrapping a <see cref="System.Threading.Tasks.Task" /> in <c>.Returns(...)</c>.
+/// </remarks>
 public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs and its return value is used as the default value for un-configured invocations; when
+	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IReturnMethodSetup<TReturn, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return to the sequence; <paramref name="callback" /> is invoked on each matching invocation
+	///     and its result is returned.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Returns(Func<TReturn> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Accepts(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;(), It.IsAny&lt;bool&gt;())
+	///         .Returns(true).For(2)   // first two calls return true
+	///         .Returns(false).Forever(); // remaining calls return false
+	///     </code>
+	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Returns(TReturn returnValue);
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" /> with callback support for the parameters.
+///     Parameter-aware overloads for <see cref="IReturnMethodSetup{TReturn, T1, T2, T3}" /> - <c>Do</c>,
+///     <c>Returns</c> and <c>Throws</c> variants whose callbacks receive the method's arguments.
 /// </summary>
 public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out T3> : IReturnMethodSetup<TReturn, T1, T2, T3>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> Do(Action<T1, T2, T3> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3> Do(Action<int, T1, T2, T3> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return that receives the method's arguments and produces the value to return.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Returns(Func<T1, T2, T3, TReturn> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback);
 }
 
@@ -789,81 +962,134 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2, 
 
 #pragma warning disable S2436 // Types and methods should not have too many generic parameters
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" />.
+///     Fluent surface for configuring a mocked method with four parameters that returns
+///     <typeparamref name="TReturn" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Returns(TReturn)" /> /
+///     <see cref="Throws{TException}" /> to define a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive <c>Returns</c>/<c>Throws</c>/<c>Do</c> calls build a sequence that cycles once
+///     exhausted - terminate with <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c>
+///     / <c>.When(predicate)</c> on the builders to control repetition and gating.
+///     <para />
+///     For async methods, use the generator-emitted <c>.ReturnsAsync(...)</c> / <c>.ThrowsAsync(...)</c> overloads
+///     instead of wrapping a <see cref="System.Threading.Tasks.Task" /> in <c>.Returns(...)</c>.
+/// </remarks>
 public interface IReturnMethodSetup<in TReturn, out T1, out T2, out T3, out T4> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     implementation runs and its return value is used as the default value for un-configured invocations; when
+	///     <see langword="true" /> the base-class implementation is skipped entirely.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IReturnMethodSetup<TReturn, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return to the sequence; <paramref name="callback" /> is invoked on each matching invocation
+	///     and its result is returned.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Returns(Func<TReturn> callback);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this method.
+	///     Appends <paramref name="returnValue" /> to the sequence - the next matching invocation returns this value.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.Validate(It.IsAny&lt;string&gt;(), It.IsAny&lt;int&gt;(), It.IsAny&lt;bool&gt;(), It.IsAny&lt;double&gt;())
+	///         .Returns(true).For(2)   // first two calls return true
+	///         .Returns(false).Forever(); // remaining calls return false
+	///     </code>
+	/// </example>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Returns(TReturn returnValue);
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <typeparamref name="TReturn" /> with callback support for the parameters.
+///     Parameter-aware overloads for <see cref="IReturnMethodSetup{TReturn, T1, T2, T3, T4}" /> - <c>Do</c>,
+///     <c>Returns</c> and <c>Throws</c> variants whose callbacks receive the method's arguments.
 /// </summary>
 public interface IReturnMethodSetupWithCallback<in TReturn, out T1, out T2, out T3, out T4> : IReturnMethodSetup<TReturn, T1, T2, T3, T4>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this method.
+	///     Appends a lazy return that receives the method's arguments and produces the value to return.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TReturn> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback);
 }
 
@@ -984,11 +1210,11 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2, 
 ///     Fluent surface for configuring a parameterless mocked method that returns <see langword="void" />.
 /// </summary>
 /// <remarks>
-///     Same pattern as <see cref="IReturnMethodSetup{TReturn}" /> minus the return-value overloads:
-///     chain <see cref="Do(Action)" /> for side-effects and <see cref="Throws{TException}" /> /
-///     <see cref="DoesNotThrow" /> to build a throw sequence. Consecutive entries form a sequence that cycles once
-///     exhausted - use <c>.Forever()</c>, <c>.For(n)</c>, <c>.Only(n)</c>, <c>.When(predicate)</c> on the returned
-///     builders to control repetition.
+///     Reached via <c>sut.Mock.Setup.MethodName()</c>. Chain <see cref="Throws{TException}" /> /
+///     <see cref="DoesNotThrow" /> to build a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive entries form a sequence that cycles once exhausted - terminate with
+///     <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c> /
+///     <c>.When(predicate)</c> on the builders to control repetition and gating.
 /// </remarks>
 public interface IVoidMethodSetup : IMethodSetup
 {
@@ -999,10 +1225,12 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
 	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IVoidMethodSetup SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Appends a side-effect callback; <paramref name="callback" /> runs whenever the method is invoked.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder Do(Action callback);
 
@@ -1012,7 +1240,8 @@ public interface IVoidMethodSetup : IMethodSetup
 	IVoidMethodSetupCallbackBuilder Do(Action<int> callback);
 
 	/// <summary>
-	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IVoidMethodSetupParallelCallbackBuilder TransitionTo(string scenario);
 
@@ -1020,6 +1249,10 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Appends a &quot;does-nothing&quot; entry to the sequence - useful between <see cref="Throws{TException}" />
 	///     entries to model &quot;throw, succeed, throw&quot; patterns.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.DoWork()
@@ -1034,18 +1267,30 @@ public interface IVoidMethodSetup : IMethodSetup
 	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
 	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
 	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder Throws(Exception exception);
 
 	/// <summary>
 	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
 	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder Throws(Func<Exception> callback);
 }
 
@@ -1141,71 +1386,104 @@ public interface IVoidMethodSetupReturnWhenBuilder : IVoidMethodSetup
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" />.
+///     Fluent surface for configuring a mocked method with one parameter that returns <see langword="void" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /
+///     <see cref="DoesNotThrow" /> to build a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive entries form a sequence that cycles once exhausted - terminate with
+///     <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c> /
+///     <c>.When(predicate)</c> on the builders to control repetition and gating.
+/// </remarks>
 public interface IVoidMethodSetup<out T1> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
+	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IVoidMethodSetup<T1> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IVoidMethodSetupParallelCallbackBuilder<T1> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers an iteration in the sequence of method invocations, that does not throw.
+	///     Appends a &quot;does-nothing&quot; entry to the sequence - useful between <see cref="Throws{TException}" />
+	///     entries to model &quot;throw, succeed, throw&quot; patterns.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetup<T1> DoesNotThrow();
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" /> with callback support for the parameter.
+///     Parameter-aware overloads for <see cref="IVoidMethodSetup{T1}" /> - <c>Do</c> and <c>Throws</c> variants
+///     whose callbacks receive the method's argument.
 /// </summary>
 public interface IVoidMethodSetupWithCallback<out T1> : IVoidMethodSetup<T1>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's argument whenever the method is invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1> Do(Action<T1> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's argument.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1> Do(Action<int, T1> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's argument to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1> Throws(Func<T1, Exception> callback);
 }
 
@@ -1318,71 +1596,104 @@ public interface IVoidMethodSetupParameterIgnorer<out T1>
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" />.
+///     Fluent surface for configuring a mocked method with two parameters that returns <see langword="void" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /
+///     <see cref="DoesNotThrow" /> to build a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive entries form a sequence that cycles once exhausted - terminate with
+///     <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c> /
+///     <c>.When(predicate)</c> on the builders to control repetition and gating.
+/// </remarks>
 public interface IVoidMethodSetup<out T1, out T2> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
+	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IVoidMethodSetup<T1, T2> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers an iteration in the sequence of method invocations, that does not throw.
+	///     Appends a &quot;does-nothing&quot; entry to the sequence - useful between <see cref="Throws{TException}" />
+	///     entries to model &quot;throw, succeed, throw&quot; patterns.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetup<T1, T2> DoesNotThrow();
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" /> with callback support for the parameters.
+///     Parameter-aware overloads for <see cref="IVoidMethodSetup{T1, T2}" /> - <c>Do</c> and <c>Throws</c> variants
+///     whose callbacks receive the method's arguments.
 /// </summary>
 public interface IVoidMethodSetupWithCallback<out T1, out T2> : IVoidMethodSetup<T1, T2>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2> Do(Action<T1, T2> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2> Do(Action<int, T1, T2> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2> Throws(Func<T1, T2, Exception> callback);
 }
 
@@ -1495,71 +1806,104 @@ public interface IVoidMethodSetupParameterIgnorer<out T1, out T2>
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" />.
+///     Fluent surface for configuring a mocked method with three parameters that returns <see langword="void" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /
+///     <see cref="DoesNotThrow" /> to build a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive entries form a sequence that cycles once exhausted - terminate with
+///     <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c> /
+///     <c>.When(predicate)</c> on the builders to control repetition and gating.
+/// </remarks>
 public interface IVoidMethodSetup<out T1, out T2, out T3> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
+	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IVoidMethodSetup<T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers an iteration in the sequence of method invocations, that does not throw.
+	///     Appends a &quot;does-nothing&quot; entry to the sequence - useful between <see cref="Throws{TException}" />
+	///     entries to model &quot;throw, succeed, throw&quot; patterns.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetup<T1, T2, T3> DoesNotThrow();
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" /> with callback support for the parameters.
+///     Parameter-aware overloads for <see cref="IVoidMethodSetup{T1, T2, T3}" /> - <c>Do</c> and <c>Throws</c>
+///     variants whose callbacks receive the method's arguments.
 /// </summary>
 public interface IVoidMethodSetupWithCallback<out T1, out T2, out T3> : IVoidMethodSetup<T1, T2, T3>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> Do(Action<T1, T2, T3> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3> Do(Action<int, T1, T2, T3> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback);
 }
 
@@ -1672,71 +2016,104 @@ public interface IVoidMethodSetupParameterIgnorer<out T1, out T2, out T3>
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" />.
+///     Fluent surface for configuring a mocked method with four parameters that returns <see langword="void" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /
+///     <see cref="DoesNotThrow" /> to build a sequence of responses, and <see cref="Do(Action)" /> to attach
+///     side-effects. Consecutive entries form a sequence that cycles once exhausted - terminate with
+///     <c>.Forever()</c> to freeze on the last entry, or use <c>.For(n)</c> / <c>.Only(n)</c> /
+///     <c>.When(predicate)</c> on the builders to control repetition and gating.
+/// </remarks>
 public interface IVoidMethodSetup<out T1, out T2, out T3, out T4> : IMethodSetup
 {
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this method only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="true" /> the base-class implementation is skipped
+	///     entirely; when <see langword="false" /> (the default on mocks) it runs as part of the invocation.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IVoidMethodSetup<T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback to the sequence; <paramref name="callback" /> runs whenever the method is
+	///     invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> Do(Action callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> when the method is called.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the method is invoked - useful
+	///     to model state transitions.
 	/// </summary>
 	IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4> TransitionTo(string scenario);
 
 	/// <summary>
-	///     Registers an iteration in the sequence of method invocations, that does not throw.
+	///     Appends a &quot;does-nothing&quot; entry to the sequence - useful between <see cref="Throws{TException}" />
+	///     entries to model &quot;throw, succeed, throw&quot; patterns.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetup<T1, T2, T3, T4> DoesNotThrow();
 
 	/// <summary>
-	///     Registers an <typeparamref name="TException" /> to throw when the method is invoked.
+	///     Appends an entry that throws a freshly-constructed <typeparamref name="TException" /> on the next matching
+	///     invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the method is invoked.
+	///     Appends an entry that throws <paramref name="exception" /> on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws(Func<Exception> callback);
 }
 
 /// <summary>
-///     Sets up a method returning <see langword="void" /> with callback support for the parameters.
+///     Parameter-aware overloads for <see cref="IVoidMethodSetup{T1, T2, T3, T4}" /> - <c>Do</c> and <c>Throws</c>
+///     variants whose callbacks receive the method's arguments.
 /// </summary>
 public interface IVoidMethodSetupWithCallback<out T1, out T2, out T3, out T4> : IVoidMethodSetup<T1, T2, T3, T4>
 {
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives the method's arguments whenever the method is invoked.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to execute when the method is called.
+	///     Appends a side-effect callback that receives a zero-based invocation counter and the method's arguments.
 	/// </summary>
 	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the method is invoked.
+	///     Appends an entry that invokes <paramref name="callback" /> with the method's arguments to build the
+	///     exception thrown on the next matching invocation.
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Throws</c>/<c>DoesNotThrow</c> multiple times to build a sequence; once exhausted it cycles back
+	///     to the first entry unless the last one is followed by <c>.Forever()</c>.
+	/// </remarks>
 	IVoidMethodSetupReturnBuilder<T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback);
 }
 

--- a/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.MethodSetup.cs
@@ -26,7 +26,7 @@ public interface IVerifiableMethodSetup
 }
 
 /// <summary>
-///     Fluent surface for configuring a parameterless mocked method that returns <typeparamref name="TReturn" />.
+///     Setup for a parameterless mocked method that returns <typeparamref name="TReturn" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName()</c>. Chain <see cref="Returns(TReturn)" /> /
@@ -249,7 +249,7 @@ public interface IReturnMethodSetupReturnWhenBuilder<in TReturn>
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked method with one parameter that returns <typeparamref name="TReturn" />.
+///     Setup for a mocked method with one parameter that returns <typeparamref name="TReturn" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Returns(TReturn)" /> /
@@ -522,7 +522,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1>
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked method with two parameters that returns <typeparamref name="TReturn" />.
+///     Setup for a mocked method with two parameters that returns <typeparamref name="TReturn" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Returns(TReturn)" /> /
@@ -795,7 +795,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2>
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked method with three parameters that returns
+///     Setup for a mocked method with three parameters that returns
 ///     <typeparamref name="TReturn" />.
 /// </summary>
 /// <remarks>
@@ -1070,7 +1070,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2, 
 
 #pragma warning disable S2436 // Types and methods should not have too many generic parameters
 /// <summary>
-///     Fluent surface for configuring a mocked method with four parameters that returns
+///     Setup for a mocked method with four parameters that returns
 ///     <typeparamref name="TReturn" />.
 /// </summary>
 /// <remarks>
@@ -1345,7 +1345,7 @@ public interface IReturnMethodSetupParameterIgnorer<in TReturn, out T1, out T2, 
 #pragma warning restore S2436 // Types and methods should not have too many generic parameters
 
 /// <summary>
-///     Fluent surface for configuring a parameterless mocked method that returns <see langword="void" />.
+///     Setup for a parameterless mocked method that returns <see langword="void" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName()</c>. Chain <see cref="Throws{TException}" /> /
@@ -1543,7 +1543,7 @@ public interface IVoidMethodSetupReturnWhenBuilder : IVoidMethodSetup
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked method with one parameter that returns <see langword="void" />.
+///     Setup for a mocked method with one parameter that returns <see langword="void" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /
@@ -1785,7 +1785,7 @@ public interface IVoidMethodSetupParameterIgnorer<out T1>
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked method with two parameters that returns <see langword="void" />.
+///     Setup for a mocked method with two parameters that returns <see langword="void" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /
@@ -2027,7 +2027,7 @@ public interface IVoidMethodSetupParameterIgnorer<out T1, out T2>
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked method with three parameters that returns <see langword="void" />.
+///     Setup for a mocked method with three parameters that returns <see langword="void" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /
@@ -2269,7 +2269,7 @@ public interface IVoidMethodSetupParameterIgnorer<out T1, out T2, out T3>
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked method with four parameters that returns <see langword="void" />.
+///     Setup for a mocked method with four parameters that returns <see langword="void" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.MethodName(...)</c>. Chain <see cref="Throws{TException}" /> /

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -47,145 +47,215 @@ public interface IInteractivePropertySetup : ISetup
 }
 
 /// <summary>
-///     Interface for setting up a property getter with fluent syntax.
+///     Fluent surface for attaching side-effects to a property's getter.
 /// </summary>
+/// <remarks>
+///     Each <c>Do</c> registers a callback that fires on every matching read. Chain multiple <c>Do</c> calls to form
+///     a sequence (cycling by default); chain <see cref="IPropertyGetterSetupCallbackBuilder{T}.InParallel" />,
+///     <see cref="IPropertyGetterSetupParallelCallbackBuilder{T}.When" />,
+///     <see cref="IPropertyGetterSetupCallbackWhenBuilder{T}.For" /> or
+///     <see cref="IPropertyGetterSetupCallbackWhenBuilder{T}.Only" /> to control repetition and gating.
+/// </remarks>
 public interface IPropertyGetterSetup<T>
 {
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's getter is accessed.
+	///     Fires <paramref name="callback" /> whenever the property's getter is read.
 	/// </summary>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.TotalDispensed.OnGet.Do(() =&gt; Console.WriteLine("Read!"));
+	///     </code>
+	/// </example>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's getter is accessed.
+	///     Fires <paramref name="callback" /> whenever the property's getter is read, passing the property's current
+	///     value.
 	/// </summary>
-	/// <remarks>
-	///     The callback receives the value of the property as single parameter.
-	/// </remarks>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action<T> callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's getter is accessed.
+	///     Fires <paramref name="callback" /> whenever the property's getter is read, passing a zero-based read counter
+	///     and the property's current value.
 	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter and the value of the property as second
-	///     parameter.
-	/// </remarks>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the property is read.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the property is read - useful
+	///     to trigger state changes driven by observed reads.
 	/// </summary>
-	/// <param name="scenario">The name of the new scenario.</param>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
 	IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
 }
 
 /// <summary>
-///     Interface for setting up a property setter with fluent syntax.
+///     Fluent surface for attaching side-effects to a property's setter.
 /// </summary>
+/// <remarks>
+///     Each <c>Do</c> registers a callback that fires on every matching write. Chain multiple <c>Do</c> calls to form
+///     a sequence (cycling by default); chain <see cref="IPropertySetterSetupCallbackBuilder{T}.InParallel" />,
+///     <see cref="IPropertySetterSetupParallelCallbackBuilder{T}.When" />,
+///     <see cref="IPropertySetterSetupCallbackWhenBuilder{T}.For" /> or
+///     <see cref="IPropertySetterSetupCallbackWhenBuilder{T}.Only" /> to control repetition and gating.
+/// </remarks>
 public interface IPropertySetterSetup<T>
 {
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set.
+	///     Fires <paramref name="callback" /> whenever the property's setter runs.
 	/// </summary>
 	IPropertySetterSetupCallbackBuilder<T> Do(Action callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set.
+	///     Fires <paramref name="callback" /> whenever the property's setter runs, passing the new value.
 	/// </summary>
-	/// <remarks>
-	///     The callback receives the value the property is set to as single parameter.
-	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.TotalDispensed.OnSet.Do(v =&gt; Console.WriteLine($"Set to {v}"));
+	///     </code>
+	/// </example>
 	IPropertySetterSetupCallbackBuilder<T> Do(Action<T> callback);
 
 	/// <summary>
-	///     Registers a callback to be invoked whenever the property's value is set.
+	///     Fires <paramref name="callback" /> whenever the property's setter runs, passing a zero-based write counter
+	///     and the new value.
 	/// </summary>
-	/// <remarks>
-	///     The callback receives an incrementing access counter as first parameter and the value the property is set to as
-	///     second parameter.
-	/// </remarks>
 	IPropertySetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
 	/// <summary>
-	///     Transitions the scenario to the given <paramref name="scenario" /> whenever the property is written to.
+	///     Switches the mock's current scenario to <paramref name="scenario" /> whenever the property is written -
+	///     useful to trigger state changes driven by observed writes.
 	/// </summary>
-	/// <param name="scenario">The name of the new scenario.</param>
+	/// <param name="scenario">The name of the scenario to transition to.</param>
 	IPropertySetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
 }
 
 /// <summary>
-///     Interface for setting up a property with fluent syntax.
+///     Fluent surface for configuring a mocked property of type <typeparamref name="T" />.
 /// </summary>
+/// <remarks>
+///     Reached via <c>sut.Mock.Setup.PropertyName</c>. Chain <see cref="InitializeWith" /> to back the property with a
+///     mutable slot, <see cref="Returns(T)" /> / <see cref="Throws{TException}" /> to define a sequence of read
+///     responses, and <see cref="OnGet" /> / <see cref="OnSet" /> to attach getter/setter callbacks. Consecutive
+///     <c>Returns</c>/<c>Throws</c> calls form a sequence that cycles once exhausted - terminate with
+///     <see cref="SetupExtensions.Forever{T}(IPropertySetupReturnWhenBuilder{T})" /> to freeze on the last entry, or
+///     <see cref="IPropertySetupReturnWhenBuilder{T}.For(int)" /> / <see cref="IPropertySetupReturnWhenBuilder{T}.Only(int)" />
+///     to control repetition.
+/// </remarks>
 public interface IPropertySetup<T>
 {
 	/// <summary>
-	///     Sets up callbacks on the getter.
+	///     Attaches callbacks that fire whenever the property's getter is accessed.
 	/// </summary>
+	/// <remarks>
+	///     See <see cref="IPropertyGetterSetup{T}" /> for the available <c>Do</c> overloads (parameterless, current
+	///     value, counter + current value) and <c>.TransitionTo(scenario)</c>.
+	/// </remarks>
 	IPropertyGetterSetup<T> OnGet { get; }
 
 	/// <summary>
-	///     Sets up callbacks on the setter.
+	///     Attaches callbacks that fire whenever the property's setter is invoked.
 	/// </summary>
+	/// <remarks>
+	///     See <see cref="IPropertySetterSetup{T}" /> for the available <c>Do</c> overloads (parameterless, new value,
+	///     counter + new value) and <c>.TransitionTo(scenario)</c>.
+	/// </remarks>
 	IPropertySetterSetup<T> OnSet { get; }
 
 	/// <summary>
-	///     Specifies if calling the base class implementation should be skipped.
+	///     Overrides <see cref="MockBehavior.SkipBaseClass" /> for this property only.
 	/// </summary>
 	/// <remarks>
-	///     If set to <see langword="false" /> (default value), the base class implementation gets called and
-	///     its return values are used as default values.
-	///     <para />
-	///     If not specified, use <see cref="MockBehavior.SkipBaseClass" />.
+	///     Only meaningful for class mocks. When <see langword="false" /> (the default on mocks) the base-class
+	///     getter/setter runs, and its return value is used as the default value for un-configured reads; when
+	///     <see langword="true" /> the base-class members are skipped entirely and only the configured behavior
+	///     (including <c>Returns</c>/<c>OnGet</c>/<c>OnSet</c>) is applied.
 	/// </remarks>
+	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
 	IPropertySetup<T> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
-	///     Register the property to have a setup without a specific value.
+	///     Registers the property with the mock without supplying a value.
 	/// </summary>
 	/// <remarks>
-	///     This is necessary when the mock uses <see cref="MockBehavior.ThrowWhenNotSetup" />.
+	///     Primarily useful under <see cref="MockBehavior.ThrowWhenNotSetup" />: it marks the property as &quot;known&quot;
+	///     so a read returns the type's default value instead of throwing. Does not affect mocks with the default
+	///     behavior, where un-configured reads already return defaults.
 	/// </remarks>
 	IPropertySetup<T> Register();
 
 	/// <summary>
-	///     Initializes the property with the given <paramref name="value" />.
+	///     Gives the property a mutable backing slot initialized to <paramref name="value" /> - subsequent setter
+	///     invocations update the slot, and reads return the current slot value.
 	/// </summary>
+	/// <remarks>
+	///     After <see cref="InitializeWith" /> the property behaves like a normal auto-property. Additional
+	///     <c>Returns</c>/<c>Throws</c> or <c>OnSet</c>/<c>OnGet</c> calls layer extra behavior on top.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.TotalDispensed.InitializeWith(42);
+	///     </code>
+	/// </example>
 	IPropertySetup<T> InitializeWith(T value);
 
 	/// <summary>
-	///     Registers the <paramref name="returnValue" /> for this property.
+	///     Appends <paramref name="returnValue" /> to the property's read-sequence - the next read returns this value
+	///     (if no earlier sequence entry is still active).
 	/// </summary>
+	/// <remarks>
+	///     Call <c>Returns</c>/<c>Throws</c> multiple times to build a sequence; once exhausted it cycles back to the
+	///     first entry unless the last entry is followed by
+	///     <see cref="SetupExtensions.Forever{T}(IPropertySetupReturnWhenBuilder{T})" />.
+	/// </remarks>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.TotalDispensed
+	///         .Returns(1)
+	///         .Returns(2)
+	///         .Throws(new Exception("boom"))
+	///         .Returns(4);
+	///     </code>
+	/// </example>
 	IPropertySetupReturnBuilder<T> Returns(T returnValue);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
+	///     Appends a lazy return to the property's read-sequence; <paramref name="callback" /> is invoked on each
+	///     matching read and its result is returned.
 	/// </summary>
 	IPropertySetupReturnBuilder<T> Returns(Func<T> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> to setup the return value for this property.
+	///     Appends a lazy return that receives the property's current value and returns the new one - useful for
+	///     incrementing or transforming the last-read value.
 	/// </summary>
+	/// <example>
+	///     <code>
+	///     sut.Mock.Setup.TotalDispensed.Returns(current =&gt; current + 10);
+	///     </code>
+	/// </example>
 	IPropertySetupReturnBuilder<T> Returns(Func<T, T> callback);
 
 	/// <summary>
-	///     Registers a <typeparamref name="TException" /> to throw when the property is read.
+	///     Appends an entry to the read-sequence that throws a freshly-constructed
+	///     <typeparamref name="TException" /> on the next matching read.
 	/// </summary>
 	IPropertySetupReturnBuilder<T> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
-	///     Registers an <paramref name="exception" /> to throw when the property is read.
+	///     Appends an entry to the read-sequence that throws <paramref name="exception" /> on the next matching read.
 	/// </summary>
 	IPropertySetupReturnBuilder<T> Throws(Exception exception);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
+	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
+	///     matching read - useful when the exception needs to reference the invocation state.
 	/// </summary>
 	IPropertySetupReturnBuilder<T> Throws(Func<Exception> callback);
 
 	/// <summary>
-	///     Registers a <paramref name="callback" /> that will calculate the exception to throw when the property is read.
+	///     Appends an entry that invokes <paramref name="callback" /> with the property's current value to build the
+	///     exception thrown on the next matching read.
 	/// </summary>
 	IPropertySetupReturnBuilder<T> Throws(Func<T, Exception> callback);
 }

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -76,18 +76,13 @@ public interface IPropertyGetterSetup<T>
 	/// </summary>
 	/// <param name="callback">The action to invoke on every matching invocation.</param>
 	/// <returns>A builder for chaining repetition/gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.TotalDispensed.OnGet.Do(() =&gt; Console.WriteLine("Read!"));
-	///     </code>
-	/// </example>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action callback);
 
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever the property's getter is read, passing the property's current
 	///     value.
 	/// </summary>
-	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <param name="callback">The action to invoke on every matching read; receives the property's current value.</param>
 	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action<T> callback);
 
@@ -95,7 +90,7 @@ public interface IPropertyGetterSetup<T>
 	///     Fires <paramref name="callback" /> whenever the property's getter is read, passing a zero-based read counter
 	///     and the property's current value.
 	/// </summary>
-	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <param name="callback">The action to invoke on every matching read; receives a zero-based read counter and the property's current value.</param>
 	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
@@ -130,20 +125,15 @@ public interface IPropertySetterSetup<T>
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever the property's setter runs, passing the new value.
 	/// </summary>
-	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <param name="callback">The action to invoke on every matching write; receives the new value being assigned.</param>
 	/// <returns>A builder for chaining repetition/gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.TotalDispensed.OnSet.Do(v =&gt; Console.WriteLine($"Set to {v}"));
-	///     </code>
-	/// </example>
 	IPropertySetterSetupCallbackBuilder<T> Do(Action<T> callback);
 
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever the property's setter runs, passing a zero-based write counter
 	///     and the new value.
 	/// </summary>
-	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <param name="callback">The action to invoke on every matching write; receives a zero-based write counter and the new value being assigned.</param>
 	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IPropertySetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
@@ -222,11 +212,6 @@ public interface IPropertySetup<T>
 	/// </remarks>
 	/// <param name="value">The initial value assigned to the property's backing field.</param>
 	/// <returns>The same setup instance, to allow chaining.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.TotalDispensed.InitializeWith(42);
-	///     </code>
-	/// </example>
 	IPropertySetup<T> InitializeWith(T value);
 
 	/// <summary>
@@ -240,15 +225,6 @@ public interface IPropertySetup<T>
 	/// </remarks>
 	/// <param name="returnValue">The value returned on the next matching invocation.</param>
 	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.TotalDispensed
-	///         .Returns(1)
-	///         .Returns(2)
-	///         .Throws(new Exception("boom"))
-	///         .Returns(4);
-	///     </code>
-	/// </example>
 	IPropertySetupReturnBuilder<T> Returns(T returnValue);
 
 	/// <summary>
@@ -263,13 +239,8 @@ public interface IPropertySetup<T>
 	///     Appends a lazy return that receives the property's current value and returns the new one - useful for
 	///     incrementing or transforming the last-read value.
 	/// </summary>
-	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <param name="callback">The factory invoked on every matching read; receives the property's current value and produces the next return value.</param>
 	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
-	/// <example>
-	///     <code>
-	///     sut.Mock.Setup.TotalDispensed.Returns(current =&gt; current + 10);
-	///     </code>
-	/// </example>
 	IPropertySetupReturnBuilder<T> Returns(Func<T, T> callback);
 
 	/// <summary>

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -15,6 +15,10 @@ public interface IInteractivePropertySetup : ISetup
 	///     <paramref name="invocation" /> may be <see langword="null" /> when interaction recording is skipped
 	///     (see <see cref="MockBehavior.SkipInteractionRecording" />).
 	/// </remarks>
+	/// <typeparam name="T">The property type.</typeparam>
+	/// <param name="invocation">The recorded interaction for the setter access, or <see langword="null" /> when recording is skipped.</param>
+	/// <param name="value">The value being assigned to the property.</param>
+	/// <param name="behavior">The mock behavior in effect for this invocation.</param>
 	void InvokeSetter<T>(IInteraction? invocation, T value, MockBehavior behavior);
 
 	/// <summary>
@@ -25,11 +29,18 @@ public interface IInteractivePropertySetup : ISetup
 	///     <paramref name="invocation" /> may be <see langword="null" /> when interaction recording is skipped
 	///     (see <see cref="MockBehavior.SkipInteractionRecording" />).
 	/// </remarks>
+	/// <typeparam name="TResult">The property type returned by the getter.</typeparam>
+	/// <param name="invocation">The recorded interaction for the getter access, or <see langword="null" /> when recording is skipped.</param>
+	/// <param name="behavior">The mock behavior in effect for this invocation.</param>
+	/// <param name="defaultValueGenerator">Factory producing the default value when no configured response applies.</param>
+	/// <returns>The value produced by the configured setup or by <paramref name="defaultValueGenerator" />.</returns>
 	TResult InvokeGetter<TResult>(IInteraction? invocation, MockBehavior behavior, Func<TResult> defaultValueGenerator);
 
 	/// <summary>
 	///     Checks if the <paramref name="propertyAccess" /> matches the setup.
 	/// </summary>
+	/// <param name="propertyAccess">The property access to test against this setup.</param>
+	/// <returns><see langword="true" /> when the setup matches the access; otherwise <see langword="false" />.</returns>
 	bool Matches(PropertyAccess propertyAccess);
 
 	/// <summary>
@@ -38,11 +49,13 @@ public interface IInteractivePropertySetup : ISetup
 	/// <remarks>
 	///     When not explicitly set on the <see cref="IPropertySetup{T}" />, returns <see langword="null" />.
 	/// </remarks>
+	/// <returns>The configured override, or <see langword="null" /> when not set.</returns>
 	bool? SkipBaseClass();
 
 	/// <summary>
 	///     Initialize the <see cref="IPropertySetup{T}" /> with the <paramref name="value" />.
 	/// </summary>
+	/// <param name="value">The initial value assigned to the property's backing field.</param>
 	void InitializeWith(object? value);
 }
 
@@ -61,6 +74,8 @@ public interface IPropertyGetterSetup<T>
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever the property's getter is read.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.TotalDispensed.OnGet.Do(() =&gt; Console.WriteLine("Read!"));
@@ -72,12 +87,16 @@ public interface IPropertyGetterSetup<T>
 	///     Fires <paramref name="callback" /> whenever the property's getter is read, passing the property's current
 	///     value.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action<T> callback);
 
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever the property's getter is read, passing a zero-based read counter
 	///     and the property's current value.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IPropertyGetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
 	/// <summary>
@@ -85,6 +104,7 @@ public interface IPropertyGetterSetup<T>
 	///     to trigger state changes driven by observed reads.
 	/// </summary>
 	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
 }
 
@@ -103,11 +123,15 @@ public interface IPropertySetterSetup<T>
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever the property's setter runs.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IPropertySetterSetupCallbackBuilder<T> Do(Action callback);
 
 	/// <summary>
 	///     Fires <paramref name="callback" /> whenever the property's setter runs, passing the new value.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.TotalDispensed.OnSet.Do(v =&gt; Console.WriteLine($"Set to {v}"));
@@ -119,6 +143,8 @@ public interface IPropertySetterSetup<T>
 	///     Fires <paramref name="callback" /> whenever the property's setter runs, passing a zero-based write counter
 	///     and the new value.
 	/// </summary>
+	/// <param name="callback">The action to invoke on every matching invocation; receives a zero-based invocation counter and the method arguments.</param>
+	/// <returns>A builder for chaining repetition/gating operators.</returns>
 	IPropertySetterSetupCallbackBuilder<T> Do(Action<int, T> callback);
 
 	/// <summary>
@@ -126,6 +152,7 @@ public interface IPropertySetterSetup<T>
 	///     useful to trigger state changes driven by observed writes.
 	/// </summary>
 	/// <param name="scenario">The name of the scenario to transition to.</param>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IPropertySetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
 }
 
@@ -171,6 +198,7 @@ public interface IPropertySetup<T>
 	///     (including <c>Returns</c>/<c>OnGet</c>/<c>OnSet</c>) is applied.
 	/// </remarks>
 	/// <param name="skipBaseClass">Whether to skip the base-class implementation. Defaults to <see langword="true" />.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IPropertySetup<T> SkippingBaseClass(bool skipBaseClass = true);
 
 	/// <summary>
@@ -181,6 +209,7 @@ public interface IPropertySetup<T>
 	///     so a read returns the type's default value instead of throwing. Does not affect mocks with the default
 	///     behavior, where un-configured reads already return defaults.
 	/// </remarks>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	IPropertySetup<T> Register();
 
 	/// <summary>
@@ -191,6 +220,8 @@ public interface IPropertySetup<T>
 	///     After <see cref="InitializeWith" /> the property behaves like a normal auto-property. Additional
 	///     <c>Returns</c>/<c>Throws</c> or <c>OnSet</c>/<c>OnGet</c> calls layer extra behavior on top.
 	/// </remarks>
+	/// <param name="value">The initial value assigned to the property's backing field.</param>
+	/// <returns>The same setup instance, to allow chaining.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.TotalDispensed.InitializeWith(42);
@@ -207,6 +238,8 @@ public interface IPropertySetup<T>
 	///     first entry unless the last entry is followed by
 	///     <see cref="SetupExtensions.Forever{T}(IPropertySetupReturnWhenBuilder{T})" />.
 	/// </remarks>
+	/// <param name="returnValue">The value returned on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.TotalDispensed
@@ -222,12 +255,16 @@ public interface IPropertySetup<T>
 	///     Appends a lazy return to the property's read-sequence; <paramref name="callback" /> is invoked on each
 	///     matching read and its result is returned.
 	/// </summary>
+	/// <param name="callback">The factory invoked on every matching invocation to produce the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IPropertySetupReturnBuilder<T> Returns(Func<T> callback);
 
 	/// <summary>
 	///     Appends a lazy return that receives the property's current value and returns the new one - useful for
 	///     incrementing or transforming the last-read value.
 	/// </summary>
+	/// <param name="callback">The factory invoked on every matching invocation; receives the method arguments and produces the return value.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	/// <example>
 	///     <code>
 	///     sut.Mock.Setup.TotalDispensed.Returns(current =&gt; current + 10);
@@ -239,24 +276,32 @@ public interface IPropertySetup<T>
 	///     Appends an entry to the read-sequence that throws a freshly-constructed
 	///     <typeparamref name="TException" /> on the next matching read.
 	/// </summary>
+	/// <typeparam name="TException">The exception type; a new instance is created per invocation.</typeparam>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IPropertySetupReturnBuilder<T> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <summary>
 	///     Appends an entry to the read-sequence that throws <paramref name="exception" /> on the next matching read.
 	/// </summary>
+	/// <param name="exception">The exception to throw on the next matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IPropertySetupReturnBuilder<T> Throws(Exception exception);
 
 	/// <summary>
 	///     Appends an entry that invokes <paramref name="callback" /> to build the exception thrown on the next
 	///     matching read - useful when the exception needs to reference the invocation state.
 	/// </summary>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IPropertySetupReturnBuilder<T> Throws(Func<Exception> callback);
 
 	/// <summary>
 	///     Appends an entry that invokes <paramref name="callback" /> with the property's current value to build the
 	///     exception thrown on the next matching read.
 	/// </summary>
+	/// <param name="callback">The factory that produces the exception thrown on every matching invocation.</param>
+	/// <returns>A builder for chaining additional returns/throws or gating operators.</returns>
 	IPropertySetupReturnBuilder<T> Throws(Func<T, Exception> callback);
 }
 
@@ -271,6 +316,8 @@ public interface IPropertyGetterSetupParallelCallbackBuilder<T> : IPropertyGette
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the property has been accessed so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IPropertyGetterSetupCallbackWhenBuilder<T> When(Func<int, bool> predicate);
 }
 
@@ -282,6 +329,7 @@ public interface IPropertyGetterSetupCallbackBuilder<T> : IPropertyGetterSetupPa
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
 }
 
@@ -297,6 +345,8 @@ public interface IPropertyGetterSetupCallbackWhenBuilder<T> : IPropertySetup<T>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IPropertyGetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IPropertyGetterSetupCallbackWhenBuilder<T> For(int times);
 
 	/// <summary>
@@ -306,6 +356,8 @@ public interface IPropertyGetterSetupCallbackWhenBuilder<T> : IPropertySetup<T>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IPropertyGetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IPropertySetup<T> Only(int times);
 }
 
@@ -320,6 +372,8 @@ public interface IPropertySetterSetupParallelCallbackBuilder<T> : IPropertySette
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the property has been accessed so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IPropertySetterSetupCallbackWhenBuilder<T> When(Func<int, bool> predicate);
 }
 
@@ -331,6 +385,7 @@ public interface IPropertySetterSetupCallbackBuilder<T> : IPropertySetterSetupPa
 	/// <summary>
 	///     Runs the callback in parallel to the other callbacks.
 	/// </summary>
+	/// <returns>A builder for chaining <c>.When(...)</c>, <c>.For(n)</c>, or <c>.Only(n)</c>.</returns>
 	IPropertySetterSetupParallelCallbackBuilder<T> InParallel();
 }
 
@@ -346,6 +401,8 @@ public interface IPropertySetterSetupCallbackWhenBuilder<T> : IPropertySetup<T>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IPropertySetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IPropertySetterSetupCallbackWhenBuilder<T> For(int times);
 
 	/// <summary>
@@ -355,6 +412,8 @@ public interface IPropertySetterSetupCallbackWhenBuilder<T> : IPropertySetup<T>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IPropertySetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IPropertySetup<T> Only(int times);
 }
 
@@ -369,6 +428,8 @@ public interface IPropertySetupReturnBuilder<T> : IPropertySetupReturnWhenBuilde
 	/// <remarks>
 	///     Provides a zero-based counter indicating how many times the property has been accessed so far.
 	/// </remarks>
+	/// <param name="predicate">A predicate receiving a zero-based counter of how many times the method has been invoked so far.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IPropertySetupReturnWhenBuilder<T> When(Func<int, bool> predicate);
 }
 
@@ -384,6 +445,8 @@ public interface IPropertySetupReturnWhenBuilder<T> : IPropertySetup<T>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IPropertySetupReturnBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions before the callback cycles back to the first entry in the sequence.</param>
+	/// <returns>A builder for chaining <c>.For(n)</c> or <c>.Only(n)</c>.</returns>
 	IPropertySetupReturnWhenBuilder<T> For(int times);
 
 	/// <summary>
@@ -393,5 +456,7 @@ public interface IPropertySetupReturnWhenBuilder<T> : IPropertySetup<T>
 	///     The number of times is only counted for actual executions (
 	///     <see cref="IPropertySetupReturnBuilder{T}.When(Func{int, bool})" /> evaluates to <see langword="true" />).
 	/// </remarks>
+	/// <param name="times">The number of executions after which the callback stops firing.</param>
+	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IPropertySetup<T> Only(int times);
 }

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -60,7 +60,7 @@ public interface IInteractivePropertySetup : ISetup
 }
 
 /// <summary>
-///     Fluent surface for attaching side-effects to a property's getter.
+///     Setup for attaching side-effects to a property's getter.
 /// </summary>
 /// <remarks>
 ///     Each <c>Do</c> registers a callback that fires on every matching read. Chain multiple <c>Do</c> calls to form
@@ -104,7 +104,7 @@ public interface IPropertyGetterSetup<T>
 }
 
 /// <summary>
-///     Fluent surface for attaching side-effects to a property's setter.
+///     Setup for attaching side-effects to a property's setter.
 /// </summary>
 /// <remarks>
 ///     Each <c>Do</c> registers a callback that fires on every matching write. Chain multiple <c>Do</c> calls to form
@@ -147,16 +147,14 @@ public interface IPropertySetterSetup<T>
 }
 
 /// <summary>
-///     Fluent surface for configuring a mocked property of type <typeparamref name="T" />.
+///     Setup for configuring a mocked property of type <typeparamref name="T" />.
 /// </summary>
 /// <remarks>
 ///     Reached via <c>sut.Mock.Setup.PropertyName</c>. Chain <see cref="InitializeWith" /> to back the property with a
 ///     mutable slot, <see cref="Returns(T)" /> / <see cref="Throws{TException}" /> to define a sequence of read
 ///     responses, and <see cref="OnGet" /> / <see cref="OnSet" /> to attach getter/setter callbacks. Consecutive
-///     <c>Returns</c>/<c>Throws</c> calls form a sequence that cycles once exhausted - terminate with
-///     <see cref="SetupExtensions.Forever{T}(IPropertySetupReturnWhenBuilder{T})" /> to freeze on the last entry, or
-///     <see cref="IPropertySetupReturnWhenBuilder{T}.For(int)" /> / <see cref="IPropertySetupReturnWhenBuilder{T}.Only(int)" />
-///     to control repetition.
+///     <c>Returns</c>/<c>Throws</c> calls form a sequence that cycles once exhausted &#8212; terminate with
+///     <c>.Forever()</c> to freeze on the last entry, or <c>.For(n)</c> / <c>.Only(n)</c> to control repetition.
 /// </remarks>
 public interface IPropertySetup<T>
 {

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -50,28 +50,41 @@ public abstract class PropertySetup : IInteractivePropertySetup
 		=> InitializeValue(value);
 
 	/// <summary>
-	///     Initializes the property with the <paramref name="value" />.
+	///     Seeds the property's backing storage with <paramref name="value" />. Called once per property at
+	///     initialization or after a scenario reset.
 	/// </summary>
+	/// <param name="value">The initial value; boxed to <see cref="object" /> because the property type is hidden behind the abstract.</param>
 	protected abstract void InitializeValue(object? value);
 
 	/// <summary>
-	///     Gets the flag indicating if the base class implementation should be skipped.
+	///     Returns the per-setup override of <see cref="MockBehavior.SkipBaseClass" />, or <see langword="null" />
+	///     when the mock-wide behavior should apply.
 	/// </summary>
+	/// <returns><see langword="true" /> to always skip, <see langword="false" /> to always call, <see langword="null" /> to defer to <see cref="MockBehavior.SkipBaseClass" />.</returns>
 	protected abstract bool? GetSkipBaseClass();
 
 	/// <summary>
-	///     Checks if the <paramref name="propertyAccess" /> matches the setup.
+	///     Returns whether this setup applies to the given <paramref name="propertyAccess" />.
 	/// </summary>
+	/// <param name="propertyAccess">The recorded access being matched.</param>
+	/// <returns><see langword="true" /> when this setup should handle the access.</returns>
 	protected abstract bool Matches(PropertyAccess propertyAccess);
 
 	/// <summary>
-	///     Invokes the setter logic with the given <paramref name="value" />.
+	///     Runs the setter flow for <paramref name="value" />.
 	/// </summary>
+	/// <typeparam name="TValue">The property's value type.</typeparam>
+	/// <param name="value">The value being assigned.</param>
+	/// <param name="behavior">The mock's active behavior.</param>
 	protected abstract void InvokeSetter<TValue>(TValue value, MockBehavior behavior);
 
 	/// <summary>
-	///     Invokes the getter logic and returns the value of type <typeparamref name="TResult" />.
+	///     Runs the getter flow and returns the property value.
 	/// </summary>
+	/// <typeparam name="TResult">The property's value type.</typeparam>
+	/// <param name="behavior">The mock's active behavior.</param>
+	/// <param name="defaultValueGenerator">Fallback producer used when the setup cannot supply a value.</param>
+	/// <returns>The resolved getter value.</returns>
 	protected abstract TResult InvokeGetter<TResult>(MockBehavior behavior, Func<TResult> defaultValueGenerator);
 
 #if !DEBUG

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -8,8 +8,21 @@ using Mockolate.Interactions;
 namespace Mockolate.Verify;
 
 /// <summary>
-///     The result of a verification containing the matching interactions.
+///     The intermediate result of a <c>sut.Mock.Verify.MemberName(...)</c> call - carries the recorded interactions
+///     that match the verification predicate, waiting for a terminating count assertion.
 /// </summary>
+/// <remarks>
+///     Obtained from <c>sut.Mock.Verify</c>, <c>sut.Mock.VerifyProtected</c>, <c>sut.Mock.VerifyStatic</c> or
+///     <c>sut.Mock.InScenario(...).Verify</c>. Nothing is asserted until a terminator runs - until then the object
+///     can still be composed:
+///     <list type="bullet">
+///       <item><description>Terminate with a count assertion from <see cref="VerificationResultExtensions" /> - <c>Once()</c>, <c>Never()</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>, <c>AtMost(n)</c>, <c>Between(min, max)</c>, <c>Times(n)</c> - to turn the result into a pass/fail check that throws <see cref="MockVerificationException" /> on mismatch.</description></item>
+///       <item><description>Chain <c>.Then(next)</c> to assert an ordering between two verifications.</description></item>
+///       <item><description>Call <see cref="Within(TimeSpan)" /> and/or <see cref="WithCancellation(CancellationToken)" /> before the terminator to wait for interactions produced on a background thread (synchronous wait; use the <c>aweXpect.Mockolate</c> package for the asynchronous variant).</description></item>
+///       <item><description>When the verification matcher uses <c>It.*</c> parameter matchers, the nested <see cref="IgnoreParameters" /> subtype also exposes <c>AnyParameters()</c> to widen the match to any argument list.</description></item>
+///     </list>
+/// </remarks>
+/// <typeparam name="TVerify">The mock's <c>IMockVerifyFor...</c> facade, used to continue verification chains (<c>Then</c>, <c>AnyParameters</c>).</typeparam>
 #if !DEBUG
 [System.Diagnostics.DebuggerNonUserCode]
 #endif

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -16,13 +16,13 @@ namespace Mockolate.Verify;
 ///     <c>sut.Mock.InScenario(...).Verify</c>. Nothing is asserted until a terminator runs - until then the object
 ///     can still be composed:
 ///     <list type="bullet">
-///       <item><description>Terminate with a count assertion from <see cref="VerificationResultExtensions" /> - <c>Once()</c>, <c>Never()</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>, <c>AtMost(n)</c>, <c>Between(min, max)</c>, <c>Times(n)</c> - to turn the result into a pass/fail check that throws <see cref="MockVerificationException" /> on mismatch.</description></item>
+///       <item><description>Terminate with a count assertion from <see cref="VerificationResultExtensions" /> &#8212; <c>Once()</c>, <c>Never()</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>, <c>AtMost(n)</c>, <c>Between(min, max)</c>, <c>Times(n)</c> &#8212; to turn the result into a pass/fail check that throws <see cref="MockVerificationException" /> on mismatch.</description></item>
 ///       <item><description>Chain <c>.Then(next)</c> to assert an ordering between two verifications.</description></item>
 ///       <item><description>Call <see cref="Within(TimeSpan)" /> and/or <see cref="WithCancellation(CancellationToken)" /> before the terminator to wait for interactions produced on a background thread (synchronous wait; use the <c>aweXpect.Mockolate</c> package for the asynchronous variant).</description></item>
 ///       <item><description>When the verification matcher uses <c>It.*</c> parameter matchers, the nested <see cref="IgnoreParameters" /> subtype also exposes <c>AnyParameters()</c> to widen the match to any argument list.</description></item>
 ///     </list>
 /// </remarks>
-/// <typeparam name="TVerify">The mock's <c>IMockVerifyFor...</c> facade, used to continue verification chains (<c>Then</c>, <c>AnyParameters</c>).</typeparam>
+/// <typeparam name="TVerify">The mock's verification facade, used to continue verification chains (e.g. <c>.Then(...)</c>).</typeparam>
 #if !DEBUG
 [System.Diagnostics.DebuggerNonUserCode]
 #endif

--- a/Source/Mockolate/Web/HttpClientExtensions.ReturnsAsync.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.ReturnsAsync.cs
@@ -15,20 +15,30 @@ public static partial class HttpClientExtensions
 	extension(IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> setup)
 	{
 		/// <summary>
-		///     Asynchronously returns a <see cref="HttpResponseMessage" /> with the given <paramref name="statusCode" />.
+		///     Completes the mocked request with an empty <see cref="HttpResponseMessage" /> carrying the given
+		///     <paramref name="statusCode" />.
 		/// </summary>
+		/// <param name="statusCode">The <see cref="HttpStatusCode" /> to return.</param>
+		/// <returns>The setup's return-builder - chain <c>.For(n)</c>, <c>.Forever()</c> or additional <c>Returns*</c>/<c>Throws</c> entries to build a sequence.</returns>
+		/// <example>
+		///     <code>
+		///     httpClient.Mock.Setup.GetAsync(It.IsUri("*/health")).ReturnsAsync(HttpStatusCode.OK);
+		///     </code>
+		/// </example>
 		public IReturnMethodSetupReturnBuilder<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken>
 			ReturnsAsync(HttpStatusCode statusCode)
 			=> setup.ReturnsAsync(new HttpResponseMessage(statusCode));
 
 		/// <summary>
-		///     Asynchronously returns a <see cref="HttpResponseMessage" /> with the given <paramref name="statusCode" />
-		///     and <see langword="string" /> <paramref name="content" />.
+		///     Completes the mocked request with an <see cref="HttpResponseMessage" /> whose status is
+		///     <paramref name="statusCode" /> and whose body is the given <see langword="string" /> <paramref name="content" />.
 		/// </summary>
+		/// <param name="statusCode">The <see cref="HttpStatusCode" /> to return.</param>
+		/// <param name="content">The response body, encoded as UTF-8 with a default <c>text/plain</c> media type.</param>
+		/// <returns>The setup's return-builder.</returns>
 		/// <remarks>
-		///     Uses default encoding (UTF-8) and default media type ("text/plain") for the content.<br />
-		///     If you need a different encoding, use the overload that takes an <see cref="HttpContent" />.<br />
-		///     If you need a different media type, use the overload that takes an explicit media type.
+		///     For a different character encoding use the <see cref="HttpContent" /> overload; for a different media
+		///     type use the <c>(statusCode, content, mediaType)</c> overload.
 		/// </remarks>
 		public IReturnMethodSetupReturnBuilder<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken>
 			ReturnsAsync(HttpStatusCode statusCode, string content)
@@ -38,12 +48,16 @@ public static partial class HttpClientExtensions
 			});
 
 		/// <summary>
-		///     Asynchronously returns a <see cref="HttpResponseMessage" /> with the given <paramref name="statusCode" />,
-		///     <see langword="string" /> <paramref name="content" /> and <paramref name="mediaType" />.
+		///     Completes the mocked request with an <see cref="HttpResponseMessage" /> whose status is
+		///     <paramref name="statusCode" />, body is the given <see langword="string" /> <paramref name="content" />
+		///     and <c>Content-Type</c> is <paramref name="mediaType" />.
 		/// </summary>
+		/// <param name="statusCode">The <see cref="HttpStatusCode" /> to return.</param>
+		/// <param name="content">The response body, encoded as UTF-8.</param>
+		/// <param name="mediaType">The response media type, e.g. <c>"application/json"</c>.</param>
+		/// <returns>The setup's return-builder.</returns>
 		/// <remarks>
-		///     Uses default encoding (UTF-8) for the content.<br />
-		///     If you need a different encoding, use the overload that takes an <see cref="HttpContent" />.
+		///     For a non-UTF-8 encoding use the <see cref="HttpContent" /> overload.
 		/// </remarks>
 		public IReturnMethodSetupReturnBuilder<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken>
 			ReturnsAsync(HttpStatusCode statusCode, string content, string mediaType)
@@ -53,9 +67,12 @@ public static partial class HttpClientExtensions
 			});
 
 		/// <summary>
-		///     Asynchronously returns a <see cref="HttpResponseMessage" /> with the given <paramref name="statusCode" />
-		///     and <paramref name="bytes" />.
+		///     Completes the mocked request with an <see cref="HttpResponseMessage" /> whose status is
+		///     <paramref name="statusCode" /> and whose body is the given raw <paramref name="bytes" />.
 		/// </summary>
+		/// <param name="statusCode">The <see cref="HttpStatusCode" /> to return.</param>
+		/// <param name="bytes">The response body as a raw byte array (wrapped in a <see cref="ByteArrayContent" />).</param>
+		/// <returns>The setup's return-builder.</returns>
 		public IReturnMethodSetupReturnBuilder<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken>
 			ReturnsAsync(HttpStatusCode statusCode, byte[] bytes)
 			=> setup.ReturnsAsync(new HttpResponseMessage(statusCode)
@@ -64,9 +81,14 @@ public static partial class HttpClientExtensions
 			});
 
 		/// <summary>
-		///     Asynchronously returns a <see cref="HttpResponseMessage" /> with the given <paramref name="statusCode" />,
-		///     <paramref name="bytes" /> and <paramref name="mediaType" />.
+		///     Completes the mocked request with an <see cref="HttpResponseMessage" /> whose status is
+		///     <paramref name="statusCode" />, body is the given raw <paramref name="bytes" /> and <c>Content-Type</c>
+		///     is <paramref name="mediaType" />.
 		/// </summary>
+		/// <param name="statusCode">The <see cref="HttpStatusCode" /> to return.</param>
+		/// <param name="bytes">The response body as a raw byte array.</param>
+		/// <param name="mediaType">The response media type applied as a <see cref="MediaTypeHeaderValue" />.</param>
+		/// <returns>The setup's return-builder.</returns>
 		public IReturnMethodSetupReturnBuilder<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken>
 			ReturnsAsync(HttpStatusCode statusCode, byte[] bytes, string mediaType)
 		{
@@ -79,9 +101,12 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Asynchronously returns a <see cref="HttpResponseMessage" /> with the given <paramref name="statusCode" />
-		///     and <paramref name="content" />.
+		///     Completes the mocked request with an <see cref="HttpResponseMessage" /> whose status is
+		///     <paramref name="statusCode" /> and whose body is the supplied <see cref="HttpContent" />.
 		/// </summary>
+		/// <param name="statusCode">The <see cref="HttpStatusCode" /> to return.</param>
+		/// <param name="content">The response body - use this overload for custom encodings, streams or structured content (e.g. <see cref="System.Net.Http.MultipartContent" />).</param>
+		/// <returns>The setup's return-builder.</returns>
 		public IReturnMethodSetupReturnBuilder<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken>
 			ReturnsAsync(HttpStatusCode statusCode, HttpContent content)
 			=> setup.ReturnsAsync(new HttpResponseMessage(statusCode)

--- a/Source/Mockolate/Web/HttpClientExtensions.ReturnsAsync.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.ReturnsAsync.cs
@@ -20,11 +20,6 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="statusCode">The <see cref="HttpStatusCode" /> to return.</param>
 		/// <returns>The setup's return-builder - chain <c>.For(n)</c>, <c>.Forever()</c> or additional <c>Returns*</c>/<c>Throws</c> entries to build a sequence.</returns>
-		/// <example>
-		///     <code>
-		///     httpClient.Mock.Setup.GetAsync(It.IsUri("*/health")).ReturnsAsync(HttpStatusCode.OK);
-		///     </code>
-		/// </example>
 		public IReturnMethodSetupReturnBuilder<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken>
 			ReturnsAsync(HttpStatusCode statusCode)
 			=> setup.ReturnsAsync(new HttpResponseMessage(statusCode));

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
@@ -19,13 +19,13 @@ public static partial class HttpClientExtensions
 		///     Sets up <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
 		///     covers code paths that call <c>HttpClient.DeleteAsync</c> with an explicit <see cref="CancellationToken" />.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> DeleteAsync(
 			IParameter<string?> requestUri)
 			=> setup.DeleteAsync(requestUri, It.IsAny<CancellationToken>());

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
@@ -16,28 +16,39 @@ public static partial class HttpClientExtensions
 	extension(IMockSetup<HttpClient> setup)
 	{
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
+		///     covers code paths that call <c>HttpClient.DeleteAsync</c> with an explicit <see cref="CancellationToken" />.
+		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> DeleteAsync(
 			IParameter<string?> requestUri)
 			=> setup.DeleteAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?)" /> on the mocked <see cref="HttpClient" />
+		///     for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> DeleteAsync(
 			IParameter<Uri?> requestUri)
 			=> setup.DeleteAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(string?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.DeleteAsync(string?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> DeleteAsync(
 			IParameter<string?> requestUri,
 			IParameter<CancellationToken> cancellationToken)
@@ -60,10 +71,13 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> DeleteAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<CancellationToken> cancellationToken)

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
@@ -20,7 +20,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
@@ -34,7 +34,7 @@ public static partial class HttpClientExtensions
 		///     Sets up <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?)" /> on the mocked <see cref="HttpClient" />
 		///     for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> DeleteAsync(

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Delete.cs
@@ -19,7 +19,7 @@ public static partial class HttpClientExtensions
 		///     Sets up <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
@@ -19,7 +19,7 @@ public static partial class HttpClientExtensions
 		///     Sets up <see cref="System.Net.Http.HttpClient.GetAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
@@ -16,28 +16,40 @@ public static partial class HttpClientExtensions
 	extension(IMockSetup<HttpClient> setup)
 	{
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(string?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.GetAsync(string?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
+		///     covers code paths that call the <c>GetAsync</c> overloads with a <see cref="CancellationToken" /> or an
+		///     <see cref="HttpCompletionOption" />.
+		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> GetAsync(
 			IParameter<string?> requestUri)
 			=> setup.GetAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(Uri?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.GetAsync(Uri?)" /> on the mocked <see cref="HttpClient" />
+		///     for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> GetAsync(
 			IParameter<Uri?> requestUri)
 			=> setup.GetAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(string?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.GetAsync(string?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> GetAsync(
 			IParameter<string?> requestUri,
 			IParameter<CancellationToken> cancellationToken)
@@ -60,10 +72,13 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(Uri?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.GetAsync(Uri?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> GetAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<CancellationToken> cancellationToken)

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
@@ -20,7 +20,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
@@ -35,7 +35,7 @@ public static partial class HttpClientExtensions
 		///     Sets up <see cref="System.Net.Http.HttpClient.GetAsync(Uri?)" /> on the mocked <see cref="HttpClient" />
 		///     for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> GetAsync(

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Get.cs
@@ -19,14 +19,14 @@ public static partial class HttpClientExtensions
 		///     Sets up <see cref="System.Net.Http.HttpClient.GetAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
 		///     covers code paths that call the <c>GetAsync</c> overloads with a <see cref="CancellationToken" /> or an
 		///     <see cref="HttpCompletionOption" />.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> GetAsync(
 			IParameter<string?> requestUri)
 			=> setup.GetAsync(requestUri, It.IsAny<CancellationToken>());

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
@@ -21,14 +21,14 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
 		///     covers code paths that call <c>HttpClient.PatchAsync</c> with an explicit <see cref="CancellationToken" />.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PatchAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
@@ -17,10 +17,18 @@ public static partial class HttpClientExtensions
 	extension(IMockSetup<HttpClient> setup)
 	{
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
+		///     body matches <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
+		///     covers code paths that call <c>HttpClient.PatchAsync</c> without an explicit <see cref="CancellationToken" />.
+		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PatchAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -30,10 +38,14 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(Uri?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PatchAsync(Uri?, HttpContent?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
+		///     body matches <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PatchAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -43,10 +55,15 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" />, <paramref name="content" /> and
+		///     <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PatchAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?> content,
@@ -71,10 +88,15 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PatchAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" />, <paramref name="content" /> and
+		///     <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PatchAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?> content,

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
@@ -21,7 +21,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Patch.cs
@@ -23,11 +23,11 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
-		///     covers code paths that call <c>HttpClient.PatchAsync</c> without an explicit <see cref="CancellationToken" />.
+		///     covers code paths that call <c>HttpClient.PatchAsync</c> with an explicit <see cref="CancellationToken" />.
 		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PatchAsync(
 			IParameter<string?> requestUri,
@@ -42,7 +42,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
@@ -22,11 +22,11 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body (equivalent to <c>It.IsAny&lt;HttpContent?&gt;()</c>).</param>
-		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
-		///     covers code paths that call <c>HttpClient.PostAsync</c> without an explicit <see cref="CancellationToken" />.
+		///     covers code paths that call <c>HttpClient.PostAsync</c> with an explicit <see cref="CancellationToken" />.
 		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PostAsync(
 			IParameter<string?> requestUri,
@@ -43,7 +43,7 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PostAsync(
 			IParameter<Uri?> requestUri,

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
@@ -16,10 +16,18 @@ public static partial class HttpClientExtensions
 	extension(IMockSetup<HttpClient> setup)
 	{
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
+		///     body matches <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body (equivalent to <c>It.IsAny&lt;HttpContent?&gt;()</c>).</param>
+		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
+		///     covers code paths that call <c>HttpClient.PostAsync</c> without an explicit <see cref="CancellationToken" />.
+		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PostAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -29,10 +37,14 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(Uri?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PostAsync(Uri?, HttpContent?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
+		///     body matches <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PostAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -42,10 +54,15 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" />, <paramref name="content" /> and
+		///     <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PostAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?> content,
@@ -70,10 +87,15 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PostAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" />, <paramref name="content" /> and
+		///     <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PostAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?> content,

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
@@ -20,7 +20,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body (equivalent to <c>It.IsAny&lt;HttpContent?&gt;()</c>).</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Post.cs
@@ -20,14 +20,14 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body (equivalent to <c>It.IsAny&lt;HttpContent?&gt;()</c>).</param>
-		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
 		///     covers code paths that call <c>HttpClient.PostAsync</c> with an explicit <see cref="CancellationToken" />.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body (equivalent to <c>It.IsAny&lt;HttpContent?&gt;()</c>).</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PostAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
@@ -22,11 +22,11 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
-		///     covers code paths that call <c>HttpClient.PutAsync</c> without an explicit <see cref="CancellationToken" />.
+		///     covers code paths that call <c>HttpClient.PutAsync</c> with an explicit <see cref="CancellationToken" />.
 		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PutAsync(
 			IParameter<string?> requestUri,
@@ -41,7 +41,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
@@ -20,7 +20,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
@@ -20,14 +20,14 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
 		///     body matches <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
 		///     covers code paths that call <c>HttpClient.PutAsync</c> with an explicit <see cref="CancellationToken" />.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PutAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)

--- a/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Setup.Put.cs
@@ -16,10 +16,18 @@ public static partial class HttpClientExtensions
 	extension(IMockSetup<HttpClient> setup)
 	{
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
+		///     body matches <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Mockolate intercepts the underlying <c>SendAsync</c> call on the injected handler, so this setup also
+		///     covers code paths that call <c>HttpClient.PutAsync</c> without an explicit <see cref="CancellationToken" />.
+		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PutAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -29,10 +37,14 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(Uri?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PutAsync(Uri?, HttpContent?)" /> on the mocked
+		///     <see cref="HttpClient" /> for requests whose URI matches <paramref name="requestUri" /> and whose
+		///     body matches <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PutAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -42,10 +54,15 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" />, <paramref name="content" /> and
+		///     <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PutAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?> content,
@@ -70,10 +87,15 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Setup for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Sets up <see cref="System.Net.Http.HttpClient.PutAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
+		///     for requests matching <paramref name="requestUri" />, <paramref name="content" /> and
+		///     <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> PutAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?> content,

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
@@ -20,7 +20,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
@@ -35,7 +35,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?)" /> on the mocked
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> DeleteAsync(

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
@@ -19,14 +19,14 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
 		///     <c>DeleteAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
 		///     satisfying the supplied matchers.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> DeleteAsync(
 			IParameter<string?> requestUri)
 			=> verify.DeleteAsync(requestUri, It.IsAny<CancellationToken>());

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
@@ -16,28 +16,41 @@ public static partial class HttpClientExtensions
 	extension(IMockVerify<HttpClient> verify)
 	{
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" /> on the mocked
+		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
+		///     <c>DeleteAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
+		///     satisfying the supplied matchers.
+		/// </remarks>
 		public VerificationResult<HttpClient> DeleteAsync(
 			IParameter<string?> requestUri)
 			=> verify.DeleteAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?)" /> on the mocked
+		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> DeleteAsync(
 			IParameter<Uri?> requestUri)
 			=> verify.DeleteAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(string?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> DeleteAsync(
 			IParameter<string?> requestUri,
 			IParameter<CancellationToken> cancellationToken)
@@ -60,10 +73,14 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.DeleteAsync(Uri?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> DeleteAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<CancellationToken> cancellationToken)

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Delete.cs
@@ -19,7 +19,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.DeleteAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
@@ -19,14 +19,14 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.GetAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
 		///     <c>GetAsync</c> overload (with <see cref="CancellationToken" /> or <see cref="HttpCompletionOption" />)
 		///     that produced a request satisfying the supplied matchers.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> GetAsync(
 			IParameter<string?> requestUri)
 			=> verify.GetAsync(requestUri, It.IsAny<CancellationToken>());

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
@@ -16,28 +16,41 @@ public static partial class HttpClientExtensions
 	extension(IMockVerify<HttpClient> verify)
 	{
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(string?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.GetAsync(string?)" /> on the mocked
+		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
+		///     <c>GetAsync</c> overload (with <see cref="CancellationToken" /> or <see cref="HttpCompletionOption" />)
+		///     that produced a request satisfying the supplied matchers.
+		/// </remarks>
 		public VerificationResult<HttpClient> GetAsync(
 			IParameter<string?> requestUri)
 			=> verify.GetAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(string?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.GetAsync(Uri?)" /> on the mocked
+		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> GetAsync(
 			IParameter<Uri?> requestUri)
 			=> verify.GetAsync(requestUri, It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(string?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.GetAsync(string?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> GetAsync(
 			IParameter<string?> requestUri,
 			IParameter<CancellationToken> cancellationToken)
@@ -59,10 +72,14 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.GetAsync(string?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.GetAsync(Uri?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> GetAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<CancellationToken> cancellationToken)

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
@@ -20,7 +20,7 @@ public static partial class HttpClientExtensions
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
@@ -35,7 +35,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.GetAsync(Uri?)" /> on the mocked
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> GetAsync(

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Get.cs
@@ -19,7 +19,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.GetAsync(string?)" /> on the mocked
 		///     <see cref="HttpClient" /> matching <paramref name="requestUri" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
@@ -22,7 +22,7 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
@@ -41,7 +41,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PatchAsync(Uri?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
@@ -17,10 +17,18 @@ public static partial class HttpClientExtensions
 	extension(IMockVerify<HttpClient> verify)
 	{
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" /> on the
+		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
+		///     <c>PatchAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
+		///     satisfying the supplied matchers.
+		/// </remarks>
 		public VerificationResult<HttpClient> PatchAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -30,10 +38,13 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PatchAsync(Uri?, HttpContent?)" /> on the
+		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PatchAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -43,10 +54,15 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" />, <paramref name="content" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PatchAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?> content,
@@ -72,10 +88,15 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.PatchAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" />, <paramref name="content" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PatchAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?> content,

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
@@ -20,7 +20,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Patch.cs
@@ -20,15 +20,15 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PatchAsync(string?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
 		///     <c>PatchAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
 		///     satisfying the supplied matchers.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PatchAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
@@ -19,15 +19,15 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
 		///     <c>PostAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
 		///     satisfying the supplied matchers.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PostAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
@@ -19,7 +19,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
@@ -21,7 +21,7 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Post.cs
@@ -16,10 +16,18 @@ public static partial class HttpClientExtensions
 	extension(IMockVerify<HttpClient> verify)
 	{
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" /> on the
+		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
+		///     <c>PostAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
+		///     satisfying the supplied matchers.
+		/// </remarks>
 		public VerificationResult<HttpClient> PostAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -29,10 +37,13 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PostAsync(Uri?, HttpContent?)" /> on the
+		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PostAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -42,10 +53,15 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" />, <paramref name="content" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PostAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?> content,
@@ -71,10 +87,15 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PostAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.PostAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" />, <paramref name="content" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PostAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?> content,

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
@@ -16,10 +16,18 @@ public static partial class HttpClientExtensions
 	extension(IMockVerify<HttpClient> verify)
 	{
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" /> on the
+		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
+		///     <c>PutAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
+		///     satisfying the supplied matchers.
+		/// </remarks>
 		public VerificationResult<HttpClient> PutAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -29,10 +37,13 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" />.
+		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PutAsync(Uri?, HttpContent?)" /> on the
+		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PutAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?>? content = null)
@@ -42,10 +53,15 @@ public static partial class HttpClientExtensions
 				It.IsAny<CancellationToken>());
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" />, <paramref name="content" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PutAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?> content,
@@ -71,10 +87,15 @@ public static partial class HttpClientExtensions
 		}
 
 		/// <summary>
-		///     Validates the invocations for the method
-		///     <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" />
-		///     with the given <paramref name="requestUri" /> and <paramref name="cancellationToken" />.
+		///     Verifies invocations of
+		///     <see cref="System.Net.Http.HttpClient.PutAsync(Uri?, HttpContent?, System.Threading.CancellationToken)" />
+		///     matching <paramref name="requestUri" />, <paramref name="content" /> and <paramref name="cancellationToken" />.
 		/// </summary>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="content">An <see cref="HttpContent" /> matcher for the request body.</param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken" /> matcher - pass <c>It.IsAny&lt;CancellationToken&gt;()</c> to accept any token.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PutAsync(
 			IParameter<Uri?> requestUri,
 			IParameter<HttpContent?> content,

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
@@ -19,15 +19,15 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
-		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
 		///     <c>PutAsync</c> overload (with or without <see cref="CancellationToken" />) that produced a request
 		///     satisfying the supplied matchers.
 		/// </remarks>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public VerificationResult<HttpClient> PutAsync(
 			IParameter<string?> requestUri,
 			IParameter<HttpContent?>? content = null)

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
@@ -19,7 +19,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PutAsync(string?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
+		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.Verify.Put.cs
@@ -21,7 +21,7 @@ public static partial class HttpClientExtensions
 		/// </summary>
 		/// <param name="requestUri">A <see langword="string" /> URI matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw string.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
-		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with <c>.Once()</c>, <c>.AtLeast(n)</c>, etc.</returns>
+		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Matches on the underlying <c>SendAsync</c> invocation, so the verification succeeds for any
@@ -40,7 +40,7 @@ public static partial class HttpClientExtensions
 		///     Verifies invocations of <see cref="System.Net.Http.HttpClient.PutAsync(Uri?, HttpContent?)" /> on the
 		///     mocked <see cref="HttpClient" /> matching <paramref name="requestUri" /> and <paramref name="content" />.
 		/// </summary>
-		/// <param name="requestUri">A <see cref="Uri" /> matcher.</param>
+		/// <param name="requestUri">A <see cref="Uri" /> matcher - typically <c>It.IsUri(...)</c>, <c>It.Is(uri)</c> or a raw <see cref="Uri" />.</param>
 		/// <param name="content">An optional <see cref="HttpContent" /> matcher; <see langword="null" /> accepts any body.</param>
 		/// <returns>An intermediate <see cref="VerificationResult{HttpClient}" /> - terminate with a count assertion.</returns>
 		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>

--- a/Source/Mockolate/Web/HttpClientExtensions.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.cs
@@ -15,19 +15,45 @@ using Mockolate.Internals.Polyfills;
 namespace Mockolate;
 
 /// <summary>
-///     Extensions for mocking <see cref="HttpClient" />.
+///     Fluent <c>Setup</c> / <c>Verify</c> surface for a mocked <see cref="HttpClient" /> - turns HTTP method
+///     calls (<c>GetAsync</c>, <c>PostAsync</c>, <c>PutAsync</c>, <c>PatchAsync</c>, <c>DeleteAsync</c> and the
+///     underlying <see cref="HttpClient.SendAsync(HttpRequestMessage, CancellationToken)" />) into expectations.
 /// </summary>
+/// <remarks>
+///     How it works: calling <c>HttpClient.CreateMock()</c> returns a mock whose constructor injects a mocked
+///     <see cref="HttpMessageHandler" />. These extensions route setup/verify calls through that handler, so any
+///     <c>HttpClient</c> method that ultimately goes through <c>SendAsync</c> can be intercepted by verb.
+///     <para />
+///     Typical flow:
+///     <list type="bullet">
+///       <item><description>Setup: <c>httpClient.Mock.Setup.PostAsync(uriMatcher, contentMatcher).ReturnsAsync(response)</c> -  see <c>HttpClientExtensions.Setup.*</c>.</description></item>
+///       <item><description>Verify: <c>httpClient.Mock.Verify.GetAsync(uriMatcher).Once()</c> - see <c>HttpClientExtensions.Verify.*</c>.</description></item>
+///       <item><description>Match request pieces with <see cref="ItExtensions" />: <c>It.IsUri(...)</c>, <c>It.IsHttpContent(...)</c>, <c>It.IsHttpRequestMessage(...)</c> and their fluent <c>.WithString</c> / <c>.WithBytes</c> / <c>.WithFormData</c> / <c>.WithHeaders</c> builders.</description></item>
+///     </list>
+///     <para />
+///     Throws <see cref="MockException" /> if the mock was constructed without a mockable
+///     <see cref="HttpMessageHandler" /> (e.g. <c>new HttpClient()</c> passed by hand) - the message handler
+///     injection is what makes the interception possible.
+/// </remarks>
 public static partial class HttpClientExtensions
 {
 	/// <inheritdoc cref="HttpClientExtensions" />
 	extension(IMockSetup<HttpClient> setup)
 	{
 		/// <summary>
-		///     Setup for the method
-		///     <see
-		///         cref="System.Net.Http.HttpClient.SendAsync(System.Net.Http.HttpRequestMessage, System.Threading.CancellationToken)" />
-		///     with the given <paramref name="request" />.
+		///     Sets up <see cref="HttpClient.SendAsync(HttpRequestMessage, CancellationToken)" /> directly on the
+		///     mocked <see cref="HttpClient" /> - the catch-all entry point that every verb-specific overload
+		///     (<c>GetAsync</c>, <c>PostAsync</c>, ...) routes through.
 		/// </summary>
+		/// <param name="request">A matcher for the <see cref="HttpRequestMessage" /> - usually <c>It.IsHttpRequestMessage(...)</c>.</param>
+		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
+		/// <remarks>
+		///     Prefer <c>Setup.GetAsync</c>/<c>PostAsync</c>/<c>PutAsync</c>/<c>PatchAsync</c>/<c>DeleteAsync</c> when
+		///     you only need to match by verb and URI; reach for <c>SendAsync</c> when you need the full
+		///     <see cref="HttpRequestMessage" /> (e.g. to inspect headers or non-standard verbs like <c>HEAD</c> or
+		///     <c>OPTIONS</c>).
+		/// </remarks>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> SendAsync(
 			IParameter<HttpRequestMessage> request)
 		{

--- a/Source/Mockolate/Web/HttpClientExtensions.cs
+++ b/Source/Mockolate/Web/HttpClientExtensions.cs
@@ -45,15 +45,15 @@ public static partial class HttpClientExtensions
 		///     mocked <see cref="HttpClient" /> - the catch-all entry point that every verb-specific overload
 		///     (<c>GetAsync</c>, <c>PostAsync</c>, ...) routes through.
 		/// </summary>
-		/// <param name="request">A matcher for the <see cref="HttpRequestMessage" /> - usually <c>It.IsHttpRequestMessage(...)</c>.</param>
-		/// <returns>A setup handle - chain <c>.ReturnsAsync(...)</c>, <c>.Throws&lt;T&gt;()</c> or the other fluent terminators.</returns>
-		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		/// <remarks>
 		///     Prefer <c>Setup.GetAsync</c>/<c>PostAsync</c>/<c>PutAsync</c>/<c>PatchAsync</c>/<c>DeleteAsync</c> when
 		///     you only need to match by verb and URI; reach for <c>SendAsync</c> when you need the full
 		///     <see cref="HttpRequestMessage" /> (e.g. to inspect headers or non-standard verbs like <c>HEAD</c> or
 		///     <c>OPTIONS</c>).
 		/// </remarks>
+		/// <param name="request">A matcher for the <see cref="HttpRequestMessage" /> - usually <c>It.IsHttpRequestMessage(...)</c>.</param>
+		/// <returns>A setup handle - chain a terminator like <c>.ReturnsAsync(...)</c>.</returns>
+		/// <exception cref="MockException">The mock was not created with a mockable <see cref="System.Net.Http.HttpMessageHandler" /> constructor parameter.</exception>
 		public IReturnMethodSetup<Task<HttpResponseMessage>, HttpRequestMessage, CancellationToken> SendAsync(
 			IParameter<HttpRequestMessage> request)
 		{

--- a/Source/Mockolate/Web/HttpFormDataValue.cs
+++ b/Source/Mockolate/Web/HttpFormDataValue.cs
@@ -3,21 +3,28 @@ using System;
 namespace Mockolate.Web;
 
 /// <summary>
-///     The value of an HTTP form data parameter.
+///     Expected value of a single form-data field, used with <c>It.IsHttpContent().WithFormData(...)</c>.
 /// </summary>
+/// <remarks>
+///     The base class performs ordinal string equality. Subclasses can match by wildcard, regex or a predicate. A
+///     plain <see langword="string" /> is implicitly convertible for convenience.
+/// </remarks>
 public class HttpFormDataValue
 {
 	private readonly string _value;
 
 	/// <inheritdoc cref="HttpFormDataValue" />
+	/// <param name="value">The exact field value to match.</param>
 	public HttpFormDataValue(string value)
 	{
 		_value = value;
 	}
 
 	/// <summary>
-	///     Checks whether the given form data parameter value matches this value.
+	///     Returns <see langword="true" /> when the observed <paramref name="parameterValue" /> matches this expectation.
 	/// </summary>
+	/// <param name="parameterValue">The field value observed in the form-data body.</param>
+	/// <returns><see langword="true" /> when it matches; <see langword="false" /> otherwise.</returns>
 	public virtual bool Matches(string parameterValue)
 		=> _value.Equals(parameterValue, StringComparison.Ordinal);
 
@@ -26,8 +33,10 @@ public class HttpFormDataValue
 		=> _value;
 
 	/// <summary>
-	///     Implicitly converts a string to an <see cref="HttpFormDataValue" />.
+	///     Implicit conversion from <see langword="string" /> to <see cref="HttpFormDataValue" /> &#8212; lets callers
+	///     write a raw string in place of a wrapped value.
 	/// </summary>
+	/// <param name="value">The exact field value to match.</param>
 	public static implicit operator HttpFormDataValue(string value)
 	{
 		return new HttpFormDataValue(value);

--- a/Source/Mockolate/Web/HttpHeaderValue.cs
+++ b/Source/Mockolate/Web/HttpHeaderValue.cs
@@ -1,27 +1,37 @@
 namespace Mockolate.Web;
 
 /// <summary>
-///     The value of an HTTP header.
+///     Expected value of an HTTP header, used with <c>It.IsHttpContent().WithHeaders(...)</c> and related matchers.
 /// </summary>
+/// <remarks>
+///     The base class performs ordinal string equality. Subclasses (created via the static helpers on the derived
+///     types) can match by wildcard, regex or a predicate. A plain <see langword="string" /> is implicitly convertible
+///     to an <see cref="HttpHeaderValue" /> for convenience.
+/// </remarks>
 public class HttpHeaderValue
 {
 	private readonly string _value;
 
 	/// <inheritdoc cref="HttpHeaderValue" />
+	/// <param name="value">The exact header value to match.</param>
 	public HttpHeaderValue(string value)
 	{
 		_value = value;
 	}
 
 	/// <summary>
-	///     Checks whether the given header value matches this value.
+	///     Returns <see langword="true" /> when the observed <paramref name="headerValue" /> matches this expectation.
 	/// </summary>
+	/// <param name="headerValue">The header value observed on the request.</param>
+	/// <returns><see langword="true" /> when it matches; <see langword="false" /> otherwise.</returns>
 	public virtual bool Matches(string headerValue)
 		=> _value.Equals(headerValue);
 
 	/// <summary>
-	///     Implicitly converts a string to an <see cref="HttpHeaderValue" />.
+	///     Implicit conversion from <see langword="string" /> to <see cref="HttpHeaderValue" /> &#8212; lets callers
+	///     write a raw string in place of a wrapped value.
 	/// </summary>
+	/// <param name="value">The exact header value to match.</param>
 	public static implicit operator HttpHeaderValue(string value)
 	{
 		return new HttpHeaderValue(value);

--- a/Source/Mockolate/Web/HttpQueryParameterValue.cs
+++ b/Source/Mockolate/Web/HttpQueryParameterValue.cs
@@ -3,21 +3,28 @@ using System;
 namespace Mockolate.Web;
 
 /// <summary>
-///     The value of an HTTP query parameter.
+///     Expected value of a single query-string parameter, used with <c>It.IsUri().WithQuery(...)</c>.
 /// </summary>
+/// <remarks>
+///     The base class performs ordinal string equality. Subclasses can match by wildcard, regex or a predicate. A
+///     plain <see langword="string" /> is implicitly convertible for convenience.
+/// </remarks>
 public class HttpQueryParameterValue
 {
 	private readonly string _value;
 
 	/// <inheritdoc cref="HttpQueryParameterValue" />
+	/// <param name="value">The exact parameter value to match.</param>
 	public HttpQueryParameterValue(string value)
 	{
 		_value = value;
 	}
 
 	/// <summary>
-	///     Checks whether the given query parameter value matches this value.
+	///     Returns <see langword="true" /> when the observed <paramref name="parameterValue" /> matches this expectation.
 	/// </summary>
+	/// <param name="parameterValue">The URL-decoded value observed on the request URI.</param>
+	/// <returns><see langword="true" /> when it matches; <see langword="false" /> otherwise.</returns>
 	public virtual bool Matches(string parameterValue)
 		=> _value.Equals(parameterValue, StringComparison.Ordinal);
 
@@ -26,8 +33,10 @@ public class HttpQueryParameterValue
 		=> _value;
 
 	/// <summary>
-	///     Implicitly converts a string to an <see cref="HttpQueryParameterValue" />.
+	///     Implicit conversion from <see langword="string" /> to <see cref="HttpQueryParameterValue" /> &#8212; lets
+	///     callers write a raw string in place of a wrapped value.
 	/// </summary>
+	/// <param name="value">The exact parameter value to match.</param>
 	public static implicit operator HttpQueryParameterValue(string value)
 	{
 		return new HttpQueryParameterValue(value);

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.WithBytes.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.WithBytes.cs
@@ -9,8 +9,14 @@ public static partial class ItExtensions
 	extension(IHttpContentParameter parameter)
 	{
 		/// <summary>
-		///     Expects the binary content to be equal to the given <paramref name="bytes" />.
+		///     Expects the binary content to be byte-for-byte equal to <paramref name="bytes" />.
 		/// </summary>
+		/// <param name="bytes">The expected byte payload.</param>
+		/// <returns>The same <see cref="IHttpContentParameter" /> for chaining additional <c>.With*</c> constraints.</returns>
+		/// <remarks>
+		///     Shorthand for <c>.WithBytes(actual =&gt; bytes.SequenceEqual(actual))</c>. For a custom predicate &#8212;
+		///     e.g. size or header checks &#8212; use the predicate overload.
+		/// </remarks>
 		public IHttpContentParameter WithBytes(byte[] bytes)
 			=> parameter.WithBytes(bytes.SequenceEqual);
 	}

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.WithFormData.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.WithFormData.cs
@@ -17,14 +17,27 @@ public static partial class ItExtensions
 	extension(IHttpContentParameter parameter)
 	{
 		/// <summary>
-		///     Expects the form data content to contain the given <paramref name="key" />-<paramref name="value" /> pair.
+		///     Expects the form-data body to contain the pair <paramref name="key" />=<paramref name="value" />.
 		/// </summary>
+		/// <param name="key">The form-data key that must be present.</param>
+		/// <param name="value">The expected value for <paramref name="key" />. Implicitly converts from <see langword="string" />.</param>
+		/// <returns>A <see cref="IFormDataContentParameter" /> that can be narrowed further or tightened with <see cref="IFormDataContentParameter.Exactly" />.</returns>
+		/// <remarks>
+		///     By default only the listed pairs must appear; the body may contain extras. Chain
+		///     <see cref="IFormDataContentParameter.Exactly" /> to reject any additional pair.
+		/// </remarks>
 		public IFormDataContentParameter WithFormData(string key, HttpFormDataValue value)
 			=> parameter.WithFormData((key, value)!);
 
 		/// <summary>
-		///     Expects the form data content to contain the given <paramref name="values" />.
+		///     Expects the form-data body to contain all given <paramref name="values" /> (additional pairs are allowed).
 		/// </summary>
+		/// <param name="values">The expected key/value pairs; each <see cref="HttpFormDataValue" /> can be a literal, a pattern or a predicate.</param>
+		/// <returns>A <see cref="IFormDataContentParameter" /> that can be narrowed further or tightened with <see cref="IFormDataContentParameter.Exactly" />.</returns>
+		/// <remarks>
+		///     Chain <see cref="IFormDataContentParameter.Exactly" /> to require that no other keys are present. Useful
+		///     for matching <c>application/x-www-form-urlencoded</c> and <c>multipart/form-data</c> request bodies.
+		/// </remarks>
 		public IFormDataContentParameter WithFormData(params IEnumerable<(string Key, HttpFormDataValue Value)> values)
 		{
 			FormDataMatcher data = new(values);
@@ -33,21 +46,26 @@ public static partial class ItExtensions
 		}
 
 		/// <summary>
-		///     Expects the form data content to contain the given <paramref name="values" />.
+		///     Expects the form-data body to contain all pairs parsed from the URL-encoded <paramref name="values" />
+		///     string (e.g. <c>"a=1&amp;b=2"</c>).
 		/// </summary>
+		/// <param name="values">A URL-encoded key/value string; a leading <c>?</c> is stripped. Keys and values are URL-decoded.</param>
+		/// <returns>A <see cref="IFormDataContentParameter" /> that can be narrowed further or tightened with <see cref="IFormDataContentParameter.Exactly" />.</returns>
 		public IFormDataContentParameter WithFormData(string values)
 			=> parameter.WithFormData(FormDataMatcher.ParseFormDataParameters(values)
 				.Select(pair => (pair.Key, new HttpFormDataValue(pair.Value))));
 	}
 
 	/// <summary>
-	///     Further expectations on the form-data <see cref="HttpContent" />.
+	///     Further expectations on a form-data <see cref="HttpContent" /> body.
 	/// </summary>
 	public interface IFormDataContentParameter : IHttpContentParameter
 	{
 		/// <summary>
-		///     Expects the form data content to not contain any additional key-value pairs other than the ones already specified.
+		///     Requires the body to contain <em>exactly</em> the previously specified pairs &#8212; any additional
+		///     key/value pair causes the match to fail.
 		/// </summary>
+		/// <returns>The same <see cref="IFormDataContentParameter" />, for chaining.</returns>
 		IFormDataContentParameter Exactly();
 	}
 

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.WithHeaders.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.WithHeaders.cs
@@ -19,15 +19,21 @@ public static partial class ItExtensions
 	extension<TParameter>(IHttpHeaderParameter<TParameter> parameter)
 	{
 		/// <summary>
-		///     Expects the <see cref="HttpContent" /> to contain a header matching the <paramref name="name" /> and
-		///     <paramref name="value" />.
+		///     Expects the <see cref="HttpContent" /> to carry a header <paramref name="name" />: <paramref name="value" />.
 		/// </summary>
+		/// <param name="name">The header name to require (case-insensitive per RFC 7230).</param>
+		/// <param name="value">The expected value. Implicitly converts from <see langword="string" /> or can be a subclass of <see cref="HttpHeaderValue" /> for pattern matching.</param>
+		/// <returns>The outer parameter for chaining additional <c>.With*</c> constraints.</returns>
 		public TParameter WithHeaders(string name, HttpHeaderValue value)
 			=> parameter.WithHeaders((name, value));
 
 		/// <summary>
-		///     Expects the <see cref="HttpContent" /> to contain the given <paramref name="headers" />.
+		///     Expects the <see cref="HttpContent" /> to carry every header parsed from <paramref name="headers" />
+		///     &#8212; one per line in <c>"Name: Value"</c> form.
 		/// </summary>
+		/// <param name="headers">Raw header block; blank lines terminate parsing.</param>
+		/// <returns>The outer parameter for chaining additional <c>.With*</c> constraints.</returns>
+		/// <exception cref="ArgumentException">A non-empty line does not contain a <c>:</c> separator.</exception>
 		public TParameter WithHeaders(string headers)
 		{
 			List<(string, HttpHeaderValue)> headerList = new();
@@ -52,13 +58,16 @@ public static partial class ItExtensions
 	}
 
 	/// <summary>
-	///     Further expectations on the headers of the <see cref="HttpContent" />.
+	///     Fluent entry point for asserting HTTP headers on a request or response.
 	/// </summary>
+	/// <typeparam name="TParameter">The concrete parameter type returned for further chaining.</typeparam>
 	public interface IHttpHeaderParameter<out TParameter>
 	{
 		/// <summary>
-		///     Expects the <see cref="HttpContent" /> to contain the given <paramref name="headers" />.
+		///     Expects the <see cref="HttpContent" /> to carry every header in <paramref name="headers" />.
 		/// </summary>
+		/// <param name="headers">Pairs of header name and expected value. Additional headers on the request are allowed.</param>
+		/// <returns>The outer parameter for chaining additional <c>.With*</c> constraints.</returns>
 		TParameter WithHeaders(params IEnumerable<(string Name, HttpHeaderValue Value)> headers);
 	}
 

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.WithString.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.WithString.cs
@@ -16,8 +16,15 @@ public static partial class ItExtensions
 	extension(IHttpContentParameter parameter)
 	{
 		/// <summary>
-		///     Expects the content to have a string body that contains the <paramref name="expected" /> value.
+		///     Expects the string body to contain <paramref name="expected" />.
 		/// </summary>
+		/// <param name="expected">The substring that must appear in the decoded body.</param>
+		/// <returns>A <see cref="IStringContentBodyParameter" /> for tightening to an exact match or ignoring case.</returns>
+		/// <remarks>
+		///     Matching is ordinal by default &#8212; chain <see cref="IStringContentBodyParameter.IgnoringCase" /> to
+		///     compare case-insensitively, or <see cref="IStringContentBodyParameter.Exactly" /> to require the whole
+		///     body to equal <paramref name="expected" /> rather than merely contain it.
+		/// </remarks>
 		public IStringContentBodyParameter WithString(string expected)
 		{
 			StringMatcher data = new(expected, true);
@@ -26,8 +33,15 @@ public static partial class ItExtensions
 		}
 
 		/// <summary>
-		///     Expects the content to have a string body that matches the given wildcard <paramref name="pattern" />.
+		///     Expects the string body to match the wildcard <paramref name="pattern" /> (<c>*</c> = any sequence,
+		///     <c>?</c> = any single character).
 		/// </summary>
+		/// <param name="pattern">The wildcard pattern to match against the decoded body.</param>
+		/// <returns>
+		///     A <see cref="IStringContentBodyMatchingParameter" /> that additionally supports
+		///     <see cref="IStringContentBodyMatchingParameter.AsRegex" /> to switch the pattern semantics to
+		///     <see cref="Regex" />.
+		/// </returns>
 		public IStringContentBodyMatchingParameter WithStringMatching(string pattern)
 		{
 			StringMatcher data = new(pattern, false);
@@ -37,31 +51,36 @@ public static partial class ItExtensions
 	}
 
 	/// <summary>
-	///     Further expectations on the matching of a body of the <see cref="StringContent" />.
+	///     Further expectations on a wildcard/regex body match.
 	/// </summary>
 	public interface IStringContentBodyMatchingParameter : IStringContentBodyParameter
 	{
 		/// <summary>
-		///     Expects the body match pattern to be a <see cref="Regex" />.
+		///     Interprets the previously supplied pattern as a <see cref="Regex" /> rather than a wildcard.
 		/// </summary>
+		/// <param name="options">Regex options to apply.</param>
+		/// <param name="timeout">Optional match timeout; <see langword="null" /> disables the timeout.</param>
+		/// <returns>The same parameter, for chaining additional body constraints.</returns>
 		IStringContentBodyParameter AsRegex(
 			RegexOptions options = RegexOptions.None,
 			TimeSpan? timeout = null);
 	}
 
 	/// <summary>
-	///     Further expectations on the body of the <see cref="StringContent" />.
+	///     Further expectations on a string body match.
 	/// </summary>
 	public interface IStringContentBodyParameter : IHttpContentParameter
 	{
 		/// <summary>
-		///     Ignores case when matching the body.
+		///     Performs the match case-insensitively.
 		/// </summary>
+		/// <returns>The same parameter, for chaining.</returns>
 		IStringContentBodyParameter IgnoringCase();
 
 		/// <summary>
-		///     Requires the body to completely match the given string.
+		///     Requires the decoded body to equal the previously supplied string exactly, not just contain it.
 		/// </summary>
+		/// <returns>The same parameter, for chaining.</returns>
 		IStringContentBodyParameter Exactly();
 	}
 

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.cs
@@ -16,14 +16,39 @@ public static partial class ItExtensions
 	extension(It _)
 	{
 		/// <summary>
-		///     Expects the parameter to be an <see cref="HttpContent" />.
+		///     Matches any non-<see langword="null" /> <see cref="HttpContent" /> on a mocked
+		///     <see cref="System.Net.Http.HttpClient" /> setup or verification.
 		/// </summary>
+		/// <remarks>
+		///     Narrow the match by chaining builders on the returned <see cref="IHttpContentParameter" />:
+		///     <list type="bullet">
+		///       <item><description><c>.WithString(predicate)</c> - match the request body as a string (UTF-8 unless the <c>Content-Type</c> header specifies a charset).</description></item>
+		///       <item><description><c>.WithBytes(predicate)</c> - match the raw byte payload.</description></item>
+		///       <item><description><c>.WithMediaType(mediaType)</c> - constrain the <c>Content-Type</c> media type.</description></item>
+		///       <item><description><c>.WithHeaders(...)</c> - require specific content headers; chain <c>.IncludingRequestHeaders()</c> to also consider <see cref="HttpRequestMessage.Headers" />.</description></item>
+		///     </list>
+		///     A <see langword="null" /> body never matches.
+		/// </remarks>
+		/// <returns>A fluent matcher; pass it to <c>Setup.PostAsync</c>/<c>PutAsync</c>/<c>PatchAsync</c> or <c>Verify</c>.</returns>
+		/// <example>
+		///     <code>
+		///     httpClient.Mock.Setup.PostAsync(It.IsUri("*/orders"), It.IsHttpContent("application/json").WithString(b =&gt; b.Contains("\"sku\"")))
+		///         .ReturnsAsync(HttpStatusCode.Created);
+		///     </code>
+		/// </example>
 		public static IHttpContentParameter IsHttpContent()
 			=> new HttpContentParameter();
 
 		/// <summary>
-		///     Expects the parameter to be an <see cref="HttpContent" /> with the given <paramref name="mediaType" />.
+		///     Matches any non-<see langword="null" /> <see cref="HttpContent" /> whose <c>Content-Type</c> media type
+		///     equals <paramref name="mediaType" /> (case-insensitive).
 		/// </summary>
+		/// <param name="mediaType">The expected media type, e.g. <c>"application/json"</c> or <c>"text/plain"</c>.</param>
+		/// <remarks>
+		///     Shorthand for <c>It.IsHttpContent().WithMediaType(mediaType)</c>. Chain additional builders
+		///     (<c>.WithString(...)</c>, <c>.WithBytes(...)</c>, <c>.WithHeaders(...)</c>) to further narrow the match.
+		/// </remarks>
+		/// <returns>A fluent matcher pre-configured to require the given media type.</returns>
 		public static IHttpContentParameter IsHttpContent(string mediaType)
 			=> new HttpContentParameter().WithMediaType(mediaType);
 	}

--- a/Source/Mockolate/Web/ItExtensions.HttpContent.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpContent.cs
@@ -30,12 +30,6 @@ public static partial class ItExtensions
 		///     A <see langword="null" /> body never matches.
 		/// </remarks>
 		/// <returns>A fluent matcher; pass it to <c>Setup.PostAsync</c>/<c>PutAsync</c>/<c>PatchAsync</c> or <c>Verify</c>.</returns>
-		/// <example>
-		///     <code>
-		///     httpClient.Mock.Setup.PostAsync(It.IsUri("*/orders"), It.IsHttpContent("application/json").WithString(b =&gt; b.Contains("\"sku\"")))
-		///         .ReturnsAsync(HttpStatusCode.Created);
-		///     </code>
-		/// </example>
 		public static IHttpContentParameter IsHttpContent()
 			=> new HttpContentParameter();
 

--- a/Source/Mockolate/Web/ItExtensions.HttpRequestMessage.cs
+++ b/Source/Mockolate/Web/ItExtensions.HttpRequestMessage.cs
@@ -13,8 +13,22 @@ public static partial class ItExtensions
 	extension(It _)
 	{
 		/// <summary>
-		///     Expects the parameter to be a <see cref="HttpRequestMessage" />.
+		///     Matches any <see cref="HttpRequestMessage" />, optionally restricted to a specific HTTP
+		///     <paramref name="method" /> (<c>GET</c>, <c>POST</c>, ...).
 		/// </summary>
+		/// <param name="method">When non-<see langword="null" />, only requests with this <see cref="HttpMethod" /> match.</param>
+		/// <remarks>
+		///     Use this when you need to match on the whole request rather than individual parts. Chain builders on the
+		///     returned <see cref="IHttpRequestMessageParameter" /> to add constraints:
+		///     <list type="bullet">
+		///       <item><description><c>.WhoseUriIs(uri)</c> / <c>.WhoseUriIs(configure)</c> - constrain the request URI (same surface as <c>It.IsUri(...)</c>).</description></item>
+		///       <item><description><c>.WhoseContentIs(configure)</c> / <c>.WhoseContentIs(mediaType, configure)</c> - constrain the request body (same surface as <c>It.IsHttpContent(...)</c>).</description></item>
+		///       <item><description><c>.WithHeaders(...)</c> - require specific request headers.</description></item>
+		///     </list>
+		///     For the common verbs prefer <c>Setup.GetAsync</c>/<c>PostAsync</c>/... which internally use this matcher;
+		///     reach for <c>It.IsHttpRequestMessage(...)</c> when composing a <c>SendAsync</c>-level setup.
+		/// </remarks>
+		/// <returns>A fluent matcher for <see cref="HttpRequestMessage" /> parameters.</returns>
 		public static IHttpRequestMessageParameter IsHttpRequestMessage(HttpMethod? method = null)
 			=> new HttpRequestMessageParameter(method);
 	}

--- a/Source/Mockolate/Web/ItExtensions.Uri.cs
+++ b/Source/Mockolate/Web/ItExtensions.Uri.cs
@@ -40,54 +40,73 @@ public static partial class ItExtensions
 	}
 
 	/// <summary>
-	///     Allows adding additional constraints to a <see cref="Uri" /> parameter matcher.
+	///     Additional constraints chained off <see cref="IsUri(string?)" /> to narrow a <see cref="Uri" /> match.
 	/// </summary>
+	/// <remarks>
+	///     Every <c>.With*</c>/<c>.For*</c> returns the same instance so constraints can be combined; every one of
+	///     them must hold for the URI to match.
+	/// </remarks>
 	public interface IUriParameter : IParameterWithCallback<Uri?>
 	{
 		/// <summary>
-		///     Expects the <see cref="Uri.Scheme" /> to be "http".
+		///     Requires <see cref="Uri.Scheme" /> to be <c>http</c> (case-insensitive).
 		/// </summary>
+		/// <returns>The same parameter, for chaining.</returns>
 		IUriParameter ForHttp();
 
 		/// <summary>
-		///     Expects the <see cref="Uri.Scheme" /> to be "https".
+		///     Requires <see cref="Uri.Scheme" /> to be <c>https</c> (case-insensitive).
 		/// </summary>
+		/// <returns>The same parameter, for chaining.</returns>
 		IUriParameter ForHttps();
 
 		/// <summary>
-		///     Expects the <see cref="Uri.Host" /> to match the given <paramref name="hostPattern" /> supporting wildcards.
+		///     Requires <see cref="Uri.Host" /> to match <paramref name="hostPattern" /> (<c>*</c> = any sequence,
+		///     <c>?</c> = one character; case-insensitive).
 		/// </summary>
+		/// <param name="hostPattern">Wildcard pattern for the host part.</param>
+		/// <returns>The same parameter, for chaining.</returns>
 		IUriParameter WithHost(string hostPattern);
 
 		/// <summary>
-		///     Expects the <see cref="Uri.Port" /> to be equal to the given <paramref name="port" />.
+		///     Requires <see cref="Uri.Port" /> to equal <paramref name="port" />.
 		/// </summary>
+		/// <param name="port">Expected port number (as exposed by <see cref="Uri.Port" />, so the default port for the scheme is <c>80</c>/<c>443</c>).</param>
+		/// <returns>The same parameter, for chaining.</returns>
 		IUriParameter WithPort(int port);
 
 		/// <summary>
-		///     Expects the <see cref="Uri.AbsolutePath" /> to match the given <paramref name="pathPattern" /> supporting
-		///     wildcards.
+		///     Requires <see cref="Uri.AbsolutePath" /> to match <paramref name="pathPattern" /> after URL-decoding
+		///     (<c>*</c> = any sequence, <c>?</c> = one character; case-insensitive).
 		/// </summary>
+		/// <param name="pathPattern">Wildcard pattern for the absolute path (e.g. <c>"/api/users/*"</c>).</param>
+		/// <returns>The same parameter, for chaining.</returns>
 		IUriParameter WithPath(string pathPattern);
 
 		/// <summary>
-		///     Expects the <see cref="Uri.Query" /> to contain the parameters in the <paramref name="queryString" />.
+		///     Requires <see cref="Uri.Query" /> to contain every parameter parsed from <paramref name="queryString" />.
 		/// </summary>
+		/// <param name="queryString">Raw query string &#8212; pairs separated by <c>&amp;</c>, keys and values by <c>=</c>. A leading <c>?</c> is tolerated.</param>
+		/// <returns>The same parameter, for chaining.</returns>
 		/// <remarks>
-		///     Expect parameters to be separated by '&amp;' and the key-value pairs of the parameters to be separated by '='.
-		///     The order of the parameters is ignored.
+		///     The order of parameters is ignored, values are URL-decoded, and additional parameters on the URI are allowed.
 		/// </remarks>
 		IUriParameter WithQuery(string queryString);
 
 		/// <summary>
-		///     Expects the <see cref="Uri.Query" /> to contain the given <paramref name="key" />-<paramref name="value" />
-		///     pair.
+		///     Requires <see cref="Uri.Query" /> to contain a parameter <paramref name="key" />=<paramref name="value" />.
 		/// </summary>
+		/// <param name="key">The query parameter name that must be present.</param>
+		/// <param name="value">The expected value. Implicitly converts from <see langword="string" />; use the <see cref="HttpQueryParameterValue" /> helpers for patterns or predicates.</param>
+		/// <returns>The same parameter, for chaining.</returns>
 		IUriParameter WithQuery(string key, HttpQueryParameterValue value);
 
 		/// <summary>
-		///     Expects the <see cref="Uri.Query" /> to contain the given query <paramref name="parameters" />.
+		///     Requires <see cref="Uri.Query" /> to contain every given <paramref name="parameters" /> pair
+		///     (additional query parameters on the URI are allowed).
 		/// </summary>
+		/// <param name="parameters">Expected key/value pairs; the order is ignored.</param>
+		/// <returns>The same parameter, for chaining.</returns>
 		IUriParameter WithQuery(params IEnumerable<(string Key, HttpQueryParameterValue Value)> parameters);
 	}
 

--- a/Source/Mockolate/Web/ItExtensions.Uri.cs
+++ b/Source/Mockolate/Web/ItExtensions.Uri.cs
@@ -35,11 +35,6 @@ public static partial class ItExtensions
 		///     </list>
 		/// </remarks>
 		/// <returns>A fluent <see cref="Uri" /> matcher; pass it to <c>Setup.GetAsync</c>/<c>PostAsync</c>/... or <c>Verify</c>.</returns>
-		/// <example>
-		///     <code>
-		///     httpClient.Mock.Verify.GetAsync(It.IsUri("https://api.example.com/*").WithQuery("page", "1")).AtLeastOnce();
-		///     </code>
-		/// </example>
 		public static IUriParameter IsUri(string? pattern = null)
 			=> new UriParameter(pattern);
 	}

--- a/Source/Mockolate/Web/ItExtensions.Uri.cs
+++ b/Source/Mockolate/Web/ItExtensions.Uri.cs
@@ -17,8 +17,29 @@ public static partial class ItExtensions
 	extension(It _)
 	{
 		/// <summary>
-		///     Expects the <see cref="Uri" /> parameter to match the given <paramref name="pattern" />.
+		///     Matches a <see cref="Uri" /> (or <see langword="string" /> URI) against an optional glob
+		///     <paramref name="pattern" /> - pass <see langword="null" /> to accept any URI and narrow it further
+		///     with fluent builders on the returned <see cref="IUriParameter" />.
 		/// </summary>
+		/// <param name="pattern">
+		///     Glob pattern matched against <see cref="Uri.ToString" /> (<c>*</c> matches any sequence, <c>?</c>
+		///     matches one character). A trailing <c>/</c> on the request URI is tolerated when the pattern omits
+		///     it. Pass <see langword="null" /> to skip the pattern check and only rely on the fluent constraints.
+		/// </param>
+		/// <remarks>
+		///     Chain additional constraints on the returned matcher:
+		///     <list type="bullet">
+		///       <item><description><c>.ForHttp()</c> / <c>.ForHttps()</c> - require the scheme.</description></item>
+		///       <item><description><c>.WithHost(hostPattern)</c> / <c>.WithPort(port)</c> / <c>.WithPath(pathPattern)</c> - constrain individual URI components (host and path accept wildcards; path is URL-decoded before matching).</description></item>
+		///       <item><description><c>.WithQuery(key, value)</c> / <c>.WithQuery(queryString)</c> / <c>.WithQuery(parameters)</c> - require query parameters to be present; the order is ignored, values are URL-decoded.</description></item>
+		///     </list>
+		/// </remarks>
+		/// <returns>A fluent <see cref="Uri" /> matcher; pass it to <c>Setup.GetAsync</c>/<c>PostAsync</c>/... or <c>Verify</c>.</returns>
+		/// <example>
+		///     <code>
+		///     httpClient.Mock.Verify.GetAsync(It.IsUri("https://api.example.com/*").WithQuery("page", "1")).AtLeastOnce();
+		///     </code>
+		/// </example>
 		public static IUriParameter IsUri(string? pattern = null)
 			=> new UriParameter(pattern);
 	}

--- a/Source/Mockolate/Web/ItExtensions.cs
+++ b/Source/Mockolate/Web/ItExtensions.cs
@@ -9,8 +9,20 @@ using Mockolate.Internals.Polyfills;
 namespace Mockolate.Web;
 
 /// <summary>
-///     Extensions for parameter matchers for HTTP-related types.
+///     HTTP-aware parameter matchers for <see cref="It" /> - match against <see cref="Uri" />,
+///     <see cref="System.Net.Http.HttpRequestMessage" /> and <see cref="System.Net.Http.HttpContent" /> values
+///     when setting up or verifying a mocked <see cref="System.Net.Http.HttpClient" />.
 /// </summary>
+/// <remarks>
+///     Used alongside <see cref="HttpClientExtensions" />. Entry-point matchers:
+///     <list type="bullet">
+///       <item><description><c>It.IsUri(...)</c> - match the request URI by exact string, glob pattern or predicate, optionally asserting required query parameters.</description></item>
+///       <item><description><c>It.IsHttpRequestMessage(...)</c> - match the raw <see cref="System.Net.Http.HttpRequestMessage" />; chain <c>.WithHeaders(...)</c> to constrain headers.</description></item>
+///       <item><description><c>It.IsHttpContent(...)</c> - match the request body; chain <c>.WithString(...)</c>, <c>.WithBytes(...)</c>, <c>.WithFormData(...)</c> or <c>.WithHeaders(...)</c> to constrain by payload shape.</description></item>
+///     </list>
+///     Query-parameter matching is URL-decoded, and a trailing <c>/</c> on the request URI is tolerated when
+///     comparing against a matcher without it.
+/// </remarks>
 public static partial class ItExtensions
 {
 	private sealed class HttpQueryMatcher

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Net.Http;
+﻿using System.Linq;
+using System.Net.Http;
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
 
 namespace Mockolate.SourceGenerators.Tests;
 
@@ -1140,6 +1142,76 @@ public partial class MockGeneratorTests
 		await That(result.Diagnostics).IsEmpty();
 		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
 			.Contains("CreateMock(long big = 9999999999, double pi = 3.14)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenTypedCreateMockOverloadIsEmitted_ConstructorCrefShouldResolve()
+	{
+		const string expectedCref = "global::MyCode.MyService.MyService(int, string)";
+
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock(42, "x");
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(int value, string text) { }
+			     }
+			     """, DocumentationMode.Diagnose);
+
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains($"to invoke the <see cref=\"{expectedCref}\" /> constructor.")
+			.IgnoringNewlineStyle();
+
+		// CS1574/CS1584/CS1658 messages embed the offending cref text; if the constructor cref
+		// resolved cleanly under DocumentationMode.Diagnose, no diagnostic mentions it.
+		string[] crefFailures = result.Diagnostics
+			.Where(d => d.Contains(expectedCref))
+			.ToArray();
+		await That(crefFailures).IsEmpty();
+	}
+
+	[Fact]
+	public async Task WhenTypedCreateMockOverloadIsEmittedForGenericClass_ShouldNotEmitConstructorCref()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService<int>.CreateMock(42);
+			         }
+			     }
+
+			     public class MyService<T>
+			     {
+			         public MyService(T value) { }
+			     }
+			     """, DocumentationMode.Diagnose);
+
+		// Closed-generic constructor crefs (e.g. MyService{int}.MyService(int)) aren't valid C#
+		// cref syntax, so the generator falls back to the unlinked phrasing for generic classes
+		// rather than emit something that would surface CS1584 on the consumer side.
+		await That(result.Sources).ContainsKey("Mock.MyService_int.g.cs").WhoseValue
+			.Contains("to invoke the base-class constructor.")
+			.IgnoringNewlineStyle().And
+			.DoesNotContain("MyService.MyService(")
 			.IgnoringNewlineStyle();
 	}
 

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -78,5 +78,66 @@ public sealed partial class MockTests
 				.Contains("Raise the <see cref=\"global::MyCode.IMyBaseService.BaseEvent\"/> event.").And
 				.Contains("Verify subscriptions on the BaseEvent event of <see cref=\"global::MyCode.IMyBaseService.BaseEvent\" />.");
 		}
+
+		[Fact]
+		public async Task PlainInterface_ShouldOmitConditionalRemarkBullets()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = IPlain.CreateMock();
+				         }
+				     }
+
+				     public interface IPlain
+				     {
+				         int GetValue();
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.IPlain.g.cs").WhoseValue
+				.DoesNotContain("<c>Raise</c> - trigger events declared on the mocked type.").And
+				.DoesNotContain("<c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c>").And
+				.DoesNotContain("<c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c>").And
+				.DoesNotContain("<c>.Mock.Raise</c> triggers events declared on the mocked type.");
+		}
+
+		[Fact]
+		public async Task InterfaceWithEvents_ShouldIncludeRaiseRemarkBullet()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = IHasEvent.CreateMock();
+				         }
+				     }
+
+				     public interface IHasEvent
+				     {
+				         event EventHandler Changed;
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.IHasEvent.g.cs").WhoseValue
+				.Contains("<c>Raise</c> - trigger events declared on the mocked type.").And
+				.Contains("<c>.Mock.Raise</c> triggers events declared on the mocked type.").And
+				.DoesNotContain("<c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c>").And
+				.DoesNotContain("<c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c>");
+		}
 	}
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/Generator.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/Generator.cs
@@ -46,9 +46,13 @@ public static class Generator
 	];
 
 	public static GeneratorResult Run([StringSyntax("c#-test")] string source, params Type[] assemblyTypes)
+		=> Run(source, DocumentationMode.Parse, assemblyTypes);
+
+	public static GeneratorResult Run([StringSyntax("c#-test")] string source,
+		DocumentationMode documentationMode, params Type[] assemblyTypes)
 	{
 		MockGenerator generator = new();
-		CSharpParseOptions parseOptions = new(LanguageVersion.Latest);
+		CSharpParseOptions parseOptions = new(LanguageVersion.Latest, documentationMode);
 		SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
 
 		CSharpCompilation compilation = CSharpCompilation.Create(
@@ -57,7 +61,11 @@ public static class Generator
 			GetReferences(assemblyTypes),
 			new CSharpCompilationOptions(OutputKind.ConsoleApplication));
 
-		GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+		GeneratorDriver driver = CSharpGeneratorDriver.Create(
+			generators: [generator.AsSourceGenerator(),],
+			additionalTexts: [],
+			parseOptions: parseOptions,
+			optionsProvider: null);
 		driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation,
 			out ImmutableArray<Diagnostic> diagnostics);
 

--- a/Tests/Mockolate.Tests/OverlappingSetupsTests.cs
+++ b/Tests/Mockolate.Tests/OverlappingSetupsTests.cs
@@ -1,0 +1,79 @@
+using Mockolate.Tests.MockIndexers;
+using Mockolate.Tests.MockMethods;
+using Mockolate.Tests.MockProperties;
+
+namespace Mockolate.Tests;
+
+public sealed class OverlappingSetupsTests
+{
+	[Fact]
+	public async Task Method_MostRecentlyDefinedSetup_ShouldWin_WhenMatchersOverlap()
+	{
+		SetupMethodTests.IMethodService sut = SetupMethodTests.IMethodService.CreateMock();
+
+		sut.Mock.Setup.MyIntMethodWithParameters(It.Is(0), It.Is("foo")).Returns(1);
+		sut.Mock.Setup.MyIntMethodWithParameters(It.Is(0), It.Is("foo")).Returns(2);
+		sut.Mock.Setup.MyIntMethodWithParameters(It.Is(0), It.Is("foo")).Returns(3);
+
+		int result = sut.MyIntMethodWithParameters(0, "foo");
+
+		await That(result).IsEqualTo(3);
+	}
+
+	[Fact]
+	public async Task Method_NarrowMatcherDefinedLater_ShouldWinForMatchingArguments()
+	{
+		SetupMethodTests.IMethodService sut = SetupMethodTests.IMethodService.CreateMock();
+
+		sut.Mock.Setup.MyIntMethodWithParameters(It.IsAny<int>(), It.IsAny<string>()).Returns(1);
+		sut.Mock.Setup.MyIntMethodWithParameters(It.Is(0), It.Is("foo")).Returns(2);
+
+		int matching = sut.MyIntMethodWithParameters(0, "foo");
+		int nonMatching = sut.MyIntMethodWithParameters(1, "bar");
+
+		await That(matching).IsEqualTo(2);
+		await That(nonMatching).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task Method_BroadMatcherDefinedLater_ShouldWinEvenForArgumentsTheNarrowMatcherCovered()
+	{
+		SetupMethodTests.IMethodService sut = SetupMethodTests.IMethodService.CreateMock();
+
+		sut.Mock.Setup.MyIntMethodWithParameters(It.Is(0), It.Is("foo")).Returns(2);
+		sut.Mock.Setup.MyIntMethodWithParameters(It.IsAny<int>(), It.IsAny<string>()).Returns(1);
+
+		int previouslyNarrowMatch = sut.MyIntMethodWithParameters(0, "foo");
+
+		await That(previouslyNarrowMatch).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task Property_LaterReturnsCall_ShouldReplacePreviousSetup()
+	{
+		SetupPropertyTests.IPropertyService sut = SetupPropertyTests.IPropertyService.CreateMock();
+
+		sut.Mock.Setup.MyProperty.Returns(1);
+		sut.Mock.Setup.MyProperty.Returns(2);
+		sut.Mock.Setup.MyProperty.Returns(3);
+
+		int result = sut.MyProperty;
+
+		await That(result).IsEqualTo(3);
+	}
+
+	[Fact]
+	public async Task Indexer_NarrowMatcherDefinedLater_ShouldWinForMatchingArguments()
+	{
+		SetupIndexerTests.IIndexerService sut = SetupIndexerTests.IIndexerService.CreateMock();
+
+		sut.Mock.Setup[It.IsAny<int>()].InitializeWith("foo");
+		sut.Mock.Setup[It.Is(2)].InitializeWith("bar");
+
+		string matching = sut[2];
+		string nonMatching = sut[1];
+
+		await That(matching).IsEqualTo("bar");
+		await That(nonMatching).IsEqualTo("foo");
+	}
+}


### PR DESCRIPTION
This PR improves the XML documentation generated and exposed by Mockolate’s fluent setup/verify APIs, and adds source-generator tests to ensure conditional documentation content is emitted/omitted correctly.

**Changes:**
- Expanded XML docs across setup interfaces and matcher helpers (remarks, examples, clearer semantics).
- Enhanced source generator XML-doc helpers (multi-line `<remarks>`, `<example>`, `<exception>`, and safe XML text escaping) and updated generated mock accessor docs accordingly.
- Added generator tests ensuring conditional remark bullets (e.g., “Raise”) are included only when applicable.