### PR TITLE
coverage: ChunkedSlotStorage growth, NextSequence, Verified, fallback paths

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Interactions/ChunkedSlotStorageTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/ChunkedSlotStorageTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using Mockolate.Interactions;
+
+namespace Mockolate.Internal.Tests.Interactions;
+
+public class ChunkedSlotStorageTests
+{
+	[Fact]
+	public async Task Clear_AfterMultipleChunks_ResetsCountAndAllowsRefill()
+	{
+		const int total = (ChunkedSlotStorage<int>.ChunkSize * 2) + 5;
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+
+		for (int i = 0; i < total; i++)
+		{
+			buffer.Append("Foo", i);
+		}
+
+		buffer.Clear();
+		await That(buffer.Count).IsEqualTo(0);
+
+		buffer.Append("Foo", 99);
+
+		await That(buffer.Count).IsEqualTo(1);
+		await That(((MethodInvocation<int>)store.Single()).Parameter1).IsEqualTo(99);
+	}
+
+	[Fact]
+	public async Task SlotForWrite_AcrossMultipleChunks_PreservesAllRecords()
+	{
+		const int total = ChunkedSlotStorage<int>.ChunkSize * 3;
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+
+		for (int i = 0; i < total; i++)
+		{
+			buffer.Append("Foo", i);
+		}
+
+		List<IInteraction> ordered = [..store,];
+
+		await That(ordered).HasCount(total);
+		for (int i = 0; i < total; i++)
+		{
+			await That(((MethodInvocation<int>)ordered[i]).Parameter1).IsEqualTo(i);
+		}
+	}
+
+	[Fact]
+	public async Task SlotForWrite_BeyondInitialChunksArrayLength_ExpandsArrayUnderLock()
+	{
+		const int total = (ChunkedSlotStorage<int>.ChunkSize * 4) + 1;
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+
+		for (int i = 0; i < total; i++)
+		{
+			buffer.Append("Foo", i);
+		}
+
+		List<IInteraction> ordered = [..store,];
+
+		await That(ordered).HasCount(total);
+		for (int i = 0; i < total; i++)
+		{
+			await That(((MethodInvocation<int>)ordered[i]).Parameter1).IsEqualTo(i);
+		}
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
@@ -46,6 +46,33 @@ public class FastMockInteractionsTests
 	}
 
 	[Fact]
+	public async Task Clear_FallbackPath_ShouldNotResurfaceOldRecordsAfterRefill()
+	{
+		IMockInteractions sut = new FastMockInteractions(0);
+		MethodInvocation first = new("first");
+		MethodInvocation second = new("second");
+
+		sut.RegisterInteraction(first);
+		sut.RegisterInteraction(second);
+
+		sut.Clear();
+
+		MethodInvocation third = new("third");
+		MethodInvocation fourth = new("fourth");
+		sut.RegisterInteraction(third);
+		sut.RegisterInteraction(fourth);
+
+		List<IInteraction> ordered = [..sut,];
+
+		await That(sut.Count).IsEqualTo(2);
+		await That(ordered).HasCount(2);
+		await That(ordered.Contains(first)).IsFalse();
+		await That(ordered.Contains(second)).IsFalse();
+		await That(ordered[0]).IsSameAs(third);
+		await That(ordered[1]).IsSameAs(fourth);
+	}
+
+	[Fact]
 	public async Task Clear_ShouldFireOnClearing()
 	{
 		FastMockInteractions sut = new(1);
@@ -162,6 +189,37 @@ public class FastMockInteractionsTests
 	}
 
 	[Fact]
+	public async Task GetOrCreateFallbackBuffer_ConcurrentRace_RecordsAllInteractions()
+	{
+		const int threads = 8;
+		const int callsPerThread = 25;
+		IMockInteractions sut = new FastMockInteractions(0);
+
+		using ManualResetEventSlim start = new(false);
+		Task[] tasks = new Task[threads];
+		for (int t = 0; t < threads; t++)
+		{
+			int threadId = t;
+#pragma warning disable xUnit1051
+			tasks[t] = Task.Run(() =>
+#pragma warning restore xUnit1051
+			{
+				start.Wait();
+				for (int i = 0; i < callsPerThread; i++)
+				{
+					sut.RegisterInteraction(new MethodInvocation($"t{threadId}-{i}"));
+				}
+			});
+		}
+
+		start.Set();
+		await Task.WhenAll(tasks);
+
+		await That(sut.Count).IsEqualTo(threads * callsPerThread);
+		await That(sut.ToList()).HasCount(threads * callsPerThread);
+	}
+
+	[Fact]
 	public async Task GetUnverifiedInteractions_AcrossMultipleBuffers_ShouldUnionFastAndSlowVerifications()
 	{
 		FastMockInteractions sut = new(2);
@@ -262,6 +320,20 @@ public class FastMockInteractionsTests
 		IReadOnlyCollection<IInteraction> unverified = sut.GetUnverifiedInteractions();
 
 		await That(unverified).HasCount(1);
+	}
+
+	[Fact]
+	public async Task NextSequence_ShouldReturnZeroBasedMonotonicValues()
+	{
+		FastMockInteractions sut = new(0);
+
+		long first = sut.NextSequence();
+		long second = sut.NextSequence();
+		long third = sut.NextSequence();
+
+		await That(first).IsEqualTo(0L);
+		await That(second).IsEqualTo(1L);
+		await That(third).IsEqualTo(2L);
 	}
 
 	[Fact]
@@ -372,6 +444,55 @@ public class FastMockInteractionsTests
 
 		await That(skipping.SkipInteractionRecording).IsTrue();
 		await That(recording.SkipInteractionRecording).IsFalse();
+	}
+
+	[Fact]
+	public async Task SnapshotOrdered_WithMultipleSlowPathFallbackEntries_PreservesOrder()
+	{
+		IMockInteractions sut = new FastMockInteractions(0);
+		MethodInvocation first = new("first");
+		MethodInvocation second = new("second");
+		MethodInvocation third = new("third");
+
+		sut.RegisterInteraction(first);
+		sut.RegisterInteraction(second);
+		sut.RegisterInteraction(third);
+
+		List<IInteraction> ordered = [..sut,];
+
+		await That(ordered).HasCount(3);
+		await That(ordered[0]).IsSameAs(first);
+		await That(ordered[1]).IsSameAs(second);
+		await That(ordered[2]).IsSameAs(third);
+	}
+
+	[Fact]
+	public async Task Verified_BeforeAnyAppend_OnSecondCallAddsToExistingSet()
+	{
+		FastMockInteractions sut = new(1);
+		FastMethod0Buffer buffer = sut.InstallMethod(0);
+
+		((IMockInteractions)sut).Verified([]);
+
+		buffer.Append("Foo");
+		MethodInvocation appended = (MethodInvocation)sut.Single();
+		((IMockInteractions)sut).Verified([appended,]);
+
+		await That(sut.GetUnverifiedInteractions()).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Verified_WithMultipleInteractions_AddsAllToInternalSet()
+	{
+		FastMockInteractions sut = new(1);
+		FastMethod0Buffer buffer = sut.InstallMethod(0);
+		buffer.Append("first");
+		buffer.Append("second");
+
+		List<IInteraction> all = [..sut,];
+		((IMockInteractions)sut).Verified(all);
+
+		await That(sut.GetUnverifiedInteractions()).IsEmpty();
 	}
 
 	public sealed class MethodBufferTests

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
@@ -200,7 +200,7 @@ public class FastMockInteractionsTests
 		for (int t = 0; t < threads; t++)
 		{
 			int threadId = t;
-#pragma warning disable xUnit1051
+#pragma warning disable xUnit1051 // intentionally not using a cancellation token here; the threads run a short, deterministic loop
 			tasks[t] = Task.Run(() =>
 #pragma warning restore xUnit1051
 			{
@@ -444,26 +444,6 @@ public class FastMockInteractionsTests
 
 		await That(skipping.SkipInteractionRecording).IsTrue();
 		await That(recording.SkipInteractionRecording).IsFalse();
-	}
-
-	[Fact]
-	public async Task SnapshotOrdered_WithMultipleSlowPathFallbackEntries_PreservesOrder()
-	{
-		IMockInteractions sut = new FastMockInteractions(0);
-		MethodInvocation first = new("first");
-		MethodInvocation second = new("second");
-		MethodInvocation third = new("third");
-
-		sut.RegisterInteraction(first);
-		sut.RegisterInteraction(second);
-		sut.RegisterInteraction(third);
-
-		List<IInteraction> ordered = [..sut,];
-
-		await That(ordered).HasCount(3);
-		await That(ordered[0]).IsSameAs(first);
-		await That(ordered[1]).IsSameAs(second);
-		await That(ordered[2]).IsSameAs(third);
 	}
 
 	[Fact]


### PR DESCRIPTION
Adds targeted internal tests to increase coverage around interaction recording/verification edge-cases and the chunked slot storage growth/clear behavior.

**Changes:**
- Added new `FastMockInteractions` tests for fallback-path clearing, concurrent fallback registration, sequence allocation, verified-set accumulation, and ordered enumeration.
- Added a new `ChunkedSlotStorageTests` suite covering multi-chunk growth, chunks-array expansion, and clear-then-refill behavior.