### PR TITLE
perf: speedup source generator

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -11,6 +11,7 @@ namespace Mockolate.SourceGenerators.Entities;
 internal class Class : IEquatable<Class>
 {
 	private readonly IAssemblySymbol _sourceAssembly;
+	private readonly int _surfaceHash;
 	private List<Event>? _allEvents;
 	private List<Method>? _allMethods;
 	private List<Property>? _allProperties;
@@ -137,6 +138,8 @@ internal class Class : IEquatable<Class>
 
 		ReservedNames = ComputeReservedNames(type);
 
+		_surfaceHash = ComputeSurfaceHash();
+
 		bool ShouldIncludeMember(ISymbol member)
 		{
 			if (IsInterface || member.IsAbstract)
@@ -146,6 +149,28 @@ internal class Class : IEquatable<Class>
 
 			return Helpers.IsOverridableFrom(member, _sourceAssembly);
 		}
+	}
+
+	/// <summary>
+	///     Folds the member surface (methods, properties, events, recursive base/interface chain,
+	///     reserved names, kind, required-member flag) into a single content-derived integer.
+	///     Roslyn's incremental cache uses <see cref="Equals(Class?)" /> to decide whether a
+	///     downstream stage's input changed; if equality only checked the type's name, an edit
+	///     that altered the member surface but not the name would let stale generated source
+	///     persist. Folding members into a hash keeps the comparison O(1) on the cache hot path
+	///     while still invalidating on any surface change.
+	/// </summary>
+	private int ComputeSurfaceHash()
+	{
+		int hash = ClassFullName.GetHashCode();
+		hash = unchecked((hash * 17) + Methods.GetHashCode());
+		hash = unchecked((hash * 17) + Properties.GetHashCode());
+		hash = unchecked((hash * 17) + Events.GetHashCode());
+		hash = unchecked((hash * 17) + InheritedTypes.GetHashCode());
+		hash = unchecked((hash * 17) + ReservedNames.GetHashCode());
+		hash = unchecked((hash * 17) + (IsInterface ? 1 : 0));
+		hash = unchecked((hash * 17) + (HasRequiredMembers ? 1 : 0));
+		return hash;
 	}
 
 	public EquatableArray<Method> Methods { get; }
@@ -160,20 +185,23 @@ internal class Class : IEquatable<Class>
 	public string ClassName { get; }
 	public string DisplayString { get; }
 
-	public static IEqualityComparer<Class> EqualityComparer { get; } = new ClassEqualityComparer();
-
 	/// <summary>
-	///     Equality is keyed only on ClassFullName: it uniquely identifies the type within a
-	///     compilation, so it's both necessary and sufficient as a Roslyn incremental cache key.
-	///     Two Class instances built from the same fully-qualified type are interchangeable from
-	///     the generator's perspective — the body of the type is reified deterministically by the
-	///     constructor. Comparing the full Methods/Properties/Events graph would be quadratic in
-	///     member count and dwarfs the rest of the generator on large mock surfaces.
+	///     Equality is keyed on <see cref="ClassFullName" /> plus a content-derived hash of the
+	///     member surface (<see cref="ComputeSurfaceHash" />). The full name alone is necessary
+	///     but not sufficient as a Roslyn incremental cache key: across edits, a target type can
+	///     keep its name while its members change, and a name-only comparison would let Roslyn
+	///     skip downstream stages and persist stale generated source. Folding the surface into a
+	///     precomputed hash keeps the comparison O(1) on the cache hot path while still
+	///     invalidating on any change to the emitted member set. Hash collisions are theoretically
+	///     possible but the leaf entities (<see cref="Method" />, <see cref="Property" />, and
+	///     <see cref="Event" />) are records with content-based hashes that propagate through
+	///     <see cref="EquatableArray{T}" />, so different surfaces almost always hash apart.
 	/// </summary>
 	public virtual bool Equals(Class? other)
 		=> ReferenceEquals(this, other) ||
 		   (other is not null &&
 		    GetType() == other.GetType() &&
+		    _surfaceHash == other._surfaceHash &&
 		    ClassFullName == other.ClassFullName);
 
 	/// <summary>
@@ -405,7 +433,6 @@ internal class Class : IEquatable<Class>
 		return false;
 	}
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	public static IEnumerable<ITypeSymbol> GetInheritedTypes(ITypeSymbol type)
 	{
 		ITypeSymbol? current = type;
@@ -427,7 +454,6 @@ internal class Class : IEquatable<Class>
 			current = current.BaseType;
 		}
 	}
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
 	public IEnumerable<Property> AllProperties()
 	{
@@ -487,7 +513,7 @@ internal class Class : IEquatable<Class>
 
 	public override bool Equals(object? obj) => Equals(obj as Class);
 
-	public override int GetHashCode() => ClassFullName.GetHashCode();
+	public override int GetHashCode() => _surfaceHash;
 
 	public static bool operator ==(Class? left, Class? right)
 	{
@@ -497,15 +523,5 @@ internal class Class : IEquatable<Class>
 	public static bool operator !=(Class? left, Class? right)
 	{
 		return !(left == right);
-	}
-
-	private sealed class ClassEqualityComparer : IEqualityComparer<Class>
-	{
-		public bool Equals(Class? x, Class? y)
-			=> (x is null && y is null) ||
-			   (x is not null && y is not null &&
-			    x.ClassFullName == y.ClassFullName);
-
-		public int GetHashCode(Class obj) => obj.ClassFullName.GetHashCode();
 	}
 }

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -44,11 +44,6 @@ internal class Class : IEquatable<Class>
 		HasRequiredMembers = ComputeHasRequiredMembers(type);
 		ImmutableArray<ISymbol> members = type.GetMembers();
 
-		// Single-pass member walk. The original code did six separate LINQ chains over `members`
-		// (three include passes producing Methods/Properties/Events plus three except-list passes).
-		// Each `.OfType<T>()` allocated an enumerator and rewalked the array — for a class deep in
-		// the inheritance graph this work compounds across every base class. Folding into one
-		// `foreach` collapses the constant factor without changing observable behavior.
 		List<Method> methodIncludes = new();
 		List<Property> propertyIncludes = new();
 		List<Event> eventIncludes = new();
@@ -61,58 +56,58 @@ internal class Class : IEquatable<Class>
 			switch (member)
 			{
 				case IMethodSymbol methodSymbol when methodSymbol.MethodKind is MethodKind.Ordinary:
-				{
-					if (!methodSymbol.IsSealed && (IsInterface || methodSymbol.IsVirtual || methodSymbol.IsAbstract) &&
-					    ShouldIncludeMember(methodSymbol))
 					{
-						methodIncludes.Add(new Method(methodSymbol, alreadyDefinedMethods, sourceAssembly));
-					}
+						if (!methodSymbol.IsSealed && (IsInterface || methodSymbol.IsVirtual || methodSymbol.IsAbstract) &&
+						    ShouldIncludeMember(methodSymbol))
+						{
+							methodIncludes.Add(new Method(methodSymbol, alreadyDefinedMethods, sourceAssembly));
+						}
 
-					if (methodSymbol.IsSealed || HidesBaseOverridable(methodSymbol, type))
-					{
-						methodExceptCandidates.Add(new Method(methodSymbol, null, sourceAssembly));
-					}
+						if (methodSymbol.IsSealed || HidesBaseOverridable(methodSymbol, type))
+						{
+							methodExceptCandidates.Add(new Method(methodSymbol, null, sourceAssembly));
+						}
 
-					break;
-				}
-
-				case IPropertySymbol propertySymbol:
-				{
-					if (!propertySymbol.IsSealed && (IsInterface || propertySymbol.IsVirtual || propertySymbol.IsAbstract) &&
-					    ShouldIncludeMember(propertySymbol))
-					{
-						propertyIncludes.Add(new Property(propertySymbol, alreadyDefinedProperties, sourceAssembly));
-					}
-
-					if (propertySymbol.IsSealed || HidesBaseOverridable(propertySymbol, type))
-					{
-						propertyExceptCandidates.Add(new Property(propertySymbol, null, sourceAssembly));
-					}
-
-					break;
-				}
-
-				case IEventSymbol eventSymbol:
-				{
-					IMethodSymbol? invoke = (eventSymbol.Type as INamedTypeSymbol)?.DelegateInvokeMethod;
-					if (invoke is null)
-					{
 						break;
 					}
 
-					if (!eventSymbol.IsSealed && (IsInterface || eventSymbol.IsVirtual || eventSymbol.IsAbstract) &&
-					    ShouldIncludeMember(eventSymbol))
+				case IPropertySymbol propertySymbol:
 					{
-						eventIncludes.Add(new Event(eventSymbol, invoke, alreadyDefinedEvents, sourceAssembly));
+						if (!propertySymbol.IsSealed && (IsInterface || propertySymbol.IsVirtual || propertySymbol.IsAbstract) &&
+						    ShouldIncludeMember(propertySymbol))
+						{
+							propertyIncludes.Add(new Property(propertySymbol, alreadyDefinedProperties, sourceAssembly));
+						}
+
+						if (propertySymbol.IsSealed || HidesBaseOverridable(propertySymbol, type))
+						{
+							propertyExceptCandidates.Add(new Property(propertySymbol, null, sourceAssembly));
+						}
+
+						break;
 					}
 
-					if (eventSymbol.IsSealed || HidesBaseOverridable(eventSymbol, type))
+				case IEventSymbol eventSymbol:
 					{
-						eventExceptCandidates.Add(new Event(eventSymbol, invoke, null, sourceAssembly));
-					}
+						IMethodSymbol? invoke = (eventSymbol.Type as INamedTypeSymbol)?.DelegateInvokeMethod;
+						if (invoke is null)
+						{
+							break;
+						}
 
-					break;
-				}
+						if (!eventSymbol.IsSealed && (IsInterface || eventSymbol.IsVirtual || eventSymbol.IsAbstract) &&
+						    ShouldIncludeMember(eventSymbol))
+						{
+							eventIncludes.Add(new Event(eventSymbol, invoke, alreadyDefinedEvents, sourceAssembly));
+						}
+
+						if (eventSymbol.IsSealed || HidesBaseOverridable(eventSymbol, type))
+						{
+							eventExceptCandidates.Add(new Event(eventSymbol, invoke, null, sourceAssembly));
+						}
+
+						break;
+					}
 			}
 		}
 
@@ -167,10 +162,26 @@ internal class Class : IEquatable<Class>
 
 	public static IEqualityComparer<Class> EqualityComparer { get; } = new ClassEqualityComparer();
 
-	// Identifiers that the mock class shares its scope with but that aren't surfaced through
-	// Methods/Properties/Events: generic type parameters of the type itself, nested types, and
-	// fields declared on the type. A generated member colliding with any of these would either
-	// fail to compile (CS0102 / type-parameter shadowing) or hide an inherited field (CS0108).
+	/// <summary>
+	///     Equality is keyed only on ClassFullName: it uniquely identifies the type within a
+	///     compilation, so it's both necessary and sufficient as a Roslyn incremental cache key.
+	///     Two Class instances built from the same fully-qualified type are interchangeable from
+	///     the generator's perspective — the body of the type is reified deterministically by the
+	///     constructor. Comparing the full Methods/Properties/Events graph would be quadratic in
+	///     member count and dwarfs the rest of the generator on large mock surfaces.
+	/// </summary>
+	public virtual bool Equals(Class? other)
+		=> ReferenceEquals(this, other) ||
+		   (other is not null &&
+		    GetType() == other.GetType() &&
+		    ClassFullName == other.ClassFullName);
+
+	/// <summary>
+	///     Identifiers that the mock class shares its scope with but that aren't surfaced through
+	///     Methods/Properties/Events: generic type parameters of the type itself, nested types, and
+	///     fields declared on the type. A generated member colliding with any of these would either
+	///     fail to compile (CS0102 / type-parameter shadowing) or hide an inherited field (CS0108).
+	/// </summary>
 	private static EquatableArray<string> ComputeReservedNames(ITypeSymbol type)
 	{
 		HashSet<string> names = new();
@@ -286,8 +297,9 @@ internal class Class : IEquatable<Class>
 		return source.Except(except, comparer).ToList();
 	}
 
-	// In-place dedup that preserves insertion order and uses default equality. Mirrors the
-	// behavior of `.Distinct()` on the lists produced by the single-pass member walk.
+	/// <summary>
+	///     In-place deduplication of the <paramref name="list" /> that preserves insertion order and uses default equality.
+	/// </summary>
 	private static List<T> DistinctList<T>(List<T> list) where T : notnull
 	{
 		if (list.Count <= 1)
@@ -308,10 +320,13 @@ internal class Class : IEquatable<Class>
 		return result;
 	}
 
