### PR TITLE
feat!: update CreateMock overloads to accept typed constructor arguments

### DIFF
--- a/Docs/pages/01-create-mocks.md
+++ b/Docs/pages/01-create-mocks.md
@@ -11,7 +11,7 @@ IChocolateDispenser sut = IChocolateDispenser.CreateMock();
 MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock();
 
 // For classes without a default constructor:
-MyChocolateDispenserWithCtor classWithArgsMock = MyChocolateDispenserWithCtor.CreateMock(["Dark", 42]);
+MyChocolateDispenserWithCtor classWithArgsMock = MyChocolateDispenserWithCtor.CreateMock("Dark", 42);
 ```
 
 ## Customizing mock behavior
@@ -23,7 +23,7 @@ IChocolateDispenser strictMock = IChocolateDispenser.CreateMock(MockBehavior.Def
 
 // For classes with constructor parameters and custom behavior:
 MockBehavior behavior = new MockBehavior { ThrowWhenNotSetup = true };
-MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock(["Dark", 42], behavior);
+MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock(behavior, "Dark", 42);
 ```
 
 **`MockBehavior` options**

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ IChocolateDispenser sut = IChocolateDispenser.CreateMock();
 MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock();
 
 // For classes without a default constructor:
-MyChocolateDispenserWithCtor classWithArgsMock = MyChocolateDispenserWithCtor.CreateMock(["Dark", 42]);
+MyChocolateDispenserWithCtor classWithArgsMock = MyChocolateDispenserWithCtor.CreateMock("Dark", 42);
 ```
 
 ### Customizing mock behavior
@@ -102,7 +102,7 @@ IChocolateDispenser strictMock = IChocolateDispenser.CreateMock(MockBehavior.Def
 
 // For classes with constructor parameters and custom behavior:
 MockBehavior behavior = new MockBehavior { ThrowWhenNotSetup = true };
-MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock(["Dark", 42], behavior);
+MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock(behavior, "Dark", 42);
 ```
 
 **`MockBehavior` options**

--- a/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
@@ -31,9 +31,31 @@ internal readonly record struct MethodParameter
 			}
 			else
 			{
-				ExplicitDefaultValue = explicitDefaultValue;
+				ExplicitDefaultValue = AppendLiteralSuffix(explicitDefaultValue, parameterSymbol.Type);
 			}
 		}
+	}
+
+	// SymbolDisplay.FormatPrimitive strips the 'm'/'f' type suffix from the literal, which would
+	// produce invalid C# (e.g. "decimal x = 19.95" is a narrowing conversion from double). Re-add
+	// the suffix based on the effective parameter type so the generated code compiles.
+	private static string? AppendLiteralSuffix(string? value, ITypeSymbol type)
+	{
+		if (value is null or "null")
+		{
+			return value;
+		}
+
+		ITypeSymbol effectiveType = type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T, } named
+			? named.TypeArguments[0]
+			: type;
+
+		return effectiveType.SpecialType switch
+		{
+			SpecialType.System_Decimal => value + "m",
+			SpecialType.System_Single => value + "f",
+			_ => value,
+		};
 	}
 
 	public string? ExplicitDefaultValue { get; }

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
@@ -71,8 +71,8 @@ internal static partial class Sources
 		              		///     <typeparamref name="T" /> is not mockable. Calling it always throws a <see cref="global::Mockolate.Exceptions.MockException" />.
 		              		/// </summary>
 		              		/// <typeparam name="T">Type to mock, which can be an interface or a class.</typeparam>
-		              		/// <param name="constructorParameters">Ignored; reserved for the generator-emitted overload.</param>
 		              		/// <param name="mockBehavior">Ignored; reserved for the generator-emitted overload.</param>
+		              		/// <param name="constructorParameters">Ignored; reserved for the generator-emitted overload.</param>
 		              		/// <returns>This method never returns - it always throws.</returns>
 		              		/// <remarks>
 		              		///     The source generator emits a concrete <c>CreateMock</c> overload per mockable type with the same shape.
@@ -80,7 +80,25 @@ internal static partial class Sources
 		              		///     run a clean build (for example <c>dotnet clean &amp;&amp; dotnet build</c>) and verify that the type is mockable.
 		              		/// </remarks>
 		              		/// <exception cref="global::Mockolate.Exceptions.MockException">Always thrown: the source generator did not run or <typeparamref name="T" /> is not mockable.</exception>
