### PR TITLE
docs: fix cref-links

### DIFF
--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -13,11 +13,14 @@ namespace Mockolate.SourceGenerators;
 [Generator]
 public class MockGenerator : IIncrementalGenerator
 {
+	private static SourceText ToSource(string source)
+		=> SourceText.From(Sources.Sources.ExpandCrefs(source), Encoding.UTF8);
+
 	void IIncrementalGenerator.Initialize(IncrementalGeneratorInitializationContext context)
 	{
 		context.RegisterPostInitializationOutput(ctx => ctx.AddSource(
 			"Mock.g.cs",
-			SourceText.From(Sources.Sources.MockClass(), Encoding.UTF8)));
+			ToSource(Sources.Sources.MockClass())));
 
 		IncrementalValueProvider<ImmutableArray<MockClass>> expectationsToRegister = context.SyntaxProvider
 			.CreateSyntaxProvider(
@@ -53,17 +56,17 @@ public class MockGenerator : IIncrementalGenerator
 			if (mockToGenerate.Class is MockClass { Delegate: not null, } mockClass)
 			{
 				context.AddSource($"Mock.{mockToGenerate.FileName}.g.cs",
-					SourceText.From(Sources.Sources.MockDelegate(mockToGenerate.Name, mockClass, mockClass.Delegate), Encoding.UTF8));
+					ToSource(Sources.Sources.MockDelegate(mockToGenerate.Name, mockClass, mockClass.Delegate)));
 			}
 			else if (mockToGenerate.AdditionalClasses is null)
 			{
 				context.AddSource($"Mock.{mockToGenerate.FileName}.g.cs",
-					SourceText.From(Sources.Sources.MockClass(mockToGenerate.Name, mockToGenerate.Class, hasOverloadResolutionPriority), Encoding.UTF8));
+					ToSource(Sources.Sources.MockClass(mockToGenerate.Name, mockToGenerate.Class, hasOverloadResolutionPriority)));
 			}
 			else
 			{
 				context.AddSource($"Mock.{mockToGenerate.FileName}.g.cs",
-					SourceText.From(Sources.Sources.MockCombinationClass(mockToGenerate.FileName, mockToGenerate.Name, mockToGenerate.Class, mockToGenerate.AdditionalClasses, combinationSet), Encoding.UTF8));
+					ToSource(Sources.Sources.MockCombinationClass(mockToGenerate.FileName, mockToGenerate.Name, mockToGenerate.Class, mockToGenerate.AdditionalClasses, combinationSet)));
 			}
 		}
 
@@ -79,7 +82,7 @@ public class MockGenerator : IIncrementalGenerator
 		if (indexerSetups.Any())
 		{
 			context.AddSource("IndexerSetups.g.cs",
-				SourceText.From(Sources.Sources.IndexerSetups(indexerSetups), Encoding.UTF8));
+				ToSource(Sources.Sources.IndexerSetups(indexerSetups)));
 		}
 
 		HashSet<(int, bool)> methodSetups = new();
@@ -94,26 +97,25 @@ public class MockGenerator : IIncrementalGenerator
 		if (methodSetups.Any())
 		{
 			context.AddSource("MethodSetups.g.cs",
-				SourceText.From(Sources.Sources.MethodSetups(methodSetups), Encoding.UTF8));
+				ToSource(Sources.Sources.MethodSetups(methodSetups)));
 		}
 
 		const int dotNetFuncActionParameterLimit = 16;
 		if (methodSetups.Any(x => x.Item1 >= dotNetFuncActionParameterLimit))
 		{
 			context.AddSource("ActionFunc.g.cs",
-				SourceText.From(
-					Sources.Sources.ActionFunc(methodSetups
-						.Where(x => x.Item1 >= dotNetFuncActionParameterLimit)
-						.SelectMany<(int, bool), int>(x => [x.Item1, x.Item1 + 1,])
-						.Where(x => x > dotNetFuncActionParameterLimit)
-						.Distinct()), Encoding.UTF8));
+				ToSource(Sources.Sources.ActionFunc(methodSetups
+					.Where(x => x.Item1 >= dotNetFuncActionParameterLimit)
+					.SelectMany<(int, bool), int>(x => [x.Item1, x.Item1 + 1,])
+					.Where(x => x > dotNetFuncActionParameterLimit)
+					.Distinct())));
 		}
 
 		if (methodSetups.Any(x => !x.Item2))
 		{
 			context.AddSource("ReturnsThrowsAsyncExtensions.g.cs",
-				SourceText.From(Sources.Sources.ReturnsThrowsAsyncExtensions(methodSetups
-					.Where(x => !x.Item2).Select(x => x.Item1).ToArray()), Encoding.UTF8));
+				ToSource(Sources.Sources.ReturnsThrowsAsyncExtensions(methodSetups
+					.Where(x => !x.Item2).Select(x => x.Item1).ToArray())));
 		}
 
 		// Ref-struct method setups for arity > 4. The hand-written types in