-	// True when `member` (declared on `thisType`) hides an overridable member of the same
-	// signature on a base class. The hidden base cannot be overridden from a class deriving from
-	// `thisType` — the compiler resolves the override target to the hiding member first and fails
-	// with CS0506. Overrides are not hiding: they continue the virtual slot.
+	/// <summary>
+	///     True when `member` (declared on `thisType`) hides an overridable member of the same
+	///     signature on a base class. The hidden base cannot be overridden from a class deriving from
+	///     `thisType` — the compiler resolves the override target to the hiding member first and fails
+	///     with CS0506.<br />
+	///     Overrides are not hiding: they continue the virtual slot.
+	/// </summary>
 	private static bool HidesBaseOverridable(ISymbol member, ITypeSymbol thisType)
 	{
 		if (member is IMethodSymbol { IsOverride: true, } or IPropertySymbol { IsOverride: true, } or IEventSymbol { IsOverride: true, })
@@ -470,25 +485,19 @@ internal class Class : IEquatable<Class>
 		return _classNameWithoutDots = sb.ToString();
 	}
 
-	// Equality is keyed only on ClassFullName: it uniquely identifies the type within a
-	// compilation, so it's both necessary and sufficient as a Roslyn incremental cache key.
-	// Two Class instances built from the same fully-qualified type are interchangeable from
-	// the generator's perspective — the body of the type is reified deterministically by the
-	// constructor. Comparing the full Methods/Properties/Events graph would be quadratic in
-	// member count and dwarfs the rest of the generator on large mock surfaces.
-	public virtual bool Equals(Class? other)
-		=> ReferenceEquals(this, other) ||
-		   (other is not null &&
-		    GetType() == other.GetType() &&
-		    ClassFullName == other.ClassFullName);
-
 	public override bool Equals(object? obj) => Equals(obj as Class);
 
 	public override int GetHashCode() => ClassFullName.GetHashCode();
 
-	public static bool operator ==(Class? left, Class? right) => left?.Equals(right) ?? right is null;
+	public static bool operator ==(Class? left, Class? right)
+	{
+		return left?.Equals(right) ?? right is null;
+	}
 
-	public static bool operator !=(Class? left, Class? right) => !(left == right);
+	public static bool operator !=(Class? left, Class? right)
+	{
+		return !(left == right);
+	}
 
 	private sealed class ClassEqualityComparer : IEqualityComparer<Class>
 	{

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -186,25 +186,6 @@ internal class Class : IEquatable<Class>
 	public string DisplayString { get; }
 
 	/// <summary>
-	///     Equality is keyed on <see cref="ClassFullName" /> plus a content-derived hash of the
-	///     member surface (<see cref="ComputeSurfaceHash" />). The full name alone is necessary
-	///     but not sufficient as a Roslyn incremental cache key: across edits, a target type can
-	///     keep its name while its members change, and a name-only comparison would let Roslyn
-	///     skip downstream stages and persist stale generated source. Folding the surface into a
-	///     precomputed hash keeps the comparison O(1) on the cache hot path while still
-	///     invalidating on any change to the emitted member set. Hash collisions are theoretically
-	///     possible but the leaf entities (<see cref="Method" />, <see cref="Property" />, and
-	///     <see cref="Event" />) are records with content-based hashes that propagate through
-	///     <see cref="EquatableArray{T}" />, so different surfaces almost always hash apart.
-	/// </summary>
-	public virtual bool Equals(Class? other)
-		=> ReferenceEquals(this, other) ||
-		   (other is not null &&
-		    GetType() == other.GetType() &&
-		    _surfaceHash == other._surfaceHash &&
-		    ClassFullName == other.ClassFullName);
-
-	/// <summary>
 	///     Identifiers that the mock class shares its scope with but that aren't surfaced through
 	///     Methods/Properties/Events: generic type parameters of the type itself, nested types, and
 	///     fields declared on the type. A generated member colliding with any of these would either
@@ -510,6 +491,25 @@ internal class Class : IEquatable<Class>
 
 		return _classNameWithoutDots = sb.ToString();
 	}
+
+	/// <summary>
+	///     Equality is keyed on <see cref="ClassFullName" /> plus a content-derived hash of the
+	///     member surface (<see cref="ComputeSurfaceHash" />). The full name alone is necessary
+	///     but not sufficient as a Roslyn incremental cache key: across edits, a target type can
+	///     keep its name while its members change, and a name-only comparison would let Roslyn
+	///     skip downstream stages and persist stale generated source. Folding the surface into a
+	///     precomputed hash keeps the comparison O(1) on the cache hot path while still
+	///     invalidating on any change to the emitted member set. Hash collisions are theoretically
+	///     possible but the leaf entities (<see cref="Method" />, <see cref="Property" />, and
+	///     <see cref="Event" />) are records with content-based hashes that propagate through
+	///     <see cref="EquatableArray{T}" />, so different surfaces almost always hash apart.
+	/// </summary>
+	public virtual bool Equals(Class? other)
+		=> ReferenceEquals(this, other) ||
+		   (other is not null &&
+		    GetType() == other.GetType() &&
+		    _surfaceHash == other._surfaceHash &&
+		    ClassFullName == other.ClassFullName);
 
 	public override bool Equals(object? obj) => Equals(obj as Class);
 

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -8,7 +8,7 @@ using Mockolate.SourceGenerators.Internals;
 namespace Mockolate.SourceGenerators.Entities;
 
 [DebuggerDisplay("{DisplayString}")]
-internal record Class
+internal class Class : IEquatable<Class>
 {
 	private readonly IAssemblySymbol _sourceAssembly;
 	private List<Event>? _allEvents;
@@ -43,54 +43,96 @@ internal record Class
 		IsInterface = type.TypeKind == TypeKind.Interface;
 		HasRequiredMembers = ComputeHasRequiredMembers(type);
 		ImmutableArray<ISymbol> members = type.GetMembers();
-		List<Method> methods = ToListExcept(members.OfType<IMethodSymbol>()
-			// Exclude getter/setter methods
-			.Where(x => x.MethodKind is MethodKind.Ordinary)
-			.Where(x => !x.IsSealed)
-			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
-			.Where(ShouldIncludeMember)
-			.Select(x => new Method(x, alreadyDefinedMethods, sourceAssembly))
-			.Distinct(), exceptMethods, Method.ContainingTypeIndependentEqualityComparer);
+
+		// Single-pass member walk. The original code did six separate LINQ chains over `members`
+		// (three include passes producing Methods/Properties/Events plus three except-list passes).
+		// Each `.OfType<T>()` allocated an enumerator and rewalked the array — for a class deep in
+		// the inheritance graph this work compounds across every base class. Folding into one
+		// `foreach` collapses the constant factor without changing observable behavior.
+		List<Method> methodIncludes = new();
+		List<Property> propertyIncludes = new();
+		List<Event> eventIncludes = new();
+		List<Method> methodExceptCandidates = new();
+		List<Property> propertyExceptCandidates = new();
+		List<Event> eventExceptCandidates = new();
+
+		foreach (ISymbol member in members)
+		{
+			switch (member)
+			{
+				case IMethodSymbol methodSymbol when methodSymbol.MethodKind is MethodKind.Ordinary:
+				{
+					if (!methodSymbol.IsSealed && (IsInterface || methodSymbol.IsVirtual || methodSymbol.IsAbstract) &&
+					    ShouldIncludeMember(methodSymbol))
+					{
+						methodIncludes.Add(new Method(methodSymbol, alreadyDefinedMethods, sourceAssembly));
+					}
+
+					if (methodSymbol.IsSealed || HidesBaseOverridable(methodSymbol, type))
+					{
+						methodExceptCandidates.Add(new Method(methodSymbol, null, sourceAssembly));
+					}
+
+					break;
+				}
+
+				case IPropertySymbol propertySymbol:
+				{
+					if (!propertySymbol.IsSealed && (IsInterface || propertySymbol.IsVirtual || propertySymbol.IsAbstract) &&
+					    ShouldIncludeMember(propertySymbol))
+					{
+						propertyIncludes.Add(new Property(propertySymbol, alreadyDefinedProperties, sourceAssembly));
+					}
+
+					if (propertySymbol.IsSealed || HidesBaseOverridable(propertySymbol, type))
+					{
+						propertyExceptCandidates.Add(new Property(propertySymbol, null, sourceAssembly));
+					}
+
+					break;
+				}
+
+				case IEventSymbol eventSymbol:
+				{
+					IMethodSymbol? invoke = (eventSymbol.Type as INamedTypeSymbol)?.DelegateInvokeMethod;
+					if (invoke is null)
+					{
+						break;
+					}
+
+					if (!eventSymbol.IsSealed && (IsInterface || eventSymbol.IsVirtual || eventSymbol.IsAbstract) &&
+					    ShouldIncludeMember(eventSymbol))
+					{
+						eventIncludes.Add(new Event(eventSymbol, invoke, alreadyDefinedEvents, sourceAssembly));
+					}
+
+					if (eventSymbol.IsSealed || HidesBaseOverridable(eventSymbol, type))
+					{
+						eventExceptCandidates.Add(new Event(eventSymbol, invoke, null, sourceAssembly));
+					}
+
+					break;
+				}
+			}
+		}
+
+		List<Method> methods = ToListExcept(DistinctList(methodIncludes), exceptMethods, Method.ContainingTypeIndependentEqualityComparer);
 		Methods = new EquatableArray<Method>(methods.ToArray());
 
-		List<Property> properties = ToListExcept(members.OfType<IPropertySymbol>()
-			.Where(x => !x.IsSealed)
-			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
-			.Where(ShouldIncludeMember)
-			.Select(x => new Property(x, alreadyDefinedProperties, sourceAssembly))
-			.Distinct(), exceptProperties, Property.ContainingTypeIndependentEqualityComparer);
+		List<Property> properties = ToListExcept(DistinctList(propertyIncludes), exceptProperties, Property.ContainingTypeIndependentEqualityComparer);
 		Properties = new EquatableArray<Property>(properties.ToArray());
 
-		List<Event> events = ToListExcept(members.OfType<IEventSymbol>()
-			.Where(x => !x.IsSealed)
-			.Where(x => IsInterface || x.IsVirtual || x.IsAbstract)
-			.Where(ShouldIncludeMember)
-			.Select(x => (x, x.Type as INamedTypeSymbol))
-			.Where(x => x.Item2?.DelegateInvokeMethod is not null)
-			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, alreadyDefinedEvents, sourceAssembly))
-			.Distinct(), exceptEvents, Event.ContainingTypeIndependentEqualityComparer);
+		List<Event> events = ToListExcept(DistinctList(eventIncludes), exceptEvents, Event.ContainingTypeIndependentEqualityComparer);
 		Events = new EquatableArray<Event>(events.ToArray());
 
 		exceptProperties ??= new List<Property>();
-		exceptProperties.AddRange(members.OfType<IPropertySymbol>()
-			.Where(x => x.IsSealed || HidesBaseOverridable(x, type))
-			.Select(x => new Property(x, null, sourceAssembly))
-			.Distinct());
+		exceptProperties.AddRange(DistinctList(propertyExceptCandidates));
 
 		exceptMethods ??= new List<Method>();
-		exceptMethods.AddRange(members.OfType<IMethodSymbol>()
-			.Where(x => x.MethodKind is MethodKind.Ordinary)
-			.Where(x => x.IsSealed || HidesBaseOverridable(x, type))
-			.Select(x => new Method(x, null, sourceAssembly))
-			.Distinct());
+		exceptMethods.AddRange(DistinctList(methodExceptCandidates));
 
 		exceptEvents ??= new List<Event>();
-		exceptEvents.AddRange(members.OfType<IEventSymbol>()
-			.Where(x => x.IsSealed || HidesBaseOverridable(x, type))
-			.Select(x => (x, x.Type as INamedTypeSymbol))
-			.Where(x => x.Item2?.DelegateInvokeMethod is not null)
-			.Select(x => new Event(x.x, x.Item2!.DelegateInvokeMethod!, null, sourceAssembly))
-			.Distinct());
+		exceptEvents.AddRange(DistinctList(eventExceptCandidates));
 
 		InheritedTypes = new EquatableArray<Class>(
 			GetInheritedTypes(type).Select(t
@@ -242,6 +284,28 @@ internal record Class
 		}
 
 		return source.Except(except, comparer).ToList();
+	}
+
+	// In-place dedup that preserves insertion order and uses default equality. Mirrors the
+	// behavior of `.Distinct()` on the lists produced by the single-pass member walk.
+	private static List<T> DistinctList<T>(List<T> list) where T : notnull
+	{
+		if (list.Count <= 1)
+		{
+			return list;
+		}
+
+		HashSet<T> seen = new();
+		List<T> result = new(list.Count);
+		foreach (T item in list)
+		{
+			if (seen.Add(item))
+			{
+				result.Add(item);
+			}
+		}
+
+		return result;
 	}
 
 	// True when `member` (declared on `thisType`) hides an overridable member of the same
@@ -405,6 +469,26 @@ internal record Class
 
 		return _classNameWithoutDots = sb.ToString();
 	}