-		              		public static global::Mockolate.Mock.IMockGenerationDidNotRun CreateMock(object?[]? constructorParameters, global::Mockolate.MockBehavior? mockBehavior = null)
+		              		public static global::Mockolate.Mock.IMockGenerationDidNotRun CreateMock(global::Mockolate.MockBehavior? mockBehavior, object?[]? constructorParameters)
+		              		{
+		              			throw new global::Mockolate.Exceptions.MockException($"This method should not be called directly. Either '{typeof(T)}' is not mockable or the source generator did not run correctly.");
+		              		}
+
+		              		/// <summary>
+		              		///     Fallback <c>CreateMock</c> that is only resolved when the Mockolate source generator did not run or when
+		              		///     <typeparamref name="T" /> is not mockable. Calling it always throws a <see cref="global::Mockolate.Exceptions.MockException" />.
+		              		/// </summary>
+		              		/// <typeparam name="T">Type to mock, which can be an interface or a class.</typeparam>
+		              		/// <param name="constructorParameters">Ignored; reserved for the generator-emitted overload.</param>
+		              		/// <returns>This method never returns - it always throws.</returns>
+		              		/// <remarks>
+		              		///     The source generator emits a concrete <c>CreateMock</c> overload per mockable type with the same shape.
+		              		///     If you see this fallback resolved in your IDE, the generator did not run for <typeparamref name="T" />;
+		              		///     run a clean build (for example <c>dotnet clean &amp;&amp; dotnet build</c>) and verify that the type is mockable.
+		              		/// </remarks>
+		              		/// <exception cref="global::Mockolate.Exceptions.MockException">Always thrown: the source generator did not run or <typeparamref name="T" /> is not mockable.</exception>
+		              		public static global::Mockolate.Mock.IMockGenerationDidNotRun CreateMock(object?[]? constructorParameters)
 		              		{
 		              			throw new global::Mockolate.Exceptions.MockException($"This method should not be called directly. Either '{typeof(T)}' is not mockable or the source generator did not run correctly.");
 		              		}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1230,6 +1230,9 @@ internal static partial class Sources
 			return;
 		}
 
+		// Seeded signatures track the hand-written CreateMock overloads so typed overloads that
+		// would collide with them are skipped. The key order mirrors the emitted C# signature:
+		// "mockBehavior? | setup? | ctor-param-types...".
 		HashSet<string> emittedSignatures = new(StringComparer.Ordinal)
 		{
 			string.Empty,
@@ -1237,9 +1240,9 @@ internal static partial class Sources
 			$"global::System.Action<{setupType}>",
 			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>",
 			"object?[]",
-			"object?[]|global::Mockolate.MockBehavior",
-			$"object?[]|global::System.Action<{setupType}>",
-			$"object?[]|global::Mockolate.MockBehavior|global::System.Action<{setupType}>",
+			"global::Mockolate.MockBehavior|object?[]",
+			$"global::System.Action<{setupType}>|object?[]",
+			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>|object?[]",
 		};
 
 		foreach (Method constructor in constructors.Value)
@@ -1280,15 +1283,18 @@ internal static partial class Sources
 		bool includeMockBehavior, bool includeSetup, string mockBehaviorName, string setupName, string baseSig,
 		HashSet<string> emittedSignatures)
 	{
+		// Build the signature key in the same order as the emitted method signature
+		// (mockBehavior, setup, then ctor parameters) so it correctly detects collisions against
+		// other typed overloads and against the hand-written seeded overloads.
 		string sig = baseSig;
-		if (includeMockBehavior)
-		{
-			sig += "|global::Mockolate.MockBehavior";
-		}
-
 		if (includeSetup)
 		{
-			sig += $"|global::System.Action<{setupType}>";
+			sig = $"global::System.Action<{setupType}>|{sig}";
+		}
+
+		if (includeMockBehavior)
+		{
+			sig = $"global::Mockolate.MockBehavior|{sig}";
 		}
 
 		if (!emittedSignatures.Add(sig))

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -84,7 +84,7 @@ internal static partial class Sources
 			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock()").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(null, null, null);").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(null, null, (object?[]?)null);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
@@ -94,7 +94,7 @@ internal static partial class Sources
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::System.Action<")
 			.Append(setupType).Append("> setup)").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(null, null, setup);").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(null, setup, (object?[]?)null);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
@@ -103,7 +103,7 @@ internal static partial class Sources
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior)").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(null, mockBehavior, null);").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(mockBehavior, null, (object?[]?)null);").AppendLine();
 		sb.AppendLine();
 
 		sb.AppendXmlSummary(
@@ -115,7 +115,7 @@ internal static partial class Sources
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<").Append(setupType)
 			.Append("> setup)").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(null, mockBehavior, setup);").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(mockBehavior, setup, (object?[]?)null);").AppendLine();
 		sb.AppendLine();
 
 		if (!@class.IsInterface)
