### PR TITLE
docs: fix broken link to Ref Struct Parameters section in analyzers documentation

### DIFF
--- a/Docs/pages/07-analyzers.md
+++ b/Docs/pages/07-analyzers.md
@@ -54,5 +54,5 @@ environment can't emit the setup surface:
 fallback and are not flagged. Custom ref-struct parameters and indexer keys (both get and set) ARE
 supported on .NET 9+ compilation targets.
 
-See the [Ref Struct Parameters](setup/04-parameter-matching#ref-struct-parameters-net-9) section
+See the [Ref Struct Parameters](setup/parameter-matching#ref-struct-parameters-net-9) section
 for the supported surface.


### PR DESCRIPTION
This PR fixes a broken cross-reference in the analyzers documentation by updating the link target for the “Ref Struct Parameters” section so it matches the published docs route.

**Changes:**
- Update the “Ref Struct Parameters” link in the analyzers docs from `setup/04-parameter-matching` to `setup/parameter-matching` (keeping the same anchor).