+
+	// Equality is keyed only on ClassFullName: it uniquely identifies the type within a
+	// compilation, so it's both necessary and sufficient as a Roslyn incremental cache key.
+	// Two Class instances built from the same fully-qualified type are interchangeable from
+	// the generator's perspective — the body of the type is reified deterministically by the
+	// constructor. Comparing the full Methods/Properties/Events graph would be quadratic in
+	// member count and dwarfs the rest of the generator on large mock surfaces.
+	public virtual bool Equals(Class? other)
+		=> ReferenceEquals(this, other) ||
+		   (other is not null &&
+		    GetType() == other.GetType() &&
+		    ClassFullName == other.ClassFullName);
+
+	public override bool Equals(object? obj) => Equals(obj as Class);
+
+	public override int GetHashCode() => ClassFullName.GetHashCode();
+
+	public static bool operator ==(Class? left, Class? right) => left?.Equals(right) ?? right is null;
+
+	public static bool operator !=(Class? left, Class? right) => !(left == right);
 
 	private sealed class ClassEqualityComparer : IEqualityComparer<Class>
 	{

--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -13,7 +13,7 @@ internal record Event
 		UseOverride = eventSymbol.IsVirtual || eventSymbol.IsAbstract;
 		IsAbstract = eventSymbol.IsAbstract;
 		Name = Helpers.EscapeIfKeyword(eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name);
-		Type = new Type(eventSymbol.Type);
+		Type = Type.From(eventSymbol.Type);
 		ContainingType = eventSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		Delegate = new Method(delegateInvokeMethod, null, sourceAssembly);
 		Attributes = eventSymbol.GetAttributes().ToAttributeArray(sourceAssembly);

--- a/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
@@ -32,7 +32,6 @@ internal readonly record struct GenericParameter
 	public NullableAnnotation NullableAnnotation { get; }
 	public bool IsClass { get; }
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	public void AppendWhereConstraint(StringBuilder sb, string prefix, bool inheritsConstraints = false, bool isExplicitInterfaceImpl = false)
 	{
 		bool isUnconstrained = !ConstraintTypes.Any() && !IsStruct && !IsClass && !IsNotNull && !IsUnmanaged &&
@@ -119,5 +118,4 @@ internal readonly record struct GenericParameter
 			sb.Append("new()");
 		}
 	}
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 }

--- a/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
@@ -18,7 +18,7 @@ internal readonly record struct GenericParameter
 		NullableAnnotation = typeSymbol.ReferenceTypeConstraintNullableAnnotation;
 
 		ConstraintTypes = new EquatableArray<Type>(typeSymbol.ConstraintTypes
-			.Select(x => new Type(x)).ToArray());
+			.Select(Type.From).ToArray());
 	}
 
 	public EquatableArray<Type> ConstraintTypes { get; }

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -13,11 +13,11 @@ internal record Method
 		UseOverride = methodSymbol.IsVirtual || methodSymbol.IsAbstract;
 		IsAbstract = methodSymbol.IsAbstract;
 		IsStatic = methodSymbol.IsStatic;
