### PR TITLE
coverage: add tests for indexer and property setup behaviors

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
@@ -57,7 +57,7 @@ public sealed class IndexerSetupTests
 		indexerSetup.OnGet.Do(() => { callCount++; });
 		IndexerGetterAccess<int> access = new(1);
 
-		string result = indexerSetup.DoGetResult(access, "foo");
+		indexerSetup.DoGetResult(access, "foo");
 
 		await That(callCount).IsEqualTo(1);
 	}
@@ -233,7 +233,7 @@ public sealed class IndexerSetupTests
 			indexerSetup.OnGet.Do(() => { callCount++; });
 			IndexerGetterAccess<int, int> access = new(1, 2);
 
-			string result = indexerSetup.DoGetResult(access, "foo");
+			indexerSetup.DoGetResult(access, "foo");
 
 			await That(callCount).IsEqualTo(1);
 		}
@@ -333,7 +333,7 @@ public sealed class IndexerSetupTests
 		public async Task GetResult_WithFuncGenerator_AndInitialization_ShouldUseInitializationValue()
 		{
 			IndexerSetup<string, int, int> setup = new(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>());
 			setup.InitializeWith((p1, p2) => $"{p1}-{p2}");
@@ -432,7 +432,7 @@ public sealed class IndexerSetupTests
 			indexerSetup.OnGet.Do(() => { callCount++; });
 			IndexerGetterAccess<int, int, int> access = new(1, 2, 3);
 
-			string result = indexerSetup.DoGetResult(access, "foo");
+			indexerSetup.DoGetResult(access, "foo");
 
 			await That(callCount).IsEqualTo(1);
 		}
@@ -535,7 +535,7 @@ public sealed class IndexerSetupTests
 		public async Task GetResult_WithFuncGenerator_AndInitialization_ShouldUseInitializationValue()
 		{
 			IndexerSetup<string, int, int, int> setup = new(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>());
@@ -639,7 +639,7 @@ public sealed class IndexerSetupTests
 			IndexerGetterAccess<int, int, int, int> access =
 				new(1, 2, 3, 4);
 
-			string result = indexerSetup.DoGetResult(access, "foo");
+			indexerSetup.DoGetResult(access, "foo");
 
 			await That(callCount).IsEqualTo(1);
 		}
@@ -748,7 +748,7 @@ public sealed class IndexerSetupTests
 		public async Task GetResult_WithFuncGenerator_AndInitialization_ShouldUseInitializationValue()
 		{
 			IndexerSetup<string, int, int, int, int> setup = new(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
@@ -855,7 +855,7 @@ public sealed class IndexerSetupTests
 			IndexerGetterAccess<int, int, int, int, int> access =
 				new(1, 2, 3, 4, 5);
 
-			string result = indexerSetup.DoGetResult(access, "foo");
+			indexerSetup.DoGetResult(access, "foo");
 
 			await That(callCount).IsEqualTo(1);
 		}

--- a/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
@@ -239,6 +239,19 @@ public sealed class IndexerSetupTests
 		}
 
 		[Fact]
+		public async Task ExecuteSetterCallback_WhenAssignedValueDoesNotCastToTValue_ShouldNotExecute()
+		{
+			int callCount = 0;
+			MyIndexerSetup<int, int> indexerSetup = new();
+			indexerSetup.OnSet.Do(() => { callCount++; });
+			IndexerSetterAccess<int, int, string> access = new(1, 2, "bar");
+
+			indexerSetup.DoSetResult(access, 2L);
+
+			await That(callCount).IsEqualTo(0);
+		}
+
+		[Fact]
 		public async Task ExecuteSetterCallback_WhenGenericTypeDoesNotMatch_ShouldNotExecute()
 		{
 			int callCount = 0;
@@ -314,6 +327,33 @@ public sealed class IndexerSetupTests
 			await That(result).IsEqualTo("base");
 			await That(found).IsTrue();
 			await That(stored).IsEqualTo("base");
+		}
+
+		[Fact]
+		public async Task GetResult_WithFuncGenerator_AndInitialization_ShouldUseInitializationValue()
+		{
+			IndexerSetup<string, int, int> setup = new(
+				new MockRegistry(MockBehavior.Default),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>());
+			setup.InitializeWith((p1, p2) => $"{p1}-{p2}");
+			IndexerValueStorage<string> storage = new();
+			IndexerGetterAccess<int, int> access1 = new(7, 9)
+			{
+				Storage = storage,
+			};
+
+			string result = setup.GetResult<string>(access1, MockBehavior.Default, () => "fallback");
+
+			IndexerGetterAccess<int, int> access2 = new(7, 9)
+			{
+				Storage = storage,
+			};
+			bool found = access2.TryFindStoredValue(out string stored);
+
+			await That(result).IsEqualTo("7-9");
+			await That(found).IsTrue();
+			await That(stored).IsEqualTo("7-9");
 		}
 
 		private sealed class MyIndexerSetup<T1, T2>()
