### PR TITLE
coverage: Fast*Buffer parametric tests

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
@@ -1,0 +1,556 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Mockolate.Interactions;
+using Mockolate.Parameters;
+
+namespace Mockolate.Internal.Tests.Interactions;
+
+public class FastBufferBoxingAndUnverifiedTests
+{
+	[Fact]
+	public async Task FastEventBuffer_AppendBoxed_KindMatters()
+	{
+		FastMockInteractions subscribeStore = new(1);
+		FastMockInteractions unsubscribeStore = new(1);
+		FastEventBuffer subscribe = subscribeStore.InstallEventSubscribe(0);
+		FastEventBuffer unsubscribe = unsubscribeStore.InstallEventUnsubscribe(0);
+
+		subscribe.Append("E", this, SampleMethod);
+		unsubscribe.Append("E", this, SampleMethod);
+
+		await That(subscribeStore.Single()).IsExactly<EventSubscription>();
+		await That(unsubscribeStore.Single()).IsExactly<EventUnsubscription>();
+	}
+
+	[Fact]
+	public async Task FastEventBuffer_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventSubscribe(0);
+		buffer.Append("E", this, SampleMethod);
+		buffer.Append("E", this, SampleMethod);
+		buffer.Append("E", this, SampleMethod);
+
+		_ = buffer.ConsumeMatching();
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).IsEmpty();
+
+		buffer.Append("E", this, SampleMethod);
+		dest.Clear();
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(1);
+		await That(dest[0].Interaction).IsExactly<EventSubscription>();
+	}
+
+	[Fact]
+	public async Task FastEventBuffer_SubscribeAppend_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastEventBuffer buffer = store.InstallEventSubscribe(0);
+			return () => buffer.Append("E", this, SampleMethod);
+		});
+
+	[Fact]
+	public async Task FastEventBuffer_UnsubscribeAppend_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
+			return () => buffer.Append("E", this, SampleMethod);
+		});
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer1_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+			return () => buffer.Append(1);
+		});
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer2_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
+			return () => buffer.Append(1, "a");
+		});
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer3_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerGetterBuffer<int, string, bool> buffer =
+				store.InstallIndexerGetter<int, string, bool>(0);
+			return () => buffer.Append(1, "a", true);
+		});
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer4_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerGetterBuffer<int, string, bool, double> buffer =
+				store.InstallIndexerGetter<int, string, bool, double>(0);
+			return () => buffer.Append(1, "a", true, 1.0);
+		});
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer1_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+			return () => buffer.Append(1, "a");
+		});
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer2_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerSetterBuffer<int, string, bool> buffer =
+				store.InstallIndexerSetter<int, string, bool>(0);
+			return () => buffer.Append(1, "a", true);
+		});
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer3_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerSetterBuffer<int, string, bool, double> buffer =
+				store.InstallIndexerSetter<int, string, bool, double>(0);
+			return () => buffer.Append(1, "a", true, 1.0);
+		});
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer4_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+				store.InstallIndexerSetter<int, string, bool, double, char>(0);
+			return () => buffer.Append(1, "a", true, 1.0, 'x');
+		});
+
+	[Fact]
+	public async Task FastMethod1Buffer_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+			return () => buffer.Append("M", 1);
+		});
+
+	[Fact]
+	public async Task FastMethod1Buffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+
+		buffer.Append("M", 1);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastMethod2Buffer_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastMethod2Buffer<int, string> buffer = store.InstallMethod<int, string>(0);
+			return () => buffer.Append("M", 1, "a");
+		});
+
+	[Fact]
+	public async Task FastMethod3Buffer_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+			return () => buffer.Append("M", 1, "a", true);
+		});
+
+	[Fact]
+	public async Task FastMethod3Buffer_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+		buffer.Append("M", 0, "a", true);
+		buffer.Append("M", 1, "b", false);
+		buffer.Append("M", 2, "c", true);
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("b"),
+			(IParameterMatch<bool>)It.Is(false));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((MethodInvocation<int, string, bool>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((MethodInvocation<int, string, bool>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task FastMethod4Buffer_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastMethod4Buffer<int, string, bool, double> buffer =
+				store.InstallMethod<int, string, bool, double>(0);
+			return () => buffer.Append("M", 1, "a", true, 1.0);
+		});
+
+	[Fact]
+	public async Task FastMethod4Buffer_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+		buffer.Append("M", 0, "a", true, 0.5);
+		buffer.Append("M", 1, "b", false, 1.5);
+		buffer.Append("M", 2, "c", true, 2.5);
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("b"),
+			(IParameterMatch<bool>)It.Is(false),
+			(IParameterMatch<double>)It.Is(1.5));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((MethodInvocation<int, string, bool, double>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((MethodInvocation<int, string, bool, double>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task FastPropertyGetterBuffer_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+			return () => buffer.Append("P");
+		});
+
+	[Fact]
+	public async Task FastPropertyGetterBuffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+
+		buffer.Append("P");
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastPropertySetterBuffer_Append_ShouldRaiseInteractionAdded()
+		=> await VerifyRaisesInteractionAdded(store =>
+		{
+			FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+			return () => buffer.Append("P", 1);
+		});
+
+	[Fact]
+	public async Task FastPropertySetterBuffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+
+		buffer.Append("P", 5);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task IndexerGetterBuffer1_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+		buffer.Append(0);
+		buffer.Append(1);
+		buffer.Append(2);
+
+		_ = buffer.ConsumeMatching((IParameterMatch<int>)It.Is(1));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerGetterAccess<int>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerGetterAccess<int>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerGetterBuffer2_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
+		buffer.Append(0, "a");
+		buffer.Append(1, "b");
+		buffer.Append(2, "c");
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("b"));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerGetterAccess<int, string>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerGetterAccess<int, string>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerGetterBuffer3_AppendBoxed_BoxesAsIndexerGetterAccess()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerGetter<int, string, bool>(0);
+
+		buffer.Append(7, "k", true);
+
+		IndexerGetterAccess<int, string, bool> boxed =
+			(IndexerGetterAccess<int, string, bool>)store.Single();
+		await That(boxed.Parameter1).IsEqualTo(7);
+		await That(boxed.Parameter2).IsEqualTo("k");
+		await That(boxed.Parameter3).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerGetterBuffer3_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerGetter<int, string, bool>(0);
+		buffer.Append(0, "a", true);
+		buffer.Append(1, "b", false);
+		buffer.Append(2, "c", true);
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("b"),
+			(IParameterMatch<bool>)It.Is(false));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerGetterAccess<int, string, bool>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerGetterAccess<int, string, bool>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerGetterBuffer4_AppendBoxed_BoxesAsIndexerGetterAccess()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+
+		buffer.Append(7, "k", true, 3.14);
+
+		IndexerGetterAccess<int, string, bool, double> boxed =
+			(IndexerGetterAccess<int, string, bool, double>)store.Single();
+		await That(boxed.Parameter1).IsEqualTo(7);
+		await That(boxed.Parameter2).IsEqualTo("k");
+		await That(boxed.Parameter3).IsTrue();
+		await That(boxed.Parameter4).IsEqualTo(3.14);
+	}
+
+	[Fact]
+	public async Task IndexerGetterBuffer4_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+		buffer.Append(0, "a", true, 0.5);
+		buffer.Append(1, "b", false, 1.5);
+		buffer.Append(2, "c", true, 2.5);
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("b"),
+			(IParameterMatch<bool>)It.Is(false),
+			(IParameterMatch<double>)It.Is(1.5));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerGetterAccess<int, string, bool, double>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerGetterAccess<int, string, bool, double>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerSetterBuffer1_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+		buffer.Append(0, "x");
+		buffer.Append(1, "y");
+		buffer.Append(2, "z");
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("y"));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerSetterAccess<int, string>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerSetterAccess<int, string>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerSetterBuffer2_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerSetter<int, string, bool>(0);
+		buffer.Append(0, "x", true);
+		buffer.Append(1, "y", false);
+		buffer.Append(2, "z", true);
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("y"),
+			(IParameterMatch<bool>)It.Is(false));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerSetterAccess<int, string, bool>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerSetterAccess<int, string, bool>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerSetterBuffer3_AppendBoxed_BoxesAsIndexerSetterAccess()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+
+		buffer.Append(7, "k", true, 3.14);
+
+		IndexerSetterAccess<int, string, bool, double> boxed =
+			(IndexerSetterAccess<int, string, bool, double>)store.Single();
+		await That(boxed.Parameter1).IsEqualTo(7);
+		await That(boxed.Parameter2).IsEqualTo("k");
+		await That(boxed.Parameter3).IsTrue();
+		await That(boxed.TypedValue).IsEqualTo(3.14);
+	}
+
+	[Fact]
+	public async Task IndexerSetterBuffer3_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+		buffer.Append(0, "x", true, 0.5);
+		buffer.Append(1, "y", false, 1.5);
+		buffer.Append(2, "z", true, 2.5);
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("y"),
+			(IParameterMatch<bool>)It.Is(false),
+			(IParameterMatch<double>)It.Is(1.5));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerSetterAccess<int, string, bool, double>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerSetterAccess<int, string, bool, double>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerSetterBuffer4_AppendBoxed_BoxesAsIndexerSetterAccess()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+			store.InstallIndexerSetter<int, string, bool, double, char>(0);
+
+		buffer.Append(7, "k", true, 3.14, 'z');
+
+		IndexerSetterAccess<int, string, bool, double, char> boxed =
+			(IndexerSetterAccess<int, string, bool, double, char>)store.Single();
+		await That(boxed.Parameter1).IsEqualTo(7);
+		await That(boxed.Parameter2).IsEqualTo("k");
+		await That(boxed.Parameter3).IsTrue();
+		await That(boxed.Parameter4).IsEqualTo(3.14);
+		await That(boxed.TypedValue).IsEqualTo('z');
+	}
+
+	[Fact]
+	public async Task IndexerSetterBuffer4_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+			store.InstallIndexerSetter<int, string, bool, double, char>(0);
+		buffer.Append(0, "x", true, 0.5, 'a');
+		buffer.Append(1, "y", false, 1.5, 'b');
+		buffer.Append(2, "z", true, 2.5, 'c');
+
+		_ = buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("y"),
+			(IParameterMatch<bool>)It.Is(false),
+			(IParameterMatch<double>)It.Is(1.5),
+			(IParameterMatch<char>)It.Is('b'));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((IndexerSetterAccess<int, string, bool, double, char>)dest[0].Interaction).Parameter1).IsEqualTo(0);
+		await That(((IndexerSetterAccess<int, string, bool, double, char>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	private static readonly MethodInfo SampleMethod =
+		typeof(FastBufferBoxingAndUnverifiedTests).GetMethod(
+			nameof(SampleMethodImpl),
+			BindingFlags.Static | BindingFlags.NonPublic)!;
+
+	private static void SampleMethodImpl()
+	{
+	}
+
+	private static async Task VerifyRaisesInteractionAdded(Func<FastMockInteractions, Action> appendFactory)
+	{
+		FastMockInteractions store = new(1);
+		Action append = appendFactory(store);
+		int invocations = 0;
+		EventHandler handler = (_, _) => invocations++;
+		store.InteractionAdded += handler;
+
+		append();
+		append();
+
+		store.InteractionAdded -= handler;
+
+		await That(invocations).IsEqualTo(2);
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferConsumeMatchingTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferConsumeMatchingTests.cs
@@ -56,6 +56,58 @@ public class FastBufferConsumeMatchingTests
 	}
 
 	[Fact]
+	public async Task FastIndexerGetterBuffer3_ConsumeMatching_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool> buffer = store.InstallIndexerGetter<int, string, bool>(0);
+
+		buffer.Append(1, "a", true);
+		buffer.Append(2, "a", false);
+		buffer.Append(1, "b", true);
+
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.IsAny<int>(),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>())).IsEqualTo(3);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.Is(true))).IsEqualTo(2);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(false))).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer4_ConsumeMatching_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+
+		buffer.Append(1, "a", true, 1.0);
+		buffer.Append(1, "b", true, 2.0);
+		buffer.Append(2, "a", false, 3.0);
+
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.IsAny<int>(),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>())).IsEqualTo(3);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>())).IsEqualTo(2);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>())).IsEqualTo(0);
+	}
+
+	[Fact]
 	public async Task FastIndexerSetterBuffer1_ConsumeMatching_ShouldHonorMatchers()
 	{
 		FastMockInteractions store = new(1);
@@ -74,6 +126,90 @@ public class FastBufferConsumeMatchingTests
 		await That(buffer.ConsumeMatching(
 			(IParameterMatch<int>)It.Is(99),
 			(IParameterMatch<string>)It.IsAny<string>())).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer2_ConsumeMatching_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerSetter<int, string, bool>(0);
+
+		buffer.Append(1, "a", true);
+		buffer.Append(1, "b", false);
+		buffer.Append(2, "a", true);
+
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.IsAny<int>(),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>())).IsEqualTo(3);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.Is(true))).IsEqualTo(1);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>())).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer3_ConsumeMatching_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+
+		buffer.Append(1, "a", true, 1.0);
+		buffer.Append(1, "b", true, 2.0);
+		buffer.Append(2, "a", false, 1.0);
+
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.IsAny<int>(),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>())).IsEqualTo(3);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(1.0))).IsEqualTo(1);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>())).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer4_ConsumeMatching_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+			store.InstallIndexerSetter<int, string, bool, double, char>(0);
+
+		buffer.Append(1, "a", true, 1.0, 'x');
+		buffer.Append(1, "b", true, 2.0, 'x');
+		buffer.Append(2, "a", false, 3.0, 'y');
+
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.IsAny<int>(),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>(),
+			(IParameterMatch<char>)It.IsAny<char>())).IsEqualTo(3);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>(),
+			(IParameterMatch<char>)It.Is('x'))).IsEqualTo(2);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.IsAny<double>(),
+			(IParameterMatch<char>)It.IsAny<char>())).IsEqualTo(0);
 	}
 
 	[Fact]
