### PR TITLE
perf: dispatch setups by member id with closure-free matching

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -12,6 +12,28 @@ internal static partial class Sources
 {
 	private const int MaxExplicitParameters = 4;
 
+	/// <summary>
+	///     Dense ordinal of <paramref name="method" /> within <paramref name="class" />'s methods. Used
+	///     as the generator-assigned member id for the closure-free O(1) setup dispatch.
+	///     Stable across emission passes because <see cref="Class.AllMethods" /> is deterministic.
+	///     Returns -1 for a method the class does not expose (ref-struct/legacy fallback path).
+	/// </summary>
+	private static int GetMemberId(Class @class, Method method)
+	{
+		int index = 0;
+		foreach (Method m in @class.AllMethods())
+		{
+			if (Method.EqualityComparer.Equals(m, method))
+			{
+				return index;
+			}
+
+			index++;
+		}
+
+		return -1;
+	}
+
 	public static string MockClass(string name, Class @class, bool hasOverloadResolutionPriority = false)
 	{
 		EquatableArray<Method>? constructors = (@class as MockClass)?.Constructors;
@@ -2290,13 +2312,26 @@ internal static partial class Sources
 		bool supportsWrapping = !explicitInterfaceImplementation && method is { IsStatic: false, IsProtected: false, };
 		bool isAbstractOrInterface = isClassInterface || method.IsAbstract;
 
+		// Build two argument lists in parallel:
+		//   sb2  — value-only, for the closure-free GetMethodSetup<T, T1, ...>(memberId, arg1, ...)
+		//           overload used when the arity has a handwritten setup class (<= MaxExplicitParameters).
+		//   sb2b — "name", value pairs, for the legacy GetMethodSetup<T>(name, m => m.Matches(...))
+		//           lambda predicate used for arities whose setup class is source-generated and does
+		//           not yet implement IMethodMatchByValue<...>.
+		// Generic methods fall back to the legacy path: memberId identifies a method definition, but
+		// Mockolate distinguishes instantiations (`Foo<int>` vs `Foo<long>`) via the runtime-expanded
+		// name string. Losing that distinction breaks generic-argument matching.
+		bool isGenericMethod = method.GenericParameters is not null && method.GenericParameters.Value.Count > 0;
+		bool useMemberIdDispatch = !isGenericMethod && method.Parameters.Count <= MaxExplicitParameters;
 		StringBuilder sb2 = new();
+		StringBuilder sb2b = new();
 		int i = 0;
 		foreach (MethodParameter p in method.Parameters)
 		{
 			if (i++ > 0)
 			{
 				sb2.Append(", ");
+				sb2b.Append(", ");
 			}
 
 			if (p.RefKind == RefKind.Ref || p.RefKind == RefKind.In || p.RefKind == RefKind.RefReadOnlyParameter)
@@ -2304,7 +2339,8 @@ internal static partial class Sources
 				string paramRef = Helpers.GetUniqueLocalVariableName($"ref_{p.Name}", method.Parameters);
 
 				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.Name).Append(';').AppendLine();
-				sb2.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
+				sb2.Append(paramRef);
+				sb2b.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
 			}
 			else if (p.Type.SpecialGenericType == SpecialGenericType.Span ||
 			         p.Type.SpecialGenericType == SpecialGenericType.ReadOnlySpan)
@@ -2313,24 +2349,49 @@ internal static partial class Sources
 
 				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.ToNameOrWrapper()).Append(';')
 					.AppendLine();
-				sb2.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
+				sb2.Append(paramRef);
+				sb2b.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
 			}
 			else
 			{
-				sb2.Append("\"").Append(p.Name).Append("\", ").Append(
-					p.RefKind switch
-					{
-						RefKind.Out => "default",
-						_ => p.ToNameOrWrapper(),
-					});
+				string valueExpr = p.RefKind switch
+				{
+					RefKind.Out => "default",
+					_ => p.ToNameOrWrapper(),
+				};
+				sb2.Append(valueExpr);
+				sb2b.Append("\"").Append(p.Name).Append("\", ").Append(valueExpr);
 			}
 		}
 
-		sb.Append("\t\t\tvar ").Append(methodSetup)
-			.Append(" = ").Append(mockRegistry).Append(".GetMethodSetup<").Append(methodSetupType).Append(">(")
-			.Append(method.GetUniqueNameString()).Append(", m => m.Matches(");
-		sb.Append(sb2);
-		sb.AppendLine("));");
+		if (useMemberIdDispatch)
+		{
+			int memberId = GetMemberId(@class, method);
+			sb.Append("\t\t\tvar ").Append(methodSetup)
+				.Append(" = ").Append(mockRegistry).Append(".GetMethodSetup<").Append(methodSetupType);
+			if (method.Parameters.Count > 0)
+			{
+				foreach (MethodParameter p in method.Parameters)
+				{
+					sb.Append(", ").Append(p.ToTypeOrWrapper());
+				}
+			}
+
+			sb.Append(">(").Append(memberId).Append(", ").Append(method.GetUniqueNameString());
+			if (method.Parameters.Count > 0)
+			{
+				sb.Append(", ").Append(sb2);
+			}
+
+			sb.AppendLine(");");
+		}
+		else
+		{
+			sb.Append("\t\t\tvar ").Append(methodSetup)
+				.Append(" = ").Append(mockRegistry).Append(".GetMethodSetup<").Append(methodSetupType).Append(">(")
+				.Append(method.GetUniqueNameString()).Append(", m => m.Matches(")
+				.Append(sb2b).AppendLine("));");
+		}
 		sb.Append("\t\t\tbool ").Append(hasWrappedResult).Append(" = false;").AppendLine();
 		if (method.ReturnType != Type.Void)
 		{
@@ -3352,7 +3413,7 @@ internal static partial class Sources
 				Method? method = methodGroup.Single();
 				if (method.Parameters.Count > 0)
 				{
-					AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, true,
+					AppendMethodSetupImplementation(sb, @class, method, mockRegistryName, setupName, true,
 						scopeExpression: scopeExpression);
 				}
 			}
@@ -3361,18 +3422,18 @@ internal static partial class Sources
 			{
 				if (method.Parameters.Count == 0)
 				{
-					AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
+					AppendMethodSetupImplementation(sb, @class, method, mockRegistryName, setupName, false,
 						scopeExpression: scopeExpression);
 				}
 				else
 				{
-					AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
+					AppendMethodSetupImplementation(sb, @class, method, mockRegistryName, setupName, false,
 						scopeExpression: scopeExpression);
 					if (method.Parameters.Count <= MaxExplicitParameters)
 					{
 						foreach (bool[] valueFlags in GenerateValueFlagCombinations(method.Parameters))
 						{
-							AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
+							AppendMethodSetupImplementation(sb, @class, method, mockRegistryName, setupName, false,
 								valueFlags: valueFlags, scopeExpression: scopeExpression);
 						}
 					}
@@ -3382,7 +3443,7 @@ internal static partial class Sources
 							.ToArray();
 						if (allValueFlags.Any(f => f))
 						{
-							AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
+							AppendMethodSetupImplementation(sb, @class, method, mockRegistryName, setupName, false,
 								valueFlags: allValueFlags, scopeExpression: scopeExpression);
 						}
 					}
@@ -3393,7 +3454,8 @@ internal static partial class Sources
 		#endregion
 	}
 #pragma warning disable S107 // Methods should not have too many parameters
-	private static void AppendMethodSetupImplementation(StringBuilder sb, Method method, string mockRegistryName,
+	private static void AppendMethodSetupImplementation(StringBuilder sb, Class @class, Method method,
+		string mockRegistryName,
 		string setupName,
 		bool useParameters, string? methodNameOverride = null, bool[]? valueFlags = null,
 		string? scopeExpression = null)
@@ -3551,18 +3613,51 @@ internal static partial class Sources
 			}
 		}
 
+		// The new memberId-aware ctors exist on hand-written setup classes for arity 0..4. Beyond that
+		// the setup class is source-generated (Sources.MethodSetups.cs) and still ships only the
+		// legacy `(mockRegistry, name, ...)` ctor. Generic methods also use the legacy path so that
+		// `Foo<int>` vs `Foo<long>` can be distinguished by the runtime-expanded name string.
+		bool isGenericSetupMethod = method.GenericParameters is not null && method.GenericParameters.Value.Count > 0;
+		bool useMemberIdCtor = !isGenericSetupMethod && method.Parameters.Count <= MaxExplicitParameters;
 		if (useParameters)
 		{
-			sb.Append(".WithParameters(").Append(mockRegistryName).Append(", ").Append(method.GetUniqueNameString())
-				.Append(", parameters);")
-				.AppendLine();
+			if (useMemberIdCtor)
+			{
+				int setupMemberId = GetMemberId(@class, method);
+				sb.Append(".WithParameters(").Append(mockRegistryName).Append(", ").Append(setupMemberId).Append(", ")
+					.Append(method.GetUniqueNameString())
+					.Append(", parameters");
+				foreach (MethodParameter parameter in method.Parameters)
+				{
+					sb.Append(", \"").Append(parameter.Name).Append("\"");
+				}
+
+				sb.Append(");").AppendLine();
+			}
+			else
+			{
+				sb.Append(".WithParameters(").Append(mockRegistryName).Append(", ").Append(method.GetUniqueNameString())
+					.Append(", parameters);")
+					.AppendLine();
+			}
+
 			sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(".SetupMethod(").Append(scopePrefix).Append("methodSetup);").AppendLine();
 			sb.Append("\t\t\treturn methodSetup;").AppendLine();
 		}
 		else
 		{
-			sb.Append(".WithParameterCollection(").Append(mockRegistryName).Append(", ")
-				.Append(method.GetUniqueNameString());
+			if (useMemberIdCtor)
+			{
+				int setupMemberId = GetMemberId(@class, method);
+				sb.Append(".WithParameterCollection(").Append(mockRegistryName).Append(", ").Append(setupMemberId)
+					.Append(", ").Append(method.GetUniqueNameString());
+			}
+			else
+			{
+				sb.Append(".WithParameterCollection(").Append(mockRegistryName).Append(", ")
+					.Append(method.GetUniqueNameString());
+			}
+
 			int j = 0;
 			foreach (MethodParameter parameter in method.Parameters)
 			{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -34,6 +34,96 @@ internal static partial class Sources
 		return -1;
 	}
 
+	/// <summary>
+	///     Dense ordinal of <paramref name="property" /> within the full mock surface's non-indexer
+	///     properties. Used as the generator-assigned member id for the O(1) property setup
+	///     dispatch. Indexers and non-indexer properties use separate ordinal sequences because
+	///     they live in different buckets on the runtime-side MockSetups.
+	/// </summary>
+	private static int GetPropertyMemberId(Class @class, Property property)
+	{
+		int index = 0;
+		foreach (Property p in EnumerateMockSurfaceProperties(@class))
+		{
+			if (p.IsIndexer)
+			{
+				continue;
+			}
+
+			if (Property.EqualityComparer.Equals(p, property))
+			{
+				return index;
+			}
+
+			index++;
+		}
+
+		return -1;
+	}
+
+	/// <summary>
+	///     Dense ordinal of <paramref name="indexer" /> within the full mock surface's indexer
+	///     properties. Used as the generator-assigned member id for the closure-free O(1) indexer
+	///     setup dispatch. When <paramref name="class" /> is a
+	///     <see cref="Mockolate.SourceGenerators.Entities.MockClass" /> with additional
+	///     implementations, the additional interfaces' indexers are enumerated after the mock's
+	///     own, so the id is stable across both the primary emission pass and the
+	///     per-additional-interface explicit-impl pass. Separate ordinal sequence from
+	///     <see cref="GetMemberId(Class, Method)" /> because indexer setups live in their own bucket.
+	/// </summary>
+	private static int GetIndexerMemberId(Class @class, Property indexer)
+	{
+		int index = 0;
+		foreach (Property p in EnumerateMockSurfaceProperties(@class))
+		{
+			if (!p.IsIndexer)
+			{
+				continue;
+			}
+
+			if (Property.EqualityComparer.Equals(p, indexer))
+			{
+				return index;
+			}
+
+			index++;
+		}
+
+		return -1;
+	}
+
+	/// <summary>
+	///     Enumerates the mock's full property surface: the primary class's own properties plus
+	///     the properties contributed by each <see cref="MockClass.AdditionalImplementations" />
+	///     (when present). Uses <see cref="Property.EqualityComparer" /> to drop duplicates so the
+	///     enumeration order matches <see cref="Class.AllProperties" /> for plain classes.
+	/// </summary>
+	private static IEnumerable<Property> EnumerateMockSurfaceProperties(Class @class)
+	{
+		HashSet<Property> seen = new(Property.EqualityComparer);
+		foreach (Property p in @class.AllProperties())
+		{
+			if (seen.Add(p))
+			{
+				yield return p;
+			}
+		}
+
+		if (@class is MockClass mockClass)
+		{
+			foreach (Class additional in mockClass.AdditionalImplementations)
+			{
+				foreach (Property p in additional.AllProperties())
+				{
+					if (seen.Add(p))
+					{
+						yield return p;
+					}
+				}
+			}
+		}
+	}
+
 	public static string MockClass(string name, Class @class, bool hasOverloadResolutionPriority = false)
 	{
 		EquatableArray<Method>? constructors = (@class as MockClass)?.Constructors;
@@ -1677,9 +1767,13 @@ internal static partial class Sources
 					}
 				}
 
+				// For member-id computation, use the root mock class (when emitting an additional
+				// interface's explicit implementation, `mockClass` is the outer MockClass — its
+				// full surface is what the user-side `Setup.this[...]` path registers against, so
+				// the ids must agree).
 				AppendMockSubject_ImplementClass_AddProperty(sb, property, mockRegistryName, className,
 					mockClass is not null,
-					@class.IsInterface, signatureIndex);
+					@class.IsInterface, signatureIndex, (Class?)mockClass ?? @class);
 				sb.AppendLine();
 			}
 		}
@@ -1821,9 +1915,18 @@ internal static partial class Sources
 
 	private static void AppendMockSubject_ImplementClass_AddProperty(StringBuilder sb, Property property,
 		string mockRegistryName,
-		string className, bool explicitInterfaceImplementation, bool isClassInterface, int signatureIndex)
+		string className, bool explicitInterfaceImplementation, bool isClassInterface, int signatureIndex,
+		Class @class)
 	{
 		string mockRegistry = property.IsStatic ? "MockRegistryProvider.Value" : $"this.{mockRegistryName}";
+		int indexerMemberId = property is { IsIndexer: true, IndexerParameters: not null, } &&
+		                      property.IndexerParameters.Value.Count <= MaxExplicitParameters &&
+		                      !property.IndexerParameters.Value.Any(p => p.NeedsRefStructPipeline())
+			? GetIndexerMemberId(@class, property)
+			: -1;
+		int propertyMemberId = property is { IsIndexer: false, }
+			? GetPropertyMemberId(@class, property)
+			: -1;
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(property.ContainingType.EscapeForXmlDoc()).Append('.').Append(
 				property.IndexerParameters is not null
 					? property.Name.Replace("[]",
@@ -1911,7 +2014,7 @@ internal static partial class Sources
 						Helpers.GetUniqueLocalVariableName("baseResult", property.IndexerParameters.Value);
 
 					EmitIndexerGetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
-						property.Type, property.IndexerParameters.Value);
+						property.Type, property.IndexerParameters.Value, indexerMemberId);
 					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is not ").Append(className)
 						.Append(" wraps)").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
@@ -1936,8 +2039,13 @@ internal static partial class Sources
 				else
 				{
 					sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetProperty<")
-						.AppendTypeOrWrapper(property.Type).Append(">(")
-						.Append(property.GetUniqueNameString()).Append(", () => ")
+						.AppendTypeOrWrapper(property.Type).Append(">(");
+					if (propertyMemberId >= 0)
+					{
+						sb.Append(propertyMemberId).Append(", ");
+					}
+
+					sb.Append(property.GetUniqueNameString()).Append(", () => ")
 						.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue");
 					if (!property.IsStatic)
 					{
@@ -1964,7 +2072,7 @@ internal static partial class Sources
 						Helpers.GetUniqueLocalVariableName("baseResult", property.IndexerParameters.Value);
 
 					EmitIndexerGetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
-						property.Type, property.IndexerParameters.Value);
+						property.Type, property.IndexerParameters.Value, indexerMemberId);
 					sb.Append("\t\t\t\tif (!(").Append(setupVarName).Append("?.SkipBaseClass() ?? ")
 						.Append(mockRegistry).Append(".Behavior.SkipBaseClass))").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
@@ -2003,8 +2111,13 @@ internal static partial class Sources
 				else
 				{
 					sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetProperty<")
-						.AppendTypeOrWrapper(property.Type).Append(">(")
-						.Append(property.GetUniqueNameString()).Append(", () => ")
+						.AppendTypeOrWrapper(property.Type).Append(">(");
+					if (propertyMemberId >= 0)
+					{
+						sb.Append(propertyMemberId).Append(", ");
+					}
+
+					sb.Append(property.GetUniqueNameString()).Append(", () => ")
 						.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue");
 					if (property is { IsStatic: false, } && property.Getter?.IsProtected != true)
 					{
@@ -2028,7 +2141,7 @@ internal static partial class Sources
 					Helpers.GetUniqueLocalVariableName("setup", property.IndexerParameters.Value);
 
 				EmitIndexerGetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
-					property.Type, property.IndexerParameters.Value);
+					property.Type, property.IndexerParameters.Value, indexerMemberId);
 				sb.Append("\t\t\t\treturn ").Append(setupVarName).Append(" is null").AppendLine();
 				sb.Append("\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
 					.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
@@ -2041,7 +2154,13 @@ internal static partial class Sources
 			else
 			{
 				sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetProperty<")
-					.AppendTypeOrWrapper(property.Type).Append(">(").Append(property.GetUniqueNameString())
+					.AppendTypeOrWrapper(property.Type).Append(">(");
+				if (propertyMemberId >= 0)
+				{
+					sb.Append(propertyMemberId).Append(", ");
+				}
+
+				sb.Append(property.GetUniqueNameString())
 					.Append(", () => ")
 					.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue")
 					.Append(", null);").AppendLine();
@@ -2077,7 +2196,7 @@ internal static partial class Sources
 						Helpers.GetUniqueLocalVariableName("setup", property.IndexerParameters.Value);
 
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
-						property.Type, property.IndexerParameters.Value);
+						property.Type, property.IndexerParameters.Value, indexerMemberId);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append(");")
@@ -2094,7 +2213,13 @@ internal static partial class Sources
 				else
 				{
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".SetProperty<")
-						.AppendTypeOrWrapper(property.Type).Append(">(").Append(property.GetUniqueNameString())
+						.AppendTypeOrWrapper(property.Type).Append(">(");
+					if (propertyMemberId >= 0)
+					{
+						sb.Append(propertyMemberId).Append(", ");
+					}
+
+					sb.Append(property.GetUniqueNameString())
 						.Append(", value);").AppendLine();
 					if (!property.IsStatic)
 					{
@@ -2116,7 +2241,7 @@ internal static partial class Sources
 				if (!isClassInterface && !property.IsAbstract)
 				{
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
-						property.Type, property.IndexerParameters.Value);
+						property.Type, property.IndexerParameters.Value, indexerMemberId);
 					sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append("))").AppendLine();
@@ -2149,7 +2274,7 @@ internal static partial class Sources
 				else
 				{
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
-						property.Type, property.IndexerParameters.Value);
+						property.Type, property.IndexerParameters.Value, indexerMemberId);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append(");").AppendLine();
@@ -2160,7 +2285,13 @@ internal static partial class Sources
 				if (!isClassInterface && !property.IsAbstract)
 				{
 					sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".SetProperty<")
-						.AppendTypeOrWrapper(property.Type).Append(">(").Append(property.GetUniqueNameString())
+						.AppendTypeOrWrapper(property.Type).Append(">(");
+					if (propertyMemberId >= 0)
+					{
+						sb.Append(propertyMemberId).Append(", ");
+					}
+
+					sb.Append(property.GetUniqueNameString())
 						.Append(", value))").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					if (property is { IsStatic: false, } && property.Setter?.IsProtected != true)
