### PR TITLE
fix: source generation errors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
 		<PackageVersion Include="aweXpect.Mockolate" Version="2.3.0"/>
 		<PackageVersion Include="Testably.Abstractions" Version="10.2.0"/>
+		<PackageVersion Include="Azure.Data.Tables" Version="12.11.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Moq" Version="4.20.72"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
 		<PackageVersion Include="aweXpect.Mockolate" Version="2.3.0"/>
 		<PackageVersion Include="Testably.Abstractions" Version="10.2.0"/>
 		<PackageVersion Include="Azure.Data.Tables" Version="12.11.0"/>
+		<PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Moq" Version="4.20.72"/>

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -72,19 +72,20 @@ internal record Class
 
 		exceptProperties ??= new List<Property>();
 		exceptProperties.AddRange(members.OfType<IPropertySymbol>()
-			.Where(x => x.IsSealed)
+			.Where(x => x.IsSealed || HidesBaseOverridable(x, type))
 			.Select(x => new Property(x, null, sourceAssembly))
 			.Distinct());
 
 		exceptMethods ??= new List<Method>();
 		exceptMethods.AddRange(members.OfType<IMethodSymbol>()
-			.Where(x => x.IsSealed)
+			.Where(x => x.MethodKind is MethodKind.Ordinary)
+			.Where(x => x.IsSealed || HidesBaseOverridable(x, type))
 			.Select(x => new Method(x, null, sourceAssembly))
 			.Distinct());
 
 		exceptEvents ??= new List<Event>();
 		exceptEvents.AddRange(members.OfType<IEventSymbol>()
-			.Where(x => x.IsSealed)
+			.Where(x => x.IsSealed || HidesBaseOverridable(x, type))
 			.Select(x => (x, x.Type as INamedTypeSymbol))
 			.Where(x => x.Item2?.DelegateInvokeMethod is not null)
 			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, null, sourceAssembly))
@@ -203,6 +204,70 @@ internal record Class
 		}
 
 		return source.Except(except, comparer).ToList();
