### PR TITLE
perf!: add state-passing variant of Invoke method to avoid closures

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -599,6 +599,9 @@ internal static partial class Sources
 		sb.Append(");").AppendLine();
 		sb.AppendLine();
 
+		string parameterTuple = "(" + string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"parameter{x}")) + ")";
+		string stateArgs = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"state.parameter{x}"));
+
 		sb.AppendXmlSummary("Triggers any configured parameter callbacks for the method setup with the specified parameters.");
 		sb.Append("\t\tpublic virtual void TriggerCallbacks(").Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i} parameter{i}"))).Append(")").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -609,7 +612,8 @@ internal static partial class Sources
 		sb.Append("\t\t\t\tfor (int i = 0; i < _callbacks.Count; i++)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\tvar callback = _callbacks[(currentCallbacksIndex + i) % _callbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\t\tif (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))").AppendLine();
+		sb.Append("\t\t\t\t\tif (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, ").Append(parameterTuple).Append(",").AppendLine();
+		sb.Append("\t\t\t\t\t\tstatic (invocationCount, @delegate, state) => @delegate(invocationCount, ").Append(stateArgs).Append(")))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();
 		sb.Append("\t\t\t\t\t}").AppendLine();
@@ -620,16 +624,12 @@ internal static partial class Sources
 		sb.Append("\t\t\t\tforeach (var _ in _returnCallbacks)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\tvar returnCallback = _returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\t\tif (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback))").AppendLine();
+		sb.Append("\t\t\t\t\tif (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, ").Append(parameterTuple).Append(",").AppendLine();
+		sb.Append("\t\t\t\t\t\tstatic (invocationCount, @delegate, state) => @delegate(invocationCount, ").Append(stateArgs).Append(")))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\treturn;").AppendLine();
 		sb.Append("\t\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
-		sb.Append("\t\t\tvoid Callback(int invocationCount, global::System.Action<int, ").Append(typeParams).Append("> @delegate)").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t@delegate(invocationCount, ").Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"parameter{x}"))).Append(");").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -1232,6 +1232,11 @@ internal static partial class Sources
 		sb.Append("\t\t\t=> _skipBaseClass ?? behavior.SkipBaseClass;").AppendLine();
 		sb.AppendLine();
 
+		string parameterTuple = "(" + string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}")) + ")";
+		string parameterStateArgs = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"state.p{x}"));
+		string triggerTuple = "(" + string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"parameter{x}")) + ")";
+		string triggerStateArgs = string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"state.parameter{x}"));
+
 		sb.AppendXmlSummary("Gets the registered return value.");
 		sb.Append("\t\tpublic bool TryGetReturnValue(").Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(i => $"T{i} p{i}"))).Append(", out TReturn returnValue)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -1240,8 +1245,9 @@ internal static partial class Sources
 		sb.Append("\t\t\t\tforeach (var _ in _returnCallbacks)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\tvar returnCallback = _returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\t\tif (returnCallback.Invoke<TReturn>(ref _returnCallbacks.CurrentIndex, (invocationCount, @delegate)").AppendLine();
-		sb.Append("\t\t\t\t\t\t=> @delegate(invocationCount, ").Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"p{x}"))).Append("), out TReturn? newValue))").AppendLine();
+		sb.Append("\t\t\t\t\tif (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, ").Append(parameterTuple).Append(",").AppendLine();
+		sb.Append("\t\t\t\t\t\tstatic (invocationCount, @delegate, state) => @delegate(invocationCount, ").Append(parameterStateArgs).Append("),").AppendLine();
+		sb.Append("\t\t\t\t\t\tout TReturn? newValue))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\treturnValue = newValue;").AppendLine();
 		sb.Append("\t\t\t\t\t\treturn true;").AppendLine();
@@ -1278,16 +1284,12 @@ internal static partial class Sources
 		sb.Append("\t\t\t\tfor (int i = 0; i < _callbacks.Count; i++)").AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\tvar callback = _callbacks[(currentCallbacksIndex + i) % _callbacks.Count];").AppendLine();