-		ReturnType = methodSymbol.ReturnsVoid ? Type.Void : new Type(methodSymbol.ReturnType);
+		ReturnType = methodSymbol.ReturnsVoid ? Type.Void : Type.From(methodSymbol.ReturnType);
 		Name = Helpers.EscapeIfKeyword(methodSymbol.ExplicitInterfaceImplementations.Length > 0 ? methodSymbol.ExplicitInterfaceImplementations[0].Name : methodSymbol.Name);
 		ContainingType = methodSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		Parameters = new EquatableArray<MethodParameter>(
-			methodSymbol.Parameters.Select(x => new MethodParameter(x)).ToArray());
+			methodSymbol.Parameters.Select(MethodParameter.From).ToArray());
 
 		if (methodSymbol.IsGenericMethod)
 		{

--- a/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
@@ -1,13 +1,25 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 
 internal readonly record struct MethodParameter
 {
+	internal static MethodParameter From(IParameterSymbol symbol)
+	{
+		EntityCache? cache = EntityCache.Current;
+		if (cache is null)
+		{
+			return new MethodParameter(symbol);
+		}
+
+		return cache.GetOrAddParameter(symbol, static s => new MethodParameter(s));
+	}
+
 	public MethodParameter(IParameterSymbol parameterSymbol)
 	{
-		Type = new Type(parameterSymbol.Type);
+		Type = Type.From(parameterSymbol.Type);
 		Name = Helpers.EscapeIfKeyword(parameterSymbol.Name);
 		RefKind = parameterSymbol.RefKind;
 		IsNullableAnnotated = parameterSymbol.NullableAnnotation == NullableAnnotation.Annotated;

--- a/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MethodParameter.cs
@@ -6,17 +6,6 @@ namespace Mockolate.SourceGenerators.Entities;
 
 internal readonly record struct MethodParameter
 {
-	internal static MethodParameter From(IParameterSymbol symbol)
-	{
-		EntityCache? cache = EntityCache.Current;
-		if (cache is null)
-		{
-			return new MethodParameter(symbol);
-		}
-
-		return cache.GetOrAddParameter(symbol, static s => new MethodParameter(s));
-	}
-
 	public MethodParameter(IParameterSymbol parameterSymbol)
 	{
 		Type = Type.From(parameterSymbol.Type);
@@ -55,9 +44,22 @@ internal readonly record struct MethodParameter
 	public string Name { get; }
 	public RefKind RefKind { get; }
 
-	// SymbolDisplay.FormatPrimitive strips the 'm'/'f' type suffix from the literal, which would
-	// produce invalid C# (e.g. "decimal x = 19.95" is a narrowing conversion from double). Re-add
-	// the suffix based on the effective parameter type so the generated code compiles.
+	internal static MethodParameter From(IParameterSymbol symbol)
+	{
+		EntityCache? cache = EntityCache.Current;
+		if (cache is null)
+		{
+			return new MethodParameter(symbol);
+		}
+
+		return cache.GetOrAddParameter(symbol, static s => new MethodParameter(s));
+	}
+
+	/// <summary>
+	///     SymbolDisplay.FormatPrimitive strips the 'm'/'f' type suffix from the literal, which would
+	///     produce invalid C# (e.g. "decimal x = 19.95" is a narrowing conversion from double). Re-add
+	///     the suffix based on the effective parameter type so the generated code compiles.
+	/// </summary>
 	private static string? AppendLiteralSuffix(string? value, ITypeSymbol type)
 	{
 		if (value is null or "null")

--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -3,7 +3,7 @@ using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 
-internal record MockClass : Class
+internal sealed class MockClass : Class, IEquatable<MockClass>
 {
 	public MockClass(ITypeSymbol[] types, IAssemblySymbol sourceAssembly) : base(types[0], sourceAssembly)
 	{
@@ -38,5 +38,62 @@ internal record MockClass : Class
 		{
 			yield return additionalImplementation;
 		}
+	}
+
+	// MockClass identity is the root ClassFullName plus the ClassFullNames of any additional
+	// implementations: two mocks of the same root with different additional interfaces produce
+	// different generated files, so the per-mock incremental cache must distinguish them.
+	public bool Equals(MockClass? other)
+		=> ReferenceEquals(this, other) ||
+		   (other is not null &&
+		    ClassFullName == other.ClassFullName &&
+		    AdditionalImplementationsEqual(AdditionalImplementations, other.AdditionalImplementations));
+
+	public override bool Equals(Class? other) => other is MockClass mc && Equals(mc);
+
+	public override bool Equals(object? obj) => Equals(obj as MockClass);
+
+	public override int GetHashCode()
+	{
+		int hash = ClassFullName.GetHashCode();
+		Class[]? additional = AdditionalImplementations.AsArray();
+		if (additional is null)
+		{
+			return hash;
+		}
+
+		int multiplier = 17;
+		foreach (Class c in additional)
+		{
+			hash = unchecked(hash + c.ClassFullName.GetHashCode() * multiplier);
+			multiplier *= 17;
+		}
+
+		return hash;
+	}
+
+	private static bool AdditionalImplementationsEqual(EquatableArray<Class> left, EquatableArray<Class> right)
+	{
+		if (left.Count != right.Count)
+		{
+			return false;
+		}
+
+		Class[]? leftArray = left.AsArray();
+		Class[]? rightArray = right.AsArray();
+		if (leftArray is null || rightArray is null)
+		{
+			return leftArray is null && rightArray is null;
+		}
+
+		for (int i = 0; i < leftArray.Length; i++)
+		{
+			if (leftArray[i].ClassFullName != rightArray[i].ClassFullName)
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -5,6 +5,8 @@ namespace Mockolate.SourceGenerators.Entities;
 
 internal sealed class MockClass : Class, IEquatable<MockClass>
 {
+	private readonly int _mockSurfaceHash;
+
 	public MockClass(ITypeSymbol[] types, IAssemblySymbol sourceAssembly) : base(types[0], sourceAssembly)
 	{
 		AdditionalImplementations = new EquatableArray<Class>(
@@ -23,6 +25,8 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 				Delegate = new Method(namedTypeSymbol.DelegateInvokeMethod, null, sourceAssembly);
 			}
 		}
+
+		_mockSurfaceHash = ComputeMockSurfaceHash();
 	}
 
 	public Method? Delegate { get; }
@@ -32,15 +36,18 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 	public EquatableArray<Class> AdditionalImplementations { get; }
 
 	/// <summary>
-	///     MockClass identity is the root ClassFullName plus the ClassFullNames of any additional
-	///     implementations: two mocks of the same root with different additional interfaces produce
-	///     different generated files, so the per-mock incremental cache must distinguish them.
+	///     MockClass equality is keyed on <see cref="Class.ClassFullName" /> plus a content-derived
+	///     hash that folds the base surface together with the mock-only fields
+	///     (<see cref="AdditionalImplementations" />, <see cref="Constructors" />,
+	///     <see cref="Delegate" />). Two mocks of the same root with different additional
+	///     interfaces, different constructor surfaces, or different delegate signatures must hash
+	///     apart so Roslyn's incremental cache invalidates when any of those change.
 	/// </summary>
 	public bool Equals(MockClass? other)
 		=> ReferenceEquals(this, other) ||
 		   (other is not null &&
-		    ClassFullName == other.ClassFullName &&
-		    AdditionalImplementationsEqual(AdditionalImplementations, other.AdditionalImplementations));
+		    _mockSurfaceHash == other._mockSurfaceHash &&
+		    ClassFullName == other.ClassFullName);
 
 	public IEnumerable<Class> AllImplementations()
 	{
@@ -55,47 +62,22 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 
 	public override bool Equals(object? obj) => Equals(obj as MockClass);
 
-	public override int GetHashCode()
+	public override int GetHashCode() => _mockSurfaceHash;
+
+	private int ComputeMockSurfaceHash()
 	{
-		int hash = ClassFullName.GetHashCode();
-		Class[]? additional = AdditionalImplementations.AsArray();
-		if (additional is null)
+		int hash = base.GetHashCode();
+		hash = unchecked((hash * 17) + AdditionalImplementations.GetHashCode());
+		if (Constructors is { } constructors)
 		{
-			return hash;
+			hash = unchecked((hash * 17) + constructors.GetHashCode());
 		}
 
-		int multiplier = 17;
-		foreach (Class c in additional)
+		if (Delegate is { } @delegate)
 		{
-			hash = unchecked(hash + (c.ClassFullName.GetHashCode() * multiplier));
-			multiplier *= 17;
+			hash = unchecked((hash * 17) + @delegate.GetHashCode());
 		}
 
 		return hash;
-	}
-
-	private static bool AdditionalImplementationsEqual(EquatableArray<Class> left, EquatableArray<Class> right)
-	{
-		if (left.Count != right.Count)
-		{
-			return false;
-		}
-
-		Class[]? leftArray = left.AsArray();
-		Class[]? rightArray = right.AsArray();
-		if (leftArray is null || rightArray is null)
-		{
-			return leftArray is null && rightArray is null;
-		}
-
-		for (int i = 0; i < leftArray.Length; i++)
-		{
-			if (leftArray[i].ClassFullName != rightArray[i].ClassFullName)
-			{
-				return false;
-			}
-		}
-
-		return true;
 	}
 }

--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -35,6 +35,15 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 
 	public EquatableArray<Class> AdditionalImplementations { get; }
 
+	public IEnumerable<Class> AllImplementations()
+	{
+		yield return this;
+		foreach (Class additionalImplementation in AdditionalImplementations)
+		{
+			yield return additionalImplementation;
+		}
+	}
+
 	/// <summary>
 	///     MockClass equality is keyed on <see cref="Class.ClassFullName" /> plus a content-derived
 	///     hash that folds the base surface together with the mock-only fields
@@ -48,15 +57,6 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 		   (other is not null &&
 		    _mockSurfaceHash == other._mockSurfaceHash &&
 		    ClassFullName == other.ClassFullName);
-
-	public IEnumerable<Class> AllImplementations()
-	{
-		yield return this;
-		foreach (Class additionalImplementation in AdditionalImplementations)
-		{
-			yield return additionalImplementation;
-		}
-	}
 
 	public override bool Equals(Class? other) => other is MockClass mc && Equals(mc);
 

--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -31,6 +31,17 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 
 	public EquatableArray<Class> AdditionalImplementations { get; }
 
+	/// <summary>
+	///     MockClass identity is the root ClassFullName plus the ClassFullNames of any additional
+	///     implementations: two mocks of the same root with different additional interfaces produce
+	///     different generated files, so the per-mock incremental cache must distinguish them.
+	/// </summary>
+	public bool Equals(MockClass? other)
+		=> ReferenceEquals(this, other) ||
+		   (other is not null &&
+		    ClassFullName == other.ClassFullName &&
+		    AdditionalImplementationsEqual(AdditionalImplementations, other.AdditionalImplementations));
+
 	public IEnumerable<Class> AllImplementations()
 	{
 		yield return this;
@@ -39,15 +50,6 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 			yield return additionalImplementation;
 		}
 	}
-
-	// MockClass identity is the root ClassFullName plus the ClassFullNames of any additional
-	// implementations: two mocks of the same root with different additional interfaces produce
-	// different generated files, so the per-mock incremental cache must distinguish them.
-	public bool Equals(MockClass? other)
-		=> ReferenceEquals(this, other) ||
-		   (other is not null &&
-		    ClassFullName == other.ClassFullName &&
-		    AdditionalImplementationsEqual(AdditionalImplementations, other.AdditionalImplementations));
 
 	public override bool Equals(Class? other) => other is MockClass mc && Equals(mc);
 
@@ -65,7 +67,7 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 		int multiplier = 17;
 		foreach (Class c in additional)
 		{
-			hash = unchecked(hash + c.ClassFullName.GetHashCode() * multiplier);
+			hash = unchecked(hash + (c.ClassFullName.GetHashCode() * multiplier));
 			multiplier *= 17;
 		}
 

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -13,7 +13,7 @@ internal record Property
 		UseOverride = propertySymbol.IsVirtual || propertySymbol.IsAbstract;
 		string rawName = propertySymbol.ExplicitInterfaceImplementations.Length > 0 ? propertySymbol.ExplicitInterfaceImplementations[0].Name : propertySymbol.Name;
 		Name = propertySymbol.IsIndexer ? rawName : Helpers.EscapeIfKeyword(rawName);
-		Type = new Type(propertySymbol.Type);
+		Type = Type.From(propertySymbol.Type);
 		ContainingType = propertySymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
 		IsIndexer = propertySymbol.IsIndexer;
 		IsAbstract = propertySymbol.IsAbstract;
@@ -21,7 +21,7 @@ internal record Property
 		if (IsIndexer && propertySymbol.Parameters.Length > 0)
 		{
 			IndexerParameters = new EquatableArray<MethodParameter>(
-				propertySymbol.Parameters.Select(x => new MethodParameter(x)).ToArray());
+				propertySymbol.Parameters.Select(MethodParameter.From).ToArray());
 		}
 
 		Attributes = propertySymbol.GetAttributes().ToAttributeArray(sourceAssembly);

--- a/Source/Mockolate.SourceGenerators/Entities/Type.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Type.cs
@@ -11,6 +11,19 @@ internal record Type
 		DisplayName = fullname;
 	}
 
+	// Shared factory: route through the per-compilation cache (when one is on this thread's
+	// scope) so identical ITypeSymbol references reuse a single Type record.
+	internal static Type From(ITypeSymbol typeSymbol)
+	{
+		EntityCache? cache = EntityCache.Current;
+		if (cache is null)
+		{
+			return new Type(typeSymbol);
+		}
+
+		return cache.GetOrAddType(typeSymbol, static s => new Type(s));
+	}
+
 	internal Type(ITypeSymbol typeSymbol)
 	{
 		// Removes '*' from multi-dimensional array types
@@ -22,12 +35,12 @@ internal record Type
 			if (typeSymbol.IsTupleType)
 			{
 				TupleTypes = new EquatableArray<Type>(namedTypeSymbol.TupleElements
-					.Select(x => new Type(x.Type))
+					.Select(x => From(x.Type))
 					.ToArray());
 			}
 
 			GenericTypeParameters = new EquatableArray<Type>(namedTypeSymbol.TypeArguments
-				.Select(x => new Type(x))
+				.Select(From)
 				.ToArray());
 		}
 

--- a/Source/Mockolate.SourceGenerators/Entities/Type.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Type.cs
@@ -11,19 +11,6 @@ internal record Type
 		DisplayName = fullname;
 	}
 
-	// Shared factory: route through the per-compilation cache (when one is on this thread's
-	// scope) so identical ITypeSymbol references reuse a single Type record.
-	internal static Type From(ITypeSymbol typeSymbol)
-	{
-		EntityCache? cache = EntityCache.Current;
-		if (cache is null)
-		{
-			return new Type(typeSymbol);
-		}
-
-		return cache.GetOrAddType(typeSymbol, static s => new Type(s));
-	}
-
 	internal Type(ITypeSymbol typeSymbol)
 	{
 		// Removes '*' from multi-dimensional array types
@@ -73,6 +60,21 @@ internal record Type
 	public string Fullname { get; }
 
 	public string DisplayName { get; }
+
+	/// <summary>
+	///     Shared factory: route through the per-compilation cache (when one is on this thread's
+	///     scope) so identical ITypeSymbol references reuse a single Type record.
+	/// </summary>
+	internal static Type From(ITypeSymbol typeSymbol)
+	{
+		EntityCache? cache = EntityCache.Current;
+		if (cache is null)
+		{
+			return new Type(typeSymbol);
+		}
+
+		return cache.GetOrAddType(typeSymbol, static s => new Type(s));
+	}
 
 	private static bool IsIFormattable(ITypeSymbol typeSymbol)
 	{

--- a/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Mockolate.SourceGenerators.Entities;
+using Type = Mockolate.SourceGenerators.Entities.Type;
+
+namespace Mockolate.SourceGenerators.Internals;
+
+/// <summary>
+///     Per-compilation cache for symbol-keyed entity records. Roslyn returns canonical
+///     <see cref="ITypeSymbol" /> instances for the same type within one compilation, so
+///     deduplicating on symbol identity is sound and lets a generator build that touches the
+///     same shared types (<c>string</c>, <c>int</c>, <see cref="System.Threading.Tasks.Task" />,
+///     etc.) hundreds of times allocate the entity record only once.
+/// </summary>
+/// <remarks>
+///     Caches MUST NOT cross compilation boundaries — the symbols won't survive. The
+///     <see cref="ConditionalWeakTable{TKey,TValue}" /> guarantees the cache is collected when
+///     the <see cref="Compilation" /> is. Cache lookup is exposed through
+///     <see cref="EnterScope" /> so the existing entity constructors can stay parameter-stable.
+/// </remarks>
+internal sealed class EntityCache
+{
+	private static readonly ConditionalWeakTable<Compilation, EntityCache> _caches = new();
+
+	[ThreadStatic]
+	private static EntityCache? _current;
+
+	// IncludeNullability is essential — Default would treat `string` and `string?` as the same
+	// key, but the resulting Type/MethodParameter records carry different `CanBeNullable` /
+	// `IsNullableAnnotated` flags and produce different generated code.
+	private readonly ConcurrentDictionary<ITypeSymbol, Type> _types = new(SymbolEqualityComparer.IncludeNullability);
+	private readonly ConcurrentDictionary<IParameterSymbol, MethodParameter> _parameters = new(SymbolEqualityComparer.IncludeNullability);
+
+	public static EntityCache? Current => _current;
+
+	public static EntityCache GetOrCreate(Compilation compilation)
+		=> _caches.GetValue(compilation, static _ => new EntityCache());
+
+	public static Scope EnterScope(EntityCache cache)
+	{
+		EntityCache? previous = _current;
+		_current = cache;
+		return new Scope(previous);
+	}
+
+	public Type GetOrAddType(ITypeSymbol symbol, System.Func<ITypeSymbol, Type> factory)
+		=> _types.GetOrAdd(symbol, factory);
+
+	public MethodParameter GetOrAddParameter(IParameterSymbol symbol, System.Func<IParameterSymbol, MethodParameter> factory)
+		=> _parameters.GetOrAdd(symbol, factory);
+
+	public readonly struct Scope : System.IDisposable
+	{
+		private readonly EntityCache? _previous;
+
+		internal Scope(EntityCache? previous)
+		{
+			_previous = previous;
+		}
+
+		public void Dispose() => _current = _previous;
+	}
+}

--- a/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
@@ -23,34 +23,34 @@ internal sealed class EntityCache
 {
 	private static readonly ConditionalWeakTable<Compilation, EntityCache> _caches = new();
 
-	[ThreadStatic]
-	private static EntityCache? _current;
+	private readonly ConcurrentDictionary<IParameterSymbol, MethodParameter> _parameters = new(SymbolEqualityComparer.IncludeNullability);
 
 	// IncludeNullability is essential — Default would treat `string` and `string?` as the same
 	// key, but the resulting Type/MethodParameter records carry different `CanBeNullable` /
 	// `IsNullableAnnotated` flags and produce different generated code.
 	private readonly ConcurrentDictionary<ITypeSymbol, Type> _types = new(SymbolEqualityComparer.IncludeNullability);
-	private readonly ConcurrentDictionary<IParameterSymbol, MethodParameter> _parameters = new(SymbolEqualityComparer.IncludeNullability);
 
-	public static EntityCache? Current => _current;
+	[field: ThreadStatic] public static EntityCache? Current { get; private set; }
 
 	public static EntityCache GetOrCreate(Compilation compilation)
 		=> _caches.GetValue(compilation, static _ => new EntityCache());
 
 	public static Scope EnterScope(EntityCache cache)
 	{
-		EntityCache? previous = _current;
-		_current = cache;
+		EntityCache? previous = Current;
+		Current = cache;
 		return new Scope(previous);
 	}
 
-	public Type GetOrAddType(ITypeSymbol symbol, System.Func<ITypeSymbol, Type> factory)
+	private static void ExitScope(EntityCache? previous) => Current = previous;
+
+	public Type GetOrAddType(ITypeSymbol symbol, Func<ITypeSymbol, Type> factory)
 		=> _types.GetOrAdd(symbol, factory);
 
-	public MethodParameter GetOrAddParameter(IParameterSymbol symbol, System.Func<IParameterSymbol, MethodParameter> factory)
+	public MethodParameter GetOrAddParameter(IParameterSymbol symbol, Func<IParameterSymbol, MethodParameter> factory)
 		=> _parameters.GetOrAdd(symbol, factory);
 
-	public readonly struct Scope : System.IDisposable
+	public readonly struct Scope : IDisposable
 	{
 		private readonly EntityCache? _previous;
 
@@ -59,6 +59,6 @@ internal sealed class EntityCache
 			_previous = previous;
 		}
 
-		public void Dispose() => _current = _previous;
+		public void Dispose() => ExitScope(_previous);
 	}
 }

--- a/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
@@ -42,8 +42,6 @@ internal sealed class EntityCache
 		return new Scope(previous);
 	}
 
-	private static void ExitScope(EntityCache? previous) => Current = previous;
-
 	public Type GetOrAddType(ITypeSymbol symbol, Func<ITypeSymbol, Type> factory)
 		=> _types.GetOrAdd(symbol, factory);
 
@@ -52,6 +50,8 @@ internal sealed class EntityCache
 
 	public readonly struct Scope : IDisposable
 	{
+		private static void ExitScope(EntityCache? previous) => Current = previous;
+		
 		private readonly EntityCache? _previous;
 
 		internal Scope(EntityCache? previous)

--- a/Source/Mockolate.SourceGenerators/Internals/IsExternalInit.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/IsExternalInit.cs
@@ -1,0 +1,8 @@
+// Shim required by C# 9's `init` accessor when targeting frameworks (netstandard2.0) that don't
+// define System.Runtime.CompilerServices.IsExternalInit. Lets the source generator project use
+// positional record syntax for cache-key value types.
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}

--- a/Source/Mockolate.SourceGenerators/Internals/IsExternalInit.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/IsExternalInit.cs
@@ -1,8 +1,17 @@
-// Shim required by C# 9's `init` accessor when targeting frameworks (netstandard2.0) that don't
-// define System.Runtime.CompilerServices.IsExternalInit. Lets the source generator project use
-// positional record syntax for cache-key value types.
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable
+// ReSharper disable once CheckNamespace
 namespace System.Runtime.CompilerServices;
 
-internal static class IsExternalInit
-{
-}
+/// <summary>
+///     Shim required by C# 9's `init` accessor when targeting frameworks (netstandard2.0) that don't
+///     define System.Runtime.CompilerServices.IsExternalInit. Lets the source generator project use
+///     positional record syntax for cache-key value types.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[DebuggerNonUserCode]
+internal static class IsExternalInit;
+
+#pragma warning restore

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -442,7 +442,9 @@ public class MockGenerator : IIncrementalGenerator
 		return new EquatableArray<NamedMock>(result.ToArray());
 
 		static string LookupName(Dictionary<string, string> map, Class @class)
-			=> map.TryGetValue(@class.ClassFullName, out string? v) ? v : "";
+		{
+			return map.TryGetValue(@class.ClassFullName, out string? v) ? v : "";
+		}
 	}
 
 	private static EquatableArray<MockAsExtensionPair> CollectAsExtensionPairs(EquatableArray<NamedMock> mocks)
@@ -524,6 +526,7 @@ public class MockGenerator : IIncrementalGenerator
 		{
 			additionalArr[i] = (additionalNamed[i].Name, additionalNamed[i].Class);
 		}
+
 		context.AddSource($"Mock.{fileName}.g.cs",
 			ToSource(Sources.Sources.MockCombinationClass(fileName, named.ParentName, @class, additionalArr)));
 	}
@@ -538,7 +541,10 @@ internal readonly record struct MethodSetupKey(int Arity, bool IsVoid);
 internal readonly record struct RefStructIndexerSetup(int Arity, bool HasGetter, bool HasSetter);
 
 internal readonly record struct MockAsExtensionPair(
-	string SourceName, string SourceFullName, string OtherName, string OtherFullName)
+	string SourceName,
+	string SourceFullName,
+	string OtherName,
+	string OtherFullName)
 {
 	public static MockAsExtensionPair Create(string nameA, string fullNameA, string nameB, string fullNameB)
 		=> string.CompareOrdinal(nameA, nameB) <= 0
@@ -566,7 +572,7 @@ internal sealed class RefStructAggregate : IEquatable<RefStructAggregate>
 
 	public override bool Equals(object? obj) => Equals(obj as RefStructAggregate);
 
-	public override int GetHashCode() => unchecked(MethodSetups.GetHashCode() * 17 + IndexerSetups.GetHashCode());
+	public override int GetHashCode() => unchecked((MethodSetups.GetHashCode() * 17) + IndexerSetups.GetHashCode());
 }
 
 internal readonly record struct NamedClass(string Name, Class Class);
@@ -621,11 +627,11 @@ internal sealed class NamedMock : IEquatable<NamedMock>
 	public override int GetHashCode()
 	{
 		int hash = FileName.GetHashCode();
-		hash = unchecked(hash * 17 + ParentName.GetHashCode());
-		hash = unchecked(hash * 17 + Mock.GetHashCode());
+		hash = unchecked((hash * 17) + ParentName.GetHashCode());
+		hash = unchecked((hash * 17) + Mock.GetHashCode());
 		if (AdditionalClasses is { } additional)
 		{
-			hash = unchecked(hash * 17 + additional.GetHashCode());
+			hash = unchecked((hash * 17) + additional.GetHashCode());
 		}
 
 		return hash;

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Mockolate.SourceGenerators.Entities;
+using Mockolate.SourceGenerators.Internals;
 using Type = Mockolate.SourceGenerators.Entities.Type;
 
 namespace Mockolate.SourceGenerators;
@@ -19,18 +20,136 @@ public class MockGenerator : IIncrementalGenerator
 			"Mock.g.cs",
 			ToSource(Sources.Sources.MockClass())));
 