+	}
+
+	// True when `member` (declared on `thisType`) hides an overridable member of the same
+	// signature on a base class. The hidden base cannot be overridden from a class deriving from
+	// `thisType` — the compiler resolves the override target to the hiding member first and fails
+	// with CS0506. Overrides are not hiding: they continue the virtual slot.
+	private static bool HidesBaseOverridable(ISymbol member, ITypeSymbol thisType)
+	{
+		if (member is IMethodSymbol { IsOverride: true, } or IPropertySymbol { IsOverride: true, } or IEventSymbol { IsOverride: true, })
+		{
+			return false;
+		}
+
+		for (INamedTypeSymbol? b = thisType.BaseType; b is not null; b = b.BaseType)
+		{
+			foreach (ISymbol candidate in b.GetMembers(member.Name))
+			{
+				if (candidate.Kind != member.Kind || candidate.IsStatic != member.IsStatic)
+				{
+					continue;
+				}
+
+				if (!(candidate.IsVirtual || candidate.IsAbstract || candidate.IsOverride) || candidate.IsSealed)
+				{
+					continue;
+				}
+
+				if (SignatureMatches(member, candidate))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static bool SignatureMatches(ISymbol a, ISymbol b)
+		=> (a, b) switch
+		{
+			(IMethodSymbol ma, IMethodSymbol mb) => ParametersMatch(ma.Parameters, mb.Parameters) &&
+			                                        ma.TypeParameters.Length == mb.TypeParameters.Length,
+			(IPropertySymbol pa, IPropertySymbol pb) => ParametersMatch(pa.Parameters, pb.Parameters),
+			(IEventSymbol, IEventSymbol) => true,
+			_ => false,
+		};
+
+	private static bool ParametersMatch(ImmutableArray<IParameterSymbol> a, ImmutableArray<IParameterSymbol> b)
+	{
+		if (a.Length != b.Length)
+		{
+			return false;
+		}
+
+		for (int i = 0; i < a.Length; i++)
+		{
+			if (a[i].RefKind != b[i].RefKind ||
+			    !SymbolEqualityComparer.Default.Equals(a[i].Type, b[i].Type))
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	public static IEnumerable<ITypeSymbol> GetInheritedTypes(ITypeSymbol type)

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -270,6 +270,7 @@ internal record Class
 		return true;
 	}
 
+#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	public static IEnumerable<ITypeSymbol> GetInheritedTypes(ITypeSymbol type)
 	{
 		ITypeSymbol? current = type;
@@ -291,6 +292,7 @@ internal record Class
 			current = current.BaseType;
 		}
 	}
+#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
 	public IEnumerable<Property> AllProperties()
 	{

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -48,7 +48,7 @@ internal record Class
 			.Where(x => !x.IsSealed)
 			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
 			.Where(ShouldIncludeMember)
-			.Select(x => new Method(x, alreadyDefinedMethods))
+			.Select(x => new Method(x, alreadyDefinedMethods, sourceAssembly))
 			.Distinct(), exceptMethods, Method.ContainingTypeIndependentEqualityComparer);
 		Methods = new EquatableArray<Method>(methods.ToArray());
 
@@ -56,7 +56,7 @@ internal record Class
 			.Where(x => !x.IsSealed)
 			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
 			.Where(ShouldIncludeMember)
-			.Select(x => new Property(x, alreadyDefinedProperties))
+			.Select(x => new Property(x, alreadyDefinedProperties, sourceAssembly))
 			.Distinct(), exceptProperties, Property.ContainingTypeIndependentEqualityComparer);
 		Properties = new EquatableArray<Property>(properties.ToArray());
 
@@ -66,20 +66,20 @@ internal record Class
 			.Where(ShouldIncludeMember)
 			.Select(x => (x, x.Type as INamedTypeSymbol))
 			.Where(x => x.Item2?.DelegateInvokeMethod is not null)
-			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, alreadyDefinedEvents))
+			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, alreadyDefinedEvents, sourceAssembly))
 			.Distinct(), exceptEvents, Event.ContainingTypeIndependentEqualityComparer);
 		Events = new EquatableArray<Event>(events.ToArray());
 
 		exceptProperties ??= new List<Property>();
 		exceptProperties.AddRange(members.OfType<IPropertySymbol>()
 			.Where(x => x.IsSealed)
-			.Select(x => new Property(x, null))
+			.Select(x => new Property(x, null, sourceAssembly))
 			.Distinct());
 
 		exceptMethods ??= new List<Method>();
 		exceptMethods.AddRange(members.OfType<IMethodSymbol>()
 			.Where(x => x.IsSealed)
-			.Select(x => new Method(x, null))
+			.Select(x => new Method(x, null, sourceAssembly))
 			.Distinct());
 
 		exceptEvents ??= new List<Event>();
@@ -87,7 +87,7 @@ internal record Class
 			.Where(x => x.IsSealed)
 			.Select(x => (x, x.Type as INamedTypeSymbol))
 			.Where(x => x.Item2?.DelegateInvokeMethod is not null)
-			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, null))
+			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, null, sourceAssembly))
 			.Distinct());
 
 		InheritedTypes = new EquatableArray<Class>(
@@ -103,13 +103,7 @@ internal record Class
 				return true;
 			}
 
-			if (member.DeclaredAccessibility is Accessibility.Internal or Accessibility.ProtectedOrInternal &&
-			    !SymbolEqualityComparer.Default.Equals(member.ContainingAssembly, _sourceAssembly))
-			{
-				return false;
-			}
-
-			return true;
+			return Helpers.IsOverridableFrom(member, _sourceAssembly);
 		}
 	}
 