@@ -398,6 +438,19 @@ public sealed class IndexerSetupTests
 		}
 
 		[Fact]
+		public async Task ExecuteSetterCallback_WhenAssignedValueDoesNotCastToTValue_ShouldNotExecute()
+		{
+			int callCount = 0;
+			MyIndexerSetup<int, int, int> indexerSetup = new();
+			indexerSetup.OnSet.Do(() => { callCount++; });
+			IndexerSetterAccess<int, int, int, string> access = new(1, 2, 3, "bar");
+
+			indexerSetup.DoSetResult(access, 2L);
+
+			await That(callCount).IsEqualTo(0);
+		}
+
+		[Fact]
 		public async Task ExecuteSetterCallback_WhenGenericTypeDoesNotMatch_ShouldNotExecute()
 		{
 			int callCount = 0;
@@ -476,6 +529,34 @@ public sealed class IndexerSetupTests
 			await That(result).IsEqualTo("base");
 			await That(found).IsTrue();
 			await That(stored).IsEqualTo("base");
+		}
+
+		[Fact]
+		public async Task GetResult_WithFuncGenerator_AndInitialization_ShouldUseInitializationValue()
+		{
+			IndexerSetup<string, int, int, int> setup = new(
+				new MockRegistry(MockBehavior.Default),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>());
+			setup.InitializeWith((p1, p2, p3) => $"{p1}-{p2}-{p3}");
+			IndexerValueStorage<string> storage = new();
+			IndexerGetterAccess<int, int, int> access1 = new(7, 8, 9)
+			{
+				Storage = storage,
+			};
+
+			string result = setup.GetResult<string>(access1, MockBehavior.Default, () => "fallback");
+
+			IndexerGetterAccess<int, int, int> access2 = new(7, 8, 9)
+			{
+				Storage = storage,
+			};
+			bool found = access2.TryFindStoredValue(out string stored);
+
+			await That(result).IsEqualTo("7-8-9");
+			await That(found).IsTrue();
+			await That(stored).IsEqualTo("7-8-9");
 		}
 
 		private sealed class MyIndexerSetup<T1, T2, T3>()
@@ -564,6 +645,20 @@ public sealed class IndexerSetupTests
 		}
 
 		[Fact]
+		public async Task ExecuteSetterCallback_WhenAssignedValueDoesNotCastToTValue_ShouldNotExecute()
+		{
+			int callCount = 0;
+			MyIndexerSetup<int, int, int, int> indexerSetup = new();
+			indexerSetup.OnSet.Do(() => { callCount++; });
+			IndexerSetterAccess<int, int, int, int, string> access =
+				new(1, 2, 3, 4, "bar");
+
+			indexerSetup.DoSetResult(access, 2L);
+
+			await That(callCount).IsEqualTo(0);
+		}
+
+		[Fact]
 		public async Task ExecuteSetterCallback_WhenGenericTypeDoesNotMatch_ShouldNotExecute()
 		{
 			int callCount = 0;
@@ -647,6 +742,35 @@ public sealed class IndexerSetupTests
 			await That(result).IsEqualTo("base");
 			await That(found).IsTrue();
 			await That(stored).IsEqualTo("base");
+		}
+
+		[Fact]
+		public async Task GetResult_WithFuncGenerator_AndInitialization_ShouldUseInitializationValue()
+		{
+			IndexerSetup<string, int, int, int, int> setup = new(
+				new MockRegistry(MockBehavior.Default),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>());
+			setup.InitializeWith((p1, p2, p3, p4) => $"{p1}-{p2}-{p3}-{p4}");
+			IndexerValueStorage<string> storage = new();
+			IndexerGetterAccess<int, int, int, int> access1 = new(6, 7, 8, 9)
+			{
+				Storage = storage,
+			};
+
+			string result = setup.GetResult<string>(access1, MockBehavior.Default, () => "fallback");
+
+			IndexerGetterAccess<int, int, int, int> access2 = new(6, 7, 8, 9)
+			{
+				Storage = storage,
+			};
+			bool found = access2.TryFindStoredValue(out string stored);
+
+			await That(result).IsEqualTo("6-7-8-9");
+			await That(found).IsTrue();
+			await That(stored).IsEqualTo("6-7-8-9");
 		}
 
 		private sealed class MyIndexerSetup<T1, T2, T3, T4>()