@@ -156,12 +158,11 @@ public class MockGenerator : IIncrementalGenerator
 		if (refStructMethodSetups.Any() || refStructIndexerArities.Any())
 		{
 			context.AddSource("RefStructMethodSetups.g.cs",
-				SourceText.From(Sources.Sources.RefStructMethodSetups(refStructMethodSetups, refStructIndexerArities),
-					Encoding.UTF8));
+				ToSource(Sources.Sources.RefStructMethodSetups(refStructMethodSetups, refStructIndexerArities)));
 		}
 
 		context.AddSource("MockBehaviorExtensions.g.cs",
-			SourceText.From(Sources.Sources.MockBehaviorExtensions(mocksToGenerate), Encoding.UTF8));
+			ToSource(Sources.Sources.MockBehaviorExtensions(mocksToGenerate)));
 	}
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -204,7 +204,7 @@ internal static partial class Sources
 		sb.AppendXmlSummary(
 			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
 		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <see cref=\"global::Mockolate.MockBehavior.Default\" />.");
+		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <c>MockBehavior.Default</c>.");
 		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
 		sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
 		sb.AppendXmlReturns(createMockReturns);
@@ -1393,16 +1393,20 @@ internal static partial class Sources
 	}
 
 	/// <summary>
-	///     Builds an XML-doc cref string for the given <paramref name="constructor" /> on
-	///     <paramref name="class" />, in the form <c>{class-cref}.{simple-name}({param-types})</c>,
-	///     or returns <see langword="null" /> when no valid cref can be produced.
+	///     Builds an XML-doc cref string and a matching short display text for the given
+	///     <paramref name="constructor" /> on <paramref name="class" />. The cref has the form
+	///     <c>{class-cref}.{simple-name}({fully-qualified-param-types})</c>; the display has the
+	///     form <c>{simple-name}({short-param-types})</c>, intended as the inner text of
+	///     <c>&lt;see cref="..."&gt;...&lt;/see&gt;</c> so the rendered prose reads
+	///     <c>the MyClass(int) constructor</c> rather than <c>the MyClass.MyClass(int) constructor</c>.
+	///     Returns <see langword="null" /> when no valid cref can be produced.
 	/// </summary>
 	/// <remarks>
 	///     Generic classes are skipped because the cref type-parameter-list syntax (e.g. <c>{T}</c>)
 	///     expects identifier tokens, not the concrete type arguments that closed generics carry —
 	///     emitting <c>MyClass{int}.MyClass(int)</c> would surface CS1584/CS1658 on the consumer side.
 	/// </remarks>
-	private static string? BuildConstructorCref(Class @class, Method constructor)
+	private static (string Cref, string Display)? BuildConstructorCref(Class @class, Method constructor)
 	{
 		string fullName = @class.ClassFullName;
 
@@ -1415,21 +1419,28 @@ internal static partial class Sources
 		string simpleName = lastDot >= 0 ? fullName.Substring(lastDot + 1) : fullName;
 
 		StringBuilder cref = new();
+		StringBuilder display = new();
 		cref.Append(fullName).Append('.').Append(simpleName).Append('(');
+		display.Append(simpleName).Append('(');
 		bool first = true;
 		foreach (MethodParameter parameter in constructor.Parameters)
 		{
 			if (!first)
 			{
 				cref.Append(", ");
+				display.Append(", ");
 			}
 
 			first = false;
 			cref.Append(parameter.Type.Fullname.EscapeForXmlDoc());
+			// Inner text of <see> is XML content, so escape '<'/'>' as entities
+			// (unlike cref attributes, which use the '{...}' shorthand).
+			display.Append(parameter.Type.DisplayName.Replace("<", "&lt;").Replace(">", "&gt;"));
 		}
 
 		cref.Append(')');
-		return cref.ToString();
+		display.Append(')');
+		return (cref.ToString(), display.ToString());
 	}
 
 #pragma warning disable S107 // Methods should not have too many parameters
@@ -1457,10 +1468,10 @@ internal static partial class Sources
 			return;
 		}
 
-		string? constructorCref = BuildConstructorCref(@class, constructor);
+		(string Cref, string Display)? constructorCref = BuildConstructorCref(@class, constructor);
 		string ctorPhrase = constructorCref is null
 			? "the base-class constructor"
-			: $"the <see cref=\"{constructorCref}\" /> constructor";
+			: $"the <see cref=\"{constructorCref.Value.Cref}\">{constructorCref.Value.Display}</see> constructor";
 
 		if (includeMockBehavior && includeSetup)
 		{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -355,6 +355,151 @@ internal static partial class Sources
 			=> value.Replace('<', '{').Replace('>', '}');
 	}
 
