### PR TITLE
feat!: omit constructor parameters overloads for interfaces and types with only parameterless constructors

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -15,6 +15,8 @@ internal static partial class Sources
 	public static string MockClass(string name, Class @class, bool hasOverloadResolutionPriority = false)
 	{
 		EquatableArray<Method>? constructors = (@class as MockClass)?.Constructors;
+		bool hasParameterizedConstructor = !@class.IsInterface &&
+		                                   constructors?.Any(m => m.Parameters.Count > 0) == true;
 		string escapedClassName = @class.ClassFullName.EscapeForXmlDoc();
 		bool hasEvents = @class.AllEvents().Any(x => !x.IsStatic);
 		bool hasStaticEvents = @class.IsInterface &&
@@ -162,7 +164,7 @@ internal static partial class Sources
 		sb.Append("\t\t\t=> CreateMock(mockBehavior, setup, (object?[]?)null);").AppendLine();
 		sb.AppendLine();
 
-		if (!@class.IsInterface)
+		if (hasParameterizedConstructor)
 		{
 			sb.AppendXmlSummary(
 				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> to invoke the base-class constructor.");
@@ -206,7 +208,7 @@ internal static partial class Sources
 		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
 		sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
 		sb.AppendXmlReturns(createMockReturns);
-		sb.Append("\t\t").Append(@class.IsInterface ? "private" : "public").Append(" static ")
+		sb.Append("\t\t").Append(hasParameterizedConstructor ? "public" : "private").Append(" static ")
 			.Append(@class.ClassFullName)
 			.Append(" CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<")
 			.Append(setupType).Append(">? setup, object?[]? constructorParameters)").AppendLine();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -242,6 +242,64 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task ForTypesWithOnlyParameterlessConstructor_ShouldOmitConstructorParametersOverloads()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyBaseClass.CreateMock();
+			         }
+			     }
+
+			     public class MyBaseClass
+			     {
+			         public MyBaseClass() { }
+			     }
+			     """);
+
+		await That(result.Sources).ContainsKey("Mock.MyBaseClass.g.cs").WhoseValue
+			.DoesNotContain("CreateMock(object?[] constructorParameters)").And
+			.DoesNotContain("CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)").And
+			.DoesNotContain("object?[] constructorParameters)").And
+			.Contains("private static global::MyCode.MyBaseClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyBaseClass>? setup, object?[]? constructorParameters)");
+	}
+
+	[Fact]
+	public async Task ForTypesWithoutExplicitConstructor_ShouldOmitConstructorParametersOverloads()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyBaseClass.CreateMock();
+			         }
+			     }
+
+			     public class MyBaseClass
+			     {
+			     }
+			     """);
+
+		await That(result.Sources).ContainsKey("Mock.MyBaseClass.g.cs").WhoseValue
+			.DoesNotContain("CreateMock(object?[] constructorParameters)").And
+			.DoesNotContain("object?[] constructorParameters)").And
+			.Contains("private static global::MyCode.MyBaseClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyBaseClass>? setup, object?[]? constructorParameters)");
+	}
+
+	[Fact]
 	public async Task ForTypesWithoutPublicOrProtectedConstructor_ShouldOnlyGenerateMockThatThrowsException()
 	{
 		GeneratorResult result = Generator


### PR DESCRIPTION
This PR updates the Mockolate source generator to stop emitting public `CreateMock(... constructorParameters ...)` overloads for interfaces and for classes that only have a parameterless constructor, reducing the generated API surface for types that don’t need constructor forwarding.

**Changes:**
- Add generator tests asserting that constructor-parameters overloads are omitted for parameterless-only and implicit-ctor classes.
- Update mock class source generation to only emit constructor-parameter overloads when a type has at least one accessible parameterized constructor.
- Make the internal “core” `CreateMock(MockBehavior?, setup?, object?[]?)` helper private for types without parameterized constructors.