### PR TITLE
fix: prefix reserved C# keywords with '@' in generated members

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -13,10 +12,7 @@ internal record Event
 		Accessibility = eventSymbol.DeclaredAccessibility;
 		UseOverride = eventSymbol.IsVirtual || eventSymbol.IsAbstract;
 		IsAbstract = eventSymbol.IsAbstract;
-		string rawName = eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name;
-		Name = SyntaxFacts.GetKeywordKind(rawName) != SyntaxKind.None
-			? "@" + rawName
-			: rawName;
+		Name = Helpers.EscapeIfKeyword(eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name);
 		Type = new Type(eventSymbol.Type);
 		ContainingType = eventSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		Delegate = new Method(delegateInvokeMethod, null, sourceAssembly);

--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -12,7 +13,10 @@ internal record Event
 		Accessibility = eventSymbol.DeclaredAccessibility;
 		UseOverride = eventSymbol.IsVirtual || eventSymbol.IsAbstract;
 		IsAbstract = eventSymbol.IsAbstract;
-		Name = eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name;
+		string rawName = eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name;
+		Name = SyntaxFacts.GetKeywordKind(rawName) != SyntaxKind.None
+			? "@" + rawName
+			: rawName;
 		Type = new Type(eventSymbol.Type);
 		ContainingType = eventSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		Delegate = new Method(delegateInvokeMethod, null, sourceAssembly);
@@ -62,7 +66,8 @@ internal record Event
 	internal string GetBackingFieldName()
 	{
 		char[] sanitized = ContainingType.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray();
-		return $"_mockolateEvent_{new string(sanitized)}_{Name}";
+		string nameForField = Name.StartsWith("@") ? Name.Substring(1) : Name;
+		return $"_mockolateEvent_{new string(sanitized)}_{nameForField}";
 	}
 
 	private sealed class EventEqualityComparer : IEqualityComparer<Event>

