### PR TITLE
refactor: remove wrappability analyzer rule and associated resources

### DIFF
--- a/Docs/pages/07-analyzers.md
+++ b/Docs/pages/07-analyzers.md
@@ -34,20 +34,34 @@ Mocked types must be mockable. This rule will prevent you from using unsupported
 
 ## Mockolate0003
 
-Ref-struct parameter mocking is not supported on this compilation. This warning fires when the
-signature of a mocked member routes through the ref-struct pipeline but the current build
-environment can't emit the setup surface:
+A mocked member's signature routes through the ref-struct pipeline in a way Mockolate can't
+emit setup surface for. The warning fires in two distinct situations.
 
-- Compilation target is older than .NET 9 — the ref-struct pipeline requires the `allows ref struct`
-  anti-constraint introduced in C# 13 / .NET 9.
-- Parameter is `out`, `ref`, or `ref readonly` and its type is a non-`Span<T>` / non-`ReadOnlySpan<T>`
-  ref struct — the mock can't round-trip the value through `IOutParameter<T>` / `IRefParameter<T>`
-  when `T` is a ref struct.
-- Method returns a non-`Span<T>` / non-`ReadOnlySpan<T>` ref struct — currently unsupported.
+**1. Compilation prerequisites not met**
 
+The ref-struct setup pipeline requires both:
+
+- A target framework of .NET 9 or later (Mockolate's ref-struct setup types are
+  `#if NET9_0_OR_GREATER`-gated).
+- An effective C# language version of 13 or later (uses the `allows ref struct` anti-constraint).
+
+When either prerequisite is missing, the warning fires for any member that passes a non-`Span<T>` /
+non-`ReadOnlySpan<T>` ref struct by value, or uses one as an indexer key. Upgrade the target
+framework and/or `<LangVersion>` to resolve it.
+
+**2. Signature shapes that are never supported**
+
+These fire on every compilation target, including .NET 9+ / C# 13+:
+
+- Parameters marked `out`, `ref`, or `ref readonly` whose type is a non-`Span<T>` /
+  non-`ReadOnlySpan<T>` ref struct — the mock can't round-trip the value through
+  `IOutParameter<T>` / `IRefParameter<T>` when `T` is a ref struct.
+- Methods returning a non-`Span<T>` / non-`ReadOnlySpan<T>` ref struct.
+
+**Note:**
 `Span<T>` and `ReadOnlySpan<T>` flow through the existing `SpanWrapper` / `ReadOnlySpanWrapper`