--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -7,7 +7,7 @@ namespace Mockolate.SourceGenerators.Entities;
 [DebuggerDisplay("{ContainingType}.{Name}")]
 internal record Event
 {
-	public Event(IEventSymbol eventSymbol, IMethodSymbol delegateInvokeMethod, List<Event>? alreadyDefinedEvents)
+	public Event(IEventSymbol eventSymbol, IMethodSymbol delegateInvokeMethod, List<Event>? alreadyDefinedEvents, IAssemblySymbol? sourceAssembly = null)
 	{
 		Accessibility = eventSymbol.DeclaredAccessibility;
 		UseOverride = eventSymbol.IsVirtual || eventSymbol.IsAbstract;
@@ -15,8 +15,8 @@ internal record Event
 		Name = eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name;
 		Type = new Type(eventSymbol.Type);
 		ContainingType = eventSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
-		Delegate = new Method(delegateInvokeMethod, null);
-		Attributes = eventSymbol.GetAttributes().ToAttributeArray();
+		Delegate = new Method(delegateInvokeMethod, null, sourceAssembly);
+		Attributes = eventSymbol.GetAttributes().ToAttributeArray(sourceAssembly);
 		IsStatic = eventSymbol.IsStatic;
 
 		if (alreadyDefinedEvents is not null)

--- a/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
@@ -33,15 +33,17 @@ internal readonly record struct GenericParameter
 	public bool IsClass { get; }
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
-	public void AppendWhereConstraint(StringBuilder sb, string prefix, bool inheritsConstraints = false)
+	public void AppendWhereConstraint(StringBuilder sb, string prefix, bool inheritsConstraints = false, bool isExplicitInterfaceImpl = false)
 	{
 		bool isUnconstrained = !ConstraintTypes.Any() && !IsStruct && !IsClass && !IsNotNull && !IsUnmanaged &&
 		                       !HasConstructor && !AllowsRefStruct;
 
 		if (isUnconstrained)
 		{
-			if (inheritsConstraints)
+			if (isExplicitInterfaceImpl)
 			{
+				// Explicit interface implementations need `where T : default` to disambiguate
+				// nullability for unconstrained type parameters. Override methods don't.
 				sb.AppendLine().Append(prefix).Append("where ").Append(Name).Append(" : default");
 			}
 

--- a/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
@@ -33,14 +33,14 @@ internal readonly record struct GenericParameter
 	public bool IsClass { get; }
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
-	public void AppendWhereConstraint(StringBuilder sb, string prefix, bool isExplicitInterfaceImpl = false)
+	public void AppendWhereConstraint(StringBuilder sb, string prefix, bool inheritsConstraints = false)
 	{
 		bool isUnconstrained = !ConstraintTypes.Any() && !IsStruct && !IsClass && !IsNotNull && !IsUnmanaged &&
 		                       !HasConstructor && !AllowsRefStruct;
 
 		if (isUnconstrained)
 		{
-			if (isExplicitInterfaceImpl)
+			if (inheritsConstraints)
 			{
 				sb.AppendLine().Append(prefix).Append("where ").Append(Name).Append(" : default");
 			}
@@ -48,9 +48,9 @@ internal readonly record struct GenericParameter
 			return;
 		}
 
-		if (isExplicitInterfaceImpl)
+		if (inheritsConstraints)
 		{
-			// Constrained type parameters are inherited in explicit interface implementations (CS0460)
+			// Constrained type parameters are inherited in override and explicit interface implementation methods (CS0460)
 			return;
 		}
 

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -7,7 +7,7 @@ namespace Mockolate.SourceGenerators.Entities;
 [DebuggerDisplay("{ContainingType}.{Name}({Parameters})")]
 internal record Method
 {
-	public Method(IMethodSymbol methodSymbol, List<Method>? alreadyDefinedMethods)
+	public Method(IMethodSymbol methodSymbol, List<Method>? alreadyDefinedMethods, IAssemblySymbol? sourceAssembly = null)
 	{
 		Accessibility = methodSymbol.DeclaredAccessibility;
 		UseOverride = methodSymbol.IsVirtual || methodSymbol.IsAbstract;
@@ -26,7 +26,7 @@ internal record Method
 			Name += $"<{string.Join(", ", GenericParameters.Value.Select(x => x.Name))}>";
 		}
 
-		Attributes = methodSymbol.GetAttributes().ToAttributeArray();
+		Attributes = methodSymbol.GetAttributes().ToAttributeArray(sourceAssembly);
 
 		if (alreadyDefinedMethods is not null)
 		{

--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -17,10 +17,10 @@ internal record MockClass : Class
 					.Where(x => x.DeclaredAccessibility == Accessibility.Protected ||
 					            x.DeclaredAccessibility == Accessibility.ProtectedOrInternal ||
 					            x.DeclaredAccessibility == Accessibility.Public)
-					.Select(x => new Method(x, null)).ToArray());
+					.Select(x => new Method(x, null, sourceAssembly)).ToArray());
 			if (namedTypeSymbol.DelegateInvokeMethod is not null)
 			{
-				Delegate = new Method(namedTypeSymbol.DelegateInvokeMethod, null);
+				Delegate = new Method(namedTypeSymbol.DelegateInvokeMethod, null, sourceAssembly);
 			}
 		}
 	}

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -7,7 +7,7 @@ namespace Mockolate.SourceGenerators.Entities;
 [DebuggerDisplay("{ContainingType}.{Name}")]
 internal record Property
 {
-	public Property(IPropertySymbol propertySymbol, List<Property>? alreadyDefinedProperties)
+	public Property(IPropertySymbol propertySymbol, List<Property>? alreadyDefinedProperties, IAssemblySymbol? sourceAssembly = null)
 	{
 		Accessibility = propertySymbol.DeclaredAccessibility;
 		UseOverride = propertySymbol.IsVirtual || propertySymbol.IsAbstract;
@@ -23,7 +23,7 @@ internal record Property
 				propertySymbol.Parameters.Select(x => new MethodParameter(x)).ToArray());
 		}
 
-		Attributes = propertySymbol.GetAttributes().ToAttributeArray();
+		Attributes = propertySymbol.GetAttributes().ToAttributeArray(sourceAssembly);
 
 		if (alreadyDefinedProperties is not null)
 		{
@@ -35,8 +35,10 @@ internal record Property
 			alreadyDefinedProperties.Add(this);
 		}
 
-		Getter = propertySymbol.GetMethod is null ? null : new Method(propertySymbol.GetMethod, null);
-		Setter = propertySymbol.SetMethod is null ? null : new Method(propertySymbol.SetMethod, null);
+		Getter = propertySymbol.GetMethod is { } getter && Helpers.IsOverridableFrom(getter, sourceAssembly)
+			? new Method(getter, null, sourceAssembly) : null;
+		Setter = propertySymbol.SetMethod is { } setter && Helpers.IsOverridableFrom(setter, sourceAssembly)
+			? new Method(setter, null, sourceAssembly) : null;
 	}
 
 	public static IEqualityComparer<Property> EqualityComparer { get; } = new PropertyEqualityComparer();

--- a/Source/Mockolate.SourceGenerators/Helpers.cs
+++ b/Source/Mockolate.SourceGenerators/Helpers.cs
@@ -46,6 +46,27 @@ internal static class Helpers
 		return candidateName;
 	}
 
+	// A member (or accessor) declared in another assembly is overridable only if the overriding
+	// assembly can actually see it. `internal` and `private protected` are invisible across assembly
+	// boundaries unless the declaring assembly grants InternalsVisibleTo. `protected internal`
+	// (= protected OR internal) is always reachable via the protected half from a derived class.
+	public static bool IsOverridableFrom(ISymbol member, IAssemblySymbol? sourceAssembly)
+	{
+		if (sourceAssembly is null ||
+		    member.DeclaredAccessibility is not (Accessibility.Internal or Accessibility.ProtectedAndInternal))
+		{
+			return true;
+		}
+
+		IAssemblySymbol containingAssembly = member.ContainingAssembly;
+		if (SymbolEqualityComparer.Default.Equals(containingAssembly, sourceAssembly))
+		{
+			return true;
+		}
+
+		return containingAssembly.GivesAccessTo(sourceAssembly);
+	}
+
 	extension(ITypeSymbol typeSymbol)
 	{
 		public SpecialGenericType GetSpecialType()
@@ -119,10 +140,12 @@ internal static class Helpers
 
 	extension(ImmutableArray<AttributeData> attributes)
 	{
-		public EquatableArray<Attribute>? ToAttributeArray()
+		public EquatableArray<Attribute>? ToAttributeArray(IAssemblySymbol? sourceAssembly = null)
 		{
 			Attribute[] consideredAttributes = attributes
-				.Where(x => x.AttributeClass != null && !IsNullableAttribute(x.AttributeClass))
+				.Where(x => x.AttributeClass is not null
+				            && !IsCompilerEmittedAttribute(x.AttributeClass)
+				            && IsAccessibleFrom(x.AttributeClass, sourceAssembly))
 				.Select(attr => new Attribute(attr))
 				.ToArray();
 			if (consideredAttributes.Length > 0)
@@ -132,10 +155,38 @@ internal static class Helpers
 
 			return null;
 
-			static bool IsNullableAttribute(INamedTypeSymbol attribute)
+			// Compiler-emitted attributes describe the shape of the original method body (nullability,
+			// iterator/async state machine types) and MUST NOT be copied onto the generated override.
+			// The state-machine attributes reference private nested compiler-generated types that are
+			// invisible outside the declaring assembly (CS0103), and the override has its own,
+			// synchronous body that is not a state machine anyway.
+			static bool IsCompilerEmittedAttribute(INamedTypeSymbol attribute)
 			{
-				return attribute.Name is "NullableContextAttribute" or "NullableAttribute" &&
-				       attribute.ContainingNamespace is { ContainingNamespace: { ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true, ContainingNamespace.Name: "System", Name: "Runtime", }, Name: "CompilerServices", };
+				if (attribute.ContainingNamespace is not { Name: "CompilerServices", ContainingNamespace: { Name: "Runtime", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true, }, }, })
+				{
+					return false;
+				}
+
+				return attribute.Name is "NullableContextAttribute" or "NullableAttribute"
+					or "AsyncStateMachineAttribute" or "IteratorStateMachineAttribute"
+					or "AsyncIteratorStateMachineAttribute";
+			}
+
+			// The attribute name is emitted verbatim into the generated code (e.g.
+			// `[global::Azure.Core.CallerShouldAudit(...)]`). If the attribute class — or any of its
+			// containing types — is not visible to the generated mock assembly, referencing it causes
+			// CS0122. Drop the attribute instead of producing uncompilable output.
+			static bool IsAccessibleFrom(INamedTypeSymbol attribute, IAssemblySymbol? sourceAssembly)
+			{
+				for (INamedTypeSymbol? t = attribute; t is not null; t = t.ContainingType)
+				{
+					if (!IsOverridableFrom(t, sourceAssembly))
+					{
+						return false;
+					}
+				}
+
+				return true;
 			}
 		}
 	}

--- a/Source/Mockolate.SourceGenerators/Helpers.cs
+++ b/Source/Mockolate.SourceGenerators/Helpers.cs
@@ -176,13 +176,33 @@ internal static class Helpers
 			// `[global::Azure.Core.CallerShouldAudit(...)]`). If the attribute class — or any of its
 			// containing types — is not visible to the generated mock assembly, referencing it causes
 			// CS0122. Drop the attribute instead of producing uncompilable output.
+			//
+			// Conservative rule: a type is accessible only if its whole containing chain is either
+			// Public, or Internal/ProtectedOrInternal with InternalsVisibleTo granted (or the
+			// same assembly). Private/Protected/ProtectedAndInternal nested types and
+			// ProtectedOrInternal across assemblies without IVT are treated as inaccessible — the
+			// `protected` half would require knowing the derivation relationship to the declaring
+			// type, which we don't verify here.
 			static bool IsAccessibleFrom(INamedTypeSymbol attribute, IAssemblySymbol? sourceAssembly)
 			{
 				for (INamedTypeSymbol? t = attribute; t is not null; t = t.ContainingType)
 				{
-					if (!IsOverridableFrom(t, sourceAssembly))
+					switch (t.DeclaredAccessibility)
 					{
-						return false;
+						case Accessibility.Public:
+							continue;
+						case Accessibility.Internal:
+						case Accessibility.ProtectedOrInternal:
+							if (sourceAssembly is null ||
+							    SymbolEqualityComparer.Default.Equals(t.ContainingAssembly, sourceAssembly) ||
+							    t.ContainingAssembly.GivesAccessTo(sourceAssembly))
+							{
+								continue;
+							}
+
+							return false;
+						default:
+							return false;
 					}
 				}
 
@@ -238,14 +258,6 @@ internal static class Helpers
 					sb.Append(", ").Append("() => ")
 						.AppendDefaultValueGeneratorFor(genericType, defaultValueName);
 				}
-
-				if (!string.IsNullOrWhiteSpace(suffix))
-				{
-					sb.Append(", ").Append(suffix);
-				}
-
-				sb.Append(")");
-				return sb;
 			}
 
 			if (!string.IsNullOrWhiteSpace(suffix))

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2252,12 +2252,12 @@ internal static partial class Sources
 		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
 		{
 			bool isOverride = !isClassInterface && method.UseOverride;
-			bool inheritsConstraints = explicitInterfaceImplementation || method.ExplicitImplementation is not null ||
-			                           isOverride || method.IsEquals() || method.IsGetHashCode() ||
-			                           method.IsToString();
+			bool isExplicitImplementation = explicitInterfaceImplementation || method.ExplicitImplementation is not null;
+			bool inheritsConstraints = isExplicitImplementation || isOverride || method.IsEquals() ||
+			                           method.IsGetHashCode() || method.IsToString();
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", inheritsConstraints);
+				gp.AppendWhereConstraint(sb, "\t\t\t", inheritsConstraints, isExplicitImplementation);
 			}
 		}
 