--- a/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -9,9 +8,7 @@ internal readonly record struct GenericParameter
 {
 	public GenericParameter(ITypeParameterSymbol typeSymbol)
 	{
-		Name = SyntaxFacts.GetKeywordKind(typeSymbol.Name) != SyntaxKind.None
-			? "@" + typeSymbol.Name
-			: typeSymbol.Name;
+		Name = Helpers.EscapeIfKeyword(typeSymbol.Name);
 		IsUnmanaged = typeSymbol.HasUnmanagedTypeConstraint;
 		IsClass = typeSymbol.HasReferenceTypeConstraint;
 		IsStruct = typeSymbol.HasValueTypeConstraint;

--- a/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -8,7 +9,9 @@ internal readonly record struct GenericParameter
 {
 	public GenericParameter(ITypeParameterSymbol typeSymbol)
 	{
-		Name = typeSymbol.Name;
+		Name = SyntaxFacts.GetKeywordKind(typeSymbol.Name) != SyntaxKind.None
+			? "@" + typeSymbol.Name
+			: typeSymbol.Name;
 		IsUnmanaged = typeSymbol.HasUnmanagedTypeConstraint;
 		IsClass = typeSymbol.HasReferenceTypeConstraint;
 		IsStruct = typeSymbol.HasValueTypeConstraint;

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -14,7 +15,10 @@ internal record Method
 		IsAbstract = methodSymbol.IsAbstract;
 		IsStatic = methodSymbol.IsStatic;
 		ReturnType = methodSymbol.ReturnsVoid ? Type.Void : new Type(methodSymbol.ReturnType);
-		Name = methodSymbol.ExplicitInterfaceImplementations.Length > 0 ? methodSymbol.ExplicitInterfaceImplementations[0].Name : methodSymbol.Name;
+		string rawName = methodSymbol.ExplicitInterfaceImplementations.Length > 0 ? methodSymbol.ExplicitInterfaceImplementations[0].Name : methodSymbol.Name;
+		Name = SyntaxFacts.GetKeywordKind(rawName) != SyntaxKind.None
+			? "@" + rawName
+			: rawName;
 		ContainingType = methodSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		Parameters = new EquatableArray<MethodParameter>(
 			methodSymbol.Parameters.Select(x => new MethodParameter(x)).ToArray());

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -15,10 +14,7 @@ internal record Method
 		IsAbstract = methodSymbol.IsAbstract;
 		IsStatic = methodSymbol.IsStatic;
 		ReturnType = methodSymbol.ReturnsVoid ? Type.Void : new Type(methodSymbol.ReturnType);
-		string rawName = methodSymbol.ExplicitInterfaceImplementations.Length > 0 ? methodSymbol.ExplicitInterfaceImplementations[0].Name : methodSymbol.Name;
-		Name = SyntaxFacts.GetKeywordKind(rawName) != SyntaxKind.None
-			? "@" + rawName
-			: rawName;
+		Name = Helpers.EscapeIfKeyword(methodSymbol.ExplicitInterfaceImplementations.Length > 0 ? methodSymbol.ExplicitInterfaceImplementations[0].Name : methodSymbol.Name);
 		ContainingType = methodSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		Parameters = new EquatableArray<MethodParameter>(
 			methodSymbol.Parameters.Select(x => new MethodParameter(x)).ToArray());

--- a/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
@@ -8,9 +8,7 @@ internal readonly record struct MethodParameter
 	public MethodParameter(IParameterSymbol parameterSymbol)
 	{
 		Type = new Type(parameterSymbol.Type);
-		Name = SyntaxFacts.GetKeywordKind(parameterSymbol.Name) != SyntaxKind.None
-			? "@" + parameterSymbol.Name
-			: parameterSymbol.Name;
+		Name = Helpers.EscapeIfKeyword(parameterSymbol.Name);
 		RefKind = parameterSymbol.RefKind;
 		IsNullableAnnotated = parameterSymbol.NullableAnnotation == NullableAnnotation.Annotated;
 		IsParams = parameterSymbol.IsParams;

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -13,9 +12,7 @@ internal record Property
 		Accessibility = propertySymbol.DeclaredAccessibility;
 		UseOverride = propertySymbol.IsVirtual || propertySymbol.IsAbstract;
 		string rawName = propertySymbol.ExplicitInterfaceImplementations.Length > 0 ? propertySymbol.ExplicitInterfaceImplementations[0].Name : propertySymbol.Name;
-		Name = !propertySymbol.IsIndexer && SyntaxFacts.GetKeywordKind(rawName) != SyntaxKind.None
-			? "@" + rawName
-			: rawName;
+		Name = propertySymbol.IsIndexer ? rawName : Helpers.EscapeIfKeyword(rawName);
 		Type = new Type(propertySymbol.Type);
 		ContainingType = propertySymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		IsIndexer = propertySymbol.IsIndexer;

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
@@ -11,7 +12,10 @@ internal record Property
 	{
 		Accessibility = propertySymbol.DeclaredAccessibility;
 		UseOverride = propertySymbol.IsVirtual || propertySymbol.IsAbstract;
-		Name = propertySymbol.ExplicitInterfaceImplementations.Length > 0 ? propertySymbol.ExplicitInterfaceImplementations[0].Name : propertySymbol.Name;
+		string rawName = propertySymbol.ExplicitInterfaceImplementations.Length > 0 ? propertySymbol.ExplicitInterfaceImplementations[0].Name : propertySymbol.Name;
+		Name = !propertySymbol.IsIndexer && SyntaxFacts.GetKeywordKind(rawName) != SyntaxKind.None
+			? "@" + rawName
+			: rawName;
 		Type = new Type(propertySymbol.Type);
 		ContainingType = propertySymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		IsIndexer = propertySymbol.IsIndexer;

--- a/Source/Mockolate.SourceGenerators/Helpers.cs
+++ b/Source/Mockolate.SourceGenerators/Helpers.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Entities;
 using Mockolate.SourceGenerators.Internals;
 using Attribute = Mockolate.SourceGenerators.Entities.Attribute;
@@ -10,6 +11,9 @@ namespace Mockolate.SourceGenerators;
 
 internal static class Helpers
 {
+	public static string EscapeIfKeyword(string name)
+		=> SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None ? "@" + name : name;
+
 	public static SymbolDisplayFormat TypeDisplayFormat { get; } = new(
 		miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
 		                      SymbolDisplayMiscellaneousOptions.UseSpecialTypes |

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -519,6 +519,39 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task MembersWithReservedNames_ShouldPrefixAtSymbol()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using Mockolate;
+
+			     namespace MyCode;
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IMyService.CreateMock();
+			         }
+			     }
+
+			     public interface IMyService
+			     {
+			         int @class { get; }
+			         string @return();
+			         void @event(int @params);
+			         @class @void<@class>(@class @ref);
+			     }
+			     """);
+
+		await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
+			.Contains("public int @class").And
+			.Contains("public string @return()").And
+			.Contains("public void @event(int @params)").And
+			.Contains("public @class @void<@class>(@class @ref)");
+	}
+
+	[Fact]
 	public async Task ShouldHandleComplexInheritanceWithSealedAndInternalMembers()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -542,6 +542,7 @@ public sealed partial class MockTests
 			         void @event(int @params);
 			         int @void<@class>(int @ref);
 			         string this[int @params, string @void] { get; set; }
+			         event EventHandler @event;
 			     }
 			     """);
 
@@ -550,7 +551,10 @@ public sealed partial class MockTests
 			.Contains("public string @return()").And
 			.Contains("public void @event(int @params)").And
 			.Contains("public int @void<@class>(int @ref)").And
-			.Contains("public string this[int @params, string @void]");
+			.Contains("public string this[int @params, string @void]").And
+			.Contains("public event global::System.EventHandler @event").And
+			.Contains("private global::System.EventHandler? _mockolateEvent_global__MyCode_IMyService_event;").And
+			.DoesNotContain("_mockolateEvent_global__MyCode_IMyService_@event");;
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -540,7 +540,8 @@ public sealed partial class MockTests
 			         int @class { get; }
 			         string @return();
 			         void @event(int @params);
-			         @class @void<@class>(@class @ref);
+			         int @void<@class>(int @ref);
+			         string this[int @params, string @void] { get; set; }
 			     }
 			     """);
 
@@ -548,7 +549,8 @@ public sealed partial class MockTests
 			.Contains("public int @class").And
 			.Contains("public string @return()").And
 			.Contains("public void @event(int @params)").And
-			.Contains("public @class @void<@class>(@class @ref)");
+			.Contains("public int @void<@class>(int @ref)").And
+			.Contains("public string this[int @params, string @void]");
 	}
 
 	[Fact]


### PR DESCRIPTION
Updates the source generator to emit valid C# when mocked members (methods/properties/events) or generic type parameters use reserved C# keywords, by escaping those identifiers with an `@` prefix.

**Changes:**
- Escape keyword-named methods, properties, events, and generic type parameters in generator entity models.
- Fix event backing-field identifier generation to avoid embedding `@` mid-identifier.
- Add a generator test covering keyword-named members.