--- a/Tests/Mockolate.Internal.Tests/Setup/PropertySetupTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/PropertySetupTests.cs
@@ -1,3 +1,4 @@
+using Mockolate.Exceptions;
 using Mockolate.Internal.Tests.TestHelpers;
 using Mockolate.Setup;
 
@@ -29,6 +30,48 @@ public sealed class PropertySetupTests
 		float value = interactive.InvokeGetter(null, MockBehavior.Default, () => 99f);
 
 		await That(value).IsEqualTo(99f);
+	}
+
+	[Fact]
+	public async Task DefaultInvokeSetter_WhenValueIsNullAndUnderlyingTypeIsNullable_ShouldStoreDefault()
+	{
+		PropertySetup.Default<int?> setup = new("p", 5);
+		IInteractivePropertySetup interactive = setup;
+
+		interactive.InvokeSetter<object?>(null, null, MockBehavior.Default);
+
+		int? value = interactive.InvokeGetter<int?>(null, MockBehavior.Default, () => 42);
+		await That(value).IsNull();
+	}
+
+	[Fact]
+	public async Task DefaultInvokeSetter_WhenValueIsNullButUnderlyingTypeIsNonNullable_ShouldThrow()
+	{
+		PropertySetup.Default<int> setup = new("p", 5);
+		IInteractivePropertySetup interactive = setup;
+
+		void Act()
+		{
+			interactive.InvokeSetter<object?>(null, null, MockBehavior.Default);
+		}
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("*int*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task DefaultInvokeSetter_WhenValueTypeMismatch_ShouldThrowWithFormattedMessage()
+	{
+		PropertySetup.Default<int> setup = new("p", 5);
+		IInteractivePropertySetup interactive = setup;
+
+		void Act()
+		{
+			interactive.InvokeSetter<string>(null, "string-value", MockBehavior.Default);
+		}
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("*'int'*'string'*").AsWildcard();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Verify/TypedVerifyFastPathTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Verify/TypedVerifyFastPathTests.cs
@@ -8,6 +8,129 @@ namespace Mockolate.Internal.Tests.Verify;
 public class TypedVerifyFastPathTests
 {
 	[Fact]
+	public async Task IndexerGot_WithoutBuffer_ProducesParametersDescriptionInExpectation()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.IndexerGot(
+			new object(), 5,
+			static _ => true,
+			() => "(5)");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("got indexer (5)");
+	}
+
+	[Fact]
+	public async Task IndexerGotTyped_WithBuffer_ProducesParametersDescriptionInExpectation()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallIndexerGetter<int>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.IndexerGotTyped(
+			new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			() => "(5)");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("got indexer (5)");
+	}
+
+	[Fact]
+	public async Task IndexerSet_WithoutBuffer_ProducesParametersDescriptionInExpectation()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		IParameterMatch<int> value = (IParameterMatch<int>)It.Is(7);
+		VerificationResult<object> result = registry.IndexerSet(
+			new object(), 5,
+			static (_, _) => true,
+			value,
+			() => "(5)");
+
+		await That(((IVerificationResult)result).Expectation).Contains("set indexer (5)");
+		await That(((IVerificationResult)result).Expectation).Contains(value.ToString()!);
+	}
+
+	[Fact]
+	public async Task IndexerSetTyped_WithBuffer_ProducesParametersDescriptionInExpectation()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallIndexerSetter<int, string>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		IParameterMatch<string> value = (IParameterMatch<string>)It.Is("v");
+		VerificationResult<object> result = registry.IndexerSetTyped(
+			new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			value,
+			() => "(5)");
+
+		await That(((IVerificationResult)result).Expectation).Contains("set indexer (5)");
+		await That(((IVerificationResult)result).Expectation).Contains(value.ToString()!);
+	}
+
+	[Fact]
+	public async Task SubscribedToTyped_WithBuffer_ProducesEventNameInExpectation()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallEventSubscribe(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.SubscribedToTyped(new object(), 0, "OnFoo");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("subscribed to event OnFoo");
+	}
+
+	[Fact]
+	public async Task SubscribedToTyped_WithMemberIdButNoBuffer_FallsBackToStringKeyedPath()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.SubscribedToTyped(new object(), 5, "OnFoo");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("subscribed to event OnFoo");
+	}
+
+	[Fact]
+	public async Task UnsubscribedFromTyped_WithBuffer_ProducesEventNameInExpectation()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallEventUnsubscribe(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.UnsubscribedFromTyped(new object(), 0, "OnFoo");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("unsubscribed from event OnFoo");
+	}
+
+	[Fact]
+	public async Task UnsubscribedFromTyped_WithMemberIdButNoBuffer_FallsBackToStringKeyedPath()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.UnsubscribedFromTyped(new object(), 5, "OnFoo");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("unsubscribed from event OnFoo");
+	}
+
+	[Fact]
+	public async Task UnsubscribedFromTyped_WithMemberIdButNonMatchingBufferKind_FallsBackToStringKeyedPath()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallMethod(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.UnsubscribedFromTyped(new object(), 0, "OnFoo");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("unsubscribed from event OnFoo");
+	}
+
+
+	[Fact]
 	public async Task VerifyMethod0_TypedFastPath_ShouldCount()
 	{
 		FastMockInteractions store = new(1);
@@ -18,7 +141,7 @@ public class TypedVerifyFastPathTests
 		buffer.Append("Foo");
 		buffer.Append("Foo");
 
-		registry.VerifyMethod<object>(new object(), 0, "Foo", () => "Foo()").Twice();
+		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Twice();
 
 		await That(true).IsTrue();
 	}