@@ -2185,7 +2316,13 @@ internal static partial class Sources
 				else
 				{
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".SetProperty<")
-						.AppendTypeOrWrapper(property.Type).Append(">(").Append(property.GetUniqueNameString())
+						.AppendTypeOrWrapper(property.Type).Append(">(");
+					if (propertyMemberId >= 0)
+					{
+						sb.Append(propertyMemberId).Append(", ");
+					}
+
+					sb.Append(property.GetUniqueNameString())
 						.AppendLine(", value);");
 				}
 			}
@@ -3310,9 +3447,14 @@ internal static partial class Sources
 	}
 
 	private static void ImplementSetupInterface(StringBuilder sb, Class @class, string mockRegistryName,
-		string setupName, MemberType memberType, string? scopeExpression = null)
+		string setupName, MemberType memberType, string? scopeExpression = null, Class? rootClass = null)
 	{
 		string scopePrefix = scopeExpression is null ? "" : scopeExpression + ", ";
+		// Member-ids are assigned against the full mock surface (the root class plus any additional
+		// interfaces), so the setup-side ctor call and the invocation-side lookup agree. When
+		// ImplementSetupInterface is called for an additional interface in MockCombination, the
+		// caller passes the outer mock class as rootClass.
+		Class memberIdSource = rootClass ?? @class;
 
 		#region Properties
 
@@ -3321,6 +3463,7 @@ internal static partial class Sources
 			   property.MemberType == memberType;
 		foreach (Property property in @class.AllProperties().Where(propertyPredicate))
 		{
+			int propertyMemberId = GetPropertyMemberId(memberIdSource, property);
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
 			sb.Append(
 					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
@@ -3331,7 +3474,13 @@ internal static partial class Sources
 			sb.Append("\t\t\tget").AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tvar propertySetup = new global::Mockolate.Setup.PropertySetup<")
-				.Append(property.Type.Fullname).Append(">(").Append(mockRegistryName).Append(", ")
+				.Append(property.Type.Fullname).Append(">(");
+			if (propertyMemberId >= 0)
+			{
+				sb.Append(propertyMemberId).Append(", ");
+			}
+
+			sb.Append(mockRegistryName).Append(", ")
 				.Append(property.GetUniqueNameString()).Append(");")
 				.AppendLine();
 			sb.Append("\t\t\t\tthis.").Append(mockRegistryName).Append(".SetupProperty(").Append(scopePrefix).Append("propertySetup);").AppendLine();
@@ -3376,12 +3525,13 @@ internal static partial class Sources
 			           indexer.MemberType == memberType;
 		foreach (Property indexer in @class.AllProperties().Where(indexerPredicate))
 		{
-			AppendIndexerSetupImplementation(sb, indexer, mockRegistryName, setupName, scopeExpression: scopeExpression);
+			AppendIndexerSetupImplementation(sb, indexer, mockRegistryName, setupName, @class: memberIdSource,
+				scopeExpression: scopeExpression);
 			if (indexer.IndexerParameters!.Value.Count <= MaxExplicitParameters)
 			{
 				foreach (bool[] valueFlags in GenerateValueFlagCombinations(indexer.IndexerParameters.Value))
 				{
-					AppendIndexerSetupImplementation(sb, indexer, mockRegistryName, setupName, valueFlags, scopeExpression);
+					AppendIndexerSetupImplementation(sb, indexer, mockRegistryName, setupName, valueFlags, scopeExpression, memberIdSource);
 				}
 			}
 			else
@@ -3390,7 +3540,7 @@ internal static partial class Sources
 					.ToArray();
 				if (allValueFlags.Any(f => f))
 				{
-					AppendIndexerSetupImplementation(sb, indexer, mockRegistryName, setupName, allValueFlags, scopeExpression);
+					AppendIndexerSetupImplementation(sb, indexer, mockRegistryName, setupName, allValueFlags, scopeExpression, memberIdSource);
 				}
 			}
 		}
@@ -3884,8 +4034,13 @@ internal static partial class Sources
 	}
 
 	private static void AppendIndexerSetupImplementation(StringBuilder sb, Property indexer, string mockRegistryName,
-		string setupName, bool[]? valueFlags = null, string? scopeExpression = null)
+		string setupName, bool[]? valueFlags = null, string? scopeExpression = null, Class? @class = null)
 	{
+		int indexerMemberId = @class is not null &&
+		                      indexer.IndexerParameters!.Value.Count <= MaxExplicitParameters &&
+		                      !indexer.IndexerParameters.Value.Any(p => p.NeedsRefStructPipeline())
+			? GetIndexerMemberId(@class, indexer)
+			: -1;
 		// Mirror AppendIndexerSetupDefinition: dispatch to the appropriate ref-struct facade
 		// implementation depending on whether the indexer has a getter, a setter, or both.
 		if (indexer.IndexerParameters!.Value.Any(p => p.NeedsRefStructPipeline()))
@@ -3963,7 +4118,13 @@ internal static partial class Sources
 			sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
 		}
 
-		sb.Append(">(").Append(mockRegistryName);
+		sb.Append(">(");
+		if (indexerMemberId >= 0)
+		{
+			sb.Append(indexerMemberId).Append(", ");
+		}
+
+		sb.Append(mockRegistryName);
 		int j = 0;
 		foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
 		{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -408,7 +408,8 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockSetupFor").Append(item.Name).AppendLine();
 			sb.AppendLine();
-			ImplementSetupInterface(sb, item.Class, mockRegistryName, $"IMockSetupFor{item.Name}", MemberType.Public);
+			ImplementSetupInterface(sb, item.Class, mockRegistryName, $"IMockSetupFor{item.Name}", MemberType.Public,
+				rootClass: @class);
 			sb.Append("\t\t#endregion IMockSetupFor").Append(item.Name).AppendLine();
 		}
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -144,13 +144,18 @@ internal static partial class Sources
 		bool hasRefParams = delegateMethod.Parameters.Any(p => p.RefKind is RefKind.Ref);
 		string wpc = Helpers.GetUniqueLocalVariableName("wpc", delegateMethod.Parameters);
 
+		// sb2 feeds the closure-free GetMethodSetup<T, T1, ...>(memberId, arg1, ...) call when
+		// the arity has a handwritten setup class; sb2b feeds the legacy lambda-predicate form.
+		bool useMemberIdDispatch = delegateMethod.Parameters.Count <= MaxExplicitParameters;
 		StringBuilder sb2 = new();
+		StringBuilder sb2b = new();
 		int i = 0;
 		foreach (MethodParameter p in delegateMethod.Parameters)
 		{
 			if (i++ > 0)
 			{
 				sb2.Append(", ");
+				sb2b.Append(", ");
 			}
 
 			if (p.RefKind == RefKind.Ref)
@@ -158,7 +163,8 @@ internal static partial class Sources
 				string paramRef = Helpers.GetUniqueLocalVariableName($"ref_{p.Name}", delegateMethod.Parameters);
 
 				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.Name).Append(';').AppendLine();
-				sb2.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
+				sb2.Append(paramRef);
+				sb2b.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
 			}
 			else if (p.Type.SpecialGenericType == SpecialGenericType.Span ||
 			         p.Type.SpecialGenericType == SpecialGenericType.ReadOnlySpan)
@@ -167,24 +173,49 @@ internal static partial class Sources
 
 				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.ToNameOrWrapper()).Append(';')
 					.AppendLine();
-				sb2.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
+				sb2.Append(paramRef);
+				sb2b.Append("\"").Append(p.Name).Append("\", ").Append(paramRef);
 			}
 			else
 			{
-				sb2.Append("\"").Append(p.Name).Append("\", ").Append(
-					p.RefKind switch
-					{
-						RefKind.Out => "default",
-						_ => p.ToNameOrWrapper(),
-					});
+				string valueExpr = p.RefKind switch
+				{
+					RefKind.Out => "default",
+					_ => p.ToNameOrWrapper(),
+				};
+				sb2.Append(valueExpr);
+				sb2b.Append("\"").Append(p.Name).Append("\", ").Append(valueExpr);
 			}
 		}
 
-		sb.Append("\t\t\tvar ").Append(methodSetup)
-			.Append(" = this.").Append(mockRegistryName).Append(".GetMethodSetup<").Append(methodSetupType).Append(">(")
-			.Append(delegateMethod.GetUniqueNameString()).Append(", m => m.Matches(");
-		sb.Append(sb2);
-		sb.AppendLine("));");
+		if (useMemberIdDispatch)
+		{
+			int memberId = GetMemberId(@class, delegateMethod);
+			sb.Append("\t\t\tvar ").Append(methodSetup)
+				.Append(" = this.").Append(mockRegistryName).Append(".GetMethodSetup<").Append(methodSetupType);
+			if (delegateMethod.Parameters.Count > 0)
+			{
+				foreach (MethodParameter p in delegateMethod.Parameters)
+				{
+					sb.Append(", ").Append(p.ToTypeOrWrapper());
+				}
+			}
+
+			sb.Append(">(").Append(memberId).Append(", ").Append(delegateMethod.GetUniqueNameString());
+			if (delegateMethod.Parameters.Count > 0)
+			{
+				sb.Append(", ").Append(sb2);
+			}
+
+			sb.AppendLine(");");
+		}
+		else
+		{
+			sb.Append("\t\t\tvar ").Append(methodSetup)
+				.Append(" = this.").Append(mockRegistryName).Append(".GetMethodSetup<").Append(methodSetupType).Append(">(")
+				.Append(delegateMethod.GetUniqueNameString()).Append(", m => m.Matches(")
+				.Append(sb2b).AppendLine("));");
+		}
 
 		if (hasOutParams)
 		{
@@ -279,17 +310,17 @@ internal static partial class Sources
 		sb.Append("\t\t\t=> \"").Append(@class.DisplayString).Append(" mock\";").AppendLine();
 		sb.AppendLine();
 
-		AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, "Setup");
+		AppendMethodSetupImplementation(sb, @class, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, "Setup");
 		if (delegateMethod.Parameters.Count > 0)
 		{
-			AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", true, "Setup");
+			AppendMethodSetupImplementation(sb, @class, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", true, "Setup");
 		}
 
 		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
 		{
 			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
 			{
-				AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, "Setup", valueFlags);
+				AppendMethodSetupImplementation(sb, @class, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, "Setup", valueFlags);
 			}
 		}
 		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
@@ -297,7 +328,7 @@ internal static partial class Sources
 			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
 			if (allValueFlags.Any(f => f))
 			{
-				AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, "Setup", allValueFlags);
+				AppendMethodSetupImplementation(sb, @class, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, "Setup", allValueFlags);
 			}
 		}
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -114,14 +114,14 @@ internal static partial class Sources
 	}
 
 	/// <summary>
-	///     Emits variable declarations for the indexer getter access and matching setup:
-	///     <code>var access = new IndexerGetterAccess&lt;T...&gt;("p", p, ...);
-	///     mockRegistry.RegisterInteraction(access);
-	///     var setup = mockRegistry.GetIndexerSetup&lt;IndexerSetup&lt;TValue, T...&gt;&gt;(access);</code>
+	///     Emits variable declarations for the indexer getter access and matching setup.
+	///     When <paramref name="memberId" /> is non-negative, emits the O(1) member-id lookup
+	///     (<c>GetIndexerGetterSetup&lt;...&gt;(memberId, p...)</c>); otherwise falls back to
+	///     the legacy <c>GetIndexerSetup&lt;T&gt;(access)</c> scan.
 	/// </summary>
 	private static void EmitIndexerGetterAccessAndSetup(StringBuilder sb, string indent,
 		string mockRegistry, string accessVarName, string setupVarName,
-		Type propertyType, EquatableArray<MethodParameter> parameters)
+		Type propertyType, EquatableArray<MethodParameter> parameters, int memberId = -1)
 	{
 		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerGetterAccess<");
 		AppendIndexerParameterTypes(sb, parameters);
@@ -141,22 +141,52 @@ internal static partial class Sources
 			sb.Append(", ").AppendTypeOrWrapper(p.Type);
 		}
 
-		sb.Append(">? ").Append(setupVarName).Append(" = ").Append(mockRegistry)
-			.Append(".GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(propertyType);
-		foreach (MethodParameter p in parameters)
-		{
-			sb.Append(", ").AppendTypeOrWrapper(p.Type);
-		}
+		sb.Append(">? ").Append(setupVarName).Append(" = ").Append(mockRegistry);
 
-		sb.Append(">>(").Append(accessVarName).Append(");").AppendLine();
+		if (memberId >= 0)
+		{
+			sb.Append(".GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<")
+				.AppendTypeOrWrapper(propertyType);
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+
+			sb.Append(">");
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+
+			sb.Append(">(").Append(memberId);
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").Append(p.ToNameOrWrapper());
+			}
+
+			sb.Append(");").AppendLine();
+		}
+		else
+		{
+			sb.Append(".GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(propertyType);
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+
+			sb.Append(">>(").Append(accessVarName).Append(");").AppendLine();
+		}
 	}
 
 	/// <summary>
 	///     Emits variable declarations for the indexer setter access and matching setup.
+	///     When <paramref name="memberId" /> is non-negative, emits the O(1) member-id lookup
+	///     (<c>GetIndexerSetterSetup&lt;...&gt;(memberId, p..., value)</c>); otherwise falls back
+	///     to the legacy <c>GetIndexerSetup&lt;T&gt;(access)</c> scan.
 	/// </summary>
 	private static void EmitIndexerSetterAccessAndSetup(StringBuilder sb, string indent,
 		string mockRegistry, string accessVarName, string setupVarName,
-		Type propertyType, EquatableArray<MethodParameter> parameters)
+		Type propertyType, EquatableArray<MethodParameter> parameters, int memberId = -1)
 	{
 		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerSetterAccess<");
 		AppendIndexerParameterTypes(sb, parameters);
@@ -176,14 +206,42 @@ internal static partial class Sources
 			sb.Append(", ").AppendTypeOrWrapper(p.Type);
 		}
 
-		sb.Append(">? ").Append(setupVarName).Append(" = ").Append(mockRegistry)
-			.Append(".GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(propertyType);
-		foreach (MethodParameter p in parameters)
-		{
-			sb.Append(", ").AppendTypeOrWrapper(p.Type);
-		}
+		sb.Append(">? ").Append(setupVarName).Append(" = ").Append(mockRegistry);
 
-		sb.Append(">>(").Append(accessVarName).Append(");").AppendLine();
+		if (memberId >= 0)
+		{
+			sb.Append(".GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<")
+				.AppendTypeOrWrapper(propertyType);
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+
+			sb.Append(">");
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+
+			sb.Append(", ").AppendTypeOrWrapper(propertyType);
+			sb.Append(">(").Append(memberId);
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").Append(p.ToNameOrWrapper());
+			}
+
+			sb.Append(", value);").AppendLine();
+		}
+		else
+		{
+			sb.Append(".GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(propertyType);
+			foreach (MethodParameter p in parameters)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(p.Type);
+			}
+
+			sb.Append(">>(").Append(accessVarName).Append(");").AppendLine();
+		}
 	}
 
 	/// <summary>

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using Mockolate.Exceptions;
@@ -246,6 +247,162 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     O(1) closure-free getter-setup lookup by generator-assigned member id for
+	///     single-argument indexers. Scenario-scoped setups take precedence over the default scope.
+	/// </summary>
+	public T? GetIndexerGetterSetup<T, T1>(int memberId, T1 arg1) where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers.GetGetterByMemberId<T, T1>(memberId, arg1);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetGetterByMemberId<T, T1>(memberId, arg1);
+	}
+
+	/// <summary>
+	///     O(1) closure-free getter-setup lookup by member id for two-argument indexers.
+	/// </summary>
+	public T? GetIndexerGetterSetup<T, T1, T2>(int memberId, T1 arg1, T2 arg2) where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers.GetGetterByMemberId<T, T1, T2>(memberId, arg1, arg2);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetGetterByMemberId<T, T1, T2>(memberId, arg1, arg2);
+	}
+
+	/// <summary>
+	///     O(1) closure-free getter-setup lookup by member id for three-argument indexers.
+	/// </summary>
+	public T? GetIndexerGetterSetup<T, T1, T2, T3>(int memberId, T1 arg1, T2 arg2, T3 arg3)
+		where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers.GetGetterByMemberId<T, T1, T2, T3>(memberId, arg1, arg2, arg3);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetGetterByMemberId<T, T1, T2, T3>(memberId, arg1, arg2, arg3);
+	}
+
+	/// <summary>
+	///     O(1) closure-free getter-setup lookup by member id for four-argument indexers.
+	/// </summary>
+	public T? GetIndexerGetterSetup<T, T1, T2, T3, T4>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+		where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers
+				.GetGetterByMemberId<T, T1, T2, T3, T4>(memberId, arg1, arg2, arg3, arg4);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetGetterByMemberId<T, T1, T2, T3, T4>(memberId, arg1, arg2, arg3, arg4);
+	}
+
+	/// <summary>
+	///     O(1) closure-free setter-setup lookup by generator-assigned member id for
+	///     single-argument indexers. Scenario-scoped setups take precedence over the default scope.
+	/// </summary>
+	public T? GetIndexerSetterSetup<T, T1, TValue>(int memberId, T1 arg1, TValue value) where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers.GetSetterByMemberId<T, T1, TValue>(memberId, arg1, value);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetSetterByMemberId<T, T1, TValue>(memberId, arg1, value);
+	}
+
+	/// <summary>
+	///     O(1) closure-free setter-setup lookup by member id for two-argument indexers.
+	/// </summary>
+	public T? GetIndexerSetterSetup<T, T1, T2, TValue>(int memberId, T1 arg1, T2 arg2, TValue value)
+		where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers
+				.GetSetterByMemberId<T, T1, T2, TValue>(memberId, arg1, arg2, value);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetSetterByMemberId<T, T1, T2, TValue>(memberId, arg1, arg2, value);
+	}
+
+	/// <summary>
+	///     O(1) closure-free setter-setup lookup by member id for three-argument indexers.
+	/// </summary>
+	public T? GetIndexerSetterSetup<T, T1, T2, T3, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, TValue value)
+		where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers
+				.GetSetterByMemberId<T, T1, T2, T3, TValue>(memberId, arg1, arg2, arg3, value);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers.GetSetterByMemberId<T, T1, T2, T3, TValue>(memberId, arg1, arg2, arg3, value);
+	}
+
+	/// <summary>
+	///     O(1) closure-free setter-setup lookup by member id for four-argument indexers.
+	/// </summary>
+	public T? GetIndexerSetterSetup<T, T1, T2, T3, T4, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+		TValue value) where T : IndexerSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Indexers
+				.GetSetterByMemberId<T, T1, T2, T3, T4, TValue>(memberId, arg1, arg2, arg3, arg4, value);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Indexers
+			.GetSetterByMemberId<T, T1, T2, T3, T4, TValue>(memberId, arg1, arg2, arg3, arg4, value);
+	}
+
+	/// <summary>
 	///     Stores <paramref name="value" /> in the indexer value slot identified by <paramref name="access" />.
 	/// </summary>
 	/// <typeparam name="TResult">The indexer's value type.</typeparam>
@@ -438,6 +595,16 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     O(1) getter-flow dispatch by generator-assigned <paramref name="memberId" />. Otherwise
+	///     identical to <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" />;
+	///     the string name is only used to seed the recorded interaction and to construct the
+	///     <see cref="MockNotSetupException" /> / <see cref="PropertySetup.Default{T}" /> fallback.
+	/// </summary>
+	public TResult GetProperty<TResult>(int memberId, string propertyName, Func<TResult> defaultValueGenerator,
+		Func<TResult>? baseValueAccessor)
+		=> GetPropertyCore(memberId, propertyName, defaultValueGenerator, baseValueAccessor);
+
+	/// <summary>
 	///     Executes the getter flow for the property named <paramref name="propertyName" />, honoring configured
 	///     setups and the active <see cref="MockBehavior" />.
 	/// </summary>
@@ -449,6 +616,10 @@ public partial class MockRegistry
 	/// <exception cref="MockNotSetupException">No setup exists for the property and <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />.</exception>
 	public TResult GetProperty<TResult>(string propertyName, Func<TResult> defaultValueGenerator,
 		Func<TResult>? baseValueAccessor)