-		IncrementalValueProvider<ImmutableArray<MockClass>> expectationsToRegister = context.SyntaxProvider
+		// Per-mock stream. Equality on MockClass is now keyed only on its canonical identity
+		// (ClassFullName + AdditionalImplementations.ClassFullName), so Roslyn can correctly skip
+		// per-mock outputs when the same mock identity is rediscovered across edits.
+		IncrementalValuesProvider<MockClass> mocksProvider = context.SyntaxProvider
 			.CreateSyntaxProvider(
 				static (s, _) => s.IsCreateMethodInvocation(),
-				(ctx, _) => ctx.Node.ExtractMockOrMockFactoryCreateSyntaxOrDefault(ctx.SemanticModel))
-			.SelectMany(static (mocks, _) => mocks)
-			.Collect();
+				static (ctx, _) =>
+				{
+					// Set the per-compilation EntityCache as ambient state for this transform
+					// invocation so Type / MethodParameter constructors deduplicate identical
+					// ITypeSymbol references against an already-built record. Materialize the
+					// IEnumerable inside the using scope; the cache scope unwinds on return.
+					EntityCache cache = EntityCache.GetOrCreate(ctx.SemanticModel.Compilation);
+					using EntityCache.Scope scope = EntityCache.EnterScope(cache);
+					return ctx.Node
+						.ExtractMockOrMockFactoryCreateSyntaxOrDefault(ctx.SemanticModel)
+						.ToArray();
+				})
+			.SelectMany(static (mocks, _) => mocks);
+
+		// Stable, deduplicated, sorted view across all mocks. Used by every cross-mock stage
+		// (naming, aggregate setup files). Sorting by ClassFullName makes the array's content
+		// deterministic so downstream Select stages cache cleanly.
+		IncrementalValueProvider<EquatableArray<MockClass>> collectedMocks = mocksProvider
+			.Collect()
+			.Select(static (mocks, _) => Distinct(mocks));
 
 		IncrementalValueProvider<bool> hasOverloadResolutionPriority = context.CompilationProvider
-			.Select(static (compilation, _) => HasAttribute(compilation, "System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute"));
+			.Select(static (compilation, _) => HasAttribute(compilation,
+				"System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute"));
 