@@ -126,45 +126,46 @@ internal static partial class Sources
 			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 				.Append(" CreateMock(object?[] constructorParameters)").AppendLine();
-			sb.Append("\t\t\t=> CreateMock(constructorParameters, null, null);").AppendLine();
+			sb.Append("\t\t\t=> CreateMock(null, null, constructorParameters);").AppendLine();
 			sb.AppendLine();
 
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> and <paramref name=\"mockBehavior\" />.");
-			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" /> and <paramref name=\"constructorParameters\" />.");
 			sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
-				.Append(" CreateMock(object?[] constructorParameters, global::Mockolate.MockBehavior mockBehavior)")
+				.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)")
 				.AppendLine();
-			sb.Append("\t\t\t=> CreateMock(constructorParameters, mockBehavior, null);").AppendLine();
+			sb.Append("\t\t\t=> CreateMock(mockBehavior, null, constructorParameters);").AppendLine();
 			sb.AppendLine();
 
 			sb.AppendXmlSummary(
-				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" />, applying the given <paramref name=\"setup\" /> immediately.");
+				$"Create a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
 			sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
-				.Append(" CreateMock(object?[] constructorParameters, global::System.Action<").Append(setupType)
-				.Append("> setup)").AppendLine();
-			sb.Append("\t\t\t=> CreateMock(constructorParameters, null, setup);").AppendLine();
+				.Append(" CreateMock(global::System.Action<").Append(setupType)
+				.Append("> setup, object?[] constructorParameters)").AppendLine();
+			sb.Append("\t\t\t=> CreateMock(null, setup, constructorParameters);").AppendLine();
 			sb.AppendLine();
+
+			AppendTypedCreateMockOverloads(sb, @class, constructors, setupType, escapedClassName, createMockReturns);
 		}
 
 		sb.AppendXmlSummary(
-			$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> and <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+			$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
 		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
 		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <see cref=\"global::Mockolate.MockBehavior.Default\" />.");
 		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
+		sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\t").Append(@class.IsInterface ? "private" : "public").Append(" static ")
 			.Append(@class.ClassFullName)