+		=> GetPropertyCore(-1, propertyName, defaultValueGenerator, baseValueAccessor);
+
+	private TResult GetPropertyCore<TResult>(int memberId, string propertyName,
+		Func<TResult> defaultValueGenerator, Func<TResult>? baseValueAccessor)
 	{
 		IInteraction? interaction = null;
 		if (!Behavior.SkipInteractionRecording)
@@ -461,7 +632,7 @@ public partial class MockRegistry
 		if (baseValueAccessor is null)
 		{
 			// Stryker disable once Boolean : forceReinit only matters when a base class accessor exists; on this branch there is none, so flipping it to true triggers an extra InitializeWith call that is gated by _isUserInitialized || _isInitialized and becomes a no-op.
-			matchingSetup = ResolvePropertySetup(propertyName, defaultValueGenerator, null, false);
+			matchingSetup = ResolvePropertySetup(memberId, propertyName, defaultValueGenerator, null, false);
 
 			return ((IInteractivePropertySetup)matchingSetup).InvokeGetter(interaction, Behavior,
 				defaultValueGenerator);
@@ -481,7 +652,7 @@ public partial class MockRegistry
 			};
 
 		matchingSetup = ResolvePropertySetup(
-			propertyName, defaultValueGenerator, safeBaseValueAccessor, true);
+			memberId, propertyName, defaultValueGenerator, safeBaseValueAccessor, true);
 
 		TResult result = ((IInteractivePropertySetup)matchingSetup).InvokeGetter(interaction, Behavior,
 			defaultValueGenerator);
@@ -489,6 +660,15 @@ public partial class MockRegistry
 		capturedBaseException?.Throw();
 		return result;
 	}
+
+	/// <summary>
+	///     O(1) setter-flow dispatch by generator-assigned <paramref name="memberId" />. Otherwise
+	///     identical to <see cref="SetProperty{T}(string, T)" />; the string name is only used to
+	///     seed the recorded interaction and to construct the
+	///     <see cref="PropertySetup.Default{T}" /> fallback.
+	/// </summary>
+	public bool SetProperty<T>(int memberId, string propertyName, T value)
+		=> SetPropertyCore(memberId, propertyName, value);
 
 	/// <summary>
 	///     Executes the setter flow for the property named <paramref name="propertyName" />, honoring configured
@@ -502,6 +682,9 @@ public partial class MockRegistry
 	/// <param name="value">The value being assigned.</param>
 	/// <returns><see langword="true" /> when the base-class setter should be skipped.</returns>
 	public bool SetProperty<T>(string propertyName, T value)
+		=> SetPropertyCore(-1, propertyName, value);
+
+	private bool SetPropertyCore<T>(int memberId, string propertyName, T value)
 	{
 		IInteraction? interaction = null;
 		if (!Behavior.SkipInteractionRecording)
@@ -510,7 +693,7 @@ public partial class MockRegistry
 				new PropertySetterAccess<T>(propertyName, value));
 		}
 
-		PropertySetup matchingSetup = ResolvePropertySetup<T>(propertyName, null, null, false);
+		PropertySetup matchingSetup = ResolvePropertySetup<T>(memberId, propertyName, null, null, false);
 
 		((IInteractivePropertySetup)matchingSetup).InvokeSetter(interaction, value, Behavior);
 		return ((IInteractivePropertySetup)matchingSetup).SkipBaseClass() ?? Behavior.SkipBaseClass;
@@ -518,6 +701,7 @@ public partial class MockRegistry
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	private PropertySetup ResolvePropertySetup<TResult>(
+		int memberId,
 		string propertyName,
 		Func<TResult>? defaultValueGenerator,
 		Func<TResult>? baseValueAccessor,
@@ -526,12 +710,13 @@ public partial class MockRegistry
 		PropertySetup? existingSetup = null;
 		if (!string.IsNullOrEmpty(Scenario) &&
 		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket) &&
-		    scopedBucket.Properties.TryGetValue(propertyName, out PropertySetup? scopedSetup))
+		    TryGetPropertySetup(scopedBucket.Properties, memberId, propertyName, out PropertySetup? scopedSetup))
 		{
 			existingSetup = scopedSetup;
 		}
 
-		if (existingSetup is null && !Setup.Properties.TryGetValue(propertyName, out existingSetup))
+		if (existingSetup is null &&
+		    !TryGetPropertySetup(Setup.Properties, memberId, propertyName, out existingSetup))
 		{
 			if (Behavior.ThrowWhenNotSetup)
 			{
@@ -540,7 +725,7 @@ public partial class MockRegistry
 			}
 
 			TResult initialValue = GetInitialValue();
-			PropertySetup setup = new PropertySetup.Default<TResult>(propertyName, initialValue);
+			PropertySetup setup = new PropertySetup.Default<TResult>(memberId, propertyName, initialValue);
 			Setup.Properties.Add(setup);
 			return setup;
 		}
@@ -578,6 +763,21 @@ public partial class MockRegistry
 		}
 	}
 #pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
+
+	// Prefers the O(1) by-member-id lookup when the caller knows the id. Falls back to the
+	// name-based scan for legacy call sites (memberId < 0) and to cover setups registered via the
+	// legacy ctor: those live in `_storage` but not in `_byMemberId`, so the by-id fetch would miss
+	// them.
+	private static bool TryGetPropertySetup(MockSetups.PropertySetups bucket, int memberId, string propertyName,
+		[NotNullWhen(true)] out PropertySetup? setup)
+	{
+		if (memberId >= 0 && bucket.TryGetByMemberId(memberId, out setup))
+		{
+			return true;
+		}
+
+		return bucket.TryGetValue(propertyName, out setup);
+	}
 
 	/// <summary>
 	///     Records a subscription to the event named <paramref name="name" /> and fires registered

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -40,6 +40,104 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     O(1) closure-free lookup by generator-assigned member id for parameterless methods.
+	///     Scenario-scoped setups take precedence over the default scope.
+	/// </summary>
+	/// <typeparam name="T">The concrete <see cref="MethodSetup" /> subtype to return.</typeparam>
+	/// <param name="memberId">Dense integer id emitted by the Mockolate source generator.</param>
+	/// <param name="methodName">The qualified method name, used only for the legacy-setup fallback scan.</param>
+	/// <returns>The matching setup, or <see langword="null" /> when none was found.</returns>
+	public T? GetMethodSetup<T>(int memberId, string methodName) where T : MethodSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Methods.GetByMemberId<T>(memberId, methodName);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Methods.GetByMemberId<T>(memberId, methodName);
+	}
+
+	/// <summary>
+	///     O(1) closure-free lookup by member id for single-argument methods. Scenario-scoped setups
+	///     take precedence over the default scope.
+	/// </summary>
+	public T? GetMethodSetup<T, T1>(int memberId, string methodName, T1 arg1) where T : MethodSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Methods.GetByMemberId<T, T1>(memberId, methodName, arg1);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Methods.GetByMemberId<T, T1>(memberId, methodName, arg1);
+	}
+
+	/// <summary>
+	///     O(1) closure-free lookup by member id for two-argument methods.
+	/// </summary>
+	public T? GetMethodSetup<T, T1, T2>(int memberId, string methodName, T1 arg1, T2 arg2) where T : MethodSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Methods.GetByMemberId<T, T1, T2>(memberId, methodName, arg1, arg2);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Methods.GetByMemberId<T, T1, T2>(memberId, methodName, arg1, arg2);
+	}
+
+	/// <summary>
+	///     O(1) closure-free lookup by member id for three-argument methods.
+	/// </summary>
+	public T? GetMethodSetup<T, T1, T2, T3>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3)
+		where T : MethodSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Methods.GetByMemberId<T, T1, T2, T3>(memberId, methodName, arg1, arg2, arg3);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Methods.GetByMemberId<T, T1, T2, T3>(memberId, methodName, arg1, arg2, arg3);
+	}
+
+	/// <summary>
+	///     O(1) closure-free lookup by member id for four-argument methods.
+	/// </summary>
+	public T? GetMethodSetup<T, T1, T2, T3, T4>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+		where T : MethodSetup
+	{
+		if (!string.IsNullOrEmpty(Scenario) &&
+		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
+		{
+			T? scoped = scopedBucket.Methods.GetByMemberId<T, T1, T2, T3, T4>(memberId, methodName, arg1, arg2, arg3, arg4);
+			if (scoped is not null)
+			{
+				return scoped;
+			}
+		}
+
+		return Setup.Methods.GetByMemberId<T, T1, T2, T3, T4>(memberId, methodName, arg1, arg2, arg3, arg4);
+	}
+
+	/// <summary>
 	///     Returns the latest registered method setup of type <typeparamref name="T" /> whose name equals
 	///     <paramref name="methodName" /> and that satisfies <paramref name="predicate" />, or <see langword="null" />
 	///     when no setup matches. Scenario-scoped setups take precedence over default-scope setups.

--- a/Source/Mockolate/Setup/IIndexerMatchByValue.cs
+++ b/Source/Mockolate/Setup/IIndexerMatchByValue.cs
@@ -1,0 +1,102 @@
+namespace Mockolate.Setup;
+
+/// <summary>
+///     Closure-free match contract for a single-argument indexer getter.
+/// </summary>
+/// <remarks>
+///     Implemented by <see cref="IndexerSetup{TValue, T1}" /> so the member-id indexed lookup can
+///     evaluate a match without allocating a predicate closure.
+/// </remarks>
+public interface IIndexerGetterMatchByValue<in T1>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a getter invocation with
+	///     argument <paramref name="p1" />.
+	/// </summary>
+	bool Matches(T1 p1);
+}
+
+/// <summary>
+///     Closure-free match contract for a two-argument indexer getter.
+/// </summary>
+public interface IIndexerGetterMatchByValue<in T1, in T2>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a getter invocation with the
+	///     given arguments.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2);
+}
+
+/// <summary>
+///     Closure-free match contract for a three-argument indexer getter.
+/// </summary>
+public interface IIndexerGetterMatchByValue<in T1, in T2, in T3>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a getter invocation with the
+	///     given arguments.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2, T3 p3);
+}
+
+/// <summary>
+///     Closure-free match contract for a four-argument indexer getter.
+/// </summary>
+public interface IIndexerGetterMatchByValue<in T1, in T2, in T3, in T4>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a getter invocation with the
+	///     given arguments.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
+}
+
+/// <summary>
+///     Closure-free match contract for a single-argument indexer setter. The trailing
+///     <typeparamref name="TValue" /> is the value being assigned.
+/// </summary>
+public interface IIndexerSetterMatchByValue<in T1, in TValue>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a setter invocation with the
+	///     given argument and assigned value.
+	/// </summary>
+	bool Matches(T1 p1, TValue value);
+}
+
+/// <summary>
+///     Closure-free match contract for a two-argument indexer setter.
+/// </summary>
+public interface IIndexerSetterMatchByValue<in T1, in T2, in TValue>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a setter invocation with the
+	///     given arguments and assigned value.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2, TValue value);
+}
+
+/// <summary>
+///     Closure-free match contract for a three-argument indexer setter.
+/// </summary>
+public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in TValue>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a setter invocation with the
+	///     given arguments and assigned value.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2, T3 p3, TValue value);
+}
+
+/// <summary>
+///     Closure-free match contract for a four-argument indexer setter.
+/// </summary>
+public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in T4, in TValue>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a setter invocation with the
+	///     given arguments and assigned value.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2, T3 p3, T4 p4, TValue value);
+}

--- a/Source/Mockolate/Setup/IMethodMatchByValue.cs
+++ b/Source/Mockolate/Setup/IMethodMatchByValue.cs
@@ -1,0 +1,62 @@
+namespace Mockolate.Setup;
+
+/// <summary>
+///     Marker for a method setup that accepts no parameters. Implemented by
+///     <see cref="ReturnMethodSetup{TReturn}" /> and <see cref="VoidMethodSetup" /> so the member-id
+///     indexed lookup can match without a closure.
+/// </summary>
+public interface IMethodMatchByValue
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches a parameterless invocation.
+	/// </summary>
+	bool Matches();
+}
+
+/// <summary>
+///     Closure-free match contract for a single-parameter method setup.
+/// </summary>
+public interface IMethodMatchByValue<in T1>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches an invocation with argument
+	///     <paramref name="p1" />.
+	/// </summary>
+	bool Matches(T1 p1);
+}
+
+/// <summary>
+///     Closure-free match contract for a two-parameter method setup.
+/// </summary>
+public interface IMethodMatchByValue<in T1, in T2>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches an invocation with the given
+	///     arguments.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2);
+}
+
+/// <summary>
+///     Closure-free match contract for a three-parameter method setup.
+/// </summary>
+public interface IMethodMatchByValue<in T1, in T2, in T3>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches an invocation with the given
+	///     arguments.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2, T3 p3);
+}
+
+/// <summary>
+///     Closure-free match contract for a four-parameter method setup.
+/// </summary>
+public interface IMethodMatchByValue<in T1, in T2, in T3, in T4>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> when this setup matches an invocation with the given
+	///     arguments.
+	/// </summary>
+	bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
+}

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -27,10 +27,27 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 	///     Initializes a new instance of the <see cref="IndexerSetup" /> class bound to the given
 	///     <paramref name="mockRegistry" />.
 	/// </summary>
-	protected IndexerSetup(MockRegistry mockRegistry)
+	protected IndexerSetup(MockRegistry mockRegistry) : this(-1, mockRegistry)
 	{
+	}
+
+	/// <summary>
+	///     Initializes a new instance of the <see cref="IndexerSetup" /> class, carrying the
+	///     generator-assigned <paramref name="memberId" /> used for the fast O(1) setup lookup on
+	///     the invocation hot path.
+	/// </summary>
+	protected IndexerSetup(int memberId, MockRegistry mockRegistry)
+	{
+		MemberId = memberId;
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <summary>
+	///     Generator-assigned dense integer id for the indexer this setup targets, or <c>-1</c>
+	///     when the setup was created through a legacy path. Used by the member-id-indexed setup
+	///     store for closure-free dispatch.
+	/// </summary>
+	public int MemberId { get; }
 
 	/// <inheritdoc cref="IInteractiveIndexerSetup.Matches(IndexerAccess)" />
 	bool IInteractiveIndexerSetup.Matches(IndexerAccess indexerAccess)
@@ -128,13 +145,21 @@ public abstract class IndexerSetup : IInteractiveIndexerSetup
 #if !DEBUG
 [DebuggerNonUserCode]
 #endif
-public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch<T1> parameter1)
-	: IndexerSetup(mockRegistry),
+public class IndexerSetup<TValue, T1>(int memberId, MockRegistry mockRegistry, IParameterMatch<T1> parameter1)
+	: IndexerSetup(memberId, mockRegistry),
 		IIndexerSetupWithCallback<TValue, T1>,
 		IIndexerGetterSetupCallbackBuilder<TValue, T1>, IIndexerSetterSetupCallbackBuilder<TValue, T1>,
 		IIndexerSetupReturnBuilder<TValue, T1>,
-		IIndexerGetterSetupWithCallback<TValue, T1>, IIndexerSetterSetupWithCallback<TValue, T1>
+		IIndexerGetterSetupWithCallback<TValue, T1>, IIndexerSetterSetupWithCallback<TValue, T1>,
+		IIndexerGetterMatchByValue<T1>,
+		IIndexerSetterMatchByValue<T1, TValue>
 {
+	/// <inheritdoc cref="IndexerSetup{TValue, T1}" />
+	public IndexerSetup(MockRegistry mockRegistry, IParameterMatch<T1> parameter1)
+		: this(-1, mockRegistry, parameter1)
+	{
+	}
+
 	private Callbacks<Action<int, T1, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, TValue, TValue>>? _returnCallbacks;
 	private Callbacks<Action<int, T1, TValue>>? _setterCallbacks;
@@ -723,14 +748,23 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetup<TValue, T1, T2>(
+	int memberId,
 	MockRegistry mockRegistry,
 	IParameterMatch<T1> parameter1,
-	IParameterMatch<T2> parameter2) : IndexerSetup(mockRegistry),
+	IParameterMatch<T2> parameter2) : IndexerSetup(memberId, mockRegistry),
 	IIndexerSetupWithCallback<TValue, T1, T2>,
 	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>,
 	IIndexerSetupReturnBuilder<TValue, T1, T2>,