+	/// <summary>
+	///     Rewrites every self-closing <c>&lt;see cref="X" /&gt;</c> inside <paramref name="source" />
+	///     to <c>&lt;see cref="X"&gt;Display&lt;/see&gt;</c>, where <c>Display</c> is a simplified
+	///     version of the cref (outer namespace and enclosing types stripped, inner namespace
+	///     qualifiers inside generic arguments / parameter lists stripped to their rightmost
+	///     segment, and cref-style <c>{T}</c> generics rendered as <c>&amp;lt;T&amp;gt;</c>).
+	///     This keeps the IDE/docs link intact while making the rendered prose shorter and avoiding
+	///     the <c>Type.Type(...)</c> duplication that constructor crefs otherwise show.
+	/// </summary>
+	/// <remarks>
+	///     Tags that already carry inner text (<c>&lt;see cref="X"&gt;...&lt;/see&gt;</c>) are left
+	///     untouched so callers can override the default display when needed.
+	/// </remarks>
+	internal static string ExpandCrefs(string source)
+	{
+		const string OpenTag = "<see cref=\"";
+		int searchFrom = 0;
+		int copiedUpTo = 0;
+		StringBuilder? result = null;
+		while (true)
+		{
+			int start = source.IndexOf(OpenTag, searchFrom, StringComparison.Ordinal);
+			if (start < 0)
+			{
+				break;
+			}
+
+			int crefStart = start + OpenTag.Length;
+			int crefEnd = source.IndexOf('"', crefStart);
+			if (crefEnd < 0)
+			{
+				break;
+			}
+
+			int after = crefEnd + 1;
+			while (after < source.Length && source[after] == ' ')
+			{
+				after++;
+			}
+
+			if (after + 1 < source.Length && source[after] == '/' && source[after + 1] == '>')
+			{
+				string cref = source.Substring(crefStart, crefEnd - crefStart);
+				string display = SimplifyCrefForDisplay(cref);
+				result ??= new StringBuilder(source.Length + 64);
+				result.Append(source, copiedUpTo, start - copiedUpTo);
+				result.Append(OpenTag).Append(cref).Append("\">").Append(display).Append("</see>");
+				copiedUpTo = after + 2;
+				searchFrom = after + 2;
+			}
+			else
+			{
+				searchFrom = crefEnd + 1;
+			}
+		}
+
+		if (result is null)
+		{
+			return source;
+		}
+
+		result.Append(source, copiedUpTo, source.Length - copiedUpTo);
+		return result.ToString();
+	}
+
+	/// <summary>
+	///     Derives a short display form from a cref value.
+	///     <list type="number">
+	///         <item>Strips every <c>global::</c> prefix.</item>
+	///         <item>
+	///             Keeps everything from the last <c>.</c> that precedes the first <c>{</c> or
+	///             <c>(</c> — i.e. drops the outer namespace / enclosing-type qualifiers but
+	///             preserves a trailing <c>Type.Member</c> chain when no brackets are present.
+	///         </item>
+	///         <item>
+	///             Inside the first <c>{…}</c> / <c>(…)</c> and everything after it, reduces each
+	///             dotted identifier chain to its rightmost segment (so
+	///             <c>(System.Func{object?[], bool}, string)</c> becomes
+	///             <c>(Func{object?[], bool}, string)</c>).
+	///         </item>
+	///         <item>
+	///             Converts cref-style <c>{</c>/<c>}</c> generics to <c>&amp;lt;</c>/<c>&amp;gt;</c>
+	///             so the rendered text shows actual angle brackets.
+	///         </item>
+	///     </list>
+	/// </summary>
+	private static string SimplifyCrefForDisplay(string cref)
+	{
+		string stripped = cref.Replace("global::", string.Empty);
+		int firstBracket = stripped.IndexOfAny(['{', '(']);
+		int searchEnd = firstBracket < 0 ? stripped.Length : firstBracket;
+		int lastDot = searchEnd > 0 ? stripped.LastIndexOf('.', searchEnd - 1) : -1;
+		string simplified = lastDot >= 0 ? stripped.Substring(lastDot + 1) : stripped;
+		simplified = StripInnerNamespaces(simplified);
+		return simplified.Replace("{", "&lt;").Replace("}", "&gt;");
+	}
+
+	/// <summary>
+	///     Within the portion of <paramref name="value" /> that starts at the first <c>{</c> or
+	///     <c>(</c>, reduces every dotted identifier chain (e.g. <c>System.Collections.Generic.List</c>)
+	///     to its rightmost segment. The head preceding that first bracket is left untouched so
+	///     a legitimate <c>Type.Member</c> prefix is preserved.
+	/// </summary>
+	private static string StripInnerNamespaces(string value)
+	{
+		int firstBracket = value.IndexOfAny(['{', '(']);
+		if (firstBracket < 0)
+		{
+			return value;
+		}
+
+		StringBuilder sb = new(value.Length);
+		sb.Append(value, 0, firstBracket);
+		int i = firstBracket;
+		while (i < value.Length)
+		{
+			char c = value[i];
+			if (IsIdentifierStart(c))
+			{
+				int lastIdStart = i;
+				while (i < value.Length && (IsIdentifierPart(value[i]) || value[i] == '.'))
+				{
+					if (value[i] == '.')
+					{
+						lastIdStart = i + 1;
+					}
+
+					i++;
+				}
+
+				sb.Append(value, lastIdStart, i - lastIdStart);
+			}
+			else
+			{
+				sb.Append(c);
+				i++;
+			}
+		}
+
+		return sb.ToString();
+
+		static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
+		static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_';
+	}
+
 	extension(StringBuilder sb)
 	{
 		/// <summary>

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -1171,7 +1171,7 @@ public partial class MockGeneratorTests
 			     """, DocumentationMode.Diagnose);
 
 		await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
-			.Contains($"to invoke the <see cref=\"{expectedCref}\" /> constructor.")
+			.Contains($"to invoke the <see cref=\"{expectedCref}\">MyService(int, string)</see> constructor.")
 			.IgnoringNewlineStyle();
 
 		// CS1574/CS1584/CS1658 messages embed the offending cref text; if the constructor cref

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
@@ -71,7 +71,7 @@ public sealed partial class MockTests
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
 					.Contains("""
 					          		/// <summary>
-					          		///     Setup for the event <see cref="global::MyCode.IMyService.SomeEvent" />.
+					          		///     Setup for the event <see cref="global::MyCode.IMyService.SomeEvent">SomeEvent</see>.
 					          		/// </summary>
 					          		global::Mockolate.Setup.EventSetup SomeEvent { get; }
 					          """).IgnoringNewlineStyle().And

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -69,14 +69,14 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-				.Contains("Setup for the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\" />.").And
-				.Contains("Verify interactions with the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\" />.").And
-				.Contains("Setup for the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\" />").And
-				.Contains("Verify interactions with the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\" />.").And
-				.Contains("Setup for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\"/>.").And
-				.Contains("Verify invocations for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\"/>.").And
-				.Contains("Raise the <see cref=\"global::MyCode.IMyBaseService.BaseEvent\"/> event.").And
-				.Contains("Verify subscriptions on the BaseEvent event of <see cref=\"global::MyCode.IMyBaseService.BaseEvent\" />.");
+				.Contains("Setup for the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\">BaseProperty</see>.").And
+				.Contains("Verify interactions with the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\">BaseProperty</see>.").And
+				.Contains("Setup for the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\">this[string]</see>").And
+				.Contains("Verify interactions with the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\">this[string]</see>.").And
+				.Contains("Setup for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\">BaseMethod()</see>.").And
+				.Contains("Verify invocations for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\">BaseMethod()</see>.").And
+				.Contains("Raise the <see cref=\"global::MyCode.IMyBaseService.BaseEvent\">BaseEvent</see> event.").And
+				.Contains("Verify subscriptions on the BaseEvent event of <see cref=\"global::MyCode.IMyBaseService.BaseEvent\">BaseEvent</see>.");
 		}
 
 		[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -324,8 +324,8 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Program_DoSomething.g.cs").WhoseValue
-				.Contains("Verify invocations for the delegate <see cref=\"global::MyCode.Program.DoSomething\"/> with the given <paramref name=\"x\"/>, <paramref name=\"y\"/>.").And
-				.Contains("Verify invocations for the delegate <see cref=\"global::MyCode.Program.DoSomething\"/> with the given <paramref name=\"parameters\"/>.").And
+				.Contains("Verify invocations for the delegate <see cref=\"global::MyCode.Program.DoSomething\">DoSomething</see> with the given <paramref name=\"x\"/>, <paramref name=\"y\"/>.").And
+				.Contains("Verify invocations for the delegate <see cref=\"global::MyCode.Program.DoSomething\">DoSomething</see> with the given <paramref name=\"parameters\"/>.").And
 				.DoesNotContain("Verify invocations for the method <see cref=\"global::MyCode.Program.DoSomething.Verify(");
 		}
 	}


### PR DESCRIPTION
This PR improves the readability of XML documentation produced by the source generator by expanding self-closing `<see cref="..."/>` tags into `<see cref="...">Display</see>` form, and updates generator tests to match the new output.

**Changes:**
- Add `Sources.ExpandCrefs(...)` to rewrite self-closing `<see cref="..."/>` tags with a derived display text.
- Update constructor XML doc generation to emit `<see>` tags with explicit inner text to avoid `Type.Type(...)` duplication in rendered docs.
- Update source-generator tests’ string expectations to match the expanded `<see>` format.