-		sb.Append("\t\t\t\t\tif (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))").AppendLine();
+		sb.Append("\t\t\t\t\tif (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, ").Append(triggerTuple).Append(",").AppendLine();
+		sb.Append("\t\t\t\t\t\tstatic (invocationCount, @delegate, state) => @delegate(invocationCount, ").Append(triggerStateArgs).Append(")))").AppendLine();
 		sb.Append("\t\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\t\twasInvoked = true;").AppendLine();
 		sb.Append("\t\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
-		sb.Append("\t\t\tvoid Callback(int invocationCount, global::System.Action<int, ").Append(typeParams).Append("> @delegate)").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t@delegate(invocationCount, ").Append(string.Join(", ", Enumerable.Range(1, numberOfParameters).Select(x => $"parameter{x}"))).Append(");").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();

--- a/Source/Mockolate/Setup/Callback.cs
+++ b/Source/Mockolate/Setup/Callback.cs
@@ -111,124 +111,7 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	/// <summary>
 	///     Invokes the wrapped delegate when all gating predicates (<c>.When</c>/<c>.For</c>/<c>.Only</c>) are
-	///     satisfied, feeding the zero-based invocation count to <paramref name="callback" />.
-	/// </summary>
-	/// <param name="wasInvoked">Whether an earlier callback in the same sequence has already run for this interaction (serial-mode gating).</param>
-	/// <param name="index">Shared sequence index; advanced by this call when the sequence moves on to the next entry.</param>
-	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count.</param>
-	/// <returns><see langword="true" /> when the callback ran exclusively (serial mode) &#8212; signalling that no later serial callback should fire.</returns>
-	public bool Invoke(bool wasInvoked, ref int index, Action<int, TDelegate> callback)
-	{
-		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
-		{
-			_invocationCount++;
-			return false;
-		}
-
-		_invocationCount++;
-
-		if (RunInParallel)
-		{
-			if (!wasInvoked)
-			{
-				Interlocked.Increment(ref index);
-			}
-
-			_forIterationCount++;
-			_matchingCount++;
-			callback(_invocationCount - 1, @delegate);
-		}
-		else if (!wasInvoked)
-		{
-			if (!HasForSpecified || !CheckMatching(_forIterationCount + 1))
-			{
-				Interlocked.Increment(ref index);
-				_forIterationCount = 0;
-			}
-			else
-			{
-				_forIterationCount++;
-			}
-
-			_matchingCount++;
-			callback(_invocationCount - 1, @delegate);
-		}
-
-		return !RunInParallel;
-	}
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
-
-	/// <summary>
-	///     Invokes the wrapped delegate when all gating predicates are satisfied, always advancing the shared
-	///     sequence index.
-	/// </summary>
-	/// <param name="index">Shared sequence index; always advanced by this call.</param>
-	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count.</param>
-	/// <returns><see langword="true" /> when the callback ran; <see langword="false" /> when gating skipped it.</returns>
-	public bool Invoke(ref int index, Action<int, TDelegate> callback)
-	{
-		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
-		{
-			_invocationCount++;
-			Interlocked.Increment(ref index);
-			return false;
-		}
-
-		if (!HasForSpecified || !CheckMatching(_forIterationCount + 1))
-		{
-			Interlocked.Increment(ref index);
-			_forIterationCount = 0;
-		}
-		else
-		{
-			_forIterationCount++;
-		}
-
-		_invocationCount++;
-		_matchingCount++;
-		callback(_invocationCount - 1, @delegate);
-		return true;
-	}
-
-	/// <summary>
-	///     Invokes the wrapped delegate when all gating predicates are satisfied and captures its return value.
-	/// </summary>
-	/// <typeparam name="TReturn">The wrapped delegate's return type.</typeparam>
-	/// <param name="index">Shared sequence index; always advanced by this call.</param>
-	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count and produces the return value.</param>
-	/// <param name="returnValue">When this method returns <see langword="true" />, contains the value produced by <paramref name="callback" />; otherwise <see langword="default" />.</param>
-	/// <returns><see langword="true" /> when the callback ran; <see langword="false" /> when gating skipped it.</returns>
-	public bool Invoke<TReturn>(ref int index, Func<int, TDelegate, TReturn> callback,
-		[NotNullWhen(true)] out TReturn? returnValue)
-	{
-		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
-		{
-			_invocationCount++;
-			returnValue = default;
-			Interlocked.Increment(ref index);
-			return false;
-		}
-
-		if (!HasForSpecified || !CheckMatching(_forIterationCount + 1))
-		{
-			Interlocked.Increment(ref index);
-			_forIterationCount = 0;
-		}
-		else
-		{
-			_forIterationCount++;
-		}
-
-		_invocationCount++;
-		_matchingCount++;
-		returnValue = callback(_invocationCount - 1, @delegate)!;
-		return true;
-	}
-
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
-	/// <summary>
-	///     State-passing variant of <see cref="Invoke(bool, ref int, Action{int, TDelegate})" /> &#8212; identical
-	///     semantics, but <paramref name="state" /> is forwarded verbatim so <paramref name="callback" /> does not need
+	///     satisfied, forwarding <paramref name="state" /> to <paramref name="callback" /> so it does not need
 	///     to capture it in a closure.
 	/// </summary>
 	/// <typeparam name="TState">The caller-supplied state type.</typeparam>
@@ -280,10 +163,45 @@ public class Callback<TDelegate>(TDelegate @delegate) : Callback where TDelegate
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
 	/// <summary>
-	///     State-passing variant of
-	///     <see cref="Invoke{TReturn}(ref int, Func{int, TDelegate, TReturn}, out TReturn)" /> &#8212; identical
-	///     semantics, but <paramref name="state" /> is forwarded verbatim so <paramref name="callback" /> does not need
-	///     to capture it in a closure.
+	///     Invokes the wrapped delegate when all gating predicates are satisfied, always advancing the shared
+	///     sequence index. <paramref name="state" /> is forwarded to <paramref name="callback" /> so it does not
+	///     need to capture it in a closure.
+	/// </summary>
+	/// <typeparam name="TState">The caller-supplied state type.</typeparam>
+	/// <param name="index">Shared sequence index; always advanced by this call.</param>
+	/// <param name="state">Arbitrary caller state forwarded to <paramref name="callback" />.</param>
+	/// <param name="callback">Invoker that calls <typeparamref name="TDelegate" /> with the recorded invocation count and <paramref name="state" />.</param>
+	/// <returns><see langword="true" /> when the callback ran; <see langword="false" /> when gating skipped it.</returns>
+	public bool Invoke<TState>(ref int index, TState state,
+		Action<int, TDelegate, TState> callback)
+	{
+		if (!IsActive(_matchingCount) || !CheckInvocations(_invocationCount) || !CheckMatching(_forIterationCount))
+		{
+			_invocationCount++;
+			Interlocked.Increment(ref index);
+			return false;
+		}
+
+		if (!HasForSpecified || !CheckMatching(_forIterationCount + 1))
+		{
+			Interlocked.Increment(ref index);
+			_forIterationCount = 0;
+		}
+		else
+		{
+			_forIterationCount++;
+		}
+
+		_invocationCount++;
+		_matchingCount++;
+		callback(_invocationCount - 1, @delegate, state);
+		return true;
+	}
+
+	/// <summary>
+	///     Invokes the wrapped delegate when all gating predicates are satisfied and captures its return value.
+	///     <paramref name="state" /> is forwarded to <paramref name="callback" /> so it does not need to capture
+	///     it in a closure.
 	/// </summary>
 	/// <typeparam name="TState">The caller-supplied state type.</typeparam>
 	/// <typeparam name="TReturn">The wrapped delegate's return type.</typeparam>

--- a/Source/Mockolate/Setup/EventSetup.cs
+++ b/Source/Mockolate/Setup/EventSetup.cs
@@ -176,16 +176,11 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 		{
 			Callback<Action<int, object?, MethodInfo>> callback =
 				_subscribedCallbacks[(currentIndex + i) % _subscribedCallbacks.Count];
-			if (callback.Invoke(wasInvoked, ref _subscribedCallbacks.CurrentIndex, Dispatch))
+			if (callback.Invoke(wasInvoked, ref _subscribedCallbacks.CurrentIndex, (target, method),
+				    static (count, @delegate, state) => @delegate(count, state.target, state.method)))
 			{
 				wasInvoked = true;
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Dispatch(int invocationCount, Action<int, object?, MethodInfo> @delegate)
-		{
-			@delegate(invocationCount, target, method);
 		}
 	}
 
@@ -205,16 +200,11 @@ public class EventSetup(MockRegistry mockRegistry, string name)
 		{
 			Callback<Action<int, object?, MethodInfo>> callback =
 				_unsubscribedCallbacks[(currentIndex + i) % _unsubscribedCallbacks.Count];
-			if (callback.Invoke(wasInvoked, ref _unsubscribedCallbacks.CurrentIndex, Dispatch))
+			if (callback.Invoke(wasInvoked, ref _unsubscribedCallbacks.CurrentIndex, (target, method),
+				    static (count, @delegate, state) => @delegate(count, state.target, state.method)))
 			{
 				wasInvoked = true;
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Dispatch(int invocationCount, Action<int, object?, MethodInfo> @delegate)
-		{
-			@delegate(invocationCount, target, method);
 		}
 	}
 

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if NET10_0_OR_GREATER
-using System.Threading;
-#endif
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
 using Mockolate.Internals;
+#if NET10_0_OR_GREATER
+using System.Threading;
+#endif
 
 namespace Mockolate.Setup;
 
@@ -292,7 +292,8 @@ public class PropertySetup<T> : PropertySetup,
 			{
 				Callback<Action<int, T>> getterCallback =
 					_getterCallbacks[(currentGetterCallbacksIndex + i) % _getterCallbacks.Count];
-				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, Callback))
+				if (getterCallback.Invoke(wasInvoked, ref _getterCallbacks.CurrentIndex, this,
+					    static (count, @delegate, self) => @delegate(count, self._value)))
 				{
 					wasInvoked = true;
 				}
@@ -305,7 +306,9 @@ public class PropertySetup<T> : PropertySetup,
 			{
 				Callback<Func<int, T, T>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, ReturnCallback, out T? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, this,
+					    static (count, @delegate, self) => @delegate(count, self._value),
+					    out T? newValue))
 				{
 					_value = newValue;
 					_isInitialized = true;
@@ -326,18 +329,6 @@ public class PropertySetup<T> : PropertySetup,
 
 		throw new MockException(
 			$"The property only supports '{typeof(T).FormatType()}' and not '{typeof(TResult).FormatType()}'.");
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T> @delegate)
-		{
-			@delegate(invocationCount, _value);
-		}
-
-		[DebuggerNonUserCode]
-		T ReturnCallback(int invocationCount, Func<int, T, T> @delegate)
-		{
-			return @delegate(invocationCount, _value);
-		}
 	}
 
 	/// <inheritdoc cref="PropertySetup.InvokeSetter{TValue}(TValue, MockBehavior)" />