-	IIndexerGetterSetupWithCallback<TValue, T1, T2>, IIndexerSetterSetupWithCallback<TValue, T1, T2>
+	IIndexerGetterSetupWithCallback<TValue, T1, T2>, IIndexerSetterSetupWithCallback<TValue, T1, T2>,
+	IIndexerGetterMatchByValue<T1, T2>,
+	IIndexerSetterMatchByValue<T1, T2, TValue>
 {
+	/// <inheritdoc cref="IndexerSetup{TValue, T1, T2}" />
+	public IndexerSetup(MockRegistry mockRegistry, IParameterMatch<T1> parameter1, IParameterMatch<T2> parameter2)
+		: this(-1, mockRegistry, parameter1, parameter2)
+	{
+	}
+
 	private Callbacks<Action<int, T1, T2, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, T2, TValue, TValue>>? _returnCallbacks;
 	private Callbacks<Action<int, T1, T2, TValue>>? _setterCallbacks;
@@ -1327,15 +1361,25 @@ public class IndexerSetup<TValue, T1, T2>(
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetup<TValue, T1, T2, T3>(
+	int memberId,
 	MockRegistry mockRegistry,
 	IParameterMatch<T1> parameter1,
 	IParameterMatch<T2> parameter2,
-	IParameterMatch<T3> parameter3) : IndexerSetup(mockRegistry),
+	IParameterMatch<T3> parameter3) : IndexerSetup(memberId, mockRegistry),
 	IIndexerSetupWithCallback<TValue, T1, T2, T3>,
 	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>,
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3>,
-	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>
+	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>,
+	IIndexerGetterMatchByValue<T1, T2, T3>,
+	IIndexerSetterMatchByValue<T1, T2, T3, TValue>
 {
+	/// <inheritdoc cref="IndexerSetup{TValue, T1, T2, T3}" />
+	public IndexerSetup(MockRegistry mockRegistry, IParameterMatch<T1> parameter1,
+		IParameterMatch<T2> parameter2, IParameterMatch<T3> parameter3)
+		: this(-1, mockRegistry, parameter1, parameter2, parameter3)
+	{
+	}
+
 	private Callbacks<Action<int, T1, T2, T3, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, T2, T3, TValue, TValue>>? _returnCallbacks;
 	private Callbacks<Action<int, T1, T2, T3, TValue>>? _setterCallbacks;
@@ -1947,16 +1991,26 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 [DebuggerNonUserCode]
 #endif
 public class IndexerSetup<TValue, T1, T2, T3, T4>(
+	int memberId,
 	MockRegistry mockRegistry,
 	IParameterMatch<T1> parameter1,
 	IParameterMatch<T2> parameter2,
 	IParameterMatch<T3> parameter3,
-	IParameterMatch<T4> parameter4) : IndexerSetup(mockRegistry),
+	IParameterMatch<T4> parameter4) : IndexerSetup(memberId, mockRegistry),
 	IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>,
 	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>,
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>,
-	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>
+	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>,
+	IIndexerGetterMatchByValue<T1, T2, T3, T4>,
+	IIndexerSetterMatchByValue<T1, T2, T3, T4, TValue>
 {
+	/// <inheritdoc cref="IndexerSetup{TValue, T1, T2, T3, T4}" />
+	public IndexerSetup(MockRegistry mockRegistry, IParameterMatch<T1> parameter1,
+		IParameterMatch<T2> parameter2, IParameterMatch<T3> parameter3, IParameterMatch<T4> parameter4)
+		: this(-1, mockRegistry, parameter1, parameter2, parameter3, parameter4)
+	{
+	}
+
 	private Callbacks<Action<int, T1, T2, T3, T4, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, T2, T3, T4, TValue, TValue>>? _returnCallbacks;
 	private Callbacks<Action<int, T1, T2, T3, T4, TValue>>? _setterCallbacks;

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -15,10 +15,26 @@ public abstract class MethodSetup : IMethodSetup, IVerifiableMethodSetup
 	/// <summary>
 	///     Base class for method setups.
 	/// </summary>
-	protected MethodSetup(string name)
+	protected MethodSetup(string name) : this(-1, name)
 	{
+	}
+
+	/// <summary>
+	///     Base class for method setups, carrying the generator-assigned <paramref name="memberId" />
+	///     used for the fast O(1) setup lookup on the invocation hot path.
+	/// </summary>
+	protected MethodSetup(int memberId, string name)
+	{
+		MemberId = memberId;
 		Name = name;
 	}
+
+	/// <summary>
+	///     Generator-assigned dense integer id for the member this setup targets, or <c>-1</c> when the
+	///     setup was created through a legacy path. Used by the member-id-indexed setup store for
+	///     closure-free dispatch.
+	/// </summary>
+	public int MemberId { get; }
 
 	/// <summary>
 	///     The name of the method.

--- a/Source/Mockolate/Setup/MockSetups.Indexers.cs
+++ b/Source/Mockolate/Setup/MockSetups.Indexers.cs
@@ -21,6 +21,15 @@ internal partial class MockSetups
 		private IndexerValueStorage?[]? _valueStorages;
 		private readonly object _valueStoragesLock = new();
 
+		// Member-id-indexed setup store. Populated alongside `_storage` under the same lock.
+		// Mutable lists are kept for setup writes; `_snapshotByMemberId` is an immutable-per-generation
+		// snapshot that the invocation hot path reads without acquiring the list lock.
+		// `_hasStaleSnapshot` is set on every add; the next reader rebuilds the snapshot under the
+		// lock. Same pattern as MockSetups.MethodSetups.
+		private List<IndexerSetup>?[]? _byMemberId;
+		private volatile IndexerSetup[]?[]? _snapshotByMemberId;
+		private volatile bool _hasStaleSnapshot;
+
 		public int Count
 		{
 			get
@@ -196,7 +205,542 @@ internal partial class MockSetups
 			lock (storage)
 			{
 				storage.Add(setup);
+				int memberId = setup.MemberId;
+				if (memberId >= 0)
+				{
+					EnsureByMemberIdCapacity(memberId);
+					List<IndexerSetup>? list = _byMemberId![memberId];
+					if (list is null)
+					{
+						list = new List<IndexerSetup>();
+						_byMemberId[memberId] = list;
+					}
+
+					list.Add(setup);
+					_hasStaleSnapshot = true;
+				}
 			}
+		}
+
+		private void EnsureByMemberIdCapacity(int memberId)
+		{
+			int required = memberId + 1;
+			if (_byMemberId is null)
+			{
+				int initial = Math.Max(required, 8);
+				_byMemberId = new List<IndexerSetup>?[initial];
+				return;
+			}
+
+			if (_byMemberId.Length >= required)
+			{
+				return;
+			}
+
+			int newSize = Math.Max(required, _byMemberId.Length * 2);
+			List<IndexerSetup>?[] grown = new List<IndexerSetup>?[newSize];
+			Array.Copy(_byMemberId, grown, _byMemberId.Length);
+			_byMemberId = grown;
+		}
+
+		private IndexerSetup[]?[]? GetSnapshot()
+		{
+			IndexerSetup[]?[]? current = _snapshotByMemberId;
+			if (!_hasStaleSnapshot && current is not null)
+			{
+				return current;
+			}
+
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				if (!_hasStaleSnapshot)
+				{
+					return _snapshotByMemberId;
+				}
+
+				List<IndexerSetup>?[]? byMemberId = _byMemberId;
+				if (byMemberId is null)
+				{
+					_snapshotByMemberId = null;
+					_hasStaleSnapshot = false;
+					return null;
+				}
+
+				IndexerSetup[]?[] rebuilt = new IndexerSetup[]?[byMemberId.Length];
+				for (int i = 0; i < byMemberId.Length; i++)
+				{
+					List<IndexerSetup>? list = byMemberId[i];
+					if (list is { Count: > 0, })
+					{
+						rebuilt[i] = list.ToArray();
+					}
+				}
+
+				_snapshotByMemberId = rebuilt;
+				_hasStaleSnapshot = false;
+				return rebuilt;
+			}
+		}
+
+		/// <summary>
+		///     O(1) getter-setup lookup by generator-assigned member id for single-argument indexers.
+		///     Returns the latest-registered setup of type <typeparamref name="T" /> whose
+		///     <see cref="IIndexerGetterMatchByValue{T1}" /> accepts <paramref name="arg1" />, or
+		///     <see langword="null" /> when none matches. Invocation hot path — reads the volatile
+		///     snapshot without a lock. Falls back to a type-filtered scan of legacy setups
+		///     (<see cref="IndexerSetup.MemberId" /> &lt; 0).
+		/// </summary>
+		public T? GetGetterByMemberId<T, T1>(int memberId, T1 arg1) where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerGetterMatchByValue<T1> m && m.Matches(arg1))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyGetterByValue<T, T1>(arg1);
+		}
+
+		/// <summary>
+		///     O(1) getter-setup lookup by member id for two-argument indexers.
+		/// </summary>
+		public T? GetGetterByMemberId<T, T1, T2>(int memberId, T1 arg1, T2 arg2) where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerGetterMatchByValue<T1, T2> m
+						    && m.Matches(arg1, arg2))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyGetterByValue<T, T1, T2>(arg1, arg2);
+		}
+
+		/// <summary>
+		///     O(1) getter-setup lookup by member id for three-argument indexers.
+		/// </summary>
+		public T? GetGetterByMemberId<T, T1, T2, T3>(int memberId, T1 arg1, T2 arg2, T3 arg3)
+			where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerGetterMatchByValue<T1, T2, T3> m
+						    && m.Matches(arg1, arg2, arg3))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyGetterByValue<T, T1, T2, T3>(arg1, arg2, arg3);
+		}
+
+		/// <summary>
+		///     O(1) getter-setup lookup by member id for four-argument indexers.
+		/// </summary>
+		public T? GetGetterByMemberId<T, T1, T2, T3, T4>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+			where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerGetterMatchByValue<T1, T2, T3, T4> m
+						    && m.Matches(arg1, arg2, arg3, arg4))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyGetterByValue<T, T1, T2, T3, T4>(arg1, arg2, arg3, arg4);
+		}
+
+		/// <summary>
+		///     O(1) setter-setup lookup by generator-assigned member id for single-argument indexers.
+		/// </summary>
+		public T? GetSetterByMemberId<T, T1, TValue>(int memberId, T1 arg1, TValue value)
+			where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, TValue> m
+						    && m.Matches(arg1, value))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacySetterByValue<T, T1, TValue>(arg1, value);
+		}
+
+		/// <summary>
+		///     O(1) setter-setup lookup by member id for two-argument indexers.
+		/// </summary>
+		public T? GetSetterByMemberId<T, T1, T2, TValue>(int memberId, T1 arg1, T2 arg2, TValue value)
+			where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, T2, TValue> m
+						    && m.Matches(arg1, arg2, value))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacySetterByValue<T, T1, T2, TValue>(arg1, arg2, value);
+		}
+
+		/// <summary>
+		///     O(1) setter-setup lookup by member id for three-argument indexers.
+		/// </summary>
+		public T? GetSetterByMemberId<T, T1, T2, T3, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, TValue value)
+			where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, T2, T3, TValue> m
+						    && m.Matches(arg1, arg2, arg3, value))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacySetterByValue<T, T1, T2, T3, TValue>(arg1, arg2, arg3, value);
+		}
+
+		/// <summary>
+		///     O(1) setter-setup lookup by member id for four-argument indexers.
+		/// </summary>
+		public T? GetSetterByMemberId<T, T1, T2, T3, T4, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+			TValue value) where T : IndexerSetup
+		{
+			IndexerSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				IndexerSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						IndexerSetup setup = setups[i];
+						if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, T2, T3, T4, TValue> m
+						    && m.Matches(arg1, arg2, arg3, arg4, value))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacySetterByValue<T, T1, T2, T3, T4, TValue>(arg1, arg2, arg3, arg4, value);
+		}
+
+		// Legacy fallback: setups registered with the pre-memberId ctor (MemberId < 0) live only in
+		// `_storage`. Scan them under the list lock, newest first. The `setup is T` test filters by
+		// the concrete IndexerSetup<TValue, T1..> shape, so we don't need a name to disambiguate.
+		private T? GetLegacyGetterByValue<T, T1>(T1 arg1) where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerGetterMatchByValue<T1> m && m.Matches(arg1))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacyGetterByValue<T, T1, T2>(T1 arg1, T2 arg2) where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerGetterMatchByValue<T1, T2> m && m.Matches(arg1, arg2))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacyGetterByValue<T, T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3) where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerGetterMatchByValue<T1, T2, T3> m
+					    && m.Matches(arg1, arg2, arg3))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacyGetterByValue<T, T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+			where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerGetterMatchByValue<T1, T2, T3, T4> m
+					    && m.Matches(arg1, arg2, arg3, arg4))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacySetterByValue<T, T1, TValue>(T1 arg1, TValue value) where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, TValue> m
+					    && m.Matches(arg1, value))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacySetterByValue<T, T1, T2, TValue>(T1 arg1, T2 arg2, TValue value)
+			where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, T2, TValue> m
+					    && m.Matches(arg1, arg2, value))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacySetterByValue<T, T1, T2, T3, TValue>(T1 arg1, T2 arg2, T3 arg3, TValue value)
+			where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, T2, T3, TValue> m
+					    && m.Matches(arg1, arg2, arg3, value))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacySetterByValue<T, T1, T2, T3, T4, TValue>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, TValue value)
+			where T : IndexerSetup
+		{
+			List<IndexerSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					IndexerSetup setup = storage[i];
+					if (setup.MemberId >= 0)
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IIndexerSetterMatchByValue<T1, T2, T3, T4, TValue> m
+					    && m.Matches(arg1, arg2, arg3, arg4, value))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
 		}
 
 		internal IEnumerable<IndexerSetup> EnumerateUnusedSetupsBy(MockInteractions interactions)

--- a/Source/Mockolate/Setup/MockSetups.Methods.cs
+++ b/Source/Mockolate/Setup/MockSetups.Methods.cs
@@ -19,6 +19,15 @@ internal partial class MockSetups
 	{
 		private List<MethodSetup>? _storage;
 
+		// Member-id-indexed setup store. Populated alongside `_storage` under the same lock.
+		// Mutable lists are kept for setup writes; `_snapshotByMemberId` is an immutable-per-generation
+		// snapshot that the invocation hot path reads without acquiring the lock.
+		// `_hasStaleSnapshot` is set on every add; the next reader rebuilds the snapshot under the
+		// lock. Same pattern as TUnit's `_setupsByMemberId` / `_hasStaleSetups`.
+		private List<MethodSetup>?[]? _byMemberId;
+		private volatile MethodSetup[]?[]? _snapshotByMemberId;
+		private volatile bool _hasStaleSnapshot;
+
 		public int Count
 		{
 			get
@@ -52,7 +61,374 @@ internal partial class MockSetups
 			lock (storage)
 			{
 				storage.Add(setup);
+				int memberId = setup.MemberId;
+				if (memberId >= 0)
+				{
+					EnsureByMemberIdCapacity(memberId);
+					List<MethodSetup>? list = _byMemberId![memberId];
+					if (list is null)
+					{
+						list = new List<MethodSetup>();
+						_byMemberId[memberId] = list;
+					}
+
+					list.Add(setup);
+					_hasStaleSnapshot = true;
+				}
 			}
+		}
+
+		private void EnsureByMemberIdCapacity(int memberId)
+		{
+			int required = memberId + 1;
+			if (_byMemberId is null)
+			{
+				int initial = Math.Max(required, 8);
+				_byMemberId = new List<MethodSetup>?[initial];
+				return;
+			}
+
+			if (_byMemberId.Length >= required)
+			{
+				return;
+			}
+
+			int newSize = Math.Max(required, _byMemberId.Length * 2);
+			List<MethodSetup>?[] grown = new List<MethodSetup>?[newSize];
+			Array.Copy(_byMemberId, grown, _byMemberId.Length);
+			_byMemberId = grown;
+		}
+
+		private MethodSetup[]?[]? GetSnapshot()
+		{
+			MethodSetup[]?[]? current = _snapshotByMemberId;
+			if (!_hasStaleSnapshot && current is not null)
+			{
+				return current;
+			}
+
+			List<MethodSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				if (!_hasStaleSnapshot)
+				{
+					return _snapshotByMemberId;
+				}
+
+				List<MethodSetup>?[]? byMemberId = _byMemberId;
+				if (byMemberId is null)
+				{
+					_snapshotByMemberId = null;
+					_hasStaleSnapshot = false;
+					return null;
+				}
+
+				MethodSetup[]?[] rebuilt = new MethodSetup[]?[byMemberId.Length];
+				for (int i = 0; i < byMemberId.Length; i++)
+				{
+					List<MethodSetup>? list = byMemberId[i];
+					if (list is { Count: > 0, })
+					{
+						rebuilt[i] = list.ToArray();
+					}
+				}
+
+				_snapshotByMemberId = rebuilt;
+				_hasStaleSnapshot = false;
+				return rebuilt;
+			}
+		}
+
+		/// <summary>
+		///     O(1) setup lookup by generator-assigned member id. Returns the latest-registered setup
+		///     of type <typeparamref name="T" /> whose <see cref="IMethodMatchByValue" /> implementation
+		///     accepts the zero-argument call, or <see langword="null" /> when none matches. Invocation
+		///     hot path — reads the volatile snapshot without a lock.
+		/// </summary>
+		/// <remarks>
+		///     Falls back to scanning legacy setups (those registered through the pre-memberId ctor
+		///     with <see cref="MethodSetup.MemberId" /> &lt; 0) when the indexed bucket has no match.
+		///     Required for third-party extensions that still use the legacy ctor (e.g. Mockolate.Web).
+		/// </remarks>
+		public T? GetByMemberId<T>(int memberId, string methodName) where T : MethodSetup
+		{
+			MethodSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				MethodSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						MethodSetup setup = setups[i];
+						if (setup is T typed && setup is IMethodMatchByValue m && m.Matches())
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyByValue<T>(methodName);
+		}
+
+		/// <summary>
+		///     O(1) setup lookup by member id for single-argument methods. Closure-free, lock-free read
+		///     on the indexed path; falls back to a name+value scan of legacy setups.
+		/// </summary>
+		public T? GetByMemberId<T, T1>(int memberId, string methodName, T1 arg1) where T : MethodSetup
+		{
+			MethodSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				MethodSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						MethodSetup setup = setups[i];
+						if (setup is T typed && setup is IMethodMatchByValue<T1> m && m.Matches(arg1))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyByValue<T, T1>(methodName, arg1);
+		}
+
+		/// <summary>
+		///     O(1) setup lookup by member id for two-argument methods.
+		/// </summary>
+		public T? GetByMemberId<T, T1, T2>(int memberId, string methodName, T1 arg1, T2 arg2) where T : MethodSetup
+		{
+			MethodSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				MethodSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						MethodSetup setup = setups[i];
+						if (setup is T typed && setup is IMethodMatchByValue<T1, T2> m && m.Matches(arg1, arg2))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyByValue<T, T1, T2>(methodName, arg1, arg2);
+		}
+
+		/// <summary>
+		///     O(1) setup lookup by member id for three-argument methods.
+		/// </summary>
+		public T? GetByMemberId<T, T1, T2, T3>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3)
+			where T : MethodSetup
+		{
+			MethodSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				MethodSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						MethodSetup setup = setups[i];
+						if (setup is T typed && setup is IMethodMatchByValue<T1, T2, T3> m
+						    && m.Matches(arg1, arg2, arg3))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyByValue<T, T1, T2, T3>(methodName, arg1, arg2, arg3);
+		}
+
+		/// <summary>
+		///     O(1) setup lookup by member id for four-argument methods.
+		/// </summary>
+		public T? GetByMemberId<T, T1, T2, T3, T4>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+			where T : MethodSetup
+		{
+			MethodSetup[]?[]? snap = GetSnapshot();
+			if (snap is not null && (uint)memberId < (uint)snap.Length)
+			{
+				MethodSetup[]? setups = snap[memberId];
+				if (setups is not null)
+				{
+					for (int i = setups.Length - 1; i >= 0; i--)
+					{
+						MethodSetup setup = setups[i];
+						if (setup is T typed && setup is IMethodMatchByValue<T1, T2, T3, T4> m
+						    && m.Matches(arg1, arg2, arg3, arg4))
+						{
+							return typed;
+						}
+					}
+				}
+			}
+
+			return GetLegacyByValue<T, T1, T2, T3, T4>(methodName, arg1, arg2, arg3, arg4);
+		}
+
+		// Legacy fallback: setups registered with the pre-memberId ctor (MemberId < 0) live only in
+		// `_storage`. Scan them under the list lock, newest first, filtering by method name to avoid
+		// cross-method matches when several generated proxies share a single MockRegistry instance
+		// (e.g. HttpClient + HttpMessageHandler). The check is O(N) over legacy setups only —
+		// typically zero on the hot path.
+		private T? GetLegacyByValue<T>(string methodName) where T : MethodSetup
+		{
+			List<MethodSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					MethodSetup setup = storage[i];
+					if (setup.MemberId >= 0 || !setup.Name.Equals(methodName))
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IMethodMatchByValue m && m.Matches())
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacyByValue<T, T1>(string methodName, T1 arg1) where T : MethodSetup
+		{
+			List<MethodSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					MethodSetup setup = storage[i];
+					if (setup.MemberId >= 0 || !setup.Name.Equals(methodName))
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IMethodMatchByValue<T1> m && m.Matches(arg1))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacyByValue<T, T1, T2>(string methodName, T1 arg1, T2 arg2) where T : MethodSetup
+		{
+			List<MethodSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					MethodSetup setup = storage[i];
+					if (setup.MemberId >= 0 || !setup.Name.Equals(methodName))
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IMethodMatchByValue<T1, T2> m && m.Matches(arg1, arg2))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacyByValue<T, T1, T2, T3>(string methodName, T1 arg1, T2 arg2, T3 arg3)
+			where T : MethodSetup
+		{
+			List<MethodSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					MethodSetup setup = storage[i];
+					if (setup.MemberId >= 0 || !setup.Name.Equals(methodName))
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IMethodMatchByValue<T1, T2, T3> m
+					    && m.Matches(arg1, arg2, arg3))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		private T? GetLegacyByValue<T, T1, T2, T3, T4>(string methodName, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+			where T : MethodSetup
+		{
+			List<MethodSetup>? storage = _storage;
+			if (storage is null)
+			{
+				return null;
+			}
+
+			lock (storage)
+			{
+				for (int i = storage.Count - 1; i >= 0; i--)
+				{
+					MethodSetup setup = storage[i];
+					if (setup.MemberId >= 0 || !setup.Name.Equals(methodName))
+					{
+						continue;
+					}
+
+					if (setup is T typed && setup is IMethodMatchByValue<T1, T2, T3, T4> m
+					    && m.Matches(arg1, arg2, arg3, arg4))
+					{
+						return typed;
+					}
+				}
+			}
+
+			return null;
 		}
 
 		public MethodSetup? GetLatestOrDefault(Func<MethodSetup, bool> predicate)

--- a/Source/Mockolate/Setup/MockSetups.Properties.cs
+++ b/Source/Mockolate/Setup/MockSetups.Properties.cs
@@ -19,6 +19,13 @@ internal partial class MockSetups
 	{
 		private int _count;
 		private PropertySetup[]? _storage;
+
+		// Member-id-indexed slot table. Each property has a single setup per id (dedup by name is
+		// native to Add), so a flat PropertySetup?[] is enough — no per-slot list. Updated
+		// copy-on-write under `_writeLock`; the invocation hot path reads via Volatile.Read
+		// without a lock. Mirrors the `_byMemberId` pattern used by methods and indexers, but
+		// uses a simpler single-slot shape because Add already dedups by name.
+		private PropertySetup?[]? _byMemberId;
 #if NET10_0_OR_GREATER
 		private readonly Lock _writeLock = new();
 #else
@@ -43,10 +50,10 @@ internal partial class MockSetups
 					}
 				}
 
+				bool isDefault = setup is PropertySetup.Default;
 				if (existingIndex >= 0)
 				{
 					bool wasDefault = old[existingIndex] is PropertySetup.Default;
-					bool isDefault = setup is PropertySetup.Default;
 					// Never overwrite a user-configured setup with a default placeholder:
 					// a first property access can race with Setup...InitializeWith(...) and
 					// otherwise lose the user's setup.
@@ -70,12 +77,49 @@ internal partial class MockSetups
 					Array.Copy(old, next, old.Length);
 					next[old.Length] = setup;
 					Volatile.Write(ref _storage, next);
-					if (setup is not PropertySetup.Default)
+					if (!isDefault)
 					{
 						Volatile.Write(ref _count, _count + 1);
 					}
 				}
