### PR TITLE
refactor: optimize stateless parameter match classes

### DIFF
--- a/Source/Mockolate/It.IsAny.cs
+++ b/Source/Mockolate/It.IsAny.cs
@@ -1,3 +1,4 @@
+using System;
 using Mockolate.Internals;
 using Mockolate.Parameters;
 
@@ -22,17 +23,28 @@ public partial class It
 	/// <typeparam name="T">The declared type of the parameter.</typeparam>
 	/// <returns>A parameter matcher that accepts every value of type <typeparamref name="T" />.</returns>
 	public static IParameterWithCallback<T> IsAny<T>()
-		=> new AnyParameterMatch<T>();
+		=> AnyParameterMatch<T>.Shared;
 
 #if !DEBUG
 	[System.Diagnostics.DebuggerNonUserCode]
 #endif
-	private sealed class AnyParameterMatch<T> : TypedMatch<T>
+	private class AnyParameterMatch<T> : TypedMatch<T>
 	{
+		internal static readonly AnyParameterMatch<T> Shared = new SharedAnyParameterMatch();
+
 		protected override bool Matches(T value) => true;
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => $"It.IsAny<{typeof(T).FormatType()}>()";
+
+#if !DEBUG
+		[System.Diagnostics.DebuggerNonUserCode]
+#endif
+		private sealed class SharedAnyParameterMatch : AnyParameterMatch<T>
+		{
+			protected override IParameterWithCallback<T> AddCallback(Action<T> callback)
+				=> ((IParameterWithCallback<T>)new AnyParameterMatch<T>()).Do(callback);
+		}
 	}
 }
 #pragma warning restore S3218 // Inner class members should not shadow outer class "static" or type members

--- a/Source/Mockolate/It.IsFalse.cs
+++ b/Source/Mockolate/It.IsFalse.cs
@@ -1,3 +1,4 @@
+using System;
 using Mockolate.Parameters;
 
 namespace Mockolate;
@@ -14,18 +15,29 @@ public partial class It
 	///     opposite.
 	/// </remarks>
 	public static IParameterWithCallback<bool> IsFalse()
-		=> new FalseParameterMatch();
+		=> FalseParameterMatch.Shared;
 
 #if !DEBUG
 	[System.Diagnostics.DebuggerNonUserCode]
 #endif
-	private sealed class FalseParameterMatch : TypedMatch<bool>
+	private class FalseParameterMatch : TypedMatch<bool>
 	{
+		internal static readonly FalseParameterMatch Shared = new SharedFalseParameterMatch();
+
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />
 		protected override bool Matches(bool value) => !value;
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => "It.IsFalse()";
+
+#if !DEBUG
+		[System.Diagnostics.DebuggerNonUserCode]
+#endif
+		private sealed class SharedFalseParameterMatch : FalseParameterMatch
+		{
+			protected override IParameterWithCallback<bool> AddCallback(Action<bool> callback)
+				=> ((IParameterWithCallback<bool>)new FalseParameterMatch()).Do(callback);
+		}
 	}
 }
 #pragma warning restore S3218 // Inner class members should not shadow outer class "static" or type members

--- a/Source/Mockolate/It.IsNotNull.cs
+++ b/Source/Mockolate/It.IsNotNull.cs
@@ -1,3 +1,4 @@
+using System;
 using Mockolate.Internals;
 using Mockolate.Parameters;
 
@@ -18,13 +19,15 @@ public partial class It
 	/// <param name="toString">Optional override for the matcher's <see cref="object.ToString" /> rendering, used in failure messages.</param>
 	/// <returns>A parameter matcher that accepts every non-<see langword="null" /> argument.</returns>
 	public static IParameterWithCallback<T> IsNotNull<T>(string? toString = null)
-		=> new NotNullParameterMatch<T>(toString);
+		=> toString is null ? NotNullParameterMatch<T>.Shared : new NotNullParameterMatch<T>(toString);
 
 #if !DEBUG
 	[System.Diagnostics.DebuggerNonUserCode]
 #endif
-	private sealed class NotNullParameterMatch<T>(string? toString) : TypedMatch<T>
+	private class NotNullParameterMatch<T>(string? toString) : TypedMatch<T>
 	{
+		internal static readonly NotNullParameterMatch<T> Shared = new SharedNotNullParameterMatch();
+
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />
 		protected override bool Matches(T value) => value is not null;
 
@@ -33,6 +36,15 @@ public partial class It
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => toString ?? $"It.IsNotNull<{typeof(T).FormatType()}>()";
+
+#if !DEBUG
+		[System.Diagnostics.DebuggerNonUserCode]
+#endif
+		private sealed class SharedNotNullParameterMatch() : NotNullParameterMatch<T>(null)
+		{
+			protected override IParameterWithCallback<T> AddCallback(Action<T> callback)
+				=> ((IParameterWithCallback<T>)new NotNullParameterMatch<T>(null)).Do(callback);
+		}
 	}
 }
 #pragma warning restore S3218 // Inner class members should not shadow outer class "static" or type members