@@ -3511,7 +3511,7 @@ internal static partial class Sources
 		{
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", true);
+				gp.AppendWhereConstraint(sb, "\t\t\t", true, true);
 			}
 		}
 
@@ -4897,7 +4897,7 @@ internal static partial class Sources
 		{
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", true);
+				gp.AppendWhereConstraint(sb, "\t\t\t", true, true);
 			}
 		}
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2251,9 +2251,13 @@ internal static partial class Sources
 		sb.Append(')');
 		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
 		{
+			bool isOverride = !isClassInterface && method.UseOverride;
+			bool inheritsConstraints = explicitInterfaceImplementation || method.ExplicitImplementation is not null ||
+			                           isOverride || method.IsEquals() || method.IsGetHashCode() ||
+			                           method.IsToString();
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", explicitInterfaceImplementation);
+				gp.AppendWhereConstraint(sb, "\t\t\t", inheritsConstraints);
 			}
 		}
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2241,12 +2241,12 @@ internal static partial class Sources
 		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
 		{
 			bool isOverride = !isClassInterface && method.UseOverride;
-			bool inheritsConstraints = explicitInterfaceImplementation || method.ExplicitImplementation is not null ||
-			                           isOverride || method.IsEquals() || method.IsGetHashCode() ||
-			                           method.IsToString();
+			bool isExplicitImplementation = explicitInterfaceImplementation || method.ExplicitImplementation is not null;
+			bool inheritsConstraints = isExplicitImplementation || isOverride || method.IsEquals() ||
+			                           method.IsGetHashCode() || method.IsToString();
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", inheritsConstraints);
+				gp.AppendWhereConstraint(sb, "\t\t\t", inheritsConstraints, isExplicitImplementation);
 			}
 		}
 