+
+				UpdateByMemberId(setup, isDefault);
 			}
+		}
+
+		// Copy-on-write mirror of the name-based store, keyed by dense member id. Same
+		// "don't overwrite user setup with default" rule as the name-based path.
+		private void UpdateByMemberId(PropertySetup setup, bool isDefault)
+		{
+			int memberId = setup.MemberId;
+			if (memberId < 0)
+			{
+				return;
+			}
+
+			PropertySetup?[] old = _byMemberId ?? [];
+			int required = memberId + 1;
+			PropertySetup?[] next;
+			if (old.Length >= required)
+			{
+				PropertySetup? existing = old[memberId];
+				if (existing is not null && isDefault && existing is not PropertySetup.Default)
+				{
+					return;
+				}
+
+				next = new PropertySetup?[old.Length];
+				Array.Copy(old, next, old.Length);
+			}
+			else
+			{
+				int newLength = Math.Max(required, Math.Max(old.Length * 2, 4));
+				next = new PropertySetup?[newLength];
+				Array.Copy(old, next, old.Length);
+			}
+
+			next[memberId] = setup;
+			Volatile.Write(ref _byMemberId, next);
 		}
 
 		public bool TryGetValue(string propertyName, [NotNullWhen(true)] out PropertySetup? setup)
@@ -90,6 +134,27 @@ internal partial class MockSetups
 						setup = storage[i];
 						return true;
 					}
+				}
+			}
+
+			setup = null;
+			return false;
+		}
+
+		/// <summary>
+		///     O(1) setup lookup by generator-assigned member id. Invocation hot path — a single
+		///     volatile array read then a bounds-checked slot fetch, no locks, no string compare.
+		/// </summary>
+		public bool TryGetByMemberId(int memberId, [NotNullWhen(true)] out PropertySetup? setup)
+		{
+			PropertySetup?[]? byMemberId = Volatile.Read(ref _byMemberId);
+			if (byMemberId is not null && (uint)memberId < (uint)byMemberId.Length)
+			{
+				PropertySetup? slot = byMemberId[memberId];
+				if (slot is not null)
+				{
+					setup = slot;
+					return true;
 				}
 			}
 

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -19,6 +19,29 @@ namespace Mockolate.Setup;
 public abstract class PropertySetup : IInteractivePropertySetup
 {
 	/// <summary>
+	///     Base class for property setups.
+	/// </summary>
+	protected PropertySetup() : this(-1)
+	{
+	}
+
+	/// <summary>
+	///     Base class for property setups, carrying the generator-assigned <paramref name="memberId" />
+	///     used for the fast O(1) setup lookup on the invocation hot path.
+	/// </summary>
+	protected PropertySetup(int memberId)
+	{
+		MemberId = memberId;
+	}
+
+	/// <summary>
+	///     Generator-assigned dense integer id for the property this setup targets, or <c>-1</c>
+	///     when the setup was created through a legacy path. Used by the member-id-indexed setup
+	///     store for direct-array dispatch.
+	/// </summary>
+	public int MemberId { get; }
+
+	/// <summary>
 	///     The property name.
 	/// </summary>
 	public abstract string Name { get; }
@@ -90,8 +113,13 @@ public abstract class PropertySetup : IInteractivePropertySetup
 #if !DEBUG
 	[DebuggerNonUserCode]
 #endif
-	internal abstract class Default(string name) : PropertySetup
+	internal abstract class Default(int memberId, string name) : PropertySetup(memberId)
 	{
+		/// <inheritdoc cref="Default" />
+		protected Default(string name) : this(-1, name)
+		{
+		}
+
 		/// <inheritdoc cref="PropertySetup.Name" />
 		public override string Name => name;
 
@@ -117,9 +145,13 @@ public abstract class PropertySetup : IInteractivePropertySetup
 #if !DEBUG
 	[DebuggerNonUserCode]
 #endif
-	internal sealed class Default<T>(string name, T initialValue)
-		: Default(name)
+	internal sealed class Default<T>(int memberId, string name, T initialValue)
+		: Default(memberId, name)
 	{
+		public Default(string name, T initialValue) : this(-1, name, initialValue)
+		{
+		}
+
 		private T _value = initialValue;
 
 		/// <inheritdoc cref="PropertySetup.InvokeSetter{TValue}(TValue, MockBehavior)" />
@@ -188,7 +220,15 @@ public class PropertySetup<T> : PropertySetup,
 	/// <summary>
 	///     Sets up a property.
 	/// </summary>
-	public PropertySetup(MockRegistry mockRegistry, string name)
+	public PropertySetup(MockRegistry mockRegistry, string name) : this(-1, mockRegistry, name)
+	{
+	}
+
+	/// <summary>
+	///     Sets up a property with the generator-assigned <paramref name="memberId" /> used for the
+	///     fast O(1) setup lookup on the invocation hot path.
+	/// </summary>
+	public PropertySetup(int memberId, MockRegistry mockRegistry, string name) : base(memberId)
 	{
 		_mockRegistry = mockRegistry;
 		_name = name;

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -13,7 +13,8 @@ namespace Mockolate.Setup;
 [DebuggerNonUserCode]
 #endif
 public abstract class ReturnMethodSetup<TReturn>
-	: MethodSetup, IReturnMethodSetupCallbackBuilder<TReturn>, IReturnMethodSetupReturnBuilder<TReturn>
+	: MethodSetup, IReturnMethodSetupCallbackBuilder<TReturn>, IReturnMethodSetupReturnBuilder<TReturn>,
+	  IMethodMatchByValue
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int>>? _callbacks = [];
@@ -22,6 +23,12 @@ public abstract class ReturnMethodSetup<TReturn>
 
 	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
 	protected ReturnMethodSetup(MockRegistry mockRegistry, string name) : base(name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
+	protected ReturnMethodSetup(MockRegistry mockRegistry, int memberId, string name) : base(memberId, name)
 	{
 		_mockRegistry = mockRegistry;
 	}
@@ -263,6 +270,12 @@ public abstract class ReturnMethodSetup<TReturn>
 		{
 		}
 
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn}" />
+		public WithParameterCollection(MockRegistry mockRegistry, int memberId, string name)
+			: base(mockRegistry, memberId, name)
+		{
+		}
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn}.Matches()" />
 		public override bool Matches()
 			=> true;
@@ -281,7 +294,8 @@ public abstract class ReturnMethodSetup<TReturn>
 #endif
 public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	IReturnMethodSetupWithCallback<TReturn, T1>,
-	IReturnMethodSetupCallbackBuilder<TReturn, T1>, IReturnMethodSetupReturnBuilder<TReturn, T1>
+	IReturnMethodSetupCallbackBuilder<TReturn, T1>, IReturnMethodSetupReturnBuilder<TReturn, T1>,
+	IMethodMatchByValue<T1>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1>>? _callbacks = [];
@@ -293,6 +307,18 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
+	protected ReturnMethodSetup(MockRegistry mockRegistry, int memberId, string name) : base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1)" /> but does not require the parameter name.
+	/// </summary>
+	public abstract bool Matches(T1 p1);
 
 	/// <inheritdoc cref="IReturnMethodSetup{TReturn, T1}.SkippingBaseClass(bool)" />
 	IReturnMethodSetup<TReturn, T1> IReturnMethodSetup<TReturn, T1>.SkippingBaseClass(bool skipBaseClass)
@@ -576,11 +602,22 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 	/// </summary>
 	public class WithParameters : ReturnMethodSetup<TReturn, T1>
 	{
+		private readonly string? _parameterName1;
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
 		}
 
 		/// <summary>
@@ -594,6 +631,15 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}.Matches(T1)" />
+		public override bool Matches(T1 p1)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1),]),
 				_ => true,
 			};
 
@@ -617,6 +663,14 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 			Parameter1 = parameter1;
 		}
 
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
+		public WithParameterCollection(MockRegistry mockRegistry, int memberId, string name,
+			IParameterMatch<T1> parameter1)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameter1 = parameter1;
+		}
+
 		/// <summary>
 		///     The single parameter of the method.
 		/// </summary>
@@ -632,6 +686,10 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}.Matches(string, T1)" />
 		public override bool Matches(string p1Name, T1 p1Value)
 			=> _matchAnyParameters || Parameter1.Matches(p1Value);
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}.Matches(T1)" />
+		public override bool Matches(T1 p1)
+			=> _matchAnyParameters || Parameter1.Matches(p1);
 
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}.TriggerCallbacks(T1)" />
 		public override void TriggerCallbacks(T1 parameter1)
@@ -655,7 +713,8 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 #endif
 public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	IReturnMethodSetupWithCallback<TReturn, T1, T2>,
-	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, IReturnMethodSetupReturnBuilder<TReturn, T1, T2>
+	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, IReturnMethodSetupReturnBuilder<TReturn, T1, T2>,
+	IMethodMatchByValue<T1, T2>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1, T2>>? _callbacks = [];
@@ -667,6 +726,18 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}" />
+	protected ReturnMethodSetup(MockRegistry mockRegistry, int memberId, string name) : base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1, string, T2)" /> but does not require the parameter names.
+	/// </summary>
+	public abstract bool Matches(T1 p1, T2 p2);
 
 	/// <inheritdoc cref="IReturnMethodSetup{TReturn, T1, T2}.SkippingBaseClass(bool)" />
 	IReturnMethodSetup<TReturn, T1, T2> IReturnMethodSetup<TReturn, T1, T2>.SkippingBaseClass(bool skipBaseClass)
@@ -956,11 +1027,24 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 	/// </summary>
 	public class WithParameters : ReturnMethodSetup<TReturn, T1, T2>
 	{
+		private readonly string? _parameterName1;
+		private readonly string? _parameterName2;
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1, string parameterName2)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
+			_parameterName2 = parameterName2;
 		}
 
 		/// <summary>
@@ -974,6 +1058,15 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value, p2Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value), (p2Name, p2Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}.Matches(T1, T2)" />
+		public override bool Matches(T1 p1, T2 p2)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1, p2,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1), (_parameterName2 ?? string.Empty, p2),]),
 				_ => true,
 			};
 
@@ -994,6 +1087,15 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 		public WithParameterCollection(MockRegistry mockRegistry, string name, IParameterMatch<T1> parameter1,
 			IParameterMatch<T2> parameter2)
 			: base(mockRegistry, name)
+		{
+			Parameter1 = parameter1;
+			Parameter2 = parameter2;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}" />
+		public WithParameterCollection(MockRegistry mockRegistry, int memberId, string name,
+			IParameterMatch<T1> parameter1, IParameterMatch<T2> parameter2)
+			: base(mockRegistry, memberId, name)
 		{
 			Parameter1 = parameter1;
 			Parameter2 = parameter2;
@@ -1022,6 +1124,12 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 			   (Parameter1.Matches(p1Value) &&
 			    Parameter2.Matches(p2Value));
 
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}.Matches(T1, T2)" />
+		public override bool Matches(T1 p1, T2 p2)
+			=> _matchAnyParameters ||
+			   (Parameter1.Matches(p1) &&
+			    Parameter2.Matches(p2));
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}.TriggerCallbacks(T1, T2)" />
 		public override void TriggerCallbacks(T1 parameter1, T2 parameter2)
 		{
@@ -1045,7 +1153,8 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 #endif
 public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>,
-	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>
+	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>,
+	IMethodMatchByValue<T1, T2, T3>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1, T2, T3>>? _callbacks = [];
@@ -1057,6 +1166,18 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}" />
+	protected ReturnMethodSetup(MockRegistry mockRegistry, int memberId, string name) : base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1, string, T2, string, T3)" /> but does not require the parameter names.
+	/// </summary>
+	public abstract bool Matches(T1 p1, T2 p2, T3 p3);
 
 	/// <inheritdoc cref="IReturnMethodSetup{TReturn, T1, T2, T3}.SkippingBaseClass(bool)" />
 	IReturnMethodSetup<TReturn, T1, T2, T3> IReturnMethodSetup<TReturn, T1, T2, T3>.SkippingBaseClass(
@@ -1352,11 +1473,26 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 	/// </summary>
 	public class WithParameters : ReturnMethodSetup<TReturn, T1, T2, T3>
 	{
+		private readonly string? _parameterName1;
+		private readonly string? _parameterName2;
+		private readonly string? _parameterName3;
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1, string parameterName2, string parameterName3)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
+			_parameterName2 = parameterName2;
+			_parameterName3 = parameterName3;
 		}
 
 		/// <summary>
@@ -1370,6 +1506,15 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value, p2Value, p3Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value), (p2Name, p2Value), (p3Name, p3Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}.Matches(T1, T2, T3)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1, p2, p3,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1), (_parameterName2 ?? string.Empty, p2), (_parameterName3 ?? string.Empty, p3),]),
 				_ => true,
 			};
 
@@ -1394,6 +1539,21 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 			IParameterMatch<T2> parameter2,
 			IParameterMatch<T3> parameter3)
 			: base(mockRegistry, name)
+		{
+			Parameter1 = parameter1;
+			Parameter2 = parameter2;
+			Parameter3 = parameter3;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}" />
+		public WithParameterCollection(
+			MockRegistry mockRegistry,
+			int memberId,
+			string name,
+			IParameterMatch<T1> parameter1,
+			IParameterMatch<T2> parameter2,
+			IParameterMatch<T3> parameter3)
+			: base(mockRegistry, memberId, name)
 		{
 			Parameter1 = parameter1;
 			Parameter2 = parameter2;
@@ -1429,6 +1589,13 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 			    Parameter2.Matches(p2Value) &&
 			    Parameter3.Matches(p3Value));
 
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}.Matches(T1, T2, T3)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3)
+			=> _matchAnyParameters ||
+			   (Parameter1.Matches(p1) &&
+			    Parameter2.Matches(p2) &&
+			    Parameter3.Matches(p3));
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}.TriggerCallbacks(T1, T2, T3)" />
 		public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3)
 		{
@@ -1455,7 +1622,8 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 	IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>,
 	IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>,
-	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>
+	IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>,
+	IMethodMatchByValue<T1, T2, T3, T4>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1, T2, T3, T4>>? _callbacks = [];
@@ -1467,6 +1635,18 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}" />
+	protected ReturnMethodSetup(MockRegistry mockRegistry, int memberId, string name) : base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1, string, T2, string, T3, string, T4)" /> but does not require the parameter names.
+	/// </summary>
+	public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
 
 	/// <inheritdoc cref="IReturnMethodSetup{TReturn, T1, T2, T3, T4}.SkippingBaseClass(bool)" />
 	IReturnMethodSetup<TReturn, T1, T2, T3, T4> IReturnMethodSetup<TReturn, T1, T2, T3, T4>.SkippingBaseClass(
@@ -1769,11 +1949,28 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 	/// </summary>
 	public class WithParameters : ReturnMethodSetup<TReturn, T1, T2, T3, T4>
 	{
+		private readonly string? _parameterName1;
+		private readonly string? _parameterName2;
+		private readonly string? _parameterName3;
+		private readonly string? _parameterName4;
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1, string parameterName2, string parameterName3, string parameterName4)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
+			_parameterName2 = parameterName2;
+			_parameterName3 = parameterName3;
+			_parameterName4 = parameterName4;
 		}
 
 		/// <summary>
@@ -1788,6 +1985,15 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value, p2Value, p3Value, p4Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value), (p2Name, p2Value), (p3Name, p3Value), (p4Name, p4Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}.Matches(T1, T2, T3, T4)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1, p2, p3, p4,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1), (_parameterName2 ?? string.Empty, p2), (_parameterName3 ?? string.Empty, p3), (_parameterName4 ?? string.Empty, p4),]),
 				_ => true,
 			};
 
@@ -1813,6 +2019,23 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 			IParameterMatch<T3> parameter3,
 			IParameterMatch<T4> parameter4)
 			: base(mockRegistry, name)
+		{
+			Parameter1 = parameter1;
+			Parameter2 = parameter2;
+			Parameter3 = parameter3;
+			Parameter4 = parameter4;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}" />
+		public WithParameterCollection(
+			MockRegistry mockRegistry,
+			int memberId,
+			string name,
+			IParameterMatch<T1> parameter1,
+			IParameterMatch<T2> parameter2,
+			IParameterMatch<T3> parameter3,
+			IParameterMatch<T4> parameter4)
+			: base(mockRegistry, memberId, name)
 		{
 			Parameter1 = parameter1;
 			Parameter2 = parameter2;
@@ -1856,6 +2079,14 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 			    Parameter2.Matches(p2Value) &&
 			    Parameter3.Matches(p3Value) &&
 			    Parameter4.Matches(p4Value));
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}.Matches(T1, T2, T3, T4)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4)
+			=> _matchAnyParameters ||
+			   (Parameter1.Matches(p1) &&
+			    Parameter2.Matches(p2) &&
+			    Parameter3.Matches(p3) &&
+			    Parameter4.Matches(p4));
 
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}.TriggerCallbacks(T1, T2, T3, T4)" />
 		public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -13,7 +13,8 @@ namespace Mockolate.Setup;
 [DebuggerNonUserCode]
 #endif
 public abstract class VoidMethodSetup : MethodSetup,
-	IVoidMethodSetupCallbackBuilder, IVoidMethodSetupReturnBuilder
+	IVoidMethodSetupCallbackBuilder, IVoidMethodSetupReturnBuilder,
+	IMethodMatchByValue
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int>>? _callbacks = [];
@@ -22,6 +23,12 @@ public abstract class VoidMethodSetup : MethodSetup,
 
 	/// <inheritdoc cref="VoidMethodSetup{TReturn, T1}" />
 	protected VoidMethodSetup(MockRegistry mockRegistry, string name) : base(name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <inheritdoc cref="VoidMethodSetup{TReturn, T1}" />
+	protected VoidMethodSetup(MockRegistry mockRegistry, int memberId, string name) : base(memberId, name)
 	{
 		_mockRegistry = mockRegistry;
 	}
@@ -232,6 +239,15 @@ public abstract class VoidMethodSetup : MethodSetup,
 		{
 		}
 
+		/// <inheritdoc cref="VoidMethodSetup" />
+		public WithParameterCollection(
+			MockRegistry mockRegistry,
+			int memberId,
+			string name)
+			: base(mockRegistry, memberId, name)
+		{
+		}
+
 		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}.Matches(string, T1, string, T2, string, T3)" />
 		public override bool Matches()
 			=> true;
@@ -250,7 +266,8 @@ public abstract class VoidMethodSetup : MethodSetup,
 #endif
 public abstract class VoidMethodSetup<T1> : MethodSetup,
 	IVoidMethodSetupWithCallback<T1>,
-	IVoidMethodSetupCallbackBuilder<T1>, IVoidMethodSetupReturnBuilder<T1>
+	IVoidMethodSetupCallbackBuilder<T1>, IVoidMethodSetupReturnBuilder<T1>,
+	IMethodMatchByValue<T1>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1>>? _callbacks = [];
@@ -263,6 +280,19 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="VoidMethodSetup{T1}" />
+	protected VoidMethodSetup(MockRegistry mockRegistry, int memberId, string name)
+		: base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1)" /> but does not require the parameter name.
+	/// </summary>
+	public abstract bool Matches(T1 p1);
 
 	/// <inheritdoc cref="IVoidMethodSetup{T1}.SkippingBaseClass(bool)" />
 	IVoidMethodSetup<T1> IVoidMethodSetup<T1>.SkippingBaseClass(bool skipBaseClass)
@@ -498,11 +528,22 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 	/// </summary>
 	public class WithParameters : VoidMethodSetup<T1>
 	{
+		private readonly string? _parameterName1;
+
 		/// <inheritdoc cref="VoidMethodSetup{T1}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
 		}
 
 		/// <summary>
@@ -516,6 +557,15 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="VoidMethodSetup{T1}.Matches(T1)" />
+		public override bool Matches(T1 p1)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1),]),
 				_ => true,
 			};
 
@@ -539,6 +589,14 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 			Parameter1 = parameter1;
 		}
 
+		/// <inheritdoc cref="VoidMethodSetup{T1}" />
+		public WithParameterCollection(MockRegistry mockRegistry, int memberId, string name,
+			IParameterMatch<T1> parameter1)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameter1 = parameter1;
+		}
+
 		/// <summary>
 		///     The single parameter of the method.
 		/// </summary>
@@ -554,6 +612,10 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 		/// <inheritdoc cref="VoidMethodSetup{T1}.Matches(string, T1)" />
 		public override bool Matches(string p1Name, T1 p1Value)
 			=> _matchAnyParameters || Parameter1.Matches(p1Value);