@@ -366,7 +357,8 @@ public class PropertySetup<T> : PropertySetup,
 			{
 				Callback<Action<int, T>> setterCallback =
 					_setterCallbacks[(currentSetterCallbacksIndex + i) % _setterCallbacks.Count];
-				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, Callback))
+				if (setterCallback.Invoke(wasInvoked, ref _setterCallbacks.CurrentIndex, newValue,
+					    static (count, @delegate, state) => @delegate(count, state)))
 				{
 					wasInvoked = true;
 				}
@@ -374,12 +366,6 @@ public class PropertySetup<T> : PropertySetup,
 		}
 
 		_value = newValue;
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T> @delegate)
-		{
-			@delegate(invocationCount, newValue);
-		}
 	}
 
 	/// <inheritdoc cref="PropertySetup.InitializeValue(object?)" />

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -211,7 +211,9 @@ public abstract class ReturnMethodSetup<TReturn>
 			{
 				Callback<Func<int, TReturn>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback, out TReturn? newValue))
+				if (returnCallback.Invoke<object?, TReturn>(ref _returnCallbacks.CurrentIndex, null,
+					    static (count, @delegate, _) => @delegate(count),
+					    out TReturn? newValue))
 				{
 					returnValue = newValue;
 					return true;
@@ -221,12 +223,6 @@ public abstract class ReturnMethodSetup<TReturn>
 
 		returnValue = default!;
 		return false;
-
-		[DebuggerNonUserCode]
-		TReturn Callback(int invocationCount, Func<int, TReturn> @delegate)
-		{
-			return @delegate(invocationCount);
-		}
 	}
 
 	/// <summary>