@@ -34,7 +157,7 @@ public class TypedVerifyFastPathTests
 		buffer.Append("Foo", 1);
 		buffer.Append("Foo", 1);
 
-		await That(() => registry.VerifyMethod<object, int>(new object(), 0, "Foo",
+		await That(() => registry.VerifyMethod(new object(), 0, "Foo",
 				(IParameterMatch<int>)It.Is(1), () => "Foo(1)").Once())
 			.Throws<MockVerificationException>();
 	}
@@ -53,7 +176,7 @@ public class TypedVerifyFastPathTests
 
 		registry.VerifyMethod(new object(), 0, "Foo",
 			(IParameterMatch<int>)It.Is(1), () => "Foo(1)").Twice();
-		registry.VerifyMethod<object, int>(new object(), 0, "Foo",
+		registry.VerifyMethod(new object(), 0, "Foo",
 			(IParameterMatch<int>)It.IsAny<int>(), () => "Foo(*)").Exactly(3);
 
 		await That(true).IsTrue();
@@ -82,5 +205,64 @@ public class TypedVerifyFastPathTests
 		result.AnyParameters().Exactly(3);
 
 		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task VerifyProperty_WithMemberIdButNoBuffer_FallsBackToStringKeyedPath()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new PropertyGetterAccess("P"));
+		interactions.RegisterInteraction(new PropertyGetterAccess("P"));
+
+		VerificationResult<object> result = registry.VerifyProperty(new object(), 5, "P");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("got property P");
+		((IVerificationResult)result).Verify(arr => arr.Length == 2);
+	}
+
+	[Fact]
+	public async Task VerifyPropertySetter_WithMemberIdButNoBuffer_FallsBackToStringKeyedPath()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new PropertySetterAccess<int>("P", 1));
+		interactions.RegisterInteraction(new PropertySetterAccess<int>("P", 2));
+
+		VerificationResult<object> result = registry.VerifyProperty(
+			new object(), 5, "P", (IParameterMatch<int>)It.IsAny<int>());
+
+		await That(((IVerificationResult)result).Expectation).Contains("set property P");
+		((IVerificationResult)result).Verify(arr => arr.Length == 2);
+	}
+
+	[Fact]
+	public async Task VerifyPropertyTyped_Getter_WithBuffer_ProducesPropertyNameInExpectation()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallPropertyGetter(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object> result = registry.VerifyPropertyTyped(new object(), 0, "P");
+
+		await That(((IVerificationResult)result).Expectation).IsEqualTo("got property P");
+	}
+
+	[Fact]
+	public async Task VerifyPropertyTyped_Setter_WithBuffer_ProducesPropertyNameInExpectation()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallPropertySetter<int>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		IParameterMatch<int> value = (IParameterMatch<int>)It.Is(42);
+		VerificationResult<object> result = registry.VerifyPropertyTyped(new object(), 0, "P", value);
+
+		await That(((IVerificationResult)result).Expectation).Contains("set property P");
+		await That(((IVerificationResult)result).Expectation).Contains(value.ToString()!);
 	}
 }