+
+		/// <inheritdoc cref="VoidMethodSetup{T1}.Matches(T1)" />
+		public override bool Matches(T1 p1)
+			=> _matchAnyParameters || Parameter1.Matches(p1);
 
 		/// <inheritdoc cref="VoidMethodSetup{T1}.TriggerCallbacks(T1)" />
 		public override void TriggerCallbacks(T1 parameter1)
@@ -577,7 +639,8 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 #endif
 public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	IVoidMethodSetupWithCallback<T1, T2>,
-	IVoidMethodSetupCallbackBuilder<T1, T2>, IVoidMethodSetupReturnBuilder<T1, T2>
+	IVoidMethodSetupCallbackBuilder<T1, T2>, IVoidMethodSetupReturnBuilder<T1, T2>,
+	IMethodMatchByValue<T1, T2>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1, T2>>? _callbacks = [];
@@ -590,6 +653,19 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="VoidMethodSetup{T1, T2}" />
+	protected VoidMethodSetup(MockRegistry mockRegistry, int memberId, string name)
+		: base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1, string, T2)" /> but does not require the parameter names.
+	/// </summary>
+	public abstract bool Matches(T1 p1, T2 p2);
 
 	/// <inheritdoc cref="IVoidMethodSetup{T1, T2}.SkippingBaseClass(bool)" />
 	IVoidMethodSetup<T1, T2> IVoidMethodSetup<T1, T2>.SkippingBaseClass(bool skipBaseClass)
@@ -825,11 +901,24 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 	/// </summary>
 	public class WithParameters : VoidMethodSetup<T1, T2>
 	{
+		private readonly string? _parameterName1;
+		private readonly string? _parameterName2;
+
 		/// <inheritdoc cref="VoidMethodSetup{T1, T2}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1, string parameterName2)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
+			_parameterName2 = parameterName2;
 		}
 
 		/// <summary>
@@ -843,6 +932,15 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value, p2Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value), (p2Name, p2Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2}.Matches(T1, T2)" />
+		public override bool Matches(T1 p1, T2 p2)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1, p2,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1), (_parameterName2 ?? string.Empty, p2),]),
 				_ => true,
 			};
 
@@ -864,6 +962,16 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 			IParameterMatch<T1> parameter1,
 			IParameterMatch<T2> parameter2)
 			: base(mockRegistry, name)
+		{
+			Parameter1 = parameter1;
+			Parameter2 = parameter2;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2}" />
+		public WithParameterCollection(MockRegistry mockRegistry, int memberId, string name,
+			IParameterMatch<T1> parameter1,
+			IParameterMatch<T2> parameter2)
+			: base(mockRegistry, memberId, name)
 		{
 			Parameter1 = parameter1;
 			Parameter2 = parameter2;
@@ -892,6 +1000,12 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 				Parameter1.Matches(p1Value) &&
 				Parameter2.Matches(p2Value));
 
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2}.Matches(T1, T2)" />
+		public override bool Matches(T1 p1, T2 p2)
+			=> _matchAnyParameters || (
+				Parameter1.Matches(p1) &&
+				Parameter2.Matches(p2));
+
 		/// <inheritdoc cref="VoidMethodSetup{T1, T2}.TriggerCallbacks(T1, T2)" />
 		public override void TriggerCallbacks(T1 parameter1, T2 parameter2)
 		{
@@ -915,7 +1029,8 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 #endif
 public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	IVoidMethodSetupWithCallback<T1, T2, T3>,
-	IVoidMethodSetupCallbackBuilder<T1, T2, T3>, IVoidMethodSetupReturnBuilder<T1, T2, T3>
+	IVoidMethodSetupCallbackBuilder<T1, T2, T3>, IVoidMethodSetupReturnBuilder<T1, T2, T3>,
+	IMethodMatchByValue<T1, T2, T3>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1, T2, T3>>? _callbacks = [];
@@ -928,6 +1043,19 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}" />
+	protected VoidMethodSetup(MockRegistry mockRegistry, int memberId, string name)
+		: base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1, string, T2, string, T3)" /> but does not require the parameter names.
+	/// </summary>
+	public abstract bool Matches(T1 p1, T2 p2, T3 p3);
 
 	/// <inheritdoc cref="IVoidMethodSetup{T1, T2, T3}.SkippingBaseClass(bool)" />
 	IVoidMethodSetup<T1, T2, T3> IVoidMethodSetup<T1, T2, T3>.SkippingBaseClass(bool skipBaseClass)
@@ -1165,11 +1293,26 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 	/// </summary>
 	public class WithParameters : VoidMethodSetup<T1, T2, T3>
 	{
+		private readonly string? _parameterName1;
+		private readonly string? _parameterName2;
+		private readonly string? _parameterName3;
+
 		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1, string parameterName2, string parameterName3)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
+			_parameterName2 = parameterName2;
+			_parameterName3 = parameterName3;
 		}
 
 		/// <summary>
@@ -1183,6 +1326,15 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value, p2Value, p3Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value), (p2Name, p2Value), (p3Name, p3Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}.Matches(T1, T2, T3)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1, p2, p3,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1), (_parameterName2 ?? string.Empty, p2), (_parameterName3 ?? string.Empty, p3),]),
 				_ => true,
 			};
 
@@ -1205,6 +1357,18 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 			IParameterMatch<T2> parameter2,
 			IParameterMatch<T3> parameter3)
 			: base(mockRegistry, name)
+		{
+			Parameter1 = parameter1;
+			Parameter2 = parameter2;
+			Parameter3 = parameter3;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}" />
+		public WithParameterCollection(MockRegistry mockRegistry, int memberId, string name,
+			IParameterMatch<T1> parameter1,
+			IParameterMatch<T2> parameter2,
+			IParameterMatch<T3> parameter3)
+			: base(mockRegistry, memberId, name)
 		{
 			Parameter1 = parameter1;
 			Parameter2 = parameter2;
@@ -1240,6 +1404,13 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 				Parameter2.Matches(p2Value) &&
 				Parameter3.Matches(p3Value));
 
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}.Matches(T1, T2, T3)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3)
+			=> _matchAnyParameters || (
+				Parameter1.Matches(p1) &&
+				Parameter2.Matches(p2) &&
+				Parameter3.Matches(p3));
+
 		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}.TriggerCallbacks(T1, T2, T3)" />
 		public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3)
 		{
@@ -1264,7 +1435,8 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 #endif
 public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	IVoidMethodSetupWithCallback<T1, T2, T3, T4>,
-	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>
+	IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>,
+	IMethodMatchByValue<T1, T2, T3, T4>
 {
 	private readonly MockRegistry _mockRegistry;
 	private Callbacks<Action<int, T1, T2, T3, T4>>? _callbacks = [];
@@ -1277,6 +1449,19 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	{
 		_mockRegistry = mockRegistry;
 	}
+
+	/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}" />
+	protected VoidMethodSetup(MockRegistry mockRegistry, int memberId, string name)
+		: base(memberId, name)
+	{
+		_mockRegistry = mockRegistry;
+	}
+
+	/// <summary>
+	///     Closure-free match entry point used by the member-id indexed dispatch.
+	///     Equivalent to <see cref="Matches(string, T1, string, T2, string, T3, string, T4)" /> but does not require the parameter names.
+	/// </summary>
+	public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
 
 	/// <inheritdoc cref="IVoidMethodSetup{T1, T2, T3, T4}.SkippingBaseClass(bool)" />
 	IVoidMethodSetup<T1, T2, T3, T4> IVoidMethodSetup<T1, T2, T3, T4>.SkippingBaseClass(bool skipBaseClass)
@@ -1514,11 +1699,28 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 	/// </summary>
 	public class WithParameters : VoidMethodSetup<T1, T2, T3, T4>
 	{
+		private readonly string? _parameterName1;
+		private readonly string? _parameterName2;
+		private readonly string? _parameterName3;
+		private readonly string? _parameterName4;
+
 		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}" />
 		public WithParameters(MockRegistry mockRegistry, string name, IParameters parameters)
 			: base(mockRegistry, name)
 		{
 			Parameters = parameters;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}" />
+		public WithParameters(MockRegistry mockRegistry, int memberId, string name, IParameters parameters,
+			string parameterName1, string parameterName2, string parameterName3, string parameterName4)
+			: base(mockRegistry, memberId, name)
+		{
+			Parameters = parameters;
+			_parameterName1 = parameterName1;
+			_parameterName2 = parameterName2;
+			_parameterName3 = parameterName3;
+			_parameterName4 = parameterName4;
 		}
 
 		/// <summary>
@@ -1532,6 +1734,15 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 			{
 				IParametersMatch m => m.Matches([p1Value, p2Value, p3Value, p4Value,]),
 				INamedParametersMatch m => m.Matches([(p1Name, p1Value), (p2Name, p2Value), (p3Name, p3Value), (p4Name, p4Value),]),
+				_ => true,
+			};
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}.Matches(T1, T2, T3, T4)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4)
+			=> Parameters switch
+			{
+				IParametersMatch m => m.Matches([p1, p2, p3, p4,]),
+				INamedParametersMatch m => m.Matches([(_parameterName1 ?? string.Empty, p1), (_parameterName2 ?? string.Empty, p2), (_parameterName3 ?? string.Empty, p3), (_parameterName4 ?? string.Empty, p4),]),
 				_ => true,
 			};
 
@@ -1555,6 +1766,20 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 			IParameterMatch<T3> parameter3,
 			IParameterMatch<T4> parameter4)
 			: base(mockRegistry, name)
+		{
+			Parameter1 = parameter1;
+			Parameter2 = parameter2;
+			Parameter3 = parameter3;
+			Parameter4 = parameter4;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}" />
+		public WithParameterCollection(MockRegistry mockRegistry, int memberId, string name,
+			IParameterMatch<T1> parameter1,
+			IParameterMatch<T2> parameter2,
+			IParameterMatch<T3> parameter3,
+			IParameterMatch<T4> parameter4)
+			: base(mockRegistry, memberId, name)
 		{
 			Parameter1 = parameter1;
 			Parameter2 = parameter2;
@@ -1596,6 +1821,14 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 				Parameter2.Matches(p2Value) &&
 				Parameter3.Matches(p3Value) &&
 				Parameter4.Matches(p4Value));
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}.Matches(T1, T2, T3, T4)" />
+		public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4)
+			=> _matchAnyParameters || (
+				Parameter1.Matches(p1) &&
+				Parameter2.Matches(p2) &&
+				Parameter3.Matches(p3) &&
+				Parameter4.Matches(p4));
 
 		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}.TriggerCallbacks(T1, T2, T3, T4)" />
 		public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -208,15 +208,42 @@ namespace Mockolate
         public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup, int signatureIndex) { }
         public void ClearAllInteractions() { }
         public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access, int signatureIndex) { }
+        public T? GetIndexerGetterSetup<T, T1>(int memberId, T1 arg1)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2>(int memberId, T1 arg1, T2 arg2)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2, T3>(int memberId, T1 arg1, T2 arg2, T3 arg3)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2, T3, T4>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, TValue>(int memberId, T1 arg1, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, TValue>(int memberId, T1 arg1, T2 arg2, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, T3, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, T3, T4, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
             where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetMethodSetup<T>(int memberId, string methodName)
+            where T : Mockolate.Setup.MethodSetup { }
         public T? GetMethodSetup<T>(string methodName, System.Func<T, bool> predicate)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1>(int memberId, string methodName, T1 arg1)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2>(int memberId, string methodName, T1 arg1, T2 arg2)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2, T3>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2, T3, T4>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where T : Mockolate.Setup.MethodSetup { }
         public System.Collections.Generic.IEnumerable<T> GetMethodSetups<T>(string methodName)
             where T : Mockolate.Setup.MethodSetup { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetProperty<TResult>(int memberId, string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSet<T, TValue>(T subject, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TValue>, bool> setPredicate, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
@@ -226,6 +253,7 @@ namespace Mockolate
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
+        public bool SetProperty<T>(int memberId, string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupEvent(string scenario, Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
@@ -1002,6 +1030,22 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
+    public interface IIndexerGetterMatchByValue<in T1>
+    {
+        bool Matches(T1 p1);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2>
+    {
+        bool Matches(T1 p1, T2 p2);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2, in T3>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2, in T3, in T4>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
+    }
     public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
@@ -1097,6 +1141,22 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in TValue>
+    {
+        bool Matches(T1 p1, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in T4, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4, TValue value);
     }
     public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -1330,6 +1390,26 @@ namespace Mockolate.Setup
     public interface IMethodMatch
     {
         bool Matches(Mockolate.Interactions.MethodInvocation methodInvocation);
+    }
+    public interface IMethodMatchByValue
+    {
+        bool Matches();
+    }
+    public interface IMethodMatchByValue<in T1>
+    {
+        bool Matches(T1 p1);
+    }
+    public interface IMethodMatchByValue<in T1, in T2>
+    {
+        bool Matches(T1 p1, T2 p2);
+    }
+    public interface IMethodMatchByValue<in T1, in T2, in T3>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3);
+    }
+    public interface IMethodMatchByValue<in T1, in T2, in T3, in T4>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
     }
     public interface IMethodSetup : Mockolate.Setup.ISetup
     {
@@ -2026,6 +2106,8 @@ namespace Mockolate.Setup
     public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup(Mockolate.MockRegistry mockRegistry) { }
+        protected IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry) { }
+        public int MemberId { get; }
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue);
@@ -2036,9 +2118,10 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -2064,9 +2147,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -2092,9 +2176,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, T3, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -2120,9 +2205,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, T3, T4, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -2157,6 +2243,8 @@ namespace Mockolate.Setup
     public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVerifiableMethodSetup
     {
         protected MethodSetup(string name) { }
+        protected MethodSetup(int memberId, string name) { }
+        public int MemberId { get; }
         public string Name { get; }
         protected abstract bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction);
         protected static string FormatType(System.Type type) { }
@@ -2164,6 +2252,8 @@ namespace Mockolate.Setup
     public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
     {
         protected PropertySetup() { }
+        protected PropertySetup(int memberId) { }
+        public int MemberId { get; }
         public abstract string Name { get; }
         protected abstract bool? GetSkipBaseClass();
         protected abstract void InitializeValue(object? value);
@@ -2174,6 +2264,7 @@ namespace Mockolate.Setup
     public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        public PropertySetup(int memberId, Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }
         public Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
         public Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
@@ -2390,9 +2481,10 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public override string ToString() { }
     }
-    public abstract class ReturnMethodSetup<TReturn> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetup<TReturn>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetup<TReturn>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
         public abstract bool Matches();
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
@@ -2402,14 +2494,17 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
             public override bool Matches() { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1);
         public abstract bool Matches(string p1Name, T1 p1Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2418,7 +2513,9 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1) { }
@@ -2426,14 +2523,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1) { }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2442,8 +2543,10 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
@@ -2451,14 +2554,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2) { }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2467,9 +2574,11 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
@@ -2477,14 +2586,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2493,10 +2606,12 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
             public Mockolate.Parameters.IParameterMatch<T4> Parameter4 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
@@ -2504,6 +2619,8 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3, string parameterName4) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
         }
@@ -2515,9 +2632,10 @@ namespace Mockolate.Setup
         public static System.Span<T> op_Implicit(Mockolate.Setup.SpanWrapper<T> wrapper) { }
         public static Mockolate.Setup.SpanWrapper<T> op_Implicit(System.Span<T> span) { }
     }
-    public abstract class VoidMethodSetup : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder, Mockolate.Setup.IVoidMethodSetupReturnBuilder, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder
+    public abstract class VoidMethodSetup : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder, Mockolate.Setup.IVoidMethodSetupReturnBuilder, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder
     {
         protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public abstract bool Matches();
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2525,13 +2643,16 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
             public override bool Matches() { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
+    public abstract class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1);
         public abstract bool Matches(string p1Name, T1 p1Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2539,7 +2660,9 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1) { }
@@ -2547,13 +2670,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1) { }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
+    public abstract class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2561,8 +2688,10 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
@@ -2570,13 +2699,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2) { }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
+    public abstract class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2584,9 +2717,11 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
@@ -2594,13 +2729,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
+    public abstract class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2608,10 +2747,12 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
             public Mockolate.Parameters.IParameterMatch<T4> Parameter4 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
@@ -2619,6 +2760,8 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3, string parameterName4) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
         }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -201,15 +201,42 @@ namespace Mockolate
         public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup, int signatureIndex) { }
         public void ClearAllInteractions() { }
         public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access, int signatureIndex) { }
+        public T? GetIndexerGetterSetup<T, T1>(int memberId, T1 arg1)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2>(int memberId, T1 arg1, T2 arg2)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2, T3>(int memberId, T1 arg1, T2 arg2, T3 arg3)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2, T3, T4>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, TValue>(int memberId, T1 arg1, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, TValue>(int memberId, T1 arg1, T2 arg2, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, T3, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, T3, T4, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
             where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetMethodSetup<T>(int memberId, string methodName)
+            where T : Mockolate.Setup.MethodSetup { }
         public T? GetMethodSetup<T>(string methodName, System.Func<T, bool> predicate)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1>(int memberId, string methodName, T1 arg1)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2>(int memberId, string methodName, T1 arg1, T2 arg2)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2, T3>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2, T3, T4>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where T : Mockolate.Setup.MethodSetup { }
         public System.Collections.Generic.IEnumerable<T> GetMethodSetups<T>(string methodName)
             where T : Mockolate.Setup.MethodSetup { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetProperty<TResult>(int memberId, string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSet<T, TValue>(T subject, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TValue>, bool> setPredicate, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
@@ -219,6 +246,7 @@ namespace Mockolate
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
+        public bool SetProperty<T>(int memberId, string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupEvent(string scenario, Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
@@ -976,6 +1004,22 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
+    public interface IIndexerGetterMatchByValue<in T1>
+    {
+        bool Matches(T1 p1);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2>
+    {
+        bool Matches(T1 p1, T2 p2);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2, in T3>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2, in T3, in T4>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
+    }
     public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
@@ -1071,6 +1115,22 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in TValue>
+    {
+        bool Matches(T1 p1, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in T4, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4, TValue value);
     }
     public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -1304,6 +1364,26 @@ namespace Mockolate.Setup
     public interface IMethodMatch
     {
         bool Matches(Mockolate.Interactions.MethodInvocation methodInvocation);
+    }
+    public interface IMethodMatchByValue
+    {
+        bool Matches();
+    }
+    public interface IMethodMatchByValue<in T1>
+    {
+        bool Matches(T1 p1);
+    }
+    public interface IMethodMatchByValue<in T1, in T2>
+    {
+        bool Matches(T1 p1, T2 p2);
+    }
+    public interface IMethodMatchByValue<in T1, in T2, in T3>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3);
+    }
+    public interface IMethodMatchByValue<in T1, in T2, in T3, in T4>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
     }
     public interface IMethodSetup : Mockolate.Setup.ISetup
     {
@@ -1804,6 +1884,8 @@ namespace Mockolate.Setup
     public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup(Mockolate.MockRegistry mockRegistry) { }
+        protected IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry) { }
+        public int MemberId { get; }
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue);
@@ -1814,9 +1896,10 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1842,9 +1925,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1870,9 +1954,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, T3, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1898,9 +1983,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, T3, T4, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1935,6 +2021,8 @@ namespace Mockolate.Setup
     public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVerifiableMethodSetup
     {
         protected MethodSetup(string name) { }
+        protected MethodSetup(int memberId, string name) { }
+        public int MemberId { get; }
         public string Name { get; }
         protected abstract bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction);
         protected static string FormatType(System.Type type) { }
@@ -1942,6 +2030,8 @@ namespace Mockolate.Setup
     public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
     {
         protected PropertySetup() { }
+        protected PropertySetup(int memberId) { }
+        public int MemberId { get; }
         public abstract string Name { get; }
         protected abstract bool? GetSkipBaseClass();
         protected abstract void InitializeValue(object? value);
@@ -1952,6 +2042,7 @@ namespace Mockolate.Setup
     public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        public PropertySetup(int memberId, Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }
         public Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
         public Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
@@ -1980,9 +2071,10 @@ namespace Mockolate.Setup
         public static System.ReadOnlySpan<T> op_Implicit(Mockolate.Setup.ReadOnlySpanWrapper<T> wrapper) { }
         public static Mockolate.Setup.ReadOnlySpanWrapper<T> op_Implicit(System.ReadOnlySpan<T> span) { }
     }
-    public abstract class ReturnMethodSetup<TReturn> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetup<TReturn>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetup<TReturn>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
         public abstract bool Matches();
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
@@ -1992,14 +2084,17 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
             public override bool Matches() { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1);
         public abstract bool Matches(string p1Name, T1 p1Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2008,7 +2103,9 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1) { }
@@ -2016,14 +2113,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1) { }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2032,8 +2133,10 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
@@ -2041,14 +2144,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2) { }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2057,9 +2164,11 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
@@ -2067,14 +2176,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2083,10 +2196,12 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
             public Mockolate.Parameters.IParameterMatch<T4> Parameter4 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
@@ -2094,6 +2209,8 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3, string parameterName4) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
         }