-fallback and are not flagged. Custom ref-struct parameters and indexer keys (both get and set) ARE
-supported on .NET 9+ compilation targets.
+fallback and are never flagged. On .NET 9+ with C# 13+, by-value custom ref-struct parameters and
+ref-struct-keyed indexers (getter-only, setter-only, and get+set) are fully supported.
 
 See the [Ref Struct Parameters](setup/parameter-matching#ref-struct-parameters-net-9) section
 for the supported surface.

--- a/Docs/pages/07-analyzers.md
+++ b/Docs/pages/07-analyzers.md
@@ -34,11 +34,6 @@ Mocked types must be mockable. This rule will prevent you from using unsupported
 
 ## Mockolate0003
 
-`.Wrap()` arguments must be wrappable. The wrapped type must satisfy the same mockability rules as
-the primary mock target (interface, delegate, or non-sealed class).
-
-## Mockolate0004
-
 Ref-struct parameter mocking is not supported on this compilation. This warning fires when the
 signature of a mocked member routes through the ref-struct pipeline but the current build
 environment can't emit the setup surface:

--- a/Docs/pages/setup/04-parameter-matching.md
+++ b/Docs/pages/setup/04-parameter-matching.md
@@ -204,7 +204,7 @@ generic delegates:
   contribute their raw value as part of the composite dispatch key. If any ref-struct slot is
   matched without a projection, storage stays inactive for that setup.
 
-The following cases are rejected at compile time with diagnostic `Mockolate0004`:
+The following cases are rejected at compile time with diagnostic `Mockolate0003`:
 
 - Targeting older than .NET 9 (the feature relies on `allows ref struct`, a .NET 9 / C# 13
   feature).

--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ generic delegates:
   contribute their raw value as part of the composite dispatch key. If any ref-struct slot is
   matched without a projection, storage stays inactive for that setup.
 
-The following cases are rejected at compile time with diagnostic `Mockolate0004`:
+The following cases are rejected at compile time with diagnostic `Mockolate0003`:
 
 - Targeting older than .NET 9 (the feature relies on `allows ref struct`, a .NET 9 / C# 13
   feature).
@@ -1606,3 +1606,23 @@ Mocked types must be mockable. This rule will prevent you from using unsupported
   Type must be an interface, a delegate or a supported class (e.g. not sealed)
 - `Implementing<T>()`  
   Type must be an interface
+
+
+### Mockolate0003
+
+Ref-struct parameter mocking is not supported on this compilation. This warning fires when the
+signature of a mocked member routes through the ref-struct pipeline but the current build
+environment can't emit the setup surface:
+
+- Compilation target is older than .NET 9 — the ref-struct pipeline requires the `allows ref struct`
+  anti-constraint introduced in C# 13 / .NET 9.
+- Parameter is `out`, `ref`, or `ref readonly` and its type is a non-`Span<T>` / non-`ReadOnlySpan<T>`
+  ref struct — the mock can't round-trip the value through `IOutParameter<T>` / `IRefParameter<T>`
+  when `T` is a ref struct.
+- Method returns a non-`Span<T>` / non-`ReadOnlySpan<T>` ref struct — currently unsupported.
+
+`Span<T>` and `ReadOnlySpan<T>` flow through the existing `SpanWrapper` / `ReadOnlySpanWrapper`
+fallback and are not flagged. Custom ref-struct parameters and indexer keys (both get and set) ARE
+supported on .NET 9+ compilation targets.
+
+See the Ref Struct Parameters section for the supported surface.

--- a/README.md
+++ b/README.md
@@ -1610,19 +1610,33 @@ Mocked types must be mockable. This rule will prevent you from using unsupported
 
 ### Mockolate0003
 
-Ref-struct parameter mocking is not supported on this compilation. This warning fires when the
-signature of a mocked member routes through the ref-struct pipeline but the current build
-environment can't emit the setup surface:
+A mocked member's signature routes through the ref-struct pipeline in a way Mockolate can't
+emit setup surface for. The warning fires in two distinct situations.
 
-- Compilation target is older than .NET 9 — the ref-struct pipeline requires the `allows ref struct`
-  anti-constraint introduced in C# 13 / .NET 9.
-- Parameter is `out`, `ref`, or `ref readonly` and its type is a non-`Span<T>` / non-`ReadOnlySpan<T>`
-  ref struct — the mock can't round-trip the value through `IOutParameter<T>` / `IRefParameter<T>`
-  when `T` is a ref struct.
-- Method returns a non-`Span<T>` / non-`ReadOnlySpan<T>` ref struct — currently unsupported.
+**1. Compilation prerequisites not met**
 
+The ref-struct setup pipeline requires both:
+
+- A target framework of .NET 9 or later (Mockolate's ref-struct setup types are
+  `#if NET9_0_OR_GREATER`-gated).
+- An effective C# language version of 13 or later (uses the `allows ref struct` anti-constraint).
+
+When either prerequisite is missing, the warning fires for any member that passes a non-`Span<T>` /
+non-`ReadOnlySpan<T>` ref struct by value, or uses one as an indexer key. Upgrade the target
+framework and/or `<LangVersion>` to resolve it.
+
+**2. Signature shapes that are never supported**
+
+These fire on every compilation target, including .NET 9+ / C# 13+:
+
+- Parameters marked `out`, `ref`, or `ref readonly` whose type is a non-`Span<T>` /
+  non-`ReadOnlySpan<T>` ref struct — the mock can't round-trip the value through
+  `IOutParameter<T>` / `IRefParameter<T>` when `T` is a ref struct.
+- Methods returning a non-`Span<T>` / non-`ReadOnlySpan<T>` ref struct.
+
+**Note:**
 `Span<T>` and `ReadOnlySpan<T>` flow through the existing `SpanWrapper` / `ReadOnlySpanWrapper`
-fallback and are not flagged. Custom ref-struct parameters and indexer keys (both get and set) ARE
-supported on .NET 9+ compilation targets.
+fallback and are never flagged. On .NET 9+ with C# 13+, by-value custom ref-struct parameters and
+ref-struct-keyed indexers (getter-only, setter-only, and get+set) are fully supported.
 
 See the Ref Struct Parameters section for the supported surface.

--- a/Source/Mockolate.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Source/Mockolate.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,4 +2,4 @@
 
  Rule ID       | Category | Severity | Notes
 ---------------|----------|----------|--------------------------------------------------------
- Mockolate0004 | Usage    | Warning  | Ref-struct parameter mocking not supported on this build
+ Mockolate0003 | Usage    | Warning  | Ref-struct parameter mocking not supported on this build

--- a/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
+++ b/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
@@ -17,15 +17,15 @@ namespace Mockolate.Analyzers;
 public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 {
 	private static readonly DiagnosticDescriptor s_refStructRule = new(
-		"Mockolate0004",
-		new LocalizableResourceString(nameof(Resources.Mockolate0004Title),
+		"Mockolate0003",
+		new LocalizableResourceString(nameof(Resources.Mockolate0003Title),
 			Resources.ResourceManager, typeof(Resources)),
-		new LocalizableResourceString(nameof(Resources.Mockolate0004MessageFormat),
+		new LocalizableResourceString(nameof(Resources.Mockolate0003MessageFormat),
 			Resources.ResourceManager, typeof(Resources)),
 		"Usage",
 		DiagnosticSeverity.Warning,
 		true,
-		new LocalizableResourceString(nameof(Resources.Mockolate0004Description),
+		new LocalizableResourceString(nameof(Resources.Mockolate0003Description),
 			Resources.ResourceManager, typeof(Resources)));
 
 	/// <inheritdoc cref="DiagnosticAnalyzer.SupportedDiagnostics" />

--- a/Source/Mockolate.Analyzers/Resources.Designer.cs
+++ b/Source/Mockolate.Analyzers/Resources.Designer.cs
@@ -123,56 +123,29 @@ namespace Mockolate.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Only interface types can be wrapped with Mock.Wrap..
+        ///   Looks up a localized string describing Mockolate0003.
         /// </summary>
         internal static string Mockolate0003Description {
             get {
                 return ResourceManager.GetString("Mockolate0003Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; cannot be wrapped: {1}.
+        ///   Looks up a localized string describing Mockolate0003's message format.
         /// </summary>
         internal static string Mockolate0003MessageFormat {
             get {
                 return ResourceManager.GetString("Mockolate0003MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to Wrap arguments must be wrappable.
+        ///   Looks up a localized string describing Mockolate0003's title.
         /// </summary>
         internal static string Mockolate0003Title {
             get {
                 return ResourceManager.GetString("Mockolate0003Title", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string describing Mockolate0004.
-        /// </summary>
-        internal static string Mockolate0004Description {
-            get {
-                return ResourceManager.GetString("Mockolate0004Description", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string describing Mockolate0004's message format.
-        /// </summary>
-        internal static string Mockolate0004MessageFormat {
-            get {
-                return ResourceManager.GetString("Mockolate0004MessageFormat", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string describing Mockolate0004's title.
-        /// </summary>
-        internal static string Mockolate0004Title {
-            get {
-                return ResourceManager.GetString("Mockolate0004Title", resourceCulture);
             }
         }
     }

--- a/Source/Mockolate.Analyzers/Resources.resx
+++ b/Source/Mockolate.Analyzers/Resources.resx
@@ -146,21 +146,12 @@
     <value>Mock arguments must be mockable</value>
   </data>
 	<data name="Mockolate0003Description" xml:space="preserve">
-		<value>Only interface types can be wrapped with Mock.Wrap.</value>
-	</data>
-	<data name="Mockolate0003MessageFormat" xml:space="preserve">
-		<value>Type '{0}' cannot be wrapped: {1}</value>
-	</data>
-	<data name="Mockolate0003Title" xml:space="preserve">
-    <value>Wrap arguments must be wrappable</value>
-  </data>
-	<data name="Mockolate0004Description" xml:space="preserve">
 		<value>Methods with out/ref ref-struct parameters or non-span ref-struct return types cannot be mocked. Ref-struct parameter mocking (including ref-struct-keyed indexers) additionally requires .NET 9 or later.</value>
 	</data>
-	<data name="Mockolate0004MessageFormat" xml:space="preserve">
+	<data name="Mockolate0003MessageFormat" xml:space="preserve">
 		<value>Type '{0}' has a method '{1}' that cannot be mocked: {2}</value>
 	</data>
-	<data name="Mockolate0004Title" xml:space="preserve">
+	<data name="Mockolate0003Title" xml:space="preserve">
     <value>Ref-struct parameter mocking is not supported on this compilation</value>
   </data>
 </root>

--- a/Source/Mockolate.Analyzers/Rules.cs
+++ b/Source/Mockolate.Analyzers/Rules.cs
@@ -21,13 +21,7 @@ public static class Rules
 	public static readonly DiagnosticDescriptor MockabilityRule =
 		CreateDescriptor("Mockolate0002", UsageCategory, DiagnosticSeverity.Error);
 
-	/// <summary>
-	///     Wrap arguments must be wrappable.
-	/// </summary>
-	public static readonly DiagnosticDescriptor WrappabilityRule =
-		CreateDescriptor("Mockolate0003", UsageCategory, DiagnosticSeverity.Error);
-
-	// Mockolate0004 (ref-struct-mockability) is declared in-place on
+	// Mockolate0003 (ref-struct-mockability) is declared in-place on
 	// <see cref="MockabilityAnalyzer" /> rather than here. The Roslyn
 	// ReleaseTrackingAnalyzer needs the descriptor in the same assembly as the analyzer that
 	// lists it in SupportedDiagnostics; defining it here as a cross-file static confused it

--- a/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerRefStructTests.cs
+++ b/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerRefStructTests.cs
@@ -7,7 +7,7 @@ using Verifier = Mockolate.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<Mock
 namespace Mockolate.Analyzers.Tests;
 
 /// <summary>
-///     Coverage for the <c>Mockolate0004</c> ref-struct mockability diagnostic emitted by
+///     Coverage for the <c>Mockolate0003</c> ref-struct mockability diagnostic emitted by
 ///     <see cref="MockabilityAnalyzer" />.
 /// </summary>
 /// <remarks>
@@ -70,7 +70,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IPacketProducer", "Produce",
 					"out/ref ref-struct parameters are not supported")
@@ -100,7 +100,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IPacketMutator", "Mutate",
 					"out/ref ref-struct parameters are not supported")
@@ -132,7 +132,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IPacketInspector", "Inspect",
 					"out/ref ref-struct parameters are not supported")
@@ -162,7 +162,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IPacketFactory", "Produce",
 					"methods returning a non-span ref struct are not supported")
@@ -323,7 +323,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.PacketProducerDelegate", "Invoke",
 					"out/ref ref-struct parameters are not supported")
@@ -352,7 +352,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.PacketFactoryDelegate", "Invoke",
 					"methods returning a non-span ref struct are not supported")
@@ -389,7 +389,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IDerivedSink", "Produce",
 					"out/ref ref-struct parameters are not supported")
@@ -425,7 +425,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.DerivedProducer", "Produce",
 					"out/ref ref-struct parameters are not supported")
@@ -456,7 +456,7 @@ public class MockabilityAnalyzerRefStructTests
 			  }
 			  """,
 			LanguageVersion.CSharp12,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IPacketSink", "Consume",
 					"ref-struct parameter mocking requires C# 13 or later (uses the 'allows ref struct' anti-constraint; current LangVersion is 12.0)")
@@ -487,7 +487,7 @@ public class MockabilityAnalyzerRefStructTests
 			  }
 			  """,
 			LanguageVersion.CSharp12,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IRefStructLookup", "this[]",
 					"ref-struct-keyed indexers require C# 13 or later (uses the 'allows ref struct' anti-constraint; current LangVersion is 12.0)")
@@ -521,7 +521,7 @@ public class MockabilityAnalyzerRefStructTests
 			  	}
 			  }
 			  """,
-			new DiagnosticResult("Mockolate0004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+			new DiagnosticResult("Mockolate0003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
 				.WithLocation(0)
 				.WithArguments("MyNamespace.IOverloadedSink", "Consume",
 					"out/ref ref-struct parameters are not supported")


### PR DESCRIPTION
This PR removes the wrappability analyzer rule/resources and reassigns the ref-struct mockability diagnostic from `Mockolate0004` to `Mockolate0003`, updating tests, release tracking, and documentation accordingly.

**Changes:**
- Removed `WrappabilityRule` (`Mockolate0003`) from `Rules.cs` and deleted its associated resource strings.
- Renumbered the ref-struct mockability diagnostic from `Mockolate0004` to `Mockolate0003` across analyzer code, tests, and analyzer release metadata.
- Updated README and Docs content to reflect the new diagnostic ID and added a dedicated `Mockolate0003` documentation section.