--- a/Tests/Mockolate.Tests/SetupExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/SetupExtensionsTests.cs
@@ -100,6 +100,21 @@ public sealed class SetupExtensionsTests
 
 			await That(values).IsEqualTo([1, 1, 1,]);
 		}
+
+		[Fact]
+		public async Task OnSet_OnlyOnce_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = ISetupExtensionsTestService.CreateMock();
+			sut.Mock.Setup.MyProperty.OnSet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut.MyProperty = i;
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
 	}
 
 	public sealed class IndexerSetupReturnWhenBuilderTests
@@ -676,6 +691,68 @@ public sealed class SetupExtensionsTests
 			for (int i = 0; i < 10; i++)
 			{
 				_ = sut[10, 20, 30, 40, 50];
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnSet_OnlyOnce_With1Parameter_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = ISetupExtensionsTestService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()].OnSet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10] = i;
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnSet_OnlyOnce_With2Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = ISetupExtensionsTestService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>()].OnSet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20] = i;
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnSet_OnlyOnce_With3Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = ISetupExtensionsTestService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()].OnSet.Do(() => values.Add(1))
+				.For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20, 30] = i;
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
+
+		[Fact]
+		public async Task OnSet_OnlyOnce_With4Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = ISetupExtensionsTestService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnSet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20, 30, 40] = i;
 			}
 
 			await That(values).IsEqualTo([1, 1, 1,]);

--- a/Tests/Mockolate.Tests/SetupExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/SetupExtensionsTests.cs
@@ -757,6 +757,22 @@ public sealed class SetupExtensionsTests
 
 			await That(values).IsEqualTo([1, 1, 1,]);
 		}
+
+		[Fact]
+		public async Task OnSet_OnlyOnce_With5Parameters_WithFor_ShouldInvokeTheCallbackOnlyForTimes()
+		{
+			List<int> values = [];
+			ISetupExtensionsTestService sut = ISetupExtensionsTestService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnSet.Do(() => values.Add(1)).For(3).OnlyOnce();
+
+			for (int i = 0; i < 10; i++)
+			{
+				sut[10, 20, 30, 40, 50] = i;
+			}
+
+			await That(values).IsEqualTo([1, 1, 1,]);
+		}
 	}
 
 	public sealed class ReturnMethodSetupReturnWhenBuilderTests


### PR DESCRIPTION
Adds additional unit test coverage for setup/verify behaviors around property setters and indexer setters/getters, including fast-path verification expectation formatting and edge cases in internal setup implementations.

**Changes:**
- Added `OnSet` callback tests for `For(n).OnlyOnce()` on properties and indexers (various arities).
- Added `MockRegistry` typed fast-path verification tests to validate expectation strings and fallback paths (indexers, properties, events).
- Added internal setup tests for property setter null/type-mismatch behavior and indexer setup casting/initialization behavior.