@@ -2105,9 +2222,10 @@ namespace Mockolate.Setup
         public static System.Span<T> op_Implicit(Mockolate.Setup.SpanWrapper<T> wrapper) { }
         public static Mockolate.Setup.SpanWrapper<T> op_Implicit(System.Span<T> span) { }
     }
-    public abstract class VoidMethodSetup : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder, Mockolate.Setup.IVoidMethodSetupReturnBuilder, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder
+    public abstract class VoidMethodSetup : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder, Mockolate.Setup.IVoidMethodSetupReturnBuilder, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder
     {
         protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public abstract bool Matches();
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2115,13 +2233,16 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
             public override bool Matches() { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
+    public abstract class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1);
         public abstract bool Matches(string p1Name, T1 p1Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2129,7 +2250,9 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1) { }
@@ -2137,13 +2260,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1) { }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
+    public abstract class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2151,8 +2278,10 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
@@ -2160,13 +2289,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2) { }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
+    public abstract class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2174,9 +2307,11 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
@@ -2184,13 +2319,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
+    public abstract class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2198,10 +2337,12 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
             public Mockolate.Parameters.IParameterMatch<T4> Parameter4 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
@@ -2209,6 +2350,8 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3, string parameterName4) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
         }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -188,15 +188,42 @@ namespace Mockolate
         public TResult ApplyIndexerSetup<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.Setup.IndexerSetup setup, int signatureIndex) { }
         public void ClearAllInteractions() { }
         public TResult GetIndexerFallback<TResult>(Mockolate.Interactions.IndexerAccess access, int signatureIndex) { }
+        public T? GetIndexerGetterSetup<T, T1>(int memberId, T1 arg1)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2>(int memberId, T1 arg1, T2 arg2)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2, T3>(int memberId, T1 arg1, T2 arg2, T3 arg3)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerGetterSetup<T, T1, T2, T3, T4>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, TValue>(int memberId, T1 arg1, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, TValue>(int memberId, T1 arg1, T2 arg2, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, T3, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetIndexerSetterSetup<T, T1, T2, T3, T4, TValue>(int memberId, T1 arg1, T2 arg2, T3 arg3, T4 arg4, TValue value)
+            where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(Mockolate.Interactions.IndexerAccess access)
             where T : Mockolate.Setup.IndexerSetup { }
         public T? GetIndexerSetup<T>(System.Func<T, bool> predicate)
             where T : Mockolate.Setup.IndexerSetup { }
+        public T? GetMethodSetup<T>(int memberId, string methodName)
+            where T : Mockolate.Setup.MethodSetup { }
         public T? GetMethodSetup<T>(string methodName, System.Func<T, bool> predicate)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1>(int memberId, string methodName, T1 arg1)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2>(int memberId, string methodName, T1 arg1, T2 arg2)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2, T3>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3)
+            where T : Mockolate.Setup.MethodSetup { }
+        public T? GetMethodSetup<T, T1, T2, T3, T4>(int memberId, string methodName, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where T : Mockolate.Setup.MethodSetup { }
         public System.Collections.Generic.IEnumerable<T> GetMethodSetups<T>(string methodName)
             where T : Mockolate.Setup.MethodSetup { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetProperty<TResult>(int memberId, string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.MockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSet<T, TValue>(T subject, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TValue>, bool> setPredicate, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
@@ -206,6 +233,7 @@ namespace Mockolate
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
+        public bool SetProperty<T>(int memberId, string propertyName, T value) { }
         public void SetupEvent(Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupEvent(string scenario, Mockolate.Setup.EventSetup eventSetup) { }
         public void SetupIndexer(Mockolate.Setup.IndexerSetup indexerSetup) { }
@@ -931,6 +959,22 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
+    public interface IIndexerGetterMatchByValue<in T1>
+    {
+        bool Matches(T1 p1);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2>
+    {
+        bool Matches(T1 p1, T2 p2);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2, in T3>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3);
+    }
+    public interface IIndexerGetterMatchByValue<in T1, in T2, in T3, in T4>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
+    }
     public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
@@ -1026,6 +1070,22 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in TValue>
+    {
+        bool Matches(T1 p1, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, TValue value);
+    }
+    public interface IIndexerSetterMatchByValue<in T1, in T2, in T3, in T4, in TValue>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4, TValue value);
     }
     public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -1259,6 +1319,26 @@ namespace Mockolate.Setup
     public interface IMethodMatch
     {
         bool Matches(Mockolate.Interactions.MethodInvocation methodInvocation);
+    }
+    public interface IMethodMatchByValue
+    {
+        bool Matches();
+    }
+    public interface IMethodMatchByValue<in T1>
+    {
+        bool Matches(T1 p1);
+    }
+    public interface IMethodMatchByValue<in T1, in T2>
+    {
+        bool Matches(T1 p1, T2 p2);
+    }
+    public interface IMethodMatchByValue<in T1, in T2, in T3>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3);
+    }
+    public interface IMethodMatchByValue<in T1, in T2, in T3, in T4>
+    {
+        bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
     }
     public interface IMethodSetup : Mockolate.Setup.ISetup
     {
@@ -1759,6 +1839,8 @@ namespace Mockolate.Setup
     public abstract class IndexerSetup : Mockolate.Setup.IInteractiveIndexerSetup, Mockolate.Setup.ISetup
     {
         protected IndexerSetup(Mockolate.MockRegistry mockRegistry) { }
+        protected IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry) { }
+        public int MemberId { get; }
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, System.Func<TResult> defaultValueGenerator);
         public abstract TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior, TResult baseValue);
@@ -1769,9 +1851,10 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1797,9 +1880,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1825,9 +1909,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, T3, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1853,9 +1938,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterMatchByValue<T1, T2, T3, T4, TValue>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+        public IndexerSetup(int memberId, Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4> OnGet { get; }
         public Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4> OnSet { get; }
         public override TResult GetResult<TResult>(Mockolate.Interactions.IndexerAccess access, Mockolate.MockBehavior behavior) { }
@@ -1890,6 +1976,8 @@ namespace Mockolate.Setup
     public abstract class MethodSetup : Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVerifiableMethodSetup
     {
         protected MethodSetup(string name) { }
+        protected MethodSetup(int memberId, string name) { }
+        public int MemberId { get; }
         public string Name { get; }
         protected abstract bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction);
         protected static string FormatType(System.Type type) { }
@@ -1897,6 +1985,8 @@ namespace Mockolate.Setup
     public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
     {
         protected PropertySetup() { }
+        protected PropertySetup(int memberId) { }
+        public int MemberId { get; }
         public abstract string Name { get; }
         protected abstract bool? GetSkipBaseClass();
         protected abstract void InitializeValue(object? value);
@@ -1907,6 +1997,7 @@ namespace Mockolate.Setup
     public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        public PropertySetup(int memberId, Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }
         public Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
         public Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
@@ -1928,9 +2019,10 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public abstract class ReturnMethodSetup<TReturn> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetup<TReturn>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn>, Mockolate.Setup.IReturnMethodSetup<TReturn>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
         public abstract bool Matches();
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
@@ -1940,14 +2032,17 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
             public override bool Matches() { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1);
         public abstract bool Matches(string p1Name, T1 p1Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -1956,7 +2051,9 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1) { }
@@ -1964,14 +2061,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1) { }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -1980,8 +2081,10 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
@@ -1989,14 +2092,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2) { }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2005,9 +2112,11 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
@@ -2015,14 +2124,18 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
+    public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupParallelCallbackBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
     {
         protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected ReturnMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public bool HasReturnCallbacks { get; }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2031,10 +2144,12 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
             public Mockolate.Parameters.IParameterMatch<T4> Parameter4 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
@@ -2042,13 +2157,16 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3, string parameterName4) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder, Mockolate.Setup.IVoidMethodSetupReturnBuilder, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder
+    public abstract class VoidMethodSetup : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder, Mockolate.Setup.IVoidMethodSetupReturnBuilder, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder
     {
         protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
         public abstract bool Matches();
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2056,13 +2174,16 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
             public override bool Matches() { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
+    public abstract class VoidMethodSetup<T1> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1);
         public abstract bool Matches(string p1Name, T1 p1Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2070,7 +2191,9 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1) { }
@@ -2078,13 +2201,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1) { }
+            public override bool Matches(T1 p1) { }
             public override bool Matches(string p1Name, T1 p1Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
+    public abstract class VoidMethodSetup<T1, T2> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2092,8 +2219,10 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
@@ -2101,13 +2230,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2) { }
+            public override bool Matches(T1 p1, T2 p2) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
+    public abstract class VoidMethodSetup<T1, T2, T3> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2115,9 +2248,11 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
@@ -2125,13 +2260,17 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value) { }
             public override string ToString() { }
         }
     }
-    public abstract class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
+    public abstract class VoidMethodSetup<T1, T2, T3, T4> : Mockolate.Setup.MethodSetup, Mockolate.Setup.IMethodMatchByValue<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupParallelCallbackBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
     {
         public VoidMethodSetup(Mockolate.MockRegistry mockRegistry, string name) { }
+        protected VoidMethodSetup(Mockolate.MockRegistry mockRegistry, int memberId, string name) { }
+        public abstract bool Matches(T1 p1, T2 p2, T3 p3, T4 p4);
         public abstract bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value);
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
@@ -2139,10 +2278,12 @@ namespace Mockolate.Setup
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
+            public WithParameterCollection(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
             public Mockolate.Parameters.IParameterMatch<T1> Parameter1 { get; }
             public Mockolate.Parameters.IParameterMatch<T2> Parameter2 { get; }
             public Mockolate.Parameters.IParameterMatch<T3> Parameter3 { get; }
             public Mockolate.Parameters.IParameterMatch<T4> Parameter4 { get; }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
             public override void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
@@ -2150,6 +2291,8 @@ namespace Mockolate.Setup
         public class WithParameters : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameters(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameters parameters) { }
+            public WithParameters(Mockolate.MockRegistry mockRegistry, int memberId, string name, Mockolate.Parameters.IParameters parameters, string parameterName1, string parameterName2, string parameterName3, string parameterName4) { }
+            public override bool Matches(T1 p1, T2 p2, T3 p3, T4 p4) { }
             public override bool Matches(string p1Name, T1 p1Value, string p2Name, T2 p2Value, string p3Name, T3 p3Value, string p4Name, T4 p4Value) { }
             public override string ToString() { }
         }

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -794,7 +794,7 @@ public class GeneralTests
 			          		[global::System.ComponentModel.Localizable(false)]
 			          		public string MyMethod(string message)
 			          		{
-			          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<string, string>>("global::MyCode.IMyService.MyMethod", m => m.Matches("message", message));
+			          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<string, string>, string>(0, "global::MyCode.IMyService.MyMethod", message);
 			          			bool hasWrappedResult = false;
 			          			string wrappedResult = default!;
 			          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -71,7 +71,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<int, int>, int>(0, index);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
@@ -88,7 +88,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<int, int>, int, int>(0, index, value);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 0);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
@@ -108,7 +108,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, bool?>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool?>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int, bool?>? setup = this.MockRegistry.GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool?>, int, bool?>(1, index, isReadOnly);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
@@ -131,7 +131,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>, int, string, int>(2, index, isWriteOnly, value);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 2);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
@@ -191,7 +191,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<int, int>, int>(0, index);
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
 					          					int baseResult = this.MockRegistry.Wraps is global::MyCode.MyService wraps ? wraps[index] : base[index];
@@ -208,7 +208,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = this.MockRegistry.GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<int, int>, int, int>(0, index, value);
 					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value, 0))
 					          				{
 					          					if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
@@ -234,7 +234,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, bool>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int, bool>? setup = this.MockRegistry.GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool>, int, bool>(1, index, isReadOnly);
 					          				if (!(setup?.SkipBaseClass() ?? this.MockRegistry.Behavior.SkipBaseClass))
 					          				{
 					          					int baseResult = base[index, isReadOnly];
@@ -257,7 +257,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = this.MockRegistry.GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>, int, string, int>(2, index, isWriteOnly, value);
 					          				if (!this.MockRegistry.ApplyIndexerSetter(access, setup, value, 2))
 					          				{
 					          					base[index, isWriteOnly] = value;
@@ -277,7 +277,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<int, string>, string>(3, someAdditionalIndex);
 					          				return setup is null
 					          					? this.MockRegistry.GetIndexerFallback<int>(access, 3)
 					          					: this.MockRegistry.ApplyIndexerSetup<int>(access, setup, 3);
@@ -289,7 +289,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, string>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, string>? setup = this.MockRegistry.GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<int, string>, string, int>(3, someAdditionalIndex, value);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 3);
 					          			}
 					          		}
@@ -332,7 +332,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>, global::Mockolate.Setup.SpanWrapper<char>>(0, new global::Mockolate.Setup.SpanWrapper<char>(buffer));
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
@@ -349,7 +349,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = this.MockRegistry.GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>, global::Mockolate.Setup.SpanWrapper<char>, int>(0, new global::Mockolate.Setup.SpanWrapper<char>(buffer), value);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 0);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
@@ -369,7 +369,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerGetterSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>(1, new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values));
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
 					          					return setup is null
@@ -386,7 +386,7 @@ public sealed partial class MockTests
 					          				{
 					          					this.MockRegistry.RegisterInteraction(access);
 					          				}