--- a/Source/Mockolate/It.IsNull.cs
+++ b/Source/Mockolate/It.IsNull.cs
@@ -1,3 +1,4 @@
+using System;
 using Mockolate.Internals;
 using Mockolate.Parameters;
 
@@ -18,18 +19,29 @@ public partial class It
 	/// <param name="toString">Optional override for the matcher's <see cref="object.ToString" /> rendering, used in failure messages.</param>
 	/// <returns>A parameter matcher that only accepts <see langword="null" />.</returns>
 	public static IParameterWithCallback<T> IsNull<T>(string? toString = null)
-		=> new NullParameterMatch<T>(toString);
+		=> toString is null ? NullParameterMatch<T>.Shared : new NullParameterMatch<T>(toString);
 
 #if !DEBUG
 	[System.Diagnostics.DebuggerNonUserCode]
 #endif
-	private sealed class NullParameterMatch<T>(string? toString) : TypedMatch<T>
+	private class NullParameterMatch<T>(string? toString) : TypedMatch<T>
 	{
+		internal static readonly NullParameterMatch<T> Shared = new SharedNullParameterMatch();
+
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />
 		protected override bool Matches(T value) => value is null;
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => toString ?? $"It.IsNull<{typeof(T).FormatType()}>()";
+
+#if !DEBUG
+		[System.Diagnostics.DebuggerNonUserCode]
+#endif
+		private sealed class SharedNullParameterMatch() : NullParameterMatch<T>(null)
+		{
+			protected override IParameterWithCallback<T> AddCallback(Action<T> callback)
+				=> ((IParameterWithCallback<T>)new NullParameterMatch<T>(null)).Do(callback);
+		}
 	}
 }
 #pragma warning restore S3218 // Inner class members should not shadow outer class "static" or type members

--- a/Source/Mockolate/It.IsTrue.cs
+++ b/Source/Mockolate/It.IsTrue.cs
@@ -1,3 +1,4 @@
+using System;
 using Mockolate.Parameters;
 
 namespace Mockolate;
@@ -14,18 +15,29 @@ public partial class It
 	///     <see cref="IsFalse" /> for the opposite.
 	/// </remarks>
 	public static IParameterWithCallback<bool> IsTrue()
-		=> new TrueParameterMatch();
+		=> TrueParameterMatch.Shared;
 
 #if !DEBUG
 	[System.Diagnostics.DebuggerNonUserCode]
 #endif
-	private sealed class TrueParameterMatch : TypedMatch<bool>
+	private class TrueParameterMatch : TypedMatch<bool>
 	{
+		internal static readonly TrueParameterMatch Shared = new SharedTrueParameterMatch();
+
 		/// <inheritdoc cref="TypedMatch{T}.Matches(T)" />
 		protected override bool Matches(bool value) => value;
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString() => "It.IsTrue()";
+
+#if !DEBUG
+		[System.Diagnostics.DebuggerNonUserCode]
+#endif
+		private sealed class SharedTrueParameterMatch : TrueParameterMatch
+		{
+			protected override IParameterWithCallback<bool> AddCallback(Action<bool> callback)
+				=> ((IParameterWithCallback<bool>)new TrueParameterMatch()).Do(callback);
+		}
 	}
 }
 #pragma warning restore S3218 // Inner class members should not shadow outer class "static" or type members

--- a/Source/Mockolate/It.cs
+++ b/Source/Mockolate/It.cs
@@ -52,6 +52,16 @@ public partial class It
 
 		/// <inheritdoc cref="IParameterWithCallback{T}.Do(Action{T})" />
 		IParameterWithCallback<T> IParameterWithCallback<T>.Do(Action<T> callback)
+			=> AddCallback(callback);
+
+		/// <summary>
+		///     Attaches a <paramref name="callback" /> to this matcher and returns the matcher to continue the fluent chain.
+		/// </summary>
+		/// <remarks>
+		///     Default: mutates this instance's callback list. Override in cached/shared matcher instances to allocate a fresh
+		///     mutable copy so the singleton never accumulates per-call callbacks.
+		/// </remarks>
+		protected virtual IParameterWithCallback<T> AddCallback(Action<T> callback)
 		{
 			_callbacks ??= [];
 			_callbacks.Add(callback);

--- a/Source/Mockolate/ParameterExtensions.cs
+++ b/Source/Mockolate/ParameterExtensions.cs
@@ -22,9 +22,8 @@ public static class ParameterExtensions
 		out IParameterMonitor<T> monitor)
 	{
 		ParameterMonitor<T> parameterMonitor = new();
-		parameter.Do(v => parameterMonitor.AddValue(v));
 		monitor = parameterMonitor;
-		return parameter;
+		return parameter.Do(v => parameterMonitor.AddValue(v));
 	}
 
 	/// <summary>