-		context.RegisterSourceOutput(expectationsToRegister.Combine(hasOverloadResolutionPriority),
-			(spc, source) => Execute([..source.Left.Distinct(),], source.Right, spc));
+		// Naming step: cross-mock disambiguation. Cached as a unit; one NamedMock per emission.
+		IncrementalValueProvider<EquatableArray<NamedMock>> namedMocksAggregate = collectedMocks
+			.Select(static (arr, _) => CreateNamedMocks(arr));
+
+		IncrementalValuesProvider<NamedMock> perMock = namedMocksAggregate
+			.SelectMany(static (arr, _) => arr);
+
+		// Per-mock source output: cache hit when the NamedMock is identity-equal to last run.
+		context.RegisterSourceOutput(
+			perMock.Combine(hasOverloadResolutionPriority),
+			static (spc, source) => EmitMockFile(spc, source.Left, source.Right));
+
+		// As<T> bridge extensions across (a, b) pairs. Cross-mock dedup; one file.
+		IncrementalValueProvider<EquatableArray<MockAsExtensionPair>> asPairs = namedMocksAggregate
+			.Select(static (arr, _) => CollectAsExtensionPairs(arr));
+
+		context.RegisterSourceOutput(asPairs, static (spc, pairs) =>
+		{
+			if (pairs.Count > 0)
+			{
+				spc.AddSource("Mock.AsExtensions.g.cs",
+					ToSource(Sources.Sources.MockAsExtensions(pairs)));
+			}
+		});
+
+		// Aggregate inputs derived from per-mock projections — each aggregate caches independently.
+		IncrementalValueProvider<EquatableArray<int>> indexerSetupArities = collectedMocks
+			.Select(static (arr, _) => CollectIndexerSetupArities(arr));
+
+		context.RegisterSourceOutput(indexerSetupArities, static (spc, arities) =>
+		{
+			if (arities.Count > 0)
+			{
+				spc.AddSource("IndexerSetups.g.cs",
+					ToSource(Sources.Sources.IndexerSetups(ToHashSet(arities))));
+			}
+		});
+
+		IncrementalValueProvider<EquatableArray<MethodSetupKey>> methodSetupKeys = collectedMocks
+			.Select(static (arr, _) => CollectMethodSetupKeys(arr));
+
+		context.RegisterSourceOutput(methodSetupKeys, static (spc, keys) =>
+		{
+			if (keys.Count == 0)
+			{
+				return;
+			}
+
+			HashSet<(int, bool)> set = ToMethodSetupHashSet(keys);
+			spc.AddSource("MethodSetups.g.cs", ToSource(Sources.Sources.MethodSetups(set)));
+
+			const int dotNetFuncActionParameterLimit = 16;
+			if (set.Any(x => x.Item1 >= dotNetFuncActionParameterLimit))
+			{
+				spc.AddSource("ActionFunc.g.cs",
+					ToSource(Sources.Sources.ActionFunc(set
+						.Where(x => x.Item1 >= dotNetFuncActionParameterLimit)
+						.SelectMany<(int, bool), int>(x => [x.Item1, x.Item1 + 1,])
+						.Where(x => x > dotNetFuncActionParameterLimit)
+						.Distinct())));
+			}
+
+			if (set.Any(x => !x.Item2))
+			{
+				spc.AddSource("ReturnsThrowsAsyncExtensions.g.cs",
+					ToSource(Sources.Sources.ReturnsThrowsAsyncExtensions(set
+						.Where(x => !x.Item2).Select(x => x.Item1).ToArray())));
+			}
+		});
+
+		IncrementalValueProvider<RefStructAggregate> refStructAggregate = collectedMocks
+			.Select(static (arr, _) => CollectRefStructAggregate(arr));
+
+		context.RegisterSourceOutput(refStructAggregate, static (spc, agg) =>
+		{
+			if (agg.MethodSetups.Count == 0 && agg.IndexerSetups.Count == 0)
+			{
+				return;
+			}
+
+			HashSet<(int, bool)> methodSet = ToMethodSetupHashSet(agg.MethodSetups);
+			Dictionary<int, (bool HasGetter, bool HasSetter)> indexerArities = new();
+			foreach (RefStructIndexerSetup item in agg.IndexerSetups)
+			{
+				indexerArities[item.Arity] = (item.HasGetter, item.HasSetter);
+			}
+
+			spc.AddSource("RefStructMethodSetups.g.cs",
+				ToSource(Sources.Sources.RefStructMethodSetups(methodSet, indexerArities)));
+		});
+
+		// MockBehaviorExtensions: only depends on whether HttpClient appears as a mock target.
+		// Reduce to a bool so the aggregate cache holds across mock-set churn that doesn't toggle it.
+		IncrementalValueProvider<bool> includeHttpClient = collectedMocks
+			.Select(static (arr, _) => arr.AsArray()?.Any(m => m.ClassFullName == "global::System.Net.Http.HttpClient") ?? false);
+
+		context.RegisterSourceOutput(includeHttpClient, static (spc, hasHttp) =>
+			spc.AddSource("MockBehaviorExtensions.g.cs",
+				ToSource(Sources.Sources.MockBehaviorExtensions(hasHttp))));
 
 		static bool HasAttribute(Compilation c, string attributeName)
 		{
@@ -45,175 +164,470 @@ public class MockGenerator : IIncrementalGenerator
 	private static SourceText ToSource(string source)
 		=> SourceText.From(Sources.Sources.ExpandCrefs(source), Encoding.UTF8);
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
-	private static void Execute(ImmutableArray<MockClass> mocksToGenerate, bool hasOverloadResolutionPriority, SourceProductionContext context)
+	private static EquatableArray<MockClass> Distinct(ImmutableArray<MockClass> mocks)
 	{
-		IEnumerable<(string FileName, string Name, Class Class, (string Name, Class Class)[]? AdditionalClasses)> namedMocksToGenerate = CreateNames(mocksToGenerate);
-
-		HashSet<(string, string)> combinationSet = new();
-		foreach ((string FileName, string Name, Class Class, (string Name, Class Class)[]? AdditionalClasses) mockToGenerate in namedMocksToGenerate)
+		if (mocks.IsDefaultOrEmpty)
 		{
-			if (mockToGenerate.Class is MockClass { Delegate: not null, } mockClass)
+			return new EquatableArray<MockClass>([]);
+		}
+
+		HashSet<MockClass> seen = new();
+		List<MockClass> distinct = new(mocks.Length);
+		foreach (MockClass mc in mocks)
+		{
+			if (seen.Add(mc))
 			{
-				context.AddSource($"Mock.{mockToGenerate.FileName}.g.cs",
-					ToSource(Sources.Sources.MockDelegate(mockToGenerate.Name, mockClass, mockClass.Delegate)));
-			}
-			else if (mockToGenerate.AdditionalClasses is null)
-			{
-				context.AddSource($"Mock.{mockToGenerate.FileName}.g.cs",
-					ToSource(Sources.Sources.MockClass(mockToGenerate.Name, mockToGenerate.Class, hasOverloadResolutionPriority)));
-			}
-			else
-			{
-				context.AddSource($"Mock.{mockToGenerate.FileName}.g.cs",
-					ToSource(Sources.Sources.MockCombinationClass(mockToGenerate.FileName, mockToGenerate.Name, mockToGenerate.Class, mockToGenerate.AdditionalClasses, combinationSet)));
+				distinct.Add(mc);
 			}
 		}
 
-		HashSet<int> indexerSetups = new();
-		foreach (int item in mocksToGenerate
-			         .SelectMany(m => m.AllProperties())
-			         .Where(m => m.IndexerParameters?.Count > 4)
-			         .Select(m => m.IndexerParameters!.Value.Count))
+		distinct.Sort(static (a, b) =>
 		{
-			indexerSetups.Add(item);
-		}
-
-		if (indexerSetups.Any())
-		{
-			context.AddSource("IndexerSetups.g.cs",
-				ToSource(Sources.Sources.IndexerSetups(indexerSetups)));
-		}
-
-		HashSet<(int, bool)> methodSetups = new();
-		foreach ((int Count, bool) item in mocksToGenerate
-			         .SelectMany(m => m.AllMethods())
-			         .Where(m => m.Parameters.Count > 4)
-			         .Select(m => (m.Parameters.Count, m.ReturnType == Type.Void)))
-		{
-			methodSetups.Add(item);
-		}
-
-		if (methodSetups.Any())
-		{
-			context.AddSource("MethodSetups.g.cs",
-				ToSource(Sources.Sources.MethodSetups(methodSetups)));
-		}
-
-		const int dotNetFuncActionParameterLimit = 16;
-		if (methodSetups.Any(x => x.Item1 >= dotNetFuncActionParameterLimit))
-		{
-			context.AddSource("ActionFunc.g.cs",
-				ToSource(Sources.Sources.ActionFunc(methodSetups
-					.Where(x => x.Item1 >= dotNetFuncActionParameterLimit)
-					.SelectMany<(int, bool), int>(x => [x.Item1, x.Item1 + 1,])
-					.Where(x => x > dotNetFuncActionParameterLimit)
-					.Distinct())));
-		}
-
-		if (methodSetups.Any(x => !x.Item2))
-		{
-			context.AddSource("ReturnsThrowsAsyncExtensions.g.cs",
-				ToSource(Sources.Sources.ReturnsThrowsAsyncExtensions(methodSetups
-					.Where(x => !x.Item2).Select(x => x.Item1).ToArray())));
-		}
-
-		// Ref-struct method setups for arity > 4. The hand-written types in
-		// Source/Mockolate/Setup/RefStruct{Void,Return}MethodSetup.cs cover arities 1-4; the
-		// generator mirrors the same shape for arity 5+.
-		HashSet<(int, bool)> refStructMethodSetups = new();
-		foreach ((int Count, bool) item in mocksToGenerate
-			         .SelectMany(m => m.AllMethods())
-			         .Where(m => m.Parameters.Count > 4 &&
-			                     m.Parameters.Any(p => p.NeedsRefStructPipeline()))
-			         .Select(m => (m.Parameters.Count, m.ReturnType == Type.Void)))
-		{
-			refStructMethodSetups.Add(item);
-		}
-
-		// Ref-struct-keyed indexer setups for arity > 4. Same split as methods: arities 1-4 are
-		// hand-written; arity 5+ is generator-emitted. Per arity we track whether the getter,
-		// setter, or both accessors need to be emitted — a single mock source may declare
-		// indexers with different accessor combinations at the same arity.
-		Dictionary<int, (bool HasGetter, bool HasSetter)> refStructIndexerArities = new();
-		foreach (Property indexer in mocksToGenerate
-			         .SelectMany(m => m.AllProperties())
-			         .Where(p => p is { IsIndexer: true, IndexerParameters: not null, } &&
-			                     p.IndexerParameters.Value.Count > 4 &&
-			                     p.IndexerParameters.Value.Any(kp => kp.NeedsRefStructPipeline())))
-		{
-			int arity = indexer.IndexerParameters!.Value.Count;
-			bool hasGetter = indexer.Getter is not null;
-			bool hasSetter = indexer.Setter is not null;
-			if (refStructIndexerArities.TryGetValue(arity, out (bool, bool) existing))
+			int cmp = StringComparer.Ordinal.Compare(a.ClassFullName, b.ClassFullName);
+			if (cmp != 0)
 			{
-				refStructIndexerArities[arity] = (existing.Item1 || hasGetter, existing.Item2 || hasSetter);
+				return cmp;
 			}
-			else
+
+			Class[]? aAdds = a.AdditionalImplementations.AsArray();
+			Class[]? bAdds = b.AdditionalImplementations.AsArray();
+			int aLen = aAdds?.Length ?? 0;
+			int bLen = bAdds?.Length ?? 0;
+			cmp = aLen.CompareTo(bLen);
+			if (cmp != 0 || aAdds is null || bAdds is null)
 			{
-				refStructIndexerArities[arity] = (hasGetter, hasSetter);
+				return cmp;
 			}
-		}
 
-		if (refStructMethodSetups.Any() || refStructIndexerArities.Any())
-		{
-			context.AddSource("RefStructMethodSetups.g.cs",
-				ToSource(Sources.Sources.RefStructMethodSetups(refStructMethodSetups, refStructIndexerArities)));
-		}
+			for (int i = 0; i < aLen; i++)
+			{
+				cmp = StringComparer.Ordinal.Compare(aAdds[i].ClassFullName, bAdds[i].ClassFullName);
+				if (cmp != 0)
+				{
+					return cmp;
+				}
+			}
 
-		context.AddSource("MockBehaviorExtensions.g.cs",
-			ToSource(Sources.Sources.MockBehaviorExtensions(mocksToGenerate)));
+			return 0;
+		});
+
+		return new EquatableArray<MockClass>(distinct.ToArray());
 	}
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
-	private static IEnumerable<(string FileName, string Name, Class Class, (string Name, Class Class)[]? AdditionalClasses)> CreateNames(ImmutableArray<MockClass> mocksToGenerate)
+	private static HashSet<int> ToHashSet(EquatableArray<int> arities)
 	{
+		HashSet<int> set = new();
+		int[]? arr = arities.AsArray();
+		if (arr is null)
+		{
+			return set;
+		}
+
+		foreach (int item in arr)
+		{
+			set.Add(item);
+		}
+
+		return set;
+	}
+
+	private static HashSet<(int, bool)> ToMethodSetupHashSet(EquatableArray<MethodSetupKey> keys)
+	{
+		HashSet<(int, bool)> set = new();
+		MethodSetupKey[]? arr = keys.AsArray();
+		if (arr is null)
+		{
+			return set;
+		}
+
+		foreach (MethodSetupKey item in arr)
+		{
+			set.Add((item.Arity, item.IsVoid));
+		}
+
+		return set;
+	}
+
+	private static EquatableArray<int> CollectIndexerSetupArities(EquatableArray<MockClass> mocks)
+	{
+		MockClass[]? arr = mocks.AsArray();
+		if (arr is null)
+		{
+			return new EquatableArray<int>([]);
+		}
+
+		HashSet<int> set = new();
+		foreach (MockClass mc in arr)
+		{
+			foreach (Property property in mc.AllProperties())
+			{
+				if (property.IndexerParameters?.Count > 4)
+				{
+					set.Add(property.IndexerParameters.Value.Count);
+				}
+			}
+		}
+
+		int[] sorted = set.ToArray();
+		Array.Sort(sorted);
+		return new EquatableArray<int>(sorted);
+	}
+
+	private static EquatableArray<MethodSetupKey> CollectMethodSetupKeys(EquatableArray<MockClass> mocks)
+	{
+		MockClass[]? arr = mocks.AsArray();
+		if (arr is null)
+		{
+			return new EquatableArray<MethodSetupKey>([]);
+		}
+
+		HashSet<MethodSetupKey> set = new();
+		foreach (MockClass mc in arr)
+		{
+			foreach (Method m in mc.AllMethods())
+			{
+				if (m.Parameters.Count > 4)
+				{
+					set.Add(new MethodSetupKey(m.Parameters.Count, m.ReturnType == Type.Void));
+				}
+			}
+		}
+
+		MethodSetupKey[] sorted = set.ToArray();
+		Array.Sort(sorted, static (a, b) =>
+		{
+			int cmp = a.Arity.CompareTo(b.Arity);
+			if (cmp != 0)
+			{
+				return cmp;
+			}
+
+			return a.IsVoid.CompareTo(b.IsVoid);
+		});
+		return new EquatableArray<MethodSetupKey>(sorted);
+	}
+
+	private static RefStructAggregate CollectRefStructAggregate(EquatableArray<MockClass> mocks)
+	{
+		MockClass[]? arr = mocks.AsArray();
+		if (arr is null)
+		{
+			return new RefStructAggregate(
+				new EquatableArray<MethodSetupKey>([]),
+				new EquatableArray<RefStructIndexerSetup>([]));
+		}
+
+		HashSet<MethodSetupKey> methods = new();
+		Dictionary<int, (bool HasGetter, bool HasSetter)> indexerMap = new();
+		foreach (MockClass mc in arr)
+		{
+			foreach (Method m in mc.AllMethods())
+			{
+				if (m.Parameters.Count > 4 && m.Parameters.Any(p => p.NeedsRefStructPipeline()))
+				{
+					methods.Add(new MethodSetupKey(m.Parameters.Count, m.ReturnType == Type.Void));
+				}
+			}
+
+			foreach (Property indexer in mc.AllProperties())
+			{
+				if (indexer is { IsIndexer: true, IndexerParameters: not null, } &&
+				    indexer.IndexerParameters.Value.Count > 4 &&
+				    indexer.IndexerParameters.Value.Any(kp => kp.NeedsRefStructPipeline()))
+				{
+					int arity = indexer.IndexerParameters.Value.Count;
+					bool hasGetter = indexer.Getter is not null;
+					bool hasSetter = indexer.Setter is not null;
+					if (indexerMap.TryGetValue(arity, out (bool, bool) existing))
+					{
+						indexerMap[arity] = (existing.Item1 || hasGetter, existing.Item2 || hasSetter);
+					}
+					else
+					{
+						indexerMap[arity] = (hasGetter, hasSetter);
+					}
+				}
+			}
+		}
+
+		MethodSetupKey[] methodArr = methods.ToArray();
+		Array.Sort(methodArr, static (a, b) =>
+		{
+			int cmp = a.Arity.CompareTo(b.Arity);
+			if (cmp != 0)
+			{
+				return cmp;
+			}
+
+			return a.IsVoid.CompareTo(b.IsVoid);
+		});
+
+		RefStructIndexerSetup[] indexerArr = indexerMap
+			.OrderBy(kvp => kvp.Key)
+			.Select(kvp => new RefStructIndexerSetup(kvp.Key, kvp.Value.HasGetter, kvp.Value.HasSetter))
+			.ToArray();
+
+		return new RefStructAggregate(
+			new EquatableArray<MethodSetupKey>(methodArr),
+			new EquatableArray<RefStructIndexerSetup>(indexerArr));
+	}
+
+	private static EquatableArray<NamedMock> CreateNamedMocks(EquatableArray<MockClass> mocks)
+	{
+		MockClass[]? arr = mocks.AsArray();
+		if (arr is null || arr.Length == 0)
+		{
+			return new EquatableArray<NamedMock>([]);
+		}
+
 		HashSet<string> classNames = new(StringComparer.OrdinalIgnoreCase);
-		Dictionary<Class, string> baseClassNames = new(Class.EqualityComparer);
-		foreach (Class @class in mocksToGenerate.Where(IsValidMockDeclaration).SelectMany(x => x.AllImplementations()).Distinct(Class.EqualityComparer))
+		Dictionary<string, string> baseClassNames = new(StringComparer.Ordinal);
+		List<NamedMock> result = new(arr.Length);
+		HashSet<string> seenBaseClasses = new(StringComparer.Ordinal);
+
+		// Pass 1: assign disambiguated names to every distinct base/additional class. The order
+		// here must be deterministic so the same input set always yields the same names.
+		foreach (MockClass mc in arr)
 		{
-			string name = @class.GetClassNameWithoutDots();
+			if (!IsValidMockDeclaration(mc))
+			{
+				continue;
+			}
+
+			foreach (Class @class in mc.AllImplementations())
+			{
+				if (!seenBaseClasses.Add(@class.ClassFullName))
+				{
+					continue;
+				}
+
+				string baseName = @class.GetClassNameWithoutDots();
+				int suffix = 1;
+				string actualName = baseName;
+				while (!classNames.Add(actualName))
+				{
+					actualName = $"{baseName}_{suffix++}";
+				}
+
+				baseClassNames[@class.ClassFullName] = actualName;
+				result.Add(new NamedMock(actualName, actualName, @class, null));
+			}
+		}
+
+		// Pass 2: combination mocks (additional implementations).
+		foreach (MockClass mc in arr)
+		{
+			if (!IsValidMockDeclaration(mc) || mc.AdditionalImplementations.Count == 0)
+			{
+				continue;
+			}
+
+			string parentBaseName = mc.GetClassNameWithoutDots();
+			string combinedName = parentBaseName + "__" +
+			                      string.Join("__", mc.AdditionalImplementations.Select(t => t.GetClassNameWithoutDots()));
 			int suffix = 1;
-			string actualName = name;
+			string actualName = combinedName;
 			while (!classNames.Add(actualName))
 			{
-				actualName = $"{name}_{suffix++}";
+				actualName = $"{combinedName}_{suffix++}";
 			}
 
-			baseClassNames.Add(@class, actualName);
-			yield return (actualName, actualName, @class, null);
+			NamedClass[] additionalNamed = mc.AdditionalImplementations
+				.Select(additional => new NamedClass(LookupName(baseClassNames, additional), additional))
+				.ToArray();
+
+			result.Add(new NamedMock(actualName, LookupName(baseClassNames, mc), mc, new EquatableArray<NamedClass>(additionalNamed)));
 		}
 
-		foreach (MockClass mockClass in mocksToGenerate.Where(IsValidMockDeclaration).Where(x => x.AdditionalImplementations.Any()))
+		return new EquatableArray<NamedMock>(result.ToArray());
+
+		static string LookupName(Dictionary<string, string> map, Class @class)
+			=> map.TryGetValue(@class.ClassFullName, out string? v) ? v : "";
+	}
+
+	private static EquatableArray<MockAsExtensionPair> CollectAsExtensionPairs(EquatableArray<NamedMock> mocks)
+	{
+		NamedMock[]? arr = mocks.AsArray();
+		if (arr is null)
 		{
-			string name = mockClass.GetClassNameWithoutDots() + "__" +
-			              string.Join("__", mockClass.AdditionalImplementations.Select(t => t.GetClassNameWithoutDots()));
-
-			int suffix = 1;
-			string actualName = name;
-			while (!classNames.Add(actualName))
-			{
-				actualName = $"{name}_{suffix++}";
-			}
-
-			yield return (actualName, GetValueOrDefault(baseClassNames, mockClass), mockClass, [
-				..mockClass.AdditionalImplementations
-					.Select(additional => (GetValueOrDefault(baseClassNames, additional), additional)),
-			]);
+			return new EquatableArray<MockAsExtensionPair>([]);
 		}
 
-		static string GetValueOrDefault(Dictionary<Class, string> dictionary, Class key)
+		HashSet<MockAsExtensionPair> seen = new();
+		List<MockAsExtensionPair> ordered = new();
+		foreach (NamedMock nm in arr)
 		{
-			if (dictionary.TryGetValue(key, out string? value))
+			if (nm.AdditionalClasses is not { } additional || additional.Count == 0)
 			{
-				return value;
+				continue;
 			}
 
-			return "";
+			NamedClass[]? additionalArr = additional.AsArray();
+			if (additionalArr is null || additionalArr.Length == 0)
+			{
+				continue;
+			}
+
+			NamedClass last = additionalArr[additionalArr.Length - 1];
+
+			AddIfNew(seen, ordered, MockAsExtensionPair.Create(nm.ParentName, nm.Mock.ClassFullName, last.Name, last.Class.ClassFullName));
+			for (int i = 0; i < additionalArr.Length - 1; i++)
+			{
+				AddIfNew(seen, ordered, MockAsExtensionPair.Create(additionalArr[i].Name, additionalArr[i].Class.ClassFullName, last.Name, last.Class.ClassFullName));
+			}
 		}
+
+		MockAsExtensionPair[] sorted = ordered.ToArray();
+		Array.Sort(sorted, static (a, b) =>
+		{
+			int cmp = StringComparer.Ordinal.Compare(a.SourceName, b.SourceName);
+			if (cmp != 0)
+			{
+				return cmp;
+			}
+
+			return StringComparer.Ordinal.Compare(a.OtherName, b.OtherName);
+		});
+		return new EquatableArray<MockAsExtensionPair>(sorted);
+
+		static void AddIfNew(HashSet<MockAsExtensionPair> set, List<MockAsExtensionPair> list, MockAsExtensionPair pair)
+		{
+			if (set.Add(pair))
+			{
+				list.Add(pair);
+			}
+		}
+	}
+
+	private static void EmitMockFile(SourceProductionContext context, NamedMock named, bool hasOverloadResolutionPriority)
+	{
+		string fileName = named.FileName;
+		Class @class = named.Mock;
+
+		if (@class is MockClass { Delegate: not null, } mockClass)
+		{
+			context.AddSource($"Mock.{fileName}.g.cs",
+				ToSource(Sources.Sources.MockDelegate(named.ParentName, mockClass, mockClass.Delegate)));
+			return;
+		}
+
+		if (named.AdditionalClasses is not { } additional || additional.Count == 0)
+		{
+			context.AddSource($"Mock.{fileName}.g.cs",
+				ToSource(Sources.Sources.MockClass(named.ParentName, @class, hasOverloadResolutionPriority)));
+			return;
+		}
+
+		NamedClass[] additionalNamed = additional.AsArray() ?? [];
+		(string Name, Class Class)[] additionalArr = new (string Name, Class Class)[additionalNamed.Length];
+		for (int i = 0; i < additionalNamed.Length; i++)
+		{
+			additionalArr[i] = (additionalNamed[i].Name, additionalNamed[i].Class);
+		}
+		context.AddSource($"Mock.{fileName}.g.cs",
+			ToSource(Sources.Sources.MockCombinationClass(fileName, named.ParentName, @class, additionalArr)));
 	}
 
 	private static bool IsValidMockDeclaration(MockClass mockClass)
 		=> (mockClass.IsInterface || mockClass.Constructors is { Count: > 0, }) &&
 		   mockClass.AdditionalImplementations.All(x => x.IsInterface);