-					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>>(access);
+					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = this.MockRegistry.GetIndexerSetterSetup<global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>, global::Mockolate.Setup.ReadOnlySpanWrapper<int>, int>(1, new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values), value);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 1);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -379,7 +379,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod1(int)" />
 					          		public bool MyMethod1(int index)
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int>>("global::MyCode.IMyService.MyMethod1", m => m.Matches("index", index));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int>, int>(0, "global::MyCode.IMyService.MyMethod1", index);
 					          			bool hasWrappedResult = false;
 					          			bool wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -413,7 +413,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod2(int, bool)" />
 					          		public void MyMethod2(int index, bool isReadOnly)
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<int, bool>>("global::MyCode.IMyService.MyMethod2", m => m.Matches("index", index, "isReadOnly", isReadOnly));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<int, bool>, int, bool>(1, "global::MyCode.IMyService.MyMethod2", index, isReadOnly);
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
@@ -482,7 +482,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyDirectMethod(int)" />
 					          		public int MyDirectMethod(int value)
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>("global::MyCode.IMyService.MyDirectMethod", m => m.Matches("value", value));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(0, "global::MyCode.IMyService.MyDirectMethod", value);
 					          			bool hasWrappedResult = false;
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -516,7 +516,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase1.MyBaseMethod1(int)" />
 					          		public int MyBaseMethod1(int value)
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>("global::MyCode.IMyServiceBase1.MyBaseMethod1", m => m.Matches("value", value));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(1, "global::MyCode.IMyServiceBase1.MyBaseMethod1", value);
 					          			bool hasWrappedResult = false;
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -550,7 +550,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase2.MyBaseMethod2(int)" />
 					          		public int MyBaseMethod2(int value)
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>("global::MyCode.IMyServiceBase2.MyBaseMethod2", m => m.Matches("value", value));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(2, "global::MyCode.IMyServiceBase2.MyBaseMethod2", value);
 					          			bool hasWrappedResult = false;
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -584,7 +584,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyServiceBase3.MyBaseMethod3(int)" />
 					          		public int MyBaseMethod3(int value)
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>("global::MyCode.IMyServiceBase3.MyBaseMethod3", m => m.Matches("value", value));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(3, "global::MyCode.IMyServiceBase3.MyBaseMethod3", value);
 					          			bool hasWrappedResult = false;
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -667,7 +667,7 @@ public sealed partial class MockTests
 					          		public override void MyMethod1(int index, ref int value1, out bool flag)
 					          		{
 					          			var ref_value1 = value1;
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<int, int, bool>>("global::MyCode.MyService.MyMethod1", m => m.Matches("index", index, "value1", ref_value1, "flag", default));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<int, int, bool>, int, int, bool>(0, "global::MyCode.MyService.MyMethod1", index, ref_value1, default);
 					          			bool hasWrappedResult = false;
 					          			flag = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -720,7 +720,7 @@ public sealed partial class MockTests
 					          		protected override bool MyMethod2(int index, bool isReadOnly, ref int value1, out bool flag)
 					          		{
 					          			var ref_value1 = value1;
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool, int, bool>>("global::MyCode.MyService.MyMethod2", m => m.Matches("index", index, "isReadOnly", isReadOnly, "value1", ref_value1, "flag", default));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool, int, bool>, int, bool, int, bool>(1, "global::MyCode.MyService.MyMethod2", index, isReadOnly, ref_value1, default);
 					          			bool hasWrappedResult = false;
 					          			bool wrappedResult = default!;
 					          			flag = default!;
@@ -774,7 +774,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyOtherService.SomeOtherMethod()" />
 					          		int global::MyCode.IMyOtherService.SomeOtherMethod()
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int>>("global::MyCode.IMyOtherService.SomeOtherMethod", m => m.Matches());
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int>>(0, "global::MyCode.IMyOtherService.SomeOtherMethod");
 					          			bool hasWrappedResult = false;
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -826,7 +826,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int, bool?, string> global::Mockolate.Mock.IMockSetupForIMyService.MyMethod1(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<bool?>? c, global::Mockolate.Parameters.IParameter<string>? d)
 					          		{
-					          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int, bool?, string>.WithParameterCollection(MockRegistry, "global::MyCode.IMyService.MyMethod1", CovariantParameterAdapter<int>.Wrap(a ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<int>.Wrap(b ?? global::Mockolate.It.Is<int>(1)), CovariantParameterAdapter<bool?>.Wrap(c ?? global::Mockolate.It.Is<bool?>(null)), CovariantParameterAdapter<string>.Wrap(d ?? global::Mockolate.It.Is<string>("default")));
+					          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int, bool?, string>.WithParameterCollection(MockRegistry, 0, "global::MyCode.IMyService.MyMethod1", CovariantParameterAdapter<int>.Wrap(a ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<int>.Wrap(b ?? global::Mockolate.It.Is<int>(1)), CovariantParameterAdapter<bool?>.Wrap(c ?? global::Mockolate.It.Is<bool?>(null)), CovariantParameterAdapter<string>.Wrap(d ?? global::Mockolate.It.Is<string>("default")));
 					          			this.MockRegistry.SetupMethod(methodSetup);
 					          			return methodSetup;
 					          		}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -206,7 +206,7 @@ public sealed partial class MockTests
 					     """);
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-					.Contains("var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.ProcessData\", m => m.Matches(\"methodExecution\", methodExecution));")
+					.Contains("var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(1, \"global::MyCode.IMyService.ProcessData\", methodExecution);")
 					.IgnoringNewlineStyle().And
 					.Contains("methodSetup?.TriggerCallbacks(methodExecution);")
 					.IgnoringNewlineStyle().And
@@ -238,7 +238,7 @@ public sealed partial class MockTests
 					     """);
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-					.Contains("var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.ProcessResult\", m => m.Matches(\"result\", result));")
+					.Contains("var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(0, \"global::MyCode.IMyService.ProcessResult\", result);")
 					.IgnoringNewlineStyle().And
 					.Contains("methodSetup?.TriggerCallbacks(result);")
 					.IgnoringNewlineStyle().And
@@ -867,7 +867,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int[]> global::Mockolate.Mock.IMockSetupForIMyService.MyMethod1(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int[]>? b)
 					          		{
-					          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int[]>.WithParameterCollection(MockRegistry, "global::MyCode.IMyService.MyMethod1", CovariantParameterAdapter<int>.Wrap(a ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<int[]>.Wrap(b ?? global::Mockolate.It.IsNull<int[]>("null")));
+					          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int[]>.WithParameterCollection(MockRegistry, 0, "global::MyCode.IMyService.MyMethod1", CovariantParameterAdapter<int>.Wrap(a ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<int[]>.Wrap(b ?? global::Mockolate.It.IsNull<int[]>("null")));
 					          			this.MockRegistry.SetupMethod(methodSetup);
 					          			return methodSetup;
 					          		}
@@ -914,7 +914,7 @@ public sealed partial class MockTests
 					          		public void MyMethod1(ref int index)
 					          		{
 					          			var ref_index = index;
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<int>>("global::MyCode.IMyService.MyMethod1", m => m.Matches("index", ref_index));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<int>, int>(0, "global::MyCode.IMyService.MyMethod1", ref_index);
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
@@ -955,7 +955,7 @@ public sealed partial class MockTests
 					          		/// <inheritdoc cref="global::MyCode.IMyService.MyMethod2(int, out bool)" />
 					          		public bool MyMethod2(int index, out bool isReadOnly)
 					          		{
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool>>("global::MyCode.IMyService.MyMethod2", m => m.Matches("index", index, "isReadOnly", default));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool>, int, bool>(1, "global::MyCode.IMyService.MyMethod2", index, default);
 					          			bool hasWrappedResult = false;
 					          			bool wrappedResult = default!;
 					          			isReadOnly = default!;
@@ -1005,7 +1005,7 @@ public sealed partial class MockTests
 					          		public void MyMethod3(in global::MyCode.MyReadonlyStruct p1)
 					          		{
 					          			var ref_p1 = p1;
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>>("global::MyCode.IMyService.MyMethod3", m => m.Matches("p1", ref_p1));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>, global::MyCode.MyReadonlyStruct>(2, "global::MyCode.IMyService.MyMethod3", ref_p1);
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
@@ -1034,7 +1034,7 @@ public sealed partial class MockTests
 					          		public void MyMethod4(ref readonly global::MyCode.MyReadonlyStruct p1)
 					          		{
 					          			var ref_p1 = p1;
-					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>>("global::MyCode.IMyService.MyMethod4", m => m.Matches("p1", ref_p1));
+					          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>, global::MyCode.MyReadonlyStruct>(3, "global::MyCode.IMyService.MyMethod4", ref_p1);
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
@@ -1088,7 +1088,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		global::Mockolate.Setup.IVoidMethodSetupWithCallback<global::Mockolate.Setup.SpanWrapper<char>> global::Mockolate.Mock.IMockSetupForIMyService.MyMethod1(global::Mockolate.Parameters.ISpanParameter<char> buffer)
 					          		{
-					          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<global::Mockolate.Setup.SpanWrapper<char>>.WithParameterCollection(MockRegistry, "global::MyCode.IMyService.MyMethod1", CovariantParameterAdapter<global::Mockolate.Setup.SpanWrapper<char>>.Wrap(buffer));
+					          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<global::Mockolate.Setup.SpanWrapper<char>>.WithParameterCollection(MockRegistry, 0, "global::MyCode.IMyService.MyMethod1", CovariantParameterAdapter<global::Mockolate.Setup.SpanWrapper<char>>.Wrap(buffer));
 					          			this.MockRegistry.SetupMethod(methodSetup);
 					          			return methodSetup;
 					          		}
@@ -1096,7 +1096,7 @@ public sealed partial class MockTests
 					.Contains("""
 					          		global::Mockolate.Setup.IReturnMethodSetupWithCallback<bool, global::Mockolate.Setup.ReadOnlySpanWrapper<int>> global::Mockolate.Mock.IMockSetupForIMyService.MyMethod2(global::Mockolate.Parameters.IReadOnlySpanParameter<int> values)
 					          		{
-					          			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>.WithParameterCollection(MockRegistry, "global::MyCode.IMyService.MyMethod2", CovariantParameterAdapter<global::Mockolate.Setup.ReadOnlySpanWrapper<int>>.Wrap(values));
+					          			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>.WithParameterCollection(MockRegistry, 1, "global::MyCode.IMyService.MyMethod2", CovariantParameterAdapter<global::Mockolate.Setup.ReadOnlySpanWrapper<int>>.Wrap(values));
 					          			this.MockRegistry.SetupMethod(methodSetup);
 					          			return methodSetup;
 					          		}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -80,11 +80,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyService.SomeProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeProperty);
+					          				return this.MockRegistry.GetProperty<int>(0, "global::MyCode.IMyService.SomeProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeProperty);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomeProperty", value);
+					          				this.MockRegistry.SetProperty<int>(0, "global::MyCode.IMyService.SomeProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomeProperty = value;
@@ -98,7 +98,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<bool?>("global::MyCode.IMyService.SomeReadOnlyProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool?)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeReadOnlyProperty);
+					          				return this.MockRegistry.GetProperty<bool?>(1, "global::MyCode.IMyService.SomeReadOnlyProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool?)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeReadOnlyProperty);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -108,7 +108,7 @@ public sealed partial class MockTests
 					          		{
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<bool?>("global::MyCode.IMyService.SomeWriteOnlyProperty", value);
+					          				this.MockRegistry.SetProperty<bool?>(2, "global::MyCode.IMyService.SomeWriteOnlyProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomeWriteOnlyProperty = value;
@@ -122,11 +122,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyService.SomeInternalProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeInternalProperty);
+					          				return this.MockRegistry.GetProperty<int>(3, "global::MyCode.IMyService.SomeInternalProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeInternalProperty);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomeInternalProperty", value);
+					          				this.MockRegistry.SetProperty<int>(3, "global::MyCode.IMyService.SomeInternalProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomeInternalProperty = value;
@@ -140,11 +140,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyService.SomePrivateProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProperty);
+					          				return this.MockRegistry.GetProperty<int>(4, "global::MyCode.IMyService.SomePrivateProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProperty);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomePrivateProperty", value);
+					          				this.MockRegistry.SetProperty<int>(4, "global::MyCode.IMyService.SomePrivateProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomePrivateProperty = value;
@@ -158,11 +158,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyService.SomePrivateProtectedProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProtectedProperty);
+					          				return this.MockRegistry.GetProperty<int>(5, "global::MyCode.IMyService.SomePrivateProtectedProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProtectedProperty);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.SomePrivateProtectedProperty", value);
+					          				this.MockRegistry.SetProperty<int>(5, "global::MyCode.IMyService.SomePrivateProtectedProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.SomePrivateProtectedProperty = value;
@@ -217,11 +217,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyService.MyDirectProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyDirectProperty);
+					          				return this.MockRegistry.GetProperty<int>(0, "global::MyCode.IMyService.MyDirectProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyDirectProperty);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyService.MyDirectProperty", value);
+					          				this.MockRegistry.SetProperty<int>(0, "global::MyCode.IMyService.MyDirectProperty", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyDirectProperty = value;
@@ -235,11 +235,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyServiceBase1.MyBaseProperty1", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty1);
+					          				return this.MockRegistry.GetProperty<int>(1, "global::MyCode.IMyServiceBase1.MyBaseProperty1", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty1);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyServiceBase1.MyBaseProperty1", value);
+					          				this.MockRegistry.SetProperty<int>(1, "global::MyCode.IMyServiceBase1.MyBaseProperty1", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyBaseProperty1 = value;
@@ -253,11 +253,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyServiceBase2.MyBaseProperty2", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty2);
+					          				return this.MockRegistry.GetProperty<int>(2, "global::MyCode.IMyServiceBase2.MyBaseProperty2", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty2);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyServiceBase2.MyBaseProperty2", value);
+					          				this.MockRegistry.SetProperty<int>(2, "global::MyCode.IMyServiceBase2.MyBaseProperty2", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyBaseProperty2 = value;
@@ -271,11 +271,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyServiceBase3.MyBaseProperty3", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty3);
+					          				return this.MockRegistry.GetProperty<int>(3, "global::MyCode.IMyServiceBase3.MyBaseProperty3", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty3);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyServiceBase3.MyBaseProperty3", value);
+					          				this.MockRegistry.SetProperty<int>(3, "global::MyCode.IMyServiceBase3.MyBaseProperty3", value);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
 					          				{
 					          					wraps.MyBaseProperty3 = value;
@@ -331,11 +331,11 @@ public sealed partial class MockTests
 					          		{
 					          			protected get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.MyService.SomeProperty1", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), () => base.SomeProperty1);
+					          				return this.MockRegistry.GetProperty<int>(0, "global::MyCode.MyService.SomeProperty1", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), () => base.SomeProperty1);
 					          			}
 					          			set
 					          			{
-					          				if (!this.MockRegistry.SetProperty<int>("global::MyCode.MyService.SomeProperty1", value))
+					          				if (!this.MockRegistry.SetProperty<int>(0, "global::MyCode.MyService.SomeProperty1", value))
 					          				{
 					          					if (this.MockRegistry.Wraps is global::MyCode.MyService wraps)
 					          					{
@@ -355,11 +355,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.MyService.SomeProperty2", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is global::MyCode.MyService wraps ? () => wraps.SomeProperty2 : () => base.SomeProperty2);
+					          				return this.MockRegistry.GetProperty<int>(1, "global::MyCode.MyService.SomeProperty2", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is global::MyCode.MyService wraps ? () => wraps.SomeProperty2 : () => base.SomeProperty2);
 					          			}
 					          			protected set
 					          			{
-					          				if (!this.MockRegistry.SetProperty<int>("global::MyCode.MyService.SomeProperty2", value))
+					          				if (!this.MockRegistry.SetProperty<int>(1, "global::MyCode.MyService.SomeProperty2", value))
 					          				{
 					          					base.SomeProperty2 = value;
 					          				}
@@ -372,7 +372,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<bool?>("global::MyCode.MyService.SomeReadOnlyProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool?)!), () => base.SomeReadOnlyProperty);
+					          				return this.MockRegistry.GetProperty<bool?>(2, "global::MyCode.MyService.SomeReadOnlyProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool?)!), () => base.SomeReadOnlyProperty);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -382,7 +382,7 @@ public sealed partial class MockTests
 					          		{
 					          			set
 					          			{
-					          				if (!this.MockRegistry.SetProperty<bool?>("global::MyCode.MyService.SomeWriteOnlyProperty", value))
+					          				if (!this.MockRegistry.SetProperty<bool?>(3, "global::MyCode.MyService.SomeWriteOnlyProperty", value))
 					          				{
 					          					base.SomeWriteOnlyProperty = value;
 					          				}
@@ -396,11 +396,11 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyOtherService.SomeAdditionalProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), null);
+					          				return this.MockRegistry.GetProperty<int>(4, "global::MyCode.IMyOtherService.SomeAdditionalProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), null);
 					          			}
 					          			set
 					          			{
-					          				this.MockRegistry.SetProperty<int>("global::MyCode.IMyOtherService.SomeAdditionalProperty", value);
+					          				this.MockRegistry.SetProperty<int>(4, "global::MyCode.IMyOtherService.SomeAdditionalProperty", value);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -28,7 +28,7 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
-				.Contains("var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.MyService.ProcessData\", m => m.Matches(\"baseResult\", baseResult));")
+				.Contains("var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(0, \"global::MyCode.MyService.ProcessData\", baseResult);")
 				.IgnoringNewlineStyle().And
 				.Contains("wrappedResult = base.ProcessData(baseResult);")
 				.IgnoringNewlineStyle().And

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -30,7 +30,7 @@ public sealed partial class MockTests
 				.Contains("""
 				          		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, int, bool> global::Mockolate.Mock.IMockSetupForProgram_DoSomething.Setup(global::Mockolate.Parameters.IParameter<int>? x, global::Mockolate.Parameters.IParameter<int>? y, global::Mockolate.Parameters.IOutParameter<bool> success)
 				          		{
-				          			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, int, bool>.WithParameterCollection(MockRegistry, "global::MyCode.Program.DoSomething.Invoke", CovariantParameterAdapter<int>.Wrap(x ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<int>.Wrap(y ?? global::Mockolate.It.IsNull<int>("null")), (global::Mockolate.Parameters.IParameterMatch<bool>)(success));
+				          			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, int, bool>.WithParameterCollection(MockRegistry, -1, "global::MyCode.Program.DoSomething.Invoke", CovariantParameterAdapter<int>.Wrap(x ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<int>.Wrap(y ?? global::Mockolate.It.IsNull<int>("null")), (global::Mockolate.Parameters.IParameterMatch<bool>)(success));
 				          			this.MockRegistry.SetupMethod(methodSetup);
 				          			return methodSetup;
 				          		}
@@ -38,7 +38,7 @@ public sealed partial class MockTests
 				.Contains("""
 				          		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, int, bool> global::Mockolate.Mock.IMockSetupForProgram_DoSomething.Setup(global::Mockolate.Parameters.IParameters parameters)
 				          		{
-				          			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, int, bool>.WithParameters(MockRegistry, "global::MyCode.Program.DoSomething.Invoke", parameters);
+				          			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, int, bool>.WithParameters(MockRegistry, -1, "global::MyCode.Program.DoSomething.Invoke", parameters, "x", "y", "success");
 				          			this.MockRegistry.SetupMethod(methodSetup);
 				          			return methodSetup;
 				          		}
@@ -80,7 +80,7 @@ public sealed partial class MockTests
 				          		public global::MyCode.Program.DoSomething1 Object => new(Invoke);
 				          		private global::System.Span<char> Invoke(int x)
 				          		{
-				          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>>("global::MyCode.Program.DoSomething1.Invoke", m => m.Matches("x", x));
+				          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>, int>(-1, "global::MyCode.Program.DoSomething1.Invoke", x);
 				          			if (MockRegistry.Behavior.SkipInteractionRecording == false)
 				          			{
 				          				MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.Program.DoSomething1.Invoke", "x", x));
@@ -99,7 +99,7 @@ public sealed partial class MockTests
 				          		public global::MyCode.Program.DoSomething2 Object => new(Invoke);
 				          		private global::System.ReadOnlySpan<char> Invoke(int x)
 				          		{
-				          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>>("global::MyCode.Program.DoSomething2.Invoke", m => m.Matches("x", x));
+				          			var methodSetup = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>, int>(-1, "global::MyCode.Program.DoSomething2.Invoke", x);
 				          			if (MockRegistry.Behavior.SkipInteractionRecording == false)
 				          			{
 				          				MockRegistry.RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation<int>("global::MyCode.Program.DoSomething2.Invoke", "x", x));
@@ -140,7 +140,7 @@ public sealed partial class MockTests
 				.Contains("""
 				          		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int, int> global::Mockolate.Mock.IMockSetupForProgram_DoSomething.Setup(global::Mockolate.Parameters.IParameter<int>? x, global::Mockolate.Parameters.IRefParameter<int> y, global::Mockolate.Parameters.IOutParameter<int> z)
 				          		{
-				          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int, int>.WithParameterCollection(MockRegistry, "global::MyCode.Program.DoSomething.Invoke", CovariantParameterAdapter<int>.Wrap(x ?? global::Mockolate.It.IsNull<int>("null")), (global::Mockolate.Parameters.IParameterMatch<int>)(y), (global::Mockolate.Parameters.IParameterMatch<int>)(z));
+				          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int, int>.WithParameterCollection(MockRegistry, -1, "global::MyCode.Program.DoSomething.Invoke", CovariantParameterAdapter<int>.Wrap(x ?? global::Mockolate.It.IsNull<int>("null")), (global::Mockolate.Parameters.IParameterMatch<int>)(y), (global::Mockolate.Parameters.IParameterMatch<int>)(z));
 				          			this.MockRegistry.SetupMethod(methodSetup);
 				          			return methodSetup;
 				          		}
@@ -148,7 +148,7 @@ public sealed partial class MockTests
 				.Contains("""
 				          		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int, int> global::Mockolate.Mock.IMockSetupForProgram_DoSomething.Setup(global::Mockolate.Parameters.IParameters parameters)
 				          		{
-				          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int, int>.WithParameters(MockRegistry, "global::MyCode.Program.DoSomething.Invoke", parameters);
+				          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, int, int>.WithParameters(MockRegistry, -1, "global::MyCode.Program.DoSomething.Invoke", parameters, "x", "y", "z");
 				          			this.MockRegistry.SetupMethod(methodSetup);
 				          			return methodSetup;
 				          		}
@@ -181,7 +181,7 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Func_int_bool.g.cs").WhoseValue
-				.Contains("this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int>>(\"global::System.Func<int, bool>.Invoke\", m => m.Matches(\"arg\", arg));")
+				.Contains("this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<bool, int>, int>(-1, \"global::System.Func<int, bool>.Invoke\", arg);")
 				.IgnoringNewlineStyle().And
 				.Contains("global::System.Func<int, bool> Object").IgnoringNewlineStyle();
 		}
@@ -266,7 +266,7 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Program_ProcessResult.g.cs").WhoseValue
-				.Contains("var methodSetup1 = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(")
+				.Contains("var methodSetup1 = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.ReturnMethodSetup<int, int>, int>(-1, \"global::MyCode.Program.ProcessResult.Invoke\", methodSetup);")
 				.IgnoringNewlineStyle().And
 				.Contains("methodSetup1?.TriggerCallbacks(methodSetup);")
 				.IgnoringNewlineStyle().And
@@ -296,7 +296,7 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Program_ProcessResult.g.cs").WhoseValue
-				.Contains("var methodSetup1 = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<string, int>>(")
+				.Contains("var methodSetup1 = this.MockRegistry.GetMethodSetup<global::Mockolate.Setup.VoidMethodSetup<string, int>, string, int>(-1, \"global::MyCode.Program.ProcessResult.Invoke\", methodSetup, default);")
 				.IgnoringNewlineStyle().And
 				.Contains("methodSetup1?.TriggerCallbacks(methodSetup, value);")
 				.IgnoringNewlineStyle();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -494,7 +494,7 @@ public sealed partial class MockTests
 			.Contains("""
 			          		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int> global::Mockolate.Mock.IMockSetupForIMyService.DoSomething(global::Mockolate.Parameters.IParameter<int>? @event)
 			          		{
-			          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int>.WithParameterCollection(MockRegistry, "global::MyCode.IMyService.DoSomething", CovariantParameterAdapter<int>.Wrap(@event ?? global::Mockolate.It.IsNull<int>("null")));
+			          			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int>.WithParameterCollection(MockRegistry, 0, "global::MyCode.IMyService.DoSomething", CovariantParameterAdapter<int>.Wrap(@event ?? global::Mockolate.It.IsNull<int>("null")));
 			          			this.MockRegistry.SetupMethod(methodSetup);
 			          			return methodSetup;
 			          		}
@@ -504,7 +504,7 @@ public sealed partial class MockTests
 			          		{
 			          			get
 			          			{
-			          				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, int>(MockRegistry, CovariantParameterAdapter<int>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<int>("null")));
+			          				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, int>(0, MockRegistry, CovariantParameterAdapter<int>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<int>("null")));
 			          				this.MockRegistry.SetupIndexer(indexerSetup);
 			          				return indexerSetup;
 			          			}


### PR DESCRIPTION
Replaces the linear name-based scan on the invocation hot path with an O(1) lookup indexed by a generator-assigned member id, and drops the per-call predicate closure that captured the arguments.

- MethodSetup gains a MemberId property; generator emits a dense int per method and passes it to both the setup ctor and the invocation lookup.
- MockSetups.MethodSetups keeps a parallel _byMemberId bucket plus a volatile MethodSetup[]?[] snapshot rebuilt lazily on add, so the invocation path reads without acquiring the list lock.
- ReturnMethodSetup / VoidMethodSetup (arity 0-4) implement the new IMethodMatchByValue<T1...> interfaces and expose a name-less Matches(T1...) overload, letting the registry dispatch without the generator emitting m => m.Matches("p1", v1, ...).
- Legacy ctors and Matches(string, T...) overloads stay for third-party callers (e.g. Mockolate.Web). The indexed lookup falls back to a name-filtered scan of legacy setups when the fast path has no match, preserving correctness when registries are shared between generated proxies (HttpClient + HttpMessageHandler).
- Generic methods and arities > 4 keep using the legacy lambda path: member id identifies a method definition and can't distinguish instantiations like Foo<int> vs Foo<long>; arity > 4 uses generated setup classes that don't ship the new ctors yet.

Per-call allocation for the method benchmark drops ~25% (5.45 KB to 4.91 KB at N=10) from eliminating the closure display class.