-			.Append(
-				" CreateMock(object?[]? constructorParameters, global::Mockolate.MockBehavior? mockBehavior, global::System.Action<")
-			.Append(setupType).Append(">? setup)").AppendLine();
+			.Append(" CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<")
+			.Append(setupType).Append(">? setup, object?[]? constructorParameters)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tif (mockBehavior is not null)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
@@ -1217,6 +1218,164 @@ internal static partial class Sources
 			.Append(mockRegistryName).Append(".Interactions, interactions => new VerifyMonitor").Append(name)
 			.Append("(new global::Mockolate.MockRegistry(this.").Append(mockRegistryName).Append(", interactions)));")
 			.AppendLine();
+		sb.AppendLine();
+	}
+#pragma warning restore S107 // Methods should not have too many parameters
+
+	private static void AppendTypedCreateMockOverloads(StringBuilder sb, Class @class,
+		EquatableArray<Method>? constructors, string setupType, string escapedClassName, string createMockReturns)
+	{
+		if (constructors is null)
+		{
+			return;
+		}
+
+		HashSet<string> emittedSignatures = new(StringComparer.Ordinal)
+		{
+			string.Empty,
+			"global::Mockolate.MockBehavior",
+			$"global::System.Action<{setupType}>",
+			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>",
+			"object?[]",
+			"object?[]|global::Mockolate.MockBehavior",
+			$"object?[]|global::System.Action<{setupType}>",
+			$"object?[]|global::Mockolate.MockBehavior|global::System.Action<{setupType}>",
+		};
+
+		foreach (Method constructor in constructors.Value)
+		{
+			if (constructor.Parameters.Count == 0)
+			{
+				continue;
+			}
+
+			if (constructor.Parameters.Any(p => p.RefKind != RefKind.None || p.IsParams))
+			{
+				continue;
+			}
+
+			string mockBehaviorName = CreateUniqueParameterName(constructor.Parameters, "mockBehavior");
+			string setupName = CreateUniqueParameterName(constructor.Parameters, "setup");
+			string baseSig = string.Join("|",
+				constructor.Parameters.Select(p => p.Type.Fullname));
+
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				includeMockBehavior: false, includeSetup: false, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				includeMockBehavior: true, includeSetup: false, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				includeMockBehavior: false, includeSetup: true, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				includeMockBehavior: true, includeSetup: true, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+		}
+	}
+
+#pragma warning disable S107 // Methods should not have too many parameters
+	private static void TryEmitTypedCreateMockOverload(StringBuilder sb, Class @class, Method constructor,
+		string setupType, string escapedClassName, string createMockReturns,
+		bool includeMockBehavior, bool includeSetup, string mockBehaviorName, string setupName, string baseSig,
+		HashSet<string> emittedSignatures)
+	{
+		string sig = baseSig;
+		if (includeMockBehavior)
+		{
+			sig += "|global::Mockolate.MockBehavior";
+		}
+
+		if (includeSetup)
+		{
+			sig += $"|global::System.Action<{setupType}>";
+		}
+
+		if (!emittedSignatures.Add(sig))
+		{
+			return;
+		}
+
+		if (includeSetup)
+		{
+			sb.AppendXmlSummary(
+				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given constructor parameters, applying the given <paramref name=\"{setupName}\" /> immediately.");
+			sb.AppendXmlRemarks(
+				$"The provided <paramref name=\"{setupName}\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		}
+		else
+		{
+			sb.AppendXmlSummary(
+				$"Create a new mock of <see cref=\"{escapedClassName}\" /> using the given constructor parameters to invoke the base-class constructor.");
+		}
+
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			sb.AppendXmlParam(parameter.Name, "Value forwarded to the base-class constructor.");
+		}
+
+		if (includeMockBehavior)
+		{
+			sb.AppendXmlParam(mockBehaviorName,
+				"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		}
+
+		if (includeSetup)
+		{
+			sb.AppendXmlParam(setupName,
+				"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		}
+
+		sb.AppendXmlReturns(createMockReturns);
+		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(");
+		bool needsLeadingComma = false;
+		if (includeMockBehavior)
+		{
+			sb.Append("global::Mockolate.MockBehavior ").Append(mockBehaviorName);
+			needsLeadingComma = true;
+		}
+
+		if (includeSetup)
+		{
+			if (needsLeadingComma)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append("global::System.Action<").Append(setupType).Append("> ").Append(setupName);
+			needsLeadingComma = true;
+		}
+
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			if (needsLeadingComma)
+			{
+				sb.Append(", ");
+			}
+
+			needsLeadingComma = true;
+			sb.Append(parameter.Type.Fullname).Append(' ').Append(parameter.Name);
+			if (parameter.HasExplicitDefaultValue)
+			{
+				sb.Append(" = ").Append(parameter.ExplicitDefaultValue);
+			}
+		}
+
+		sb.Append(")").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(").Append(includeMockBehavior ? mockBehaviorName : "null").Append(", ")
+			.Append(includeSetup ? setupName : "null").Append(", new object?[] { ");
+		int argIndex = 0;
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			if (argIndex++ > 0)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append(parameter.Name);
+		}
+
+		sb.Append(" });").AppendLine();
 		sb.AppendLine();
 	}
 #pragma warning restore S107 // Methods should not have too many parameters

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -37,7 +37,7 @@ public class ExampleTests
 	[Fact]
 	public async Task BaseClassWithConstructorParameters()
 	{
-		MyClass sut = MyClass.CreateMock([3,]);
+		MyClass sut = MyClass.CreateMock(3);
 
 		sut.Mock.Setup.MyMethod(It.IsAny<int>()).Returns(5);
 

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -987,6 +987,94 @@ public class MockGeneratorTests
 	}
 
 	[Fact]
+	public async Task WhenConstructorHasDecimalDefault_ShouldAppendMSuffixInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(decimal price = 19.95m) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(decimal price = 19.95m)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasFloatDefault_ShouldAppendFSuffixInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(float factor = 3.14f) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(float factor = 3.14f)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasNullableDecimalDefault_ShouldAppendMSuffixInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     #nullable enable
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(decimal? price = 19.95m) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(decimal? price = 19.95m)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
 	public async Task WhenConstructorHasLongAndDoubleDefaults_ShouldPreserveLiteralsInTypedOverload()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -509,6 +509,513 @@ public class MockGeneratorTests
 	}
 
 	[Fact]
+	public async Task WhenClassHasConstructorWithParameters_ShouldGenerateTypedCreateMockOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock(42);
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(int value) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("public static global::MyCode.MyService CreateMock(int value)")
+			.IgnoringNewlineStyle().And
+			.Contains("=> CreateMock(null, null, new object?[] { value });")
+			.IgnoringNewlineStyle().And
+			.Contains("public static global::MyCode.MyService CreateMock(global::Mockolate.MockBehavior mockBehavior, int value)")
+			.IgnoringNewlineStyle().And
+			.Contains("public static global::MyCode.MyService CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForMyService> setup, int value)")
+			.IgnoringNewlineStyle().And
+			.Contains("public static global::MyCode.MyService CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyService> setup, int value)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenClassHasMultipleConstructors_ShouldGenerateTypedOverloadPerConstructor()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock("foo");
+			     		_ = MyService.CreateMock(1, "foo");
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(string text) { }
+			         public MyService(int number, string text) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("public static global::MyCode.MyService CreateMock(string text)")
+			.IgnoringNewlineStyle().And
+			.Contains("public static global::MyCode.MyService CreateMock(int number, string text)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasRefOrParamsParameter_ShouldNotEmitTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock([1, 2, 3]);
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(params int[] values) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.DoesNotContain("public static global::MyCode.MyService CreateMock(int[] values)")
+			.IgnoringNewlineStyle().And
+			.DoesNotContain("public static global::MyCode.MyService CreateMock(params int[] values)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenClassHasOnlyParameterlessConstructor_ShouldNotEmitAdditionalTypedOverloads()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			     	}
+			     }
+
+			     public class MyService { }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		// No typed overloads beyond the existing hand-written ones; the existing parameterless
+		// CreateMock() overload is still there and no typed overload is emitted for it.
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("public static global::MyCode.MyService CreateMock()")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasStringDefaultWithQuotes_ShouldEscapeInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(string text = "has \"quotes\"") { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(string text = \"has \\\"quotes\\\"\")")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasCharDefault_ShouldEscapeInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(char c = '\n') { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(char c = '\\n')")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasEnumDefault_ShouldCastToFullyQualifiedEnumTypeInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public enum MyKind { Alpha, Beta }
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(MyKind kind = MyKind.Beta) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(global::MyCode.MyKind kind = (global::MyCode.MyKind)1)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasNullableReferenceDefaultNull_ShouldEmitNullLiteralInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     #nullable enable
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(string? text = null) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(string? text = null)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasValueTypeDefaultNull_ShouldEmitDefaultInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public struct MyToken { public int Value; }
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(MyToken token = default) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(global::MyCode.MyToken token = default)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorsDifferOnlyByNullableValueType_ShouldEmitBothTypedOverloads()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     #nullable enable
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock(1);
+			     		_ = MyService.CreateMock((int?)1);
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(int value) { }
+			         public MyService(int? value) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("public static global::MyCode.MyService CreateMock(int value)")
+			.IgnoringNewlineStyle().And
+			.Contains("public static global::MyCode.MyService CreateMock(int? value)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorParameterIsMockBehavior_ShouldNotEmitAmbiguousTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock(Mockolate.MockBehavior.Default);
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(Mockolate.MockBehavior behavior) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		// The hand-written CreateMock(MockBehavior) overload already covers this signature.
+		// A typed single-parameter overload with the same signature would produce a duplicate
+		// definition, so the generator must skip it.
+		int matches = System.Text.RegularExpressions.Regex.Matches(
+				result.Sources["Mock.MyService.g.cs"],
+				@"CreateMock\(global::Mockolate\.MockBehavior\s+\w+\)")
+			.Count;
+		await That(matches).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task WhenConstructorParameterIsUnrelatedAction_ShouldEmitTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+			     using System;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		Action<string> callback = s => { };
+			     		_ = MyService.CreateMock(callback);
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(Action<string> callback) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		// Action<string> does not collide with the setup action type (Action<IMockSetupForMyService>),
+		// so the generator should emit the typed overload.
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(global::System.Action<string> callback)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasInParameter_ShouldNotEmitTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		int value = 42;
+			     		_ = MyService.CreateMock([value]);
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(in int value) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.DoesNotContain("CreateMock(in int value)")
+			.IgnoringNewlineStyle().And
+			.DoesNotContain("CreateMock(int value)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenGenericClassHasTypedConstructor_ShouldEmitTypedOverloadForClosedType()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService<string>.CreateMock("foo");
+			         }
+			     }
+
+			     public class MyService<T>
+			     {
+			         public MyService(T value) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		// The generator emits a mock for the closed generic MyService<string>. Locate the generated
+		// file and assert the typed overload was emitted with the substituted type argument.
+		string generated = string.Concat(result.Sources.Values);
+		await That(generated)
+			.Contains("CreateMock(string value)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenDerivedClassHasBaseClassConstructorParameters_ShouldEmitTypedOverloadForDerived()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = DerivedService.CreateMock("foo");
+			         }
+			     }
+
+			     public class BaseService
+			     {
+			         public BaseService(string text) { }
+			     }
+
+			     public class DerivedService : BaseService
+			     {
+			         public DerivedService(string text) : base(text) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.DerivedService.g.cs").WhoseValue
+			.Contains("public static global::MyCode.DerivedService CreateMock(string text)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenConstructorHasLongAndDoubleDefaults_ShouldPreserveLiteralsInTypedOverload()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock();
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(long big = 9999999999L, double pi = 3.14) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+			.Contains("CreateMock(long big = 9999999999, double pi = 3.14)")
+			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
 	public async Task WithHttpClient_ShouldAlsoGenerateMockForHttpMessageHandler()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -8,6 +8,9 @@ public partial class MockGeneratorTests
 	[GeneratedRegex(@"CreateMock\(global::Mockolate\.MockBehavior\s+\w+\)")]
 	private static partial Regex CreateMockBehaviorSignatureRegex();
 
+	[GeneratedRegex(@"CreateMock\(global::Mockolate\.MockBehavior\s+\w+,\s+int\s+\w+\)")]
+	private static partial Regex CreateMockBehaviorIntSignatureRegex();
+
 
 	[Fact]
 	public async Task SameMethodDifferingOnlyByNullability_ShouldUseExplicitImplementationForConflictingInterface()
@@ -824,6 +827,41 @@ public partial class MockGeneratorTests
 			.IgnoringNewlineStyle().And
 			.Contains("public static global::MyCode.MyService CreateMock(int? value)")
 			.IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task WhenOneCtorStartsWithMockBehaviorAndAnotherOmitsIt_ShouldNotEmitDuplicateTypedOverloads()
+	{
+		// Two constructors that could produce the same C# signature after the generator's
+		// mockBehavior-prefixed overload expansion:
+		//   - ctor A: (MockBehavior, int)      → typed overload: CreateMock(MockBehavior, int)
+		//   - ctor B: (int) + mockBehavior    → typed overload: CreateMock(MockBehavior, int)
+		// The dedup key is built in emitted-signature order (prefix first, then ctor params), so
+		// the second emission must be skipped to avoid a duplicate method definition.
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyService.CreateMock(MockBehavior.Default, 42);
+			         }
+			     }
+
+			     public class MyService
+			     {
+			         public MyService(Mockolate.MockBehavior behavior, int value) { }
+			         public MyService(int value) { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		int matches = CreateMockBehaviorIntSignatureRegex().Count(result.Sources["Mock.MyService.g.cs"]);
+		await That(matches).IsEqualTo(1);
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -1,9 +1,14 @@
 ﻿using System.Net.Http;
+using System.Text.RegularExpressions;
 
 namespace Mockolate.SourceGenerators.Tests;
 
-public class MockGeneratorTests
+public partial class MockGeneratorTests
 {
+	[GeneratedRegex(@"CreateMock\(global::Mockolate\.MockBehavior\s+\w+\)")]
+	private static partial Regex CreateMockBehaviorSignatureRegex();
+
+
 	[Fact]
 	public async Task SameMethodDifferingOnlyByNullability_ShouldUseExplicitImplementationForConflictingInterface()
 	{
@@ -848,10 +853,7 @@ public class MockGeneratorTests
 		// The hand-written CreateMock(MockBehavior) overload already covers this signature.
 		// A typed single-parameter overload with the same signature would produce a duplicate
 		// definition, so the generator must skip it.
-		int matches = System.Text.RegularExpressions.Regex.Matches(
-				result.Sources["Mock.MyService.g.cs"],
-				@"CreateMock\(global::Mockolate\.MockBehavior\s+\w+\)")
-			.Count;
+		int matches = CreateMockBehaviorSignatureRegex().Count(result.Sources["Mock.MyService.g.cs"]);
 		await That(matches).IsEqualTo(1);
 	}
 

--- a/Tests/Mockolate.Tests/MockBehaviorTests.UseConstructorParametersForTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.UseConstructorParametersForTests.cs
@@ -135,7 +135,7 @@ public sealed partial class MockBehaviorTests
 			MockBehavior behavior = MockBehavior.Default
 				.UseConstructorParametersFor<MyServiceWithMultipleConstructors>(() => [5,]);
 
-			MyServiceWithMultipleConstructors mock = MyServiceWithMultipleConstructors.CreateMock([7,], behavior);
+			MyServiceWithMultipleConstructors mock = MyServiceWithMultipleConstructors.CreateMock(behavior, [7,]);
 
 			int value = mock.Value;
 

--- a/Tests/Mockolate.Tests/MockTests.CreateTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.CreateTests.cs
@@ -129,6 +129,17 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task TypedOverload_ConstructorWithDecimalDefault_ShouldForwardExplicitValue()
+		{
+			// This test exercises the generator's default-value emission end-to-end: if the
+			// generator dropped the 'm' suffix ("decimal price = 19.95"), the generated source
+			// would fail to compile, taking the whole test project down with it.
+			MyBaseClassWithDecimalDefault sut = MyBaseClassWithDecimalDefault.CreateMock(42.50m);
+
+			await That(sut.Price).IsEqualTo(42.50m);
+		}
+
+		[Fact]
 		public async Task WithAdditionalInterfacesFromDifferentNamespaces_ShouldHaveUniqueName()
 		{
 			int invocationCount1 = 0;

--- a/Tests/Mockolate.Tests/MockTests.CreateTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.CreateTests.cs
@@ -21,8 +21,8 @@ public sealed partial class MockTests
 		public async Task With2Arguments_WithConstructorParametersAndSetups_ShouldApplySetups()
 		{
 			MyBaseClassWithConstructor mock = MyBaseClassWithConstructor.CreateMock(
-				["foo",],
-				setup => setup.VirtualMethod().Returns("bar")).Implementing<IMyService>();
+				setup => setup.VirtualMethod().Returns("bar"),
+				["foo",]).Implementing<IMyService>();
 
 			string result = mock.VirtualMethod();
 
@@ -33,9 +33,9 @@ public sealed partial class MockTests
 		public async Task With2Arguments_WithConstructorParametersMockBehaviorAndSetups_ShouldApplySetups()
 		{
 			MyBaseClassWithConstructor sut = MyBaseClassWithConstructor.CreateMock(
-					["foo",],
 					MockBehavior.Default,
-					setup => setup.VirtualMethod().Returns("bar"))
+					setup => setup.VirtualMethod().Returns("bar"),
+					["foo",])
 				.Implementing<IMyService>();
 
 			string result = sut.VirtualMethod();
@@ -60,6 +60,72 @@ public sealed partial class MockTests
 			await That(result1).IsEqualTo(2);
 			await That(result2).IsEqualTo(4);
 			await That(result3).IsEqualTo(8);
+		}
+
+		[Fact]
+		public async Task TypedOverload_SingleConstructor_ShouldForwardToBaseClass()
+		{
+			MyBaseClassWithConstructor sut = MyBaseClassWithConstructor.CreateMock("foo");
+
+			await That(sut.Text).IsEqualTo("foo");
+		}
+
+		[Fact]
+		public async Task TypedOverload_WithSetup_ShouldApplySetup()
+		{
+			MyBaseClassWithConstructor sut = MyBaseClassWithConstructor.CreateMock(
+				setup => setup.VirtualMethod().Returns("bar"),
+				"foo");
+
+			await That(sut.VirtualMethod()).IsEqualTo("bar");
+		}
+
+		[Fact]
+		public async Task TypedOverload_WithMockBehavior_ShouldUseBehavior()
+		{
+			MockBehavior behavior = MockBehavior.Default.ThrowingWhenNotSetup();
+
+			MyBaseClassWithConstructor sut = MyBaseClassWithConstructor.CreateMock(behavior, "foo");
+
+			await That(((IMock)sut).MockRegistry.Behavior).IsSameAs(behavior);
+			await That(sut.Text).IsEqualTo("foo");
+		}
+
+		[Fact]
+		public async Task TypedOverload_WithMockBehaviorAndSetup_ShouldApplyBoth()
+		{
+			MockBehavior behavior = MockBehavior.Default;
+
+			MyBaseClassWithConstructor sut = MyBaseClassWithConstructor.CreateMock(
+				behavior,
+				setup => setup.VirtualMethod().Returns("bar"),
+				"foo");
+
+			await That(((IMock)sut).MockRegistry.Behavior).IsSameAs(behavior);
+			await That(sut.VirtualMethod()).IsEqualTo("bar");
+		}
+
+		[Fact]
+		public async Task TypedOverload_MultipleConstructors_ShouldDispatchToMatchingConstructor()
+		{
+			MyBaseClassWithMultipleConstructors sutFromString =
+				MyBaseClassWithMultipleConstructors.CreateMock("foo");
+			MyBaseClassWithMultipleConstructors sutFromIntAndString =
+				MyBaseClassWithMultipleConstructors.CreateMock(42, "bar");
+
+			await That(sutFromString.Text).IsEqualTo("foo");
+			await That(sutFromString.Number).IsEqualTo(0);
+			await That(sutFromIntAndString.Text).IsEqualTo("bar");
+			await That(sutFromIntAndString.Number).IsEqualTo(42);
+		}
+
+		[Fact]
+		public async Task TypedOverload_ConstructorWithDefaultValue_ShouldApplyDefault()
+		{
+			MyBaseClassWithMultipleConstructors sut = MyBaseClassWithMultipleConstructors.CreateMock(42);
+
+			await That(sut.Text).IsEqualTo("default");
+			await That(sut.Number).IsEqualTo(42);
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -101,8 +101,8 @@ public sealed partial class MockTests
 	public async Task Create_WithConstructorParametersAndSetups_ShouldApplySetups()
 	{
 		MyBaseClassWithConstructor mock = MyBaseClassWithConstructor.CreateMock(
-			["foo",],
-			setup => setup.VirtualMethod().Returns("bar"));
+			setup => setup.VirtualMethod().Returns("bar"),
+			["foo",]);
 
 		string result = mock.VirtualMethod();
 
@@ -113,8 +113,9 @@ public sealed partial class MockTests
 	public async Task Create_WithConstructorParametersMockBehaviorAndSetups_ShouldApplySetups()
 	{
 		MyBaseClassWithConstructor mock = MyBaseClassWithConstructor.CreateMock(
-			["foo",], MockBehavior.Default,
-			setup => setup.VirtualMethod().Returns("bar"));
+			MockBehavior.Default,
+			setup => setup.VirtualMethod().Returns("bar"),
+			["foo",]);
 
 		string result = mock.VirtualMethod();
 
@@ -409,6 +410,24 @@ public sealed partial class MockTests
 
 		// ReSharper disable once UnassignedGetOnlyAutoProperty
 		public int Number { get; }
+	}
+
+	public class MyBaseClassWithMultipleConstructors
+	{
+		public MyBaseClassWithMultipleConstructors(string text)
+		{
+			Text = text;
+		}
+
+		public MyBaseClassWithMultipleConstructors(int number, string text = "default")
+		{
+			Number = number;
+			Text = text;
+		}
+
+		public int Number { get; }
+		public string Text { get; }
+		public virtual string VirtualMethod() => Text;
 	}
 
 	public interface IMyServiceWithGenericMethodsWithWhereClause

--- a/Tests/Mockolate.Tests/MockTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.cs
@@ -430,6 +430,16 @@ public sealed partial class MockTests
 		public virtual string VirtualMethod() => Text;
 	}
 
+	public class MyBaseClassWithDecimalDefault
+	{
+		public MyBaseClassWithDecimalDefault(decimal price = 19.95m)
+		{
+			Price = price;
+		}
+
+		public decimal Price { get; }
+	}
+
 	public interface IMyServiceWithGenericMethodsWithWhereClause
 	{
 		int MyMethod<T>(bool flag) where T : IChocolateDispenser;

--- a/Tests/Mockolate.Tests/Web/HttpClientTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientTests.cs
@@ -35,7 +35,7 @@ public class HttpClientTests
 
 		void Act()
 		{
-			_ = HttpClient.CreateMock([handler,], behavior2);
+			_ = HttpClient.CreateMock(behavior2, [handler,]);
 		}
 
 		await That(Act).Throws<MockException>().WithMessage(
@@ -65,7 +65,7 @@ public class HttpClientTests
 
 		void Act()
 		{
-			_ = HttpClient.CreateMock([handler,], behavior2);
+			_ = HttpClient.CreateMock(behavior2, [handler,]);
 		}
 
 		await That(Act).DoesNotThrow();


### PR DESCRIPTION
This PR updates Mockolate’s `CreateMock` API shape to support constructor calls with *typed* arguments (instead of always requiring `object?[]`), and reorders existing overloads so `MockBehavior` (and setup) come before constructor parameters. It extends the source generator to emit these typed overloads per constructor and updates tests/docs accordingly.

**Changes:**
- Reordered `CreateMock` overloads to use `CreateMock(mockBehavior, …constructorArgs)` / `CreateMock(setup, …constructorArgs)` patterns.
- Added generator support for emitting typed `CreateMock` overloads per eligible constructor (plus behavior/setup variants) and expanded generator test coverage.
- Updated unit tests, examples, and documentation to use the new overload shapes.