### PR TITLE
feat: add support for required members in generated constructors

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -41,6 +41,7 @@ internal record Class
 		}
 
 		IsInterface = type.TypeKind == TypeKind.Interface;
+		HasRequiredMembers = ComputeHasRequiredMembers(type);
 		ImmutableArray<ISymbol> members = type.GetMembers();
 		List<Method> methods = ToListExcept(members.OfType<IMethodSymbol>()
 			// Exclude getter/setter methods
@@ -114,6 +115,7 @@ internal record Class
 	public EquatableArray<Event> Events { get; }
 
 	public bool IsInterface { get; }
+	public bool HasRequiredMembers { get; }
 	public string ClassFullName { get; }
 	public string ClassName { get; }
 	public string DisplayString { get; }
@@ -268,6 +270,24 @@ internal record Class
 		}
 
 		return true;
+	}
+
+	private static bool ComputeHasRequiredMembers(ITypeSymbol type)
+	{
+		for (ITypeSymbol? current = type;
+		     current is not null && current.SpecialType != SpecialType.System_Object;
+		     current = current.BaseType)
+		{
+			foreach (ISymbol member in current.GetMembers())
+			{
+				if (member is IPropertySymbol { IsRequired: true, } or IFieldSymbol { IsRequired: true, })
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1578,7 +1578,7 @@ internal static partial class Sources
 		string mockRegistry = CreateUniqueParameterName(constructor.Parameters, "mockRegistry");
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
 		sb.Append(constructor.Attributes, "\t\t");
-		if (hasRequiredMembers)
+		if (hasRequiredMembers && constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") != true)
 		{
 			sb.Append("\t\t[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").AppendLine();
 		}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -672,7 +672,8 @@ internal static partial class Sources
 		{
 			foreach (Method constructor in constructors)
 			{
-				AppendMockSubject_BaseClassConstructor(sb, mockRegistryName, name, constructor);
+				AppendMockSubject_BaseClassConstructor(sb, mockRegistryName, name, constructor,
+					@class.HasRequiredMembers);
 			}
 		}
 		else
@@ -1572,11 +1573,16 @@ internal static partial class Sources
 	#region Mock Helpers
 
 	private static void AppendMockSubject_BaseClassConstructor(StringBuilder sb, string mockRegistryName, string name,
-		Method constructor)
+		Method constructor, bool hasRequiredMembers)
 	{
 		string mockRegistry = CreateUniqueParameterName(constructor.Parameters, "mockRegistry");
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
 		sb.Append(constructor.Attributes, "\t\t");
+		if (hasRequiredMembers)
+		{
+			sb.Append("\t\t[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").AppendLine();
+		}
+
 		sb.Append("\t\tpublic ").Append(name).Append("(global::Mockolate.MockRegistry ").Append(mockRegistry);
 		foreach (MethodParameter parameter in constructor.Parameters)
 		{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -355,7 +355,8 @@ internal static partial class Sources
 		{
 			foreach (Method constructor in constructors)
 			{
-				AppendMockSubject_BaseClassConstructor(sb, mockRegistryName, fileName, constructor);
+				AppendMockSubject_BaseClassConstructor(sb, mockRegistryName, fileName, constructor,
+					@class.HasRequiredMembers);
 			}
 		}
 		else

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -205,6 +205,40 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task ClassWithBaseConstructorAlreadyAnnotatedSetsRequiredMembers_ShouldNotDuplicateAttribute()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System.Diagnostics.CodeAnalysis;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = AnnotatedShape.CreateMock();
+				         }
+				     }
+
+				     public abstract class AnnotatedShape
+				     {
+				         public required string Name { get; init; }
+
+				         [SetsRequiredMembers]
+				         protected AnnotatedShape() { }
+
+				         public abstract int Compute();
+				     }
+				     """);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.AnnotatedShape.g.cs").WhoseValue
+				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").Once();
+		}
+
+		[Fact]
 		public async Task InterfaceWithEvents_ShouldIncludeRaiseRemarkBullet()
 		{
 			GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -110,6 +110,101 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task ClassWithRequiredMember_ShouldEmitSetsRequiredMembersOnGeneratedConstructor()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = RequiredShape.CreateMock();
+				         }
+				     }
+
+				     public abstract class RequiredShape
+				     {
+				         public required string Name { get; init; }
+				         public abstract int Compute();
+				     }
+				     """);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.RequiredShape.g.cs").WhoseValue
+				.Contains("""
+				          		[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+				          		public RequiredShape(global::Mockolate.MockRegistry mockRegistry)
+				          """)
+				.IgnoringNewlineStyle();
+		}
+
+		[Fact]
+		public async Task ClassWithoutRequiredMember_ShouldNotEmitSetsRequiredMembers()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = PlainShape.CreateMock();
+				         }
+				     }
+
+				     public abstract class PlainShape
+				     {
+				         public string Name { get; init; } = "";
+				         public abstract int Compute();
+				     }
+				     """);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.PlainShape.g.cs").WhoseValue
+				.DoesNotContain("SetsRequiredMembers");
+		}
+
+		[Fact]
+		public async Task ClassWithInheritedRequiredMember_ShouldEmitSetsRequiredMembersOnGeneratedConstructor()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = DerivedShape.CreateMock();
+				         }
+				     }
+
+				     public abstract class BaseShape
+				     {
+				         public required string Name { get; init; }
+				     }
+
+				     public abstract class DerivedShape : BaseShape
+				     {
+				         public abstract int Compute();
+				     }
+				     """);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.DerivedShape.g.cs").WhoseValue
+				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
+		}
+
+		[Fact]
 		public async Task InterfaceWithEvents_ShouldIncludeRaiseRemarkBullet()
 		{
 			GeneratorResult result = Generator


### PR DESCRIPTION
Adds generator support for C# `required` members by marking generated mock constructors with `[SetsRequiredMembers]`, allowing mocks of types with required members (including inherited required members) to be constructed via `CreateMock()` without required-member initialization diagnostics.

**Changes:**
- Add `Class.HasRequiredMembers` computed from required fields/properties across the class inheritance chain.
- Emit `[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]` on generated constructors when `HasRequiredMembers` is true (including in mock combinations).
- Add source-generator tests covering required members, non-required members, and inherited required members.