--- a/Tests/Mockolate.Tests/ItTests.IsAnyTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsAnyTests.cs
@@ -6,6 +6,27 @@ public sealed partial class ItTests
 {
 	public sealed class IsAnyTests
 	{
+		[Fact]
+		public async Task CachedMatcher_CallbackFromPriorDo_ShouldNotLeakIntoSubsequentUsage()
+		{
+			_ = It.IsAny<int>().Do(_ => throw new InvalidOperationException("callback leaked from prior use"));
+
+			IParameter<int> subsequent = It.IsAny<int>();
+
+			await That(() => ((IParameterMatch<int>)subsequent).InvokeCallbacks(42)).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task CachedMatcher_MonitorFromPriorUsage_ShouldNotLeakIntoSubsequentUsage()
+		{
+			_ = It.IsAny<int>().Monitor(out IParameterMonitor<int> leakedMonitor);
+
+			IParameter<int> subsequent = It.IsAny<int>();
+			((IParameterMatch<int>)subsequent).InvokeCallbacks(42);
+
+			await That(leakedMonitor.Values).IsEmpty();
+		}
+
 		[Theory]
 		[InlineData(null)]
 		[InlineData("")]

--- a/Tests/Mockolate.Tests/ItTests.IsFalseTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsFalseTests.cs
@@ -6,6 +6,16 @@ public sealed partial class ItTests
 {
 	public sealed class IsFalseTests
 	{
+		[Fact]
+		public async Task CachedMatcher_CallbackFromPriorDo_ShouldNotLeakIntoSubsequentUsage()
+		{
+			_ = It.IsFalse().Do(_ => throw new InvalidOperationException("callback leaked from prior use"));
+
+			IParameter<bool> subsequent = It.IsFalse();
+
+			await That(() => ((IParameterMatch<bool>)subsequent).InvokeCallbacks(false)).DoesNotThrow();
+		}
+
 		[Theory]
 		[InlineData(false, 1)]
 		[InlineData(true, 0)]

--- a/Tests/Mockolate.Tests/ItTests.IsNotNullTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNotNullTests.cs
@@ -7,6 +7,16 @@ public sealed partial class ItTests
 {
 	public sealed class IsNotNullTests
 	{
+		[Fact]
+		public async Task CachedMatcher_CallbackFromPriorDo_ShouldNotLeakIntoSubsequentUsage()
+		{
+			_ = It.IsNotNull<string>().Do(_ => throw new InvalidOperationException("callback leaked from prior use"));
+
+			IParameter<string> subsequent = It.IsNotNull<string>();
+
+			await That(() => ((IParameterMatch<string>)subsequent).InvokeCallbacks("value")).DoesNotThrow();
+		}
+
 		[Theory]
 		[InlineData(null, 0)]
 		[InlineData(1, 1)]

--- a/Tests/Mockolate.Tests/ItTests.IsNullTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNullTests.cs
@@ -7,6 +7,16 @@ public sealed partial class ItTests
 {
 	public sealed class IsNullTests
 	{
+		[Fact]
+		public async Task CachedMatcher_CallbackFromPriorDo_ShouldNotLeakIntoSubsequentUsage()
+		{
+			_ = It.IsNull<string?>().Do(_ => throw new InvalidOperationException("callback leaked from prior use"));
+
+			IParameter<string?> subsequent = It.IsNull<string?>();
+
+			await That(() => ((IParameterMatch<string?>)subsequent).InvokeCallbacks(null)).DoesNotThrow();
+		}
+
 		[Theory]
 		[InlineData(null, 1)]
 		[InlineData(1, 0)]

--- a/Tests/Mockolate.Tests/ItTests.IsTrueTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsTrueTests.cs
@@ -7,6 +7,16 @@ public sealed partial class ItTests
 	public sealed class IsTrueTests
 	{
 		[Fact]
+		public async Task CachedMatcher_CallbackFromPriorDo_ShouldNotLeakIntoSubsequentUsage()
+		{
+			_ = It.IsTrue().Do(_ => throw new InvalidOperationException("callback leaked from prior use"));
+
+			IParameter<bool> subsequent = It.IsTrue();
+
+			await That(() => ((IParameterMatch<bool>)subsequent).InvokeCallbacks(true)).DoesNotThrow();
+		}
+
+		[Fact]
 		public async Task ToString_ShouldReturnExpectedValue()
 		{
 			IParameter<bool> sut = It.IsTrue();


### PR DESCRIPTION
Refactors several stateless `It.*` parameter matchers to reduce allocations by using shared singleton instances, while ensuring per-call callbacks don’t accumulate on shared matchers.

**Changes:**
- Fix `ParameterExtensions.Monitor` to return the result of `.Do(...)` (important now that `.Do(...)` may allocate a fresh matcher instance for shared matchers).
- Introduce `TypedMatch<T>.AddCallback(...)` as an overridable hook so shared/cached matchers can remain stateless.
- Update `It.IsAny<T>()`, `It.IsNull<T>()`, `It.IsNotNull<T>()`, `It.IsTrue()`, and `It.IsFalse()` to return shared matcher instances and override callback attachment behavior.