### PR TITLE
docs: prepare analyzers for v3.0 release

### DIFF
--- a/Source/Mockolate.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Mockolate.Analyzers/AnalyzerReleases.Shipped.md
@@ -6,3 +6,4 @@
 ---------------|----------|----------|---------------------------------
  Mockolate0001 | Usage    | Error    | Verifications must be used      
  Mockolate0002 | Usage    | Error    | Mock arguments must be mockable 
+ Mockolate0003 | Usage    | Warning  | Ref-struct parameter mocking not supported on this build

--- a/Source/Mockolate.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Source/Mockolate.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,5 +1,4 @@
 ### New Rules
 
- Rule ID       | Category | Severity | Notes
----------------|----------|----------|--------------------------------------------------------
- Mockolate0003 | Usage    | Warning  | Ref-struct parameter mocking not supported on this build
+ Rule ID | Category | Severity | Notes 
+---------|----------|----------|-------


### PR DESCRIPTION
Moves analyzer rule `Mockolate0003` from the “Unshipped” release notes to the “Shipped” release notes to reflect that it’s now considered released.

**Changes:**
- Remove `Mockolate0003` from `AnalyzerReleases.Unshipped.md`.
- Add `Mockolate0003` to `AnalyzerReleases.Shipped.md`.