@@ -3500,7 +3500,7 @@ internal static partial class Sources
 		{
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", true);
+				gp.AppendWhereConstraint(sb, "\t\t\t", true, true);
 			}
 		}
 
@@ -4886,7 +4886,7 @@ internal static partial class Sources
 		{
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", true);
+				gp.AppendWhereConstraint(sb, "\t\t\t", true, true);
 			}
 		}
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2240,9 +2240,13 @@ internal static partial class Sources
 		sb.Append(')');
 		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
 		{
+			bool isOverride = !isClassInterface && method.UseOverride;
+			bool inheritsConstraints = explicitInterfaceImplementation || method.ExplicitImplementation is not null ||
+			                           isOverride || method.IsEquals() || method.IsGetHashCode() ||
+			                           method.IsToString();
 			foreach (GenericParameter gp in method.GenericParameters.Value)
 			{
-				gp.AppendWhereConstraint(sb, "\t\t\t", explicitInterfaceImplementation);
+				gp.AppendWhereConstraint(sb, "\t\t\t", inheritsConstraints);
 			}
 		}
 

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -53,7 +53,7 @@ public class ExampleTests
 		Pageable<TableEntity> pageable = Pageable<TableEntity>.FromPages([settingsPage,]);
 
 		TableClient tableClient = TableClient.CreateMock(MockBehavior.Default.SkippingBaseClass());