+}
+
+internal readonly record struct MethodSetupKey(int Arity, bool IsVoid);
+
+internal readonly record struct RefStructIndexerSetup(int Arity, bool HasGetter, bool HasSetter);
+
+internal readonly record struct MockAsExtensionPair(
+	string SourceName, string SourceFullName, string OtherName, string OtherFullName)
+{
+	public static MockAsExtensionPair Create(string nameA, string fullNameA, string nameB, string fullNameB)
+		=> string.CompareOrdinal(nameA, nameB) <= 0
+			? new MockAsExtensionPair(nameA, fullNameA, nameB, fullNameB)
+			: new MockAsExtensionPair(nameB, fullNameB, nameA, fullNameA);
+}
+
+internal sealed class RefStructAggregate : IEquatable<RefStructAggregate>
+{
+	public RefStructAggregate(
+		EquatableArray<MethodSetupKey> methodSetups,
+		EquatableArray<RefStructIndexerSetup> indexerSetups)
+	{
+		MethodSetups = methodSetups;
+		IndexerSetups = indexerSetups;
+	}
+
+	public EquatableArray<MethodSetupKey> MethodSetups { get; }
+	public EquatableArray<RefStructIndexerSetup> IndexerSetups { get; }
+
+	public bool Equals(RefStructAggregate? other)
+		=> other is not null &&
+		   MethodSetups.Equals(other.MethodSetups) &&
+		   IndexerSetups.Equals(other.IndexerSetups);
+
+	public override bool Equals(object? obj) => Equals(obj as RefStructAggregate);
+
+	public override int GetHashCode() => unchecked(MethodSetups.GetHashCode() * 17 + IndexerSetups.GetHashCode());
+}
+
+internal readonly record struct NamedClass(string Name, Class Class);
+
+internal sealed class NamedMock : IEquatable<NamedMock>
+{
+	public NamedMock(string fileName, string parentName, Class mock, EquatableArray<NamedClass>? additionalClasses)
+	{
+		FileName = fileName;
+		ParentName = parentName;
+		Mock = mock;
+		AdditionalClasses = additionalClasses;
+	}
+
+	public string FileName { get; }
+	public string ParentName { get; }
+	public Class Mock { get; }
+	public EquatableArray<NamedClass>? AdditionalClasses { get; }
+
+	public bool Equals(NamedMock? other)
+	{
+		if (other is null)
+		{
+			return false;
+		}
+
+		if (FileName != other.FileName || ParentName != other.ParentName)
+		{
+			return false;
+		}
+
+		if (!Mock.Equals(other.Mock))
+		{
+			return false;
+		}
+
+		if (AdditionalClasses is null)
+		{
+			return other.AdditionalClasses is null;
+		}
+
+		if (other.AdditionalClasses is null)
+		{
+			return false;
+		}
+
+		return AdditionalClasses.Value.Equals(other.AdditionalClasses.Value);
+	}
+
+	public override bool Equals(object? obj) => Equals(obj as NamedMock);
+
+	public override int GetHashCode()
+	{
+		int hash = FileName.GetHashCode();
+		hash = unchecked(hash * 17 + ParentName.GetHashCode());
+		hash = unchecked(hash * 17 + Mock.GetHashCode());
+		if (AdditionalClasses is { } additional)
+		{
+			hash = unchecked(hash * 17 + additional.GetHashCode());
+		}
+
+		return hash;
+	}
 }

--- a/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
+++ b/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
@@ -57,7 +57,6 @@ internal static class MockGeneratorHelpers
 		return symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().Any(IsImplementingMethod);
 	}
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	internal static IEnumerable<MockClass> ExtractMockOrMockFactoryCreateSyntaxOrDefault(
 		this SyntaxNode syntaxNode, SemanticModel semanticModel)
 	{
@@ -151,9 +150,7 @@ internal static class MockGeneratorHelpers
 			}
 		}
 	}
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	private static IEnumerable<MockClass> DiscoverMockableTypes(IEnumerable<ITypeSymbol> initialTypes,
 		IAssemblySymbol sourceAssembly)
 	{
@@ -182,7 +179,6 @@ internal static class MockGeneratorHelpers
 			}
 		}
 	}
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high
 
 	private static bool IsMockable([NotNullWhen(true)] ITypeSymbol? typeSymbol)
 		=> typeSymbol is

--- a/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
+++ b/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
@@ -22,10 +22,7 @@ internal static class MockGeneratorHelpers
 			case IdentifierNameSyntax { Identifier.ValueText: "CreateMock", }:
 				return true;
 			case GenericNameSyntax { Identifier.ValueText: "Implementing", }:
-				// `Implementing<T>` only fires inside a chain whose receiver is itself an
-				// invocation (T.CreateMock().Implementing<U>() or another Implementing<>() before
-				// it).
-				return memberAccess.Expression is InvocationExpressionSyntax;
+				return true;
 			default:
 				return false;
 		}

--- a/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
+++ b/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
@@ -24,10 +24,7 @@ internal static class MockGeneratorHelpers
 			case GenericNameSyntax { Identifier.ValueText: "Implementing", }:
 				// `Implementing<T>` only fires inside a chain whose receiver is itself an
 				// invocation (T.CreateMock().Implementing<U>() or another Implementing<>() before
-				// it). Skip the expensive semantic-model query in
-				// `ExtractMockOrMockFactoryCreateSyntaxOrDefault` for any unrelated user-defined
-				// `Implementing<>` whose receiver is a value, type, or member-access — those
-				// cannot be Mockolate calls.
+				// it).
 				return memberAccess.Expression is InvocationExpressionSyntax;
 			default:
 				return false;

--- a/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
+++ b/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
@@ -8,14 +8,31 @@ namespace Mockolate.SourceGenerators;
 internal static class MockGeneratorHelpers
 {
 	internal static bool IsCreateMethodInvocation(this SyntaxNode node)
-		=> node is InvocationExpressionSyntax
+	{
+		if (node is not InvocationExpressionSyntax
+		    {
+			    Expression: MemberAccessExpressionSyntax memberAccess,
+		    })
 		{
-			Expression: MemberAccessExpressionSyntax
-			{
-				Name: IdentifierNameSyntax { Identifier.ValueText: "CreateMock", }
-				or GenericNameSyntax { Identifier.ValueText: "Implementing", },
-			},
-		};
+			return false;
+		}
+
+		switch (memberAccess.Name)
+		{
+			case IdentifierNameSyntax { Identifier.ValueText: "CreateMock", }:
+				return true;
+			case GenericNameSyntax { Identifier.ValueText: "Implementing", }:
+				// `Implementing<T>` only fires inside a chain whose receiver is itself an
+				// invocation (T.CreateMock().Implementing<U>() or another Implementing<>() before
+				// it). Skip the expensive semantic-model query in
+				// `ExtractMockOrMockFactoryCreateSyntaxOrDefault` for any unrelated user-defined
+				// `Implementing<>` whose receiver is a value, type, or member-access — those
+				// cannot be Mockolate calls.
+				return memberAccess.Expression is InvocationExpressionSyntax;
+			default:
+				return false;
+		}
+	}
 
 	private static bool IsInGlobalMockolateNamespace(ISymbol symbol)
 		=> symbol.ContainingNamespace is { Name: "Mockolate", ContainingNamespace.IsGlobalNamespace: true, };

--- a/Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj
+++ b/Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj
@@ -8,6 +8,7 @@
 		<LangVersion>preview</LangVersion>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<NoWarn>S3776</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -846,7 +846,7 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t\treturn index >= 0 ? name.Substring(index + 1) : name;").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t}").AppendLine(); // close WithParameters
+		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		// WithParameterCollection inner class
@@ -941,7 +941,7 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t\treturn index >= 0 ? name.Substring(index + 1) : name;").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t}").AppendLine(); // close WithParameterCollection
+		sb.Append("\t\t}").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 	}
@@ -1523,7 +1523,7 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t\treturn index >= 0 ? name.Substring(index + 1) : name;").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t}").AppendLine(); // close WithParameters
+		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		// WithParameterCollection inner class
@@ -1618,7 +1618,7 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t\treturn index >= 0 ? name.Substring(index + 1) : name;").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t}").AppendLine(); // close WithParameterCollection
+		sb.Append("\t\t}").AppendLine();
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
 	}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MethodSetups.cs