@@ -247,17 +243,12 @@ public abstract class ReturnMethodSetup<TReturn>
 			{
 				Callback<Action<int>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke<object?>(wasInvoked, ref _callbacks.CurrentIndex, null,
+					    static (count, @delegate, _) => @delegate(count)))
 				{
 					wasInvoked = true;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int> @delegate)
-		{
-			@delegate(invocationCount);
 		}
 	}
 
@@ -538,7 +529,9 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 			{
 				Callback<Func<int, T1, TReturn>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback, out TReturn? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, p1,
+					    static (count, @delegate, state) => @delegate(count, state),
+					    out TReturn? newValue))
 				{
 					returnValue = newValue;
 					return true;
@@ -548,12 +541,6 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 
 		returnValue = default!;
 		return false;
-
-		[DebuggerNonUserCode]
-		TReturn Callback(int invocationCount, Func<int, T1, TReturn> @delegate)
-		{
-			return @delegate(invocationCount, p1);
-		}
 	}
 
 	/// <summary>
@@ -575,17 +562,12 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 			{
 				Callback<Action<int, T1>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, parameter1,
+					    static (count, @delegate, state) => @delegate(count, state)))
 				{
 					wasInvoked = true;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1> @delegate)
-		{
-			@delegate(invocationCount, parameter1);
 		}
 	}
 