-		var blobClient = BlobClient.CreateMock(MockBehavior.Default.ThrowingWhenNotSetup());
+		_ = BlobClient.CreateMock(MockBehavior.Default.ThrowingWhenNotSetup());
 		tableClient.Mock.Setup
 			.Query(It.IsAny<Expression<Func<TableEntity, bool>>>(), It.IsAny<int?>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())
 			.Returns(pageable);

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Mockolate.ExampleTests.TestData;
 using Mockolate.Verify;
 #if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
+using Azure.Data.Tables;
 using Mockolate.Web;
 #endif
 
@@ -33,6 +39,28 @@ public class ExampleTests
 		sut.Mock.As<IExampleRepository>().Verify.AddUser(It.Is("Bob")).Once();
 		sut.Mock.As<IOrderRepository>().Verify.AddOrder(It.Is("Bar")).Once();
 	}
+
+#if NET8_0_OR_GREATER
+	[Fact]
+	public async Task Azure_ShouldBeMockable()
+	{
+		Response response = Response.CreateMock();
+		Page<TableEntity> settingsPage = Page<TableEntity>.FromValues(
+		[
+			new TableEntity("demo", "foo"),
+		], null, response);
+		Pageable<TableEntity> pageable = Pageable<TableEntity>.FromPages([settingsPage,]);
+
+		TableClient tableClient = TableClient.CreateMock(MockBehavior.Default.SkippingBaseClass());
+		tableClient.Mock.Setup
+			.Query(It.IsAny<Expression<Func<TableEntity, bool>>>(), It.IsAny<int?>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())
+			.Returns(pageable);
+		Pageable<TableEntity>? result = tableClient.Query<TableEntity>(x => x.RowKey == "foo", 10, [], CancellationToken.None);
+
+		await That(tableClient.GetType()).IsEqualTo(typeof(Mock.TableClient));
+		await That(result.AsPages().First().GetRawResponse()).IsSameAs(response);
+	}
+#endif
 
 	[Fact]
 	public async Task BaseClassWithConstructorParameters()

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -5,13 +5,14 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure;
 using Mockolate.ExampleTests.TestData;
 using Mockolate.Verify;
 #if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