@@ -148,6 +284,14 @@ public class FastBufferConsumeMatchingTests
 			(IParameterMatch<int>)It.Is(1),
 			(IParameterMatch<string>)It.IsAny<string>(),
 			(IParameterMatch<bool>)It.Is(true))).IsEqualTo(2);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.Is(false))).IsEqualTo(0);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.IsAny<int>(),
+			(IParameterMatch<string>)It.Is<string>("b"),
+			(IParameterMatch<bool>)It.Is(false))).IsEqualTo(0);
 	}
 
 	[Fact]
@@ -176,6 +320,16 @@ public class FastBufferConsumeMatchingTests
 			(IParameterMatch<string>)It.IsAny<string>(),
 			(IParameterMatch<bool>)It.IsAny<bool>(),
 			(IParameterMatch<double>)It.IsAny<double>())).IsEqualTo(0);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.Is(false),
+			(IParameterMatch<double>)It.IsAny<double>())).IsEqualTo(0);
+		await That(buffer.ConsumeMatching(
+			(IParameterMatch<int>)It.IsAny<int>(),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.IsAny<bool>(),
+			(IParameterMatch<double>)It.Is(99.0))).IsEqualTo(0);
 	}
 
 	[Fact]


### PR DESCRIPTION
Adds additional internal test coverage for the `Fast*Buffer` interaction buffers, focusing on matcher behavior in `ConsumeMatching(...)` and correctness of boxing/unverified-enumeration paths.

**Changes:**
- Expand `FastBufferConsumeMatchingTests` to cover additional arities and negative matcher combinations for indexer getter/setter and method buffers.
- Add new `FastBufferBoxingAndUnverifiedTests` covering `AppendBoxed`, `AppendBoxedUnverified`, and `InteractionAdded` event behavior across buffer kinds/arities.