@@ -927,7 +909,9 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 			{
 				Callback<Func<int, T1, T2, TReturn>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback, out TReturn? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (p1, p2),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2),
+					    out TReturn? newValue))
 				{
 					returnValue = newValue;
 					return true;
@@ -937,12 +921,6 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 
 		returnValue = default!;
 		return false;
-
-		[DebuggerNonUserCode]
-		TReturn Callback(int invocationCount, Func<int, T1, T2, TReturn> @delegate)
-		{
-			return @delegate(invocationCount, p1, p2);
-		}
 	}
 
 	/// <summary>
@@ -964,17 +942,12 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, (parameter1, parameter2),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2)))
 				{
 					wasInvoked = true;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1, T2> @delegate)
-		{
-			@delegate(invocationCount, parameter1, parameter2);
 		}
 	}
 
@@ -1332,7 +1305,9 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 			{
 				Callback<Func<int, T1, T2, T3, TReturn>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback, out TReturn? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (p1, p2, p3),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3),
+					    out TReturn? newValue))
 				{
 					returnValue = newValue;
 					return true;
@@ -1342,12 +1317,6 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 
 		returnValue = default!;
 		return false;
-
-		[DebuggerNonUserCode]
-		TReturn Callback(int invocationCount, Func<int, T1, T2, T3, TReturn> @delegate)
-		{
-			return @delegate(invocationCount, p1, p2, p3);
-		}
 	}
 
 	/// <summary>