+using Azure;
 using Azure.Data.Tables;
+using Azure.Storage.Blobs;
 using Mockolate.Web;
 #endif
 
@@ -52,6 +53,7 @@ public class ExampleTests
 		Pageable<TableEntity> pageable = Pageable<TableEntity>.FromPages([settingsPage,]);
 
 		TableClient tableClient = TableClient.CreateMock(MockBehavior.Default.SkippingBaseClass());
+		var blobClient = BlobClient.CreateMock(MockBehavior.Default.ThrowingWhenNotSetup());
 		tableClient.Mock.Setup
 			.Query(It.IsAny<Expression<Func<TableEntity, bool>>>(), It.IsAny<int?>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())
 			.Returns(pageable);

--- a/Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj
+++ b/Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj
@@ -7,6 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Testably.Abstractions"/>
+		<PackageReference Include="Azure.Data.Tables"/>
 		<PackageReference Include="IsExternalInit">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj
+++ b/Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj
@@ -8,6 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Testably.Abstractions"/>
 		<PackageReference Include="Azure.Data.Tables"/>
+		<PackageReference Include="Azure.Storage.Blobs"/>
 		<PackageReference Include="IsExternalInit">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -43,6 +43,46 @@ public sealed partial class MockTests
 					          """).IgnoringNewlineStyle();
 			}
 
+			[Fact]
+			public async Task VirtualMethodOverride_WithConstrainedGeneric_ShouldNotRepeatConstraints()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using System;
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = MyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyInterface
+					     {
+					     }
+
+					     public class MyService
+					     {
+					         public virtual bool MyMethod<T>(T entity)
+					             where T : IMyInterface
+					         {
+					             return true;
+					         }
+					     }
+					     """);
+
+				await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
+					.Contains("""
+					          		/// <inheritdoc cref="global::MyCode.MyService.MyMethod{T}(T)" />
+					          		public override bool MyMethod<T>(T entity)
+					          		{
+					          """).IgnoringNewlineStyle().And
+					.DoesNotContain("public override bool MyMethod<T>(T entity)\n\t\t\twhere T :").IgnoringNewlineStyle().Because("CS0460: constraints on override methods are inherited from the base method");
+			}
+
 			[Theory]
 			[InlineData("class, T")]
 			[InlineData("struct")]


### PR DESCRIPTION
Fixes several source-generation compile errors by adjusting how the generator emits generic constraints, filters/propagates attributes, and determines cross-assembly overridability; adds regression tests and an example targeting Azure SDK types.

**Changes:**
- Adjust generic constraint emission for generated methods to avoid repeating inherited constraints.
- Filter out compiler-emitted and inaccessible attributes when copying attributes onto generated members.
- Improve cross-assembly overridability checks (including InternalsVisibleTo) and add tests/examples (Azure Tables).