### PR TITLE
coverage: registry skip-flag agreement, collection callbacks, Uri/HttpContent dispatch

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Parameters/ItCollectionMatchTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Parameters/ItCollectionMatchTests.cs
@@ -1,0 +1,305 @@
+using System.Collections.Generic;
+using Mockolate.Parameters;
+
+namespace Mockolate.Internal.Tests.Parameters;
+
+public class ItCollectionMatchTests
+{
+	public sealed class CollectionMatchDoTests
+	{
+		[Fact]
+		public async Task Do_RegistersCallbackForArray()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			int[]? captured = null;
+			((IParameterWithCallback<int[]>)sut).Do(value => captured = value);
+
+			int[] source = [1, 2, 3,];
+			((IParameterMatch<int[]>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForHashSet()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			HashSet<int>? captured = null;
+			((IParameterWithCallback<HashSet<int>>)sut).Do(value => captured = value);
+
+			HashSet<int> source = [1, 2, 3,];
+			((IParameterMatch<HashSet<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForICollection()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			ICollection<int>? captured = null;
+			((IParameterWithCallback<ICollection<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<ICollection<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIEnumerable()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			IEnumerable<int>? captured = null;
+			((IParameterWithCallback<IEnumerable<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IEnumerable<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIList()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			IList<int>? captured = null;
+			((IParameterWithCallback<IList<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IList<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIReadOnlyCollection()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			IReadOnlyCollection<int>? captured = null;
+			((IParameterWithCallback<IReadOnlyCollection<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IReadOnlyCollection<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIReadOnlyList()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			IReadOnlyList<int>? captured = null;
+			((IParameterWithCallback<IReadOnlyList<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IReadOnlyList<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForISet()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			ISet<int>? captured = null;
+			((IParameterWithCallback<ISet<int>>)sut).Do(value => captured = value);
+
+			HashSet<int> source = [1, 2, 3,];
+			((IParameterMatch<ISet<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForList()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			List<int>? captured = null;
+			((IParameterWithCallback<List<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<List<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForQueue()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			Queue<int>? captured = null;
+			((IParameterWithCallback<Queue<int>>)sut).Do(value => captured = value);
+
+			Queue<int> source = new();
+			source.Enqueue(1);
+			((IParameterMatch<Queue<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForStack()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			Stack<int>? captured = null;
+			((IParameterWithCallback<Stack<int>>)sut).Do(value => captured = value);
+
+			Stack<int> source = new();
+			source.Push(1);
+			((IParameterMatch<Stack<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task InvokeCallbacks_OnNonEnumerableValue_ShortCircuits()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+			int invocations = 0;
+			((IParameterWithCallback<List<int>>)sut).Do(_ => invocations++);
+
+			sut.InvokeCallbacks(new object());
+
+			await That(invocations).IsEqualTo(0);
+		}
+
+		[Fact]
+		public async Task InvokeCallbacks_WithoutAnyRegistration_DoesNotThrow()
+		{
+			It.IContainsParameter<int> sut = It.Contains(1);
+
+			void Act()
+			{
+				sut.InvokeCallbacks(new List<int>
+				{
+					1,
+				});
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+
+	public sealed class OrderedCollectionMatchDoTests
+	{
+		[Fact]
+		public async Task Do_RegistersCallbackForArray()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			int[]? captured = null;
+			((IParameterWithCallback<int[]>)sut).Do(value => captured = value);
+
+			int[] source = [1, 2, 3,];
+			((IParameterMatch<int[]>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForICollection()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			ICollection<int>? captured = null;
+			((IParameterWithCallback<ICollection<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<ICollection<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIEnumerable()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			IEnumerable<int>? captured = null;
+			((IParameterWithCallback<IEnumerable<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IEnumerable<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIList()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			IList<int>? captured = null;
+			((IParameterWithCallback<IList<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IList<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIReadOnlyCollection()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			IReadOnlyCollection<int>? captured = null;
+			((IParameterWithCallback<IReadOnlyCollection<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IReadOnlyCollection<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForIReadOnlyList()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			IReadOnlyList<int>? captured = null;
+			((IParameterWithCallback<IReadOnlyList<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<IReadOnlyList<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForList()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			List<int>? captured = null;
+			((IParameterWithCallback<List<int>>)sut).Do(value => captured = value);
+
+			List<int> source = [1, 2, 3,];
+			((IParameterMatch<List<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForQueue()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			Queue<int>? captured = null;
+			((IParameterWithCallback<Queue<int>>)sut).Do(value => captured = value);
+
+			Queue<int> source = new();
+			source.Enqueue(1);
+			((IParameterMatch<Queue<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+
+		[Fact]
+		public async Task Do_RegistersCallbackForStack()
+		{
+			It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+			Stack<int>? captured = null;
+			((IParameterWithCallback<Stack<int>>)sut).Do(value => captured = value);
+
+			Stack<int> source = new();
+			source.Push(1);
+			((IParameterMatch<Stack<int>>)sut).InvokeCallbacks(source);
+
+			await That(captured).IsSameAs(source);
+		}
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -15,6 +15,70 @@ public sealed class MockRegistryTests
 		=> typeof(MockRegistryTests).GetMethod(nameof(GetMethodInfo),
 			BindingFlags.Static | BindingFlags.NonPublic)!;
 
+	public sealed class ConstructorSkipFlagAgreementTests
+	{
+		[Fact]
+		public async Task BehaviorAndInteractions_WhenSkipFlagsDisagree_Throws()
+		{
+			MockBehavior recordingBehavior = MockBehavior.Default;
+			FastMockInteractions skippingInteractions = new(0, true);
+
+			void Act()
+			{
+				_ = new MockRegistry(recordingBehavior, skippingInteractions);
+			}
+
+			await That(Act).Throws<ArgumentException>()
+				.WithMessage("*SkipInteractionRecording*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task BehaviorAndInteractions_WhenSkippingBehaviorMeetsRecordingInteractions_Throws()
+		{
+			MockBehavior skippingBehavior = MockBehavior.Default.SkippingInteractionRecording();
+			FastMockInteractions recordingInteractions = new(0);
+
+			void Act()
+			{
+				_ = new MockRegistry(skippingBehavior, recordingInteractions);
+			}
+
+			await That(Act).Throws<ArgumentException>()
+				.WithMessage("*SkipInteractionRecording*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task RegistryAndInteractions_WhenSkipFlagsDisagree_Throws()
+		{
+			MockRegistry registry = new(MockBehavior.Default);
+			FastMockInteractions skippingInteractions = new(0, true);
+
+			void Act()
+			{
+				_ = new MockRegistry(registry, skippingInteractions);
+			}
+
+			await That(Act).Throws<ArgumentException>()
+				.WithMessage("*SkipInteractionRecording*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task RegistryAndInteractions_WhenSkippingRegistryMeetsRecordingInteractions_Throws()
+		{
+			MockBehavior skippingBehavior = MockBehavior.Default.SkippingInteractionRecording();
+			MockRegistry registry = new(skippingBehavior, new FastMockInteractions(0, true));
+			FastMockInteractions recordingInteractions = new(0);
+
+			void Act()
+			{
+				_ = new MockRegistry(registry, recordingInteractions);
+			}
+
+			await That(Act).Throws<ArgumentException>()
+				.WithMessage("*SkipInteractionRecording*").AsWildcard();
+		}
+	}
+
 	public sealed class GetIndexerSetupScenarioScopingTests
 	{
 		[Fact]

--- a/Tests/Mockolate.Internal.Tests/Web/ItExtensionsHttpContentTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Web/ItExtensionsHttpContentTests.cs
@@ -1,0 +1,95 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using Mockolate.Parameters;
+using Mockolate.Web;
+
+namespace Mockolate.Internal.Tests.Web;
+
+public class ItExtensionsHttpContentTests
+{
+	[Fact]
+	public async Task IsHttpContent_NonGeneric_DispatchesContentThroughCallback()
+	{
+		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
+		HttpContent? captured = null;
+		sut.Do(content => captured = content);
+
+		MyHttpContent target = new();
+		sut.InvokeCallbacks(target);
+
+		await That(captured).IsSameAs(target);
+	}
+
+	[Fact]
+	public async Task IsHttpContent_NonGeneric_DispatchesNullThroughCallback()
+	{
+		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
+		int invocations = 0;
+		HttpContent? captured = new MyHttpContent();
+		sut.Do(content =>
+		{
+			invocations++;
+			captured = content;
+		});
+
+		sut.InvokeCallbacks(null);
+
+		await That(invocations).IsEqualTo(1);
+		await That(captured).IsNull();
+	}
+
+	[Fact]
+	public async Task IsHttpContent_NonGeneric_IgnoresUnrelatedTypes()
+	{
+		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
+		int invocations = 0;
+		sut.Do(_ => invocations++);
+
+		sut.InvokeCallbacks("not http content");
+
+		await That(invocations).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task IsHttpContent_NonGenericMatches_ReturnsFalseForNullValue()
+	{
+		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
+
+		bool result = sut.Matches(null);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsHttpContent_NonGenericMatches_ReturnsFalseForUnrelatedType()
+	{
+		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
+
+		bool result = sut.Matches("not http content");
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsHttpContent_TypedMatches_ReturnsFalseForNullValue()
+	{
+		ItExtensions.IHttpContentParameter sut = It.IsHttpContent();
+
+		bool result = ((IParameterMatch<HttpContent?>)sut).Matches(null);
+
+		await That(result).IsFalse();
+	}
+
+	private sealed class MyHttpContent : HttpContent
+	{
+		protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+			=> Task.CompletedTask;
+
+		protected override bool TryComputeLength(out long length)
+		{
+			length = 0;
+			return false;
+		}
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Web/ItExtensionsUriTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Web/ItExtensionsUriTests.cs
@@ -1,0 +1,83 @@
+using Mockolate.Parameters;
+using Mockolate.Web;
+
+namespace Mockolate.Internal.Tests.Web;
+
+public class ItExtensionsUriTests
+{
+	[Fact]
+	public async Task IsUri_NonGeneric_DispatchesNullThroughCallback()
+	{
+		ItExtensions.IUriParameter sut = It.IsUri();
+		int invocations = 0;
+		Uri? captured = new("http://placeholder");
+		sut.Do(uri =>
+		{
+			invocations++;
+			captured = uri;
+		});
+
+		sut.InvokeCallbacks(null);
+
+		await That(invocations).IsEqualTo(1);
+		await That(captured).IsNull();
+	}
+
+	[Fact]
+	public async Task IsUri_NonGeneric_DispatchesUriThroughCallback()
+	{
+		ItExtensions.IUriParameter sut = It.IsUri();
+		Uri? captured = null;
+		sut.Do(uri => captured = uri);
+
+		Uri target = new("http://x/y");
+		sut.InvokeCallbacks(target);
+
+		await That(captured).IsSameAs(target);
+	}
+
+	[Fact]
+	public async Task IsUri_NonGeneric_IgnoresUnrelatedTypes()
+	{
+		ItExtensions.IUriParameter sut = It.IsUri();
+		int invocations = 0;
+		sut.Do(_ => invocations++);
+
+		sut.InvokeCallbacks("not a uri");
+
+		await That(invocations).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task IsUri_NonGenericMatches_ReturnsFalseForNonUriValue()
+	{
+		ItExtensions.IUriParameter sut = It.IsUri();
+
+		bool result = sut.Matches("not a uri");
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsUri_NonGenericMatches_ReturnsFalseForNullValue()
+	{
+		ItExtensions.IUriParameter sut = It.IsUri();
+
+		bool result = sut.Matches(null);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsUri_WithPattern_AcceptsBothTrailingSlashAndWithoutTrailingSlash()
+	{
+		ItExtensions.IUriParameter sut = It.IsUri("http://x/foo");
+		IParameterMatch<Uri?> matcher = (IParameterMatch<Uri?>)sut;
+
+		bool matchesWithSlash = matcher.Matches(new Uri("http://x/foo/"));
+		bool matchesWithoutSlash = matcher.Matches(new Uri("http://x/foo"));
+
+		await That(matchesWithSlash).IsTrue();
+		await That(matchesWithoutSlash).IsTrue();
+	}
+}


### PR DESCRIPTION
Adds internal test coverage for several dispatch/verification edge-cases to keep behavior consistent across parameter matchers and registry construction paths.

**Changes:**
- Added tests verifying `It.IsUri(...)` and `It.IsHttpContent()` non-generic callback dispatch and matching behavior.
- Added coverage ensuring `MockRegistry` constructors reject mismatched `SkipInteractionRecording` flags between behavior/registry and interaction stores.