@@ -2,7 +2,6 @@ using System.Text;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	public static string MethodSetups(HashSet<(int, bool)> methodSetups)
@@ -1623,4 +1622,3 @@ internal static partial class Sources
 		sb.AppendLine();
 	}
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.Mock.cs
@@ -2,7 +2,6 @@ using System.Text;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	/// <summary>
@@ -146,4 +145,3 @@ internal static partial class Sources
 		return sb.ToString();
 	}
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockAsExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockAsExtensions.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using Mockolate.SourceGenerators;
+
+namespace Mockolate.SourceGenerators.Sources;
+
+internal static partial class Sources
+{
+	/// <summary>
+	///     Emits the cross-interface <c>As&lt;T&gt;</c> bridge methods for every distinct unordered
+	///     pair of mock-extension class names that appears in any combination mock. Splitting these
+	///     out of <see cref="MockCombinationClass" /> lets the per-mock incremental output stay
+	///     stable when only the set of <c>As&lt;T&gt;</c> pairs changes, and avoids the duplicate
+	///     partial-method definitions that would otherwise occur if two combinations referenced the
+	///     same pair.
+	/// </summary>
+	public static string MockAsExtensions(IEnumerable<MockAsExtensionPair> pairs)
+	{
+		StringBuilder sb = InitializeBuilder();
+		sb.Append("#nullable enable annotations").AppendLine();
+		sb.Append("namespace Mockolate;").AppendLine();
+		sb.AppendLine();
+
+		foreach (MockAsExtensionPair pair in pairs)
+		{
+			AppendAsBridge(sb, pair.SourceName, pair.OtherName, pair.OtherFullName);
+			AppendAsBridge(sb, pair.OtherName, pair.SourceName, pair.SourceFullName);
+		}
+
+		return sb.ToString();
+	}
+
+	private static void AppendAsBridge(StringBuilder sb, string sourceName, string otherName, string otherFullName)
+	{
+		string escapedOtherName = otherFullName.EscapeForXmlDoc();
+		sb.Append("internal static partial class MockExtensionsFor").Append(otherName).AppendLine();
+		sb.Append("{").AppendLine();
+		sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(sourceName).Append(" mock)").AppendLine();
+		sb.Append("\t{").AppendLine();
+		sb.AppendXmlSummary($"Reinterprets this mock as a mock of <see cref=\"{escapedOtherName}\" /> to reach its Setup/Verify/Raise surface.");
+		sb.AppendXmlRemarks(
+			"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.");
+		sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{escapedOtherName}\" />.");
+		sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
+			$"The subject does not implement <see cref=\"{escapedOtherName}\" />.");
+		sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(otherName).Append(" As<T>() where T : ").Append(otherFullName).AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(otherName).Append(" typed)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\treturn typed;").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"The subject does not support type {typeof(T)}.\");").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.Append("\t}").AppendLine();
+		sb.Append("}").AppendLine();
+		sb.AppendLine();
+	}
+}
+

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockAsExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockAsExtensions.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Mockolate.SourceGenerators;
 
 namespace Mockolate.SourceGenerators.Sources;
 
@@ -55,4 +54,3 @@ internal static partial class Sources
 		sb.AppendLine();
 	}
 }
-

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
@@ -1,15 +1,12 @@
-using System.Collections.Immutable;
 using System.Text;
-using Mockolate.SourceGenerators.Entities;
 
 namespace Mockolate.SourceGenerators.Sources;
 
 #pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
-	public static string MockBehaviorExtensions(ImmutableArray<MockClass> mockClasses)
+	public static string MockBehaviorExtensions(bool includeHttpClient)
 	{
-		bool includeHttpClient = mockClasses.Any(m => m.ClassFullName == "global::System.Net.Http.HttpClient");
 		StringBuilder sb = InitializeBuilder();
 
 		sb.Append("""

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
@@ -2,7 +2,6 @@ using System.Text;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	public static string MockBehaviorExtensions(bool includeHttpClient)
@@ -374,4 +373,3 @@ internal static partial class Sources
 		return sb.ToString();
 	}
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -7,7 +7,6 @@ using Type = Mockolate.SourceGenerators.Entities.Type;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	private const int MaxExplicitParameters = 4;
@@ -5453,4 +5452,3 @@ internal static partial class Sources
 
 	#endregion Verify Helpers
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -11,8 +11,7 @@ internal static partial class Sources
 		string fileName,
 		string name,
 		Class @class,
-		(string Name, Class Class)[] additionalInterfaces,
-		HashSet<(string, string)> combinationSet)
+		(string Name, Class Class)[] additionalInterfaces)
 	{
 		EquatableArray<Method>? constructors = (@class as MockClass)?.Constructors;
 		string escapedClassName = @class.ClassFullName.EscapeForXmlDoc();
@@ -212,62 +211,9 @@ internal static partial class Sources
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-		#region As<T>
-
-		(string Name, Class Class)[] sources = [(name, @class), ..additionalInterfaces,];
-		foreach ((string Name, Class Class) source in sources.Take(sources.Length - 1))
-		{
-			if (!combinationSet.Add((source.Name, lastInterface.Name)) ||
-			    !combinationSet.Add((lastInterface.Name, source.Name)))
-			{
-				continue;
-			}
-
-			sb.Append("internal static partial class MockExtensionsFor").Append(lastInterface.Name).AppendLine();
-			sb.Append("{").AppendLine();
-			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" mock)").AppendLine();
-			sb.Append("\t{").AppendLine();
-			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" /> to reach its Setup/Verify/Raise surface.");
-			sb.AppendXmlRemarks(
-				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.");
-			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-			sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
-				$"The subject does not implement <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-			sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" As<T>() where T : ").Append(lastInterface.Class.ClassFullName).AppendLine();
-			sb.Append("\t\t{").AppendLine();
-			sb.Append("\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" typed)").AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\treturn typed;").AppendLine();
-			sb.Append("\t\t\t}").AppendLine();
-			sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"The subject does not support type {typeof(T)}.\");").AppendLine();
-			sb.Append("\t\t}").AppendLine();
-			sb.Append("\t}").AppendLine();
-			sb.Append("}").AppendLine();
-			sb.AppendLine();
-			sb.Append("internal static partial class MockExtensionsFor").Append(source.Name).AppendLine();
-			sb.Append("{").AppendLine();
-			sb.Append("\textension(global::Mockolate.Mock.IMockFor").Append(lastInterface.Name).Append(" mock)").AppendLine();
-			sb.Append("\t{").AppendLine();
-			sb.AppendXmlSummary($"Reinterprets this mock as a mock of <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" /> to reach its Setup/Verify/Raise surface.");
-			sb.AppendXmlRemarks(
-				"The returned accessor shares the same mock registry as this one - setups and verifications act on the same mocked instance. Use this when the mock implements multiple interfaces via <c>Implementing&lt;T&gt;()</c> and you need to configure or verify members of a different interface than the one the instance is currently typed as.");
-			sb.AppendXmlReturns($"An <c>IMockFor...</c> accessor targeting <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-			sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
-				$"The subject does not implement <see cref=\"{source.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-			sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" As<T>() where T : ").Append(source.Class.ClassFullName).AppendLine();
-			sb.Append("\t\t{").AppendLine();
-			sb.Append("\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(source.Name).Append(" typed)").AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\treturn typed;").AppendLine();
-			sb.Append("\t\t\t}").AppendLine();
-			sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"The subject does not support type {typeof(T)}.\");").AppendLine();
-			sb.Append("\t\t}").AppendLine();
-			sb.Append("\t}").AppendLine();
-			sb.Append("}").AppendLine();
-			sb.AppendLine();
-		}
-
-		#endregion As<T>
+		// As<T> bridge extensions across the (source, lastInterface) name pairs are emitted
+		// once per pair into a single aggregate file (Mock.AsExtensions.g.cs) — see
+		// MockAsExtensionPair / MockAsExtensions in MockGenerator.
 
 		#endregion Extensions
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -4,7 +4,6 @@ using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	public static string MockCombinationClass(
@@ -485,4 +484,3 @@ internal static partial class Sources
 		return sb.ToString();
 	}
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -211,10 +211,6 @@ internal static partial class Sources
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-		// As<T> bridge extensions across the (source, lastInterface) name pairs are emitted
-		// once per pair into a single aggregate file (Mock.AsExtensions.g.cs) — see
-		// MockAsExtensionPair / MockAsExtensions in MockGenerator.
-
 		#endregion Extensions
 
 		#region MockForXXX

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -5,7 +5,6 @@ using Type = Mockolate.SourceGenerators.Entities.Type;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	public static string MockDelegate(string name, MockClass @class, Method delegateMethod)
@@ -505,4 +504,3 @@ internal static partial class Sources
 		return sb.ToString();
 	}
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.RefStructMethodSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.RefStructMethodSetups.cs
@@ -2,7 +2,6 @@ using System.Text;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	/// <summary>
@@ -1202,4 +1201,3 @@ internal static partial class Sources
 		return sb.ToString();
 	}
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -191,8 +191,6 @@ internal static partial class Sources
 
 		sb.Append(indent).Append("}").AppendLine();
 
-		// Setup-side dispatch: indexer setups are always indexed under the GETTER member id (they apply to both
-		// directions). Setter call sites pass the getter id via setupMemberIdRef; getters reuse memberIdRef.
 		EmitIndexerSetupLookup(sb, indent, mockRegistry, accessVarName, setupVarName, propertyType, parameters,
 			setupMemberIdRef);
 	}
@@ -220,8 +218,6 @@ internal static partial class Sources
 
 		if (memberIdRef is null)
 		{
-			// Legacy path: no fast-buffer dispatch, fall straight through to the closure-free
-			// access-keyed lookup (matches pre-D-refactor emission shape).
 			sb.Append(indent).Append(typedSetupName).Append("? ").Append(setupVarName).Append(" = ")
 				.Append(mockRegistry).Append(".GetIndexerSetup<").Append(typedSetupName).Append(">(")
 				.Append(accessVarName).Append(");").AppendLine();
@@ -411,9 +407,6 @@ internal static partial class Sources
 	internal static string ExpandCrefs(string source)
 	{
 		const string OpenTag = "<see cref=\"";
-		// Many of the smaller generator outputs (ActionFunc.g.cs, ReturnsThrowsAsyncExtensions.g.cs,
-		// MockBehaviorExtensions.g.cs) carry no self-closing cref tags. Exit before the StringBuilder
-		// is allocated and the source is rewalked.
 		if (source.IndexOf(OpenTag, StringComparison.Ordinal) < 0)
 		{
 			return source;

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -411,6 +411,14 @@ internal static partial class Sources
 	internal static string ExpandCrefs(string source)
 	{
 		const string OpenTag = "<see cref=\"";
+		// Many of the smaller generator outputs (ActionFunc.g.cs, ReturnsThrowsAsyncExtensions.g.cs,
+		// MockBehaviorExtensions.g.cs) carry no self-closing cref tags. Exit before the StringBuilder
+		// is allocated and the source is rewalked.
+		if (source.IndexOf(OpenTag, StringComparison.Ordinal) < 0)
+		{
+			return source;
+		}
+
 		int searchFrom = 0;
 		int copiedUpTo = 0;
 		StringBuilder? result = null;

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -6,7 +6,6 @@ using Type = Mockolate.SourceGenerators.Entities.Type;
 
 namespace Mockolate.SourceGenerators.Sources;
 
-#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 internal static partial class Sources
 {
 	private static StringBuilder InitializeBuilder()
@@ -656,4 +655,3 @@ internal static partial class Sources
 				.Append(text).Append("</exception>").AppendLine();
 	}
 }
-#pragma warning restore S3776 // Cognitive Complexity of methods should not be too high

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -695,6 +695,7 @@ public partial class MockGeneratorTests
 
 		await That(result.Sources.Keys).IsEqualTo([
 			"Mock.g.cs",
+			"Mock.AsExtensions.g.cs",
 			"MockBehaviorExtensions.g.cs",
 			"Mock.IMyInterface1.g.cs",
 			"Mock.IMyInterface2.g.cs",


### PR DESCRIPTION
This PR aims to speed up the Mockolate source generator by reducing repeated work in the incremental pipeline and by lowering allocation pressure during entity/model construction and source post-processing.

**Changes:**
- Reworks the incremental generator pipeline to separate per-mock outputs from cross-mock aggregate outputs, including a new aggregate `Mock.AsExtensions.g.cs`.
- Adds a per-compilation `EntityCache` to deduplicate `Type`/`MethodParameter` entity creation and reduces LINQ/multi-pass member enumeration in `Class`.
- Adds small fast-path optimizations (e.g., early exit in `ExpandCrefs`) and adjusts tests for the new generated file.