@@ -1369,17 +1338,12 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2, T3>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, (parameter1, parameter2, parameter3),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2, state.parameter3)))
 				{
 					wasInvoked = true;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1, T2, T3> @delegate)
-		{
-			@delegate(invocationCount, parameter1, parameter2, parameter3);
 		}
 	}
 
@@ -1757,7 +1721,9 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 			{
 				Callback<Func<int, T1, T2, T3, T4, TReturn>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback, out TReturn? newValue))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (p1, p2, p3, p4),
+					    static (count, @delegate, state) => @delegate(count, state.p1, state.p2, state.p3, state.p4),
+					    out TReturn? newValue))
 				{
 					returnValue = newValue;
 					return true;
@@ -1767,12 +1733,6 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 
 		returnValue = default!;
 		return false;
-
-		[DebuggerNonUserCode]
-		TReturn Callback(int invocationCount, Func<int, T1, T2, T3, T4, TReturn> @delegate)
-		{
-			return @delegate(invocationCount, p1, p2, p3, p4);
-		}
 	}
 
 	/// <summary>
@@ -1795,17 +1755,12 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2, T3, T4>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, (parameter1, parameter2, parameter3, parameter4),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2, state.parameter3, state.parameter4)))
 				{
 					wasInvoked = true;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1, T2, T3, T4> @delegate)
-		{
-			@delegate(invocationCount, parameter1, parameter2, parameter3, parameter4);
 		}
 	}
 

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -196,7 +196,8 @@ public abstract class VoidMethodSetup : MethodSetup,
 			{
 				Callback<Action<int>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke<object?>(wasInvoked, ref _callbacks.CurrentIndex, null,
+					    static (count, @delegate, _) => @delegate(count)))
 				{
 					wasInvoked = true;
 				}
@@ -209,17 +210,12 @@ public abstract class VoidMethodSetup : MethodSetup,
 			{
 				Callback<Action<int>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback))
+				if (returnCallback.Invoke<object?>(ref _returnCallbacks.CurrentIndex, null,
+					    static (count, @delegate, _) => @delegate(count)))
 				{
 					return;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int> @delegate)
-		{
-			@delegate(invocationCount);
 		}
 	}
 
@@ -474,7 +470,8 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 			{
 				Callback<Action<int, T1>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, parameter1,
+					    static (count, @delegate, state) => @delegate(count, state)))
 				{
 					wasInvoked = true;
 				}
@@ -487,17 +484,12 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 			{
 				Callback<Action<int, T1>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, parameter1,
+					    static (count, @delegate, state) => @delegate(count, state)))
 				{
 					return;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1> @delegate)
-		{
-			@delegate(invocationCount, parameter1);
 		}
 	}
 
@@ -805,7 +797,8 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, (parameter1, parameter2),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2)))
 				{
 					wasInvoked = true;
 				}
@@ -818,17 +811,12 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (parameter1, parameter2),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2)))
 				{
 					return;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1, T2> @delegate)
-		{
-			@delegate(invocationCount, parameter1, parameter2);
 		}
 	}
 
@@ -1149,7 +1137,8 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2, T3>> callback =
 					_callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, (parameter1, parameter2, parameter3),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2, state.parameter3)))
 				{
 					wasInvoked = true;
 				}
@@ -1162,17 +1151,12 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2, T3>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (parameter1, parameter2, parameter3),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2, state.parameter3)))
 				{
 					return;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1, T2, T3> @delegate)
-		{
-			@delegate(invocationCount, parameter1, parameter2, parameter3);
 		}
 	}
 
@@ -1502,7 +1486,8 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 			for (int i = 0; i < _callbacks.Count; i++)
 			{
 				Callback<Action<int, T1, T2, T3, T4>> callback = _callbacks[(currentCallbacksIndex + i) % _callbacks.Count];
-				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, Callback))
+				if (callback.Invoke(wasInvoked, ref _callbacks.CurrentIndex, (parameter1, parameter2, parameter3, parameter4),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2, state.parameter3, state.parameter4)))
 				{
 					wasInvoked = true;
 				}
@@ -1515,17 +1500,12 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 			{
 				Callback<Action<int, T1, T2, T3, T4>> returnCallback =
 					_returnCallbacks[_returnCallbacks.CurrentIndex % _returnCallbacks.Count];
-				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, Callback))
+				if (returnCallback.Invoke(ref _returnCallbacks.CurrentIndex, (parameter1, parameter2, parameter3, parameter4),
+					    static (count, @delegate, state) => @delegate(count, state.parameter1, state.parameter2, state.parameter3, state.parameter4)))
 				{
 					return;
 				}
 			}
-		}
-
-		[DebuggerNonUserCode]
-		void Callback(int invocationCount, Action<int, T1, T2, T3, T4> @delegate)
-		{
-			@delegate(invocationCount, parameter1, parameter2, parameter3, parameter4);
 		}
 	}
 

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -934,9 +934,7 @@ namespace Mockolate.Setup
         where TDelegate : System.Delegate
     {
         public Callback(TDelegate @delegate) { }
-        public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
-        public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
-        public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
+        public bool Invoke<TState>(ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
         public bool Invoke<TState>(bool wasInvoked, ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
         public bool Invoke<TState, TReturn>(ref int index, TState state, System.Func<int, TDelegate, TState, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -908,9 +908,7 @@ namespace Mockolate.Setup
         where TDelegate : System.Delegate
     {
         public Callback(TDelegate @delegate) { }
-        public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
-        public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
-        public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
+        public bool Invoke<TState>(ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
         public bool Invoke<TState>(bool wasInvoked, ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
         public bool Invoke<TState, TReturn>(ref int index, TState state, System.Func<int, TDelegate, TState, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -863,9 +863,7 @@ namespace Mockolate.Setup
         where TDelegate : System.Delegate
     {
         public Callback(TDelegate @delegate) { }
-        public bool Invoke(ref int index, System.Action<int, TDelegate> callback) { }
-        public bool Invoke(bool wasInvoked, ref int index, System.Action<int, TDelegate> callback) { }
-        public bool Invoke<TReturn>(ref int index, System.Func<int, TDelegate, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
+        public bool Invoke<TState>(ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
         public bool Invoke<TState>(bool wasInvoked, ref int index, TState state, System.Action<int, TDelegate, TState> callback) { }
         public bool Invoke<TState, TReturn>(ref int index, TState state, System.Func<int, TDelegate, TState, TReturn> callback, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TReturn? returnValue) { }
     }

--- a/Tests/Mockolate.Internal.Tests/Setup/CallbackTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/CallbackTests.cs
@@ -19,7 +19,7 @@ public class CallbackTests
 			int index = 0;
 			for (int i = 0; i < 5; i++)
 			{
-				sut.Invoke(wasInvoked, ref index, (v, _) => values.Add(v));
+				sut.Invoke<object?>(wasInvoked, ref index, null, (v, _, _) => values.Add(v));
 			}
 
 			await That(values).IsEqualTo([2, 3,]);
@@ -40,7 +40,7 @@ public class CallbackTests
 			int index = 0;
 			for (int iteration = 1; iteration <= 10; iteration++)
 			{
-				sut.Invoke(wasInvoked, ref index, (_, _) => { });
+				sut.Invoke<object?>(wasInvoked, ref index, null, static (_, _, _) => { });
 				indexValues.Add(index);
 			}
 
@@ -62,7 +62,7 @@ public class CallbackTests
 			int index = 0;
 			for (int iteration = 1; iteration <= 10; iteration++)
 			{
-				sut.Invoke(wasInvoked, ref index, (_, _) => { });
+				sut.Invoke<object?>(wasInvoked, ref index, null, static (_, _, _) => { });
 				indexValues.Add(index);
 			}
 
@@ -81,7 +81,7 @@ public class CallbackTests
 			int index = 0;
 			for (int i = 0; i < 5; i++)
 			{
-				sut.Invoke(wasInvoked, ref index, (v, _) => values.Add(v));
+				sut.Invoke<object?>(wasInvoked, ref index, null, (v, _, _) => values.Add(v));
 			}
 
 			await That(values).IsEqualTo([0, 1,]);
@@ -106,7 +106,7 @@ public class CallbackTests
 			int index = 0;
 			for (int iteration = 1; iteration <= 10; iteration++)
 			{
-				sut.Invoke(wasInvoked, ref index, (_, c) => c());
+				sut.Invoke<object?>(wasInvoked, ref index, null, static (_, c, _) => c());
 			}
 
 			await That(invocationChecks).IsEqualTo(expectResult);
@@ -131,7 +131,7 @@ public class CallbackTests
 			bool result = false;
 			for (int iteration = 1; iteration <= iterations; iteration++)
 			{
-				result = sut.Invoke(wasInvoked, ref index, (_, _) => { });
+				result = sut.Invoke<object?>(wasInvoked, ref index, null, static (_, _, _) => { });
 			}
 
 			await That(result).IsEqualTo(expectResult);
@@ -212,7 +212,7 @@ public class CallbackTests
 			int index = 0;
 			for (int i = 0; i < 5; i++)
 			{
-				sut.Invoke(ref index, (v, _) => values.Add(v));
+				sut.Invoke<object?>(ref index, null, (v, _, _) => values.Add(v));
 			}
 
 			await That(values).IsEqualTo([2, 3,]);
@@ -236,7 +236,7 @@ public class CallbackTests
 			int index = 0;
 			for (int iteration = 1; iteration <= 10; iteration++)
 			{
-				sut.Invoke(ref index, (_, c) => c());
+				sut.Invoke<object?>(ref index, null, static (_, c, _) => c());
 			}
 
 			await That(invocationChecks).IsEqualTo(expectResult);
@@ -260,7 +260,7 @@ public class CallbackTests
 			bool result = false;
 			for (int iteration = 1; iteration <= iterations; iteration++)
 			{
-				result = sut.Invoke(ref index, (_, _) => { });
+				result = sut.Invoke<object?>(ref index, null, static (_, _, _) => { });
 			}
 
 			await That(result).IsEqualTo(expectResult);
@@ -280,7 +280,7 @@ public class CallbackTests
 			int index = 0;
 			for (int i = 0; i < 5; i++)
 			{
-				sut.Invoke<string>(ref index, (v, _) =>
+				sut.Invoke<object?, string>(ref index, null, (v, _, _) =>
 				{
 					values.Add(v);
 					return $"foo-{v}";
@@ -308,7 +308,7 @@ public class CallbackTests
 			int index = 0;
 			for (int iteration = 1; iteration <= 10; iteration++)
 			{
-				sut.Invoke(ref index, (_, c) =>
+				sut.Invoke<object?, string>(ref index, null, static (_, c, _) =>
 				{
 					c();
 					return "foo";
@@ -336,7 +336,7 @@ public class CallbackTests
 			bool result = false;
 			for (int iteration = 1; iteration <= iterations; iteration++)
 			{
-				result = sut.Invoke(ref index, (_, _) => "foo", out string? _);
+				result = sut.Invoke<object?, string>(ref index, null, static (_, _, _) => "foo", out string? _);
 			}
 
 			await That(result).IsEqualTo(expectResult);


### PR DESCRIPTION
This PR updates Mockolate’s callback invocation plumbing to support passing explicit state through `Callback<TDelegate>.Invoke(...)`, enabling static lambdas and reducing closure allocations in hot paths across setups and generated method-setup code.

**Changes:**
- Reworks `Callback<TDelegate>.Invoke(...)` APIs to accept a caller-supplied `state` passed through to the callback.
- Updates setup implementations (void/return methods, properties, events) to use static lambdas with state instead of capturing locals.
- Updates source generator templates and test/API baselines to reflect the new invocation pattern.