### PR TITLE
fix!: enable subclassing by updating MockRegistry constructors and interactions

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -69,25 +69,32 @@ internal static partial class Sources
 		};
 		if (hasEvents)
 		{
-			mockPropertyRemarks.Add("  <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item>");
+			mockPropertyRemarks.Add(
+				"  <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item>");
 		}
 
 		if (hasProtectedMembers || hasProtectedEvents)
 		{
-			mockPropertyRemarks.Add("  <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword=\"protected\" /> members on class mocks.</description></item>");
+			mockPropertyRemarks.Add(
+				"  <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword=\"protected\" /> members on class mocks.</description></item>");
 		}
 
 		if (hasStaticMembers || hasStaticEvents)
 		{
-			mockPropertyRemarks.Add("  <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword=\"static\" /> members on interface mocks.</description></item>");
+			mockPropertyRemarks.Add(
+				"  <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword=\"static\" /> members on interface mocks.</description></item>");
 		}
 
-		mockPropertyRemarks.Add("  <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item>");
-		mockPropertyRemarks.Add("  <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item>");
-		mockPropertyRemarks.Add("  <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item>");
+		mockPropertyRemarks.Add(
+			"  <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item>");
+		mockPropertyRemarks.Add(
+			"  <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item>");
+		mockPropertyRemarks.Add(
+			"  <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item>");
 		mockPropertyRemarks.Add("</list>");
 
-		sb.AppendXmlSummary($"Gets the mock accessor for <see cref=\"{escapedClassName}\" /> - the entry point for configuring setups, verifying interactions and raising events.");
+		sb.AppendXmlSummary(
+			$"Gets the mock accessor for <see cref=\"{escapedClassName}\" /> - the entry point for configuring setups, verifying interactions and raising events.");
 		sb.AppendXmlRemarks(mockPropertyRemarks.ToArray());
 		sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
 			$"The instance is not a Mockolate-generated mock of <see cref=\"{escapedClassName}\" />.");
@@ -123,12 +130,15 @@ internal static partial class Sources
 		};
 		if (hasEvents)
 		{
-			createMockRemarks.Add("  <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item>");
+			createMockRemarks.Add(
+				"  <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item>");
 		}
 
 		createMockRemarks.Add("</list>");
-		createMockRemarks.Add("With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword=\"null\" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref=\"global::Mockolate.MockBehavior\" /> to customize this (for example to make un-configured calls throw or to skip the base class).");
-		createMockRemarks.Add("Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.");
+		createMockRemarks.Add(
+			"With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword=\"null\" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref=\"global::Mockolate.MockBehavior\" /> to customize this (for example to make un-configured calls throw or to skip the base class).");
+		createMockRemarks.Add(
+			"Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.");
 
 		sb.AppendXmlSummary(
 			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
@@ -140,8 +150,10 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary(
 			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
-		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		sb.AppendXmlRemarks(
+			"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("setup",
+			"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::System.Action<")
 			.Append(setupType).Append("> setup)").AppendLine();
@@ -150,7 +162,8 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary(
 			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />.");
-		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlParam("mockBehavior",
+			"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior)").AppendLine();
@@ -159,9 +172,12 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary(
 			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
-		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
-		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		sb.AppendXmlRemarks(
+			"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("mockBehavior",
+			"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlParam("setup",
+			"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<").Append(setupType)
@@ -173,7 +189,8 @@ internal static partial class Sources
 		{
 			sb.AppendXmlSummary(
 				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> to invoke the base-class constructor.");
-			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlParam("constructorParameters",
+				"Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 				.Append(" CreateMock(object?[] constructorParameters)").AppendLine();
@@ -182,8 +199,10 @@ internal static partial class Sources
 
 			sb.AppendXmlSummary(
 				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" /> and <paramref name=\"constructorParameters\" />.");
-			sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
-			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlParam("mockBehavior",
+				"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+			sb.AppendXmlParam("constructorParameters",
+				"Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 				.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)")
@@ -193,9 +212,12 @@ internal static partial class Sources
 
 			sb.AppendXmlSummary(
 				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
-			sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-			sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
-			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlRemarks(
+				"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+			sb.AppendXmlParam("setup",
+				"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+			sb.AppendXmlParam("constructorParameters",
+				"Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
 			sb.AppendXmlReturns(createMockReturns);
 			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
 				.Append(" CreateMock(global::System.Action<").Append(setupType)
@@ -208,10 +230,14 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary(
 			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
-		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <c>MockBehavior.Default</c>.");
-		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
-		sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
+		sb.AppendXmlRemarks(
+			"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("mockBehavior",
+			"Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <c>MockBehavior.Default</c>.");
+		sb.AppendXmlParam("setup",
+			"Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
+		sb.AppendXmlParam("constructorParameters",
+			"Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
 		sb.AppendXmlReturns(createMockReturns);
 		sb.Append("\t\t").Append(hasParameterizedConstructor ? "public" : "private").Append(" static ")
 			.Append(@class.ClassFullName)
@@ -250,7 +276,8 @@ internal static partial class Sources
 
 		if (@class is { ClassFullName: "global::System.Net.Http.HttpClient", })
 		{
-			sb.Append("\t\t\tglobal::Mockolate.MockBehavior effectiveBehavior = mockBehavior ?? global::Mockolate.MockBehavior.Default;")
+			sb.Append(
+					"\t\t\tglobal::Mockolate.MockBehavior effectiveBehavior = mockBehavior ?? global::Mockolate.MockBehavior.Default;")
 				.AppendLine();
 			sb.Append(
 					"\t\t\tglobal::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(effectiveBehavior, global::Mockolate.Mock.")
@@ -443,9 +470,12 @@ internal static partial class Sources
 		#endregion CreateMock
 
 		sb.AppendXmlSummary("Creates a mock that wraps the given <paramref name=\"instance\" />.");
-		sb.AppendXmlRemarks("Public members on the mock forward to <paramref name=\"instance\" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.");
-		sb.AppendXmlParam("instance", "The real object whose calls should be forwarded. Must not be <see langword=\"null\" />.");
-		sb.AppendXmlReturns($"A new mock of <see cref=\"{escapedClassName}\" /> that delegates to <paramref name=\"instance\" />.");
+		sb.AppendXmlRemarks(
+			"Public members on the mock forward to <paramref name=\"instance\" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.");
+		sb.AppendXmlParam("instance",
+			"The real object whose calls should be forwarded. Must not be <see langword=\"null\" />.");
+		sb.AppendXmlReturns(
+			$"A new mock of <see cref=\"{escapedClassName}\" /> that delegates to <paramref name=\"instance\" />.");
 		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Wrapping(").Append(@class.ClassFullName)
 			.Append(" instance)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
@@ -483,9 +513,11 @@ internal static partial class Sources
 			"Initializes mocks of type <typeparamref name=\"T\" /> with the given <paramref name=\"setup\" />.");
 		sb.AppendXmlRemarks(
 			"The <paramref name=\"setup\" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.");
-		sb.AppendXmlTypeParam("T", $"The mockable type derived from <see cref=\"{escapedClassName}\" /> that this setup should apply to.");
+		sb.AppendXmlTypeParam("T",
+			$"The mockable type derived from <see cref=\"{escapedClassName}\" /> that this setup should apply to.");
 		sb.AppendXmlParam("setup", "Callback invoked when a new mock of <typeparamref name=\"T\" /> is created.");
-		sb.AppendXmlReturns("A new <see cref=\"global::Mockolate.MockBehavior\" /> with the registered initializer. The original instance is unchanged.");
+		sb.AppendXmlReturns(
+			"A new <see cref=\"global::Mockolate.MockBehavior\" /> with the registered initializer. The original instance is unchanged.");
 		sb.Append("\t\tpublic global::Mockolate.MockBehavior Initialize<T>(global::System.Action<").Append(setupType)
 			.Append("> setup)").AppendLine();
 		sb.Append("\t\t\twhere T : ").Append(@class.ClassFullName).AppendLine();
@@ -633,6 +665,10 @@ internal static partial class Sources
 		AppendCreateFastInteractions(sb, "\t\t", @class, memberIds, memberIdPrefix);
 		sb.AppendLine();
 
+		bool hasMockRegistryProvider = constructors?.Count > 0 || (@class.IsInterface && hasStaticMembers);
+		AppendCreateRegistryFromBehavior(sb, "\t\t", hasMockRegistryProvider);
+		sb.AppendLine();
+
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
 		sb.Append(
 				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
@@ -690,12 +726,15 @@ internal static partial class Sources
 
 			sb.Append("\t\t}").AppendLine();
 			sb.AppendLine();
+			AppendMockSubject_BehaviorConstructor(sb, name);
 		}
 		else if (constructors is not null)
 		{
 			foreach (Method constructor in constructors)
 			{
 				AppendMockSubject_BaseClassConstructor(sb, mockRegistryName, name, constructor,
+					@class.HasRequiredMembers);
+				AppendMockSubject_BehaviorBaseClassConstructor(sb, name, constructor,
 					@class.HasRequiredMembers);
 			}
 		}
@@ -707,6 +746,7 @@ internal static partial class Sources
 			sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(" = mockRegistry;").AppendLine();
 			sb.Append("\t\t}").AppendLine();
 			sb.AppendLine();
+			AppendMockSubject_BehaviorConstructor(sb, name);
 		}
 
 		AppendMockSubject_ImplementClass(sb, @class, mockRegistryName, null, memberIds, memberIdPrefix);
@@ -848,7 +888,8 @@ internal static partial class Sources
 
 		sb.AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }").AppendLine();
+		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }")
+			.AppendLine();
 		sb.Append("\t\tprivate string _scenarioName;").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t\tpublic MockInScenarioFor").Append(name)
@@ -867,7 +908,8 @@ internal static partial class Sources
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
 			sb.Append("\t\tglobal::Mockolate.Mock.IMockProtectedSetupFor").Append(name)
-				.Append(" global::Mockolate.Mock.IMockInScenarioFor").Append(name).Append(".SetupProtected").AppendLine();
+				.Append(" global::Mockolate.Mock.IMockInScenarioFor").Append(name).Append(".SetupProtected")
+				.AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 			sb.AppendLine();
 		}
@@ -895,13 +937,16 @@ internal static partial class Sources
 
 		#region IMockForXXX
 
-		sb.AppendXmlSummary($"The Mockolate accessor for a mock of <see cref=\"{escapedClassName}\" />, reached through <c>.Mock</c> on the mocked instance.", "\t");
+		sb.AppendXmlSummary(
+			$"The Mockolate accessor for a mock of <see cref=\"{escapedClassName}\" />, reached through <c>.Mock</c> on the mocked instance.",
+			"\t");
 		sb.AppendXmlRemarks([
 			"Groups every operation that acts on the mock rather than on the mocked subject: setups, verifications, event raising, scenarios and monitoring.",
 		], "\t");
 		sb.Append("\tinternal interface IMockFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary($"Configures how members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
+		sb.AppendXmlSummary(
+			$"Configures how members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
 		sb.AppendXmlRemarks([
 			"Each mocked member is available as a strongly-typed entry on this surface. Chain <c>Returns</c>, <c>ReturnsAsync</c>, <c>Throws</c>, <c>ThrowsAsync</c> or <c>Do</c> to control the response; chain <c>InitializeWith</c>/<c>Register</c> to initialize properties and indexers; chain multiple returns/throws to define a sequence; use <c>.For(n)</c>, <c>.Only(n)</c>, <c>.Forever()</c>, <c>.When(predicate)</c> to control when a callback runs.",
 			"When two setups overlap, the most recently defined one wins.",
@@ -910,7 +955,8 @@ internal static partial class Sources
 		sb.AppendLine();
 		if (hasProtectedMembers)
 		{
-			sb.AppendXmlSummary($"Configures how <see langword=\"protected\" /> virtual members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
+			sb.AppendXmlSummary(
+				$"Configures how <see langword=\"protected\" /> virtual members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
 			sb.AppendXmlRemarks([
 				"Only members declared as <see langword=\"protected\" /> (or <see langword=\"protected\" /> <see langword=\"internal\" />) on the mocked class appear here. All setup chain operators (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, sequences, <c>.For</c>/<c>.Only</c>/<c>.Forever</c>, ...) work identically to <see cref=\"Setup\" />.",
 			]);
@@ -920,7 +966,8 @@ internal static partial class Sources
 
 		if (hasStaticMembers)
 		{
-			sb.AppendXmlSummary($"Configures how <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> respond when invoked.");
+			sb.AppendXmlSummary(
+				$"Configures how <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> respond when invoked.");
 			sb.AppendXmlRemarks([
 				"Static members are scoped per async/execution flow while the mock is alive; invocations from other flows are not intercepted.",
 			]);
@@ -928,27 +975,34 @@ internal static partial class Sources
 			sb.AppendLine();
 		}
 
-		sb.AppendXmlSummary($"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> so that additional setups can be registered for that scenario.");
+		sb.AppendXmlSummary(
+			$"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> so that additional setups can be registered for that scenario.");
 		sb.AppendXmlRemarks([
 			"Scenarios let you define per-state behavior. Setups registered inside the returned <c>IMockInScenarioFor...</c> scope only apply while the mock's current scenario matches <paramref name=\"scenario\" />; switch scenarios with <see cref=\"TransitionTo\" />.",
 		]);
-		sb.AppendXmlParam("scenario", "Name of the scenario to enter. Any non-null string acts as a key; the mock starts in an unnamed default scenario.");
-		sb.AppendXmlReturns("A scoped accessor whose <c>Setup</c> (and <c>SetupProtected</c>, where applicable) register scenario-specific setups.");
+		sb.AppendXmlParam("scenario",
+			"Name of the scenario to enter. Any non-null string acts as a key; the mock starts in an unnamed default scenario.");
+		sb.AppendXmlReturns(
+			"A scoped accessor whose <c>Setup</c> (and <c>SetupProtected</c>, where applicable) register scenario-specific setups.");
 		sb.Append("\t\tIMockInScenarioFor").Append(name).Append(" InScenario(string scenario);").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary($"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> and immediately invokes <paramref name=\"setup\" /> to register scenario-specific setups.");
+		sb.AppendXmlSummary(
+			$"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> and immediately invokes <paramref name=\"setup\" /> to register scenario-specific setups.");
 		sb.AppendXmlRemarks([
 			"Equivalent to <c>InScenario(scenario)</c> followed by the setup callback, but returns the original <c>IMockFor...</c> accessor so it chains nicely at mock-creation time.",
 		]);
 		sb.AppendXmlParam("scenario", "Name of the scenario to enter.");
-		sb.AppendXmlParam("setup", "Callback that receives the scenario-scoped setup surface and registers scenario-specific setups.");
+		sb.AppendXmlParam("setup",
+			"Callback that receives the scenario-scoped setup surface and registers scenario-specific setups.");
 		sb.AppendXmlReturns("This accessor, to allow chaining.");
-		sb.Append("\t\tIMockFor").Append(name).Append(" InScenario(string scenario, global::System.Action<IMockInScenarioFor")
+		sb.Append("\t\tIMockFor").Append(name)
+			.Append(" InScenario(string scenario, global::System.Action<IMockInScenarioFor")
 			.Append(name).Append("> setup);").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary($"Switches the active scenario of the mock of <see cref=\"{escapedClassName}\" /> to <paramref name=\"scenario\" />.");
+		sb.AppendXmlSummary(
+			$"Switches the active scenario of the mock of <see cref=\"{escapedClassName}\" /> to <paramref name=\"scenario\" />.");
 		sb.AppendXmlRemarks([
 			"After the transition, setups registered via <see cref=\"InScenario(string)\" /> under that scenario take effect. Scenarios that have no matching setup for a given member fall back to the default (un-scoped) setups.",
 		]);
@@ -959,7 +1013,8 @@ internal static partial class Sources
 
 		if (hasEvents)
 		{
-			sb.AppendXmlSummary($"Triggers events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlSummary(
+				$"Triggers events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
 			sb.AppendXmlRemarks([
 				"One entry per event is generated; the signature matches the event's delegate. Only handlers that are subscribed at the moment of the <c>Raise</c> call are invoked - handlers subscribed later (or already removed) are skipped.",
 			]);
@@ -969,7 +1024,8 @@ internal static partial class Sources
 
 		if (hasProtectedEvents)
 		{
-			sb.AppendXmlSummary($"Triggers <see langword=\"protected\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlSummary(
+				$"Triggers <see langword=\"protected\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
 			sb.AppendXmlRemarks([
 				"Same semantics as <see cref=\"Raise\" /> but for events whose accessibility prevents external subscription from outside the class. Useful when testing code that subclasses the mocked type.",
 			]);
@@ -979,7 +1035,8 @@ internal static partial class Sources
 
 		if (hasStaticEvents)
 		{
-			sb.AppendXmlSummary($"Triggers <see langword=\"static\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlSummary(
+				$"Triggers <see langword=\"static\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
 			sb.AppendXmlRemarks([
 				"Static events are scoped per async/execution flow while the mock is alive.",
 			]);
@@ -987,7 +1044,8 @@ internal static partial class Sources
 			sb.AppendLine();
 		}
 
-		sb.AppendXmlSummary($"Asserts how often, and in which order, members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
+		sb.AppendXmlSummary(
+			$"Asserts how often, and in which order, members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
 		sb.AppendXmlRemarks([
 			"Each call to a member here returns a <c>VerificationResult</c> that you terminate with a count assertion: <c>Never()</c>, <c>Once()</c>, <c>Twice()</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>/<c>AtLeastOnce()</c>/<c>AtLeastTwice()</c>, <c>AtMost(n)</c>/<c>AtMostOnce()</c>/<c>AtMostTwice()</c>, <c>Between(min, max)</c> or <c>Times(predicate)</c>.",
 			"Use <c>Within(TimeSpan)</c> / <c>WithCancellation(CancellationToken)</c> before the terminator to wait for expected interactions that happen on background threads.",
@@ -997,7 +1055,8 @@ internal static partial class Sources
 		sb.AppendLine();
 		if (hasProtectedMembers || hasProtectedEvents)
 		{
-			sb.AppendXmlSummary($"Asserts how often, and in which order, <see langword=\"protected\" /> members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
+			sb.AppendXmlSummary(
+				$"Asserts how often, and in which order, <see langword=\"protected\" /> members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
 			sb.AppendXmlRemarks([
 				"Same terminators and modifiers as <see cref=\"Verify\" /> (<c>Once()</c>, <c>Exactly(n)</c>, <c>Within(...)</c>, <c>Then(...)</c>, ...); applies to <see langword=\"protected\" /> members and events instead of public ones.",
 			]);
@@ -1007,7 +1066,8 @@ internal static partial class Sources
 
 		if (hasStaticMembers || hasStaticEvents)
 		{
-			sb.AppendXmlSummary($"Asserts how often, and in which order, <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> were invoked.");
+			sb.AppendXmlSummary(
+				$"Asserts how often, and in which order, <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> were invoked.");
 			sb.AppendXmlRemarks([
 				"Same terminators and modifiers as <see cref=\"Verify\" />; scoped per async/execution flow in the same way as <see cref=\"SetupStatic\" />.",
 			]);
@@ -1019,26 +1079,32 @@ internal static partial class Sources
 		sb.AppendXmlRemarks([
 			"Useful when you want to verify &quot;this <em>particular</em> setup was hit N times&quot; without re-stating the matchers. Chain the usual count terminators (<c>Once()</c>, <c>AtLeastOnce()</c>, <c>Exactly(n)</c>, ...) on the returned result.",
 		]);
-		sb.AppendXmlParam("setup", "The setup previously registered through <see cref=\"Setup\" /> (typically returned from a <c>Returns(...)</c>/<c>Throws(...)</c> call).");
+		sb.AppendXmlParam("setup",
+			"The setup previously registered through <see cref=\"Setup\" /> (typically returned from a <c>Returns(...)</c>/<c>Throws(...)</c> call).");
 		sb.AppendXmlReturns("A <c>VerificationResult</c> that counts invocations matching the given setup.");
 		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name)
 			.Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary("Checks whether every recorded interaction on this mock has been observed by at least one <c>Verify</c> call.");
+		sb.AppendXmlSummary(
+			"Checks whether every recorded interaction on this mock has been observed by at least one <c>Verify</c> call.");
 		sb.AppendXmlRemarks([
 			"Useful in test teardown to catch unexpected interactions (&quot;strict verification&quot;): if any recorded call has never been matched by a verification, the method returns <see langword=\"false\" />.",
 		]);
-		sb.AppendXmlReturns("<see langword=\"true\" /> if every recorded interaction was verified at least once; otherwise <see langword=\"false\" />.");
+		sb.AppendXmlReturns(
+			"<see langword=\"true\" /> if every recorded interaction was verified at least once; otherwise <see langword=\"false\" />.");
 		sb.Append("\t\tbool VerifyThatAllInteractionsAreVerified();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary("Checks whether every registered setup on this mock was matched by at least one actual invocation.");
+		sb.AppendXmlSummary(
+			"Checks whether every registered setup on this mock was matched by at least one actual invocation.");
 		sb.AppendXmlRemarks([
 			"Useful to catch unused setups that silently rot as the test subject evolves.",
 		]);
-		sb.AppendXmlReturns("<see langword=\"true\" /> if every registered setup was used at least once; otherwise <see langword=\"false\" />.");
+		sb.AppendXmlReturns(
+			"<see langword=\"true\" /> if every registered setup was used at least once; otherwise <see langword=\"false\" />.");
 		sb.Append("\t\tbool VerifyThatAllSetupsAreUsed();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary("Removes every recorded interaction from this mock while keeping all registered setups intact.");
+		sb.AppendXmlSummary(
+			"Removes every recorded interaction from this mock while keeping all registered setups intact.");
 		sb.AppendXmlRemarks([
 			"Handy when a single test exercises multiple logical phases and you only want to verify the interactions of the latest phase.",
 		]);
@@ -1049,7 +1115,8 @@ internal static partial class Sources
 		sb.AppendXmlRemarks([
 			"The underlying mock keeps recording all interactions as usual - only the monitor's <c>Verify</c> view is scoped. Useful to verify only the interactions produced by a specific block of test code without resetting the mock.",
 		]);
-		sb.AppendXmlReturns("A <see cref=\"global::Mockolate.Monitor.MockMonitor{T}\" /> that exposes <c>Verify</c> over the monitored interactions and a <c>Run()</c> method that opens the recording scope.");
+		sb.AppendXmlReturns(
+			"A <see cref=\"global::Mockolate.Monitor.MockMonitor{T}\" /> that exposes <c>Verify</c> over the monitored interactions and a <c>Run()</c> method that opens the recording scope.");
 		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();")
 			.AppendLine();
 		sb.Append("\t}").AppendLine();
@@ -1060,7 +1127,8 @@ internal static partial class Sources
 
 		#region IMockInScenarioForXXX
 
-		sb.AppendXmlSummary($"Scoped access to setups for a scenario on the mock of <see cref=\"{escapedClassName}\" />.", "\t");
+		sb.AppendXmlSummary(
+			$"Scoped access to setups for a scenario on the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 		sb.Append("\tinternal interface IMockInScenarioFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.AppendXmlSummary($"Set up the mock of <see cref=\"{escapedClassName}\" /> within the scenario scope.");
@@ -1068,7 +1136,8 @@ internal static partial class Sources
 		if (hasProtectedMembers)
 		{
 			sb.AppendLine();
-			sb.AppendXmlSummary($"Set up protected members of the mock of <see cref=\"{escapedClassName}\" /> within the scenario scope.");
+			sb.AppendXmlSummary(
+				$"Set up protected members of the mock of <see cref=\"{escapedClassName}\" /> within the scenario scope.");
 			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" SetupProtected { get; }").AppendLine();
 		}
 
@@ -1213,14 +1282,18 @@ internal static partial class Sources
 		MemberIdTable memberIds, string memberIdPrefix)
 	{
 		sb.Append(indent).Append("/// <summary>").AppendLine();
-		sb.Append(indent).Append("///     Creates a <see cref=\"global::Mockolate.Interactions.FastMockInteractions\" /> sized to ")
+		sb.Append(indent)
+			.Append("///     Creates a <see cref=\"global::Mockolate.Interactions.FastMockInteractions\" /> sized to ")
 			.Append("<see cref=\"MemberCount\" /> for use as the mock's interaction store.").AppendLine();
 		sb.Append(indent).Append("/// </summary>").AppendLine();
 		sb.Append(indent)
-			.Append("internal static global::Mockolate.Interactions.FastMockInteractions CreateFastInteractions(global::Mockolate.MockBehavior behavior)")
+			.Append(
+				"internal static global::Mockolate.Interactions.FastMockInteractions CreateFastInteractions(global::Mockolate.MockBehavior behavior)")
 			.AppendLine();
 		sb.Append(indent).Append("{").AppendLine();
-		sb.Append(indent).Append("\tglobal::Mockolate.Interactions.FastMockInteractions fast = new global::Mockolate.Interactions.FastMockInteractions(MemberCount, behavior.SkipInteractionRecording);")
+		sb.Append(indent)
+			.Append(
+				"\tglobal::Mockolate.Interactions.FastMockInteractions fast = new global::Mockolate.Interactions.FastMockInteractions(MemberCount, behavior.SkipInteractionRecording);")
 			.AppendLine();
 
 		foreach (Method method in @class.AllMethods())
@@ -1258,12 +1331,14 @@ internal static partial class Sources
 			}
 
 			string getMemberIdRef = memberIdPrefix + memberIds.GetPropertyGetIdentifier(property);
-			sb.Append(indent).Append("\tglobal::Mockolate.Interactions.FastPropertyBufferFactory.InstallPropertyGetter(fast, ")
+			sb.Append(indent)
+				.Append("\tglobal::Mockolate.Interactions.FastPropertyBufferFactory.InstallPropertyGetter(fast, ")
 				.Append(getMemberIdRef).Append(");").AppendLine();
 
 			string setMemberIdRef = memberIdPrefix + memberIds.GetPropertySetIdentifier(property);
 			string propertyType = property.Type.ToTypeOrWrapper();
-			sb.Append(indent).Append("\tglobal::Mockolate.Interactions.FastPropertyBufferFactory.InstallPropertySetter<")
+			sb.Append(indent)
+				.Append("\tglobal::Mockolate.Interactions.FastPropertyBufferFactory.InstallPropertySetter<")
 				.Append(propertyType).Append(">(fast, ").Append(setMemberIdRef).Append(");").AppendLine();
 		}
 
@@ -1276,7 +1351,8 @@ internal static partial class Sources
 
 			string getMemberIdRef = memberIdPrefix + memberIds.GetIndexerGetIdentifier(indexer);
 			string setMemberIdRef = memberIdPrefix + memberIds.GetIndexerSetIdentifier(indexer);
-			string indexerKeyTypeArgs = string.Join(", ", indexer.IndexerParameters!.Value.Select(p => p.ToTypeOrWrapper()));
+			string indexerKeyTypeArgs =
+				string.Join(", ", indexer.IndexerParameters!.Value.Select(p => p.ToTypeOrWrapper()));
 			string indexerValueType = indexer.Type.ToTypeOrWrapper();
 
 			sb.Append(indent).Append("\tglobal::Mockolate.Interactions.FastIndexerBufferFactory.InstallIndexerGetter<")
@@ -1295,9 +1371,11 @@ internal static partial class Sources
 
 			string subMemberIdRef = memberIdPrefix + memberIds.GetEventSubscribeIdentifier(@event);
 			string unsubMemberIdRef = memberIdPrefix + memberIds.GetEventUnsubscribeIdentifier(@event);
-			sb.Append(indent).Append("\tglobal::Mockolate.Interactions.FastEventBufferFactory.InstallEventSubscribe(fast, ")
+			sb.Append(indent)
+				.Append("\tglobal::Mockolate.Interactions.FastEventBufferFactory.InstallEventSubscribe(fast, ")
 				.Append(subMemberIdRef).Append(");").AppendLine();
-			sb.Append(indent).Append("\tglobal::Mockolate.Interactions.FastEventBufferFactory.InstallEventUnsubscribe(fast, ")
+			sb.Append(indent)
+				.Append("\tglobal::Mockolate.Interactions.FastEventBufferFactory.InstallEventUnsubscribe(fast, ")
 				.Append(unsubMemberIdRef).Append(");").AppendLine();
 		}
 
@@ -1765,7 +1843,9 @@ internal static partial class Sources
 		string mockRegistry = CreateUniqueParameterName(constructor.Parameters, "mockRegistry");
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
 		sb.Append(constructor.Attributes, "\t\t");
-		if (hasRequiredMembers && constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") != true)
+		if (hasRequiredMembers &&
+		    constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") !=
+		    true)
 		{
 			sb.Append("\t\t[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").AppendLine();
 		}
@@ -1802,6 +1882,105 @@ internal static partial class Sources
 		sb.Append(')').AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(" = ").Append(mockRegistry).Append(';').AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+	}
+
+	/// <summary>
+	///     Emits a static helper that creates a typed-buffer-sized <c>MockRegistry</c> from a
+	///     <c>MockBehavior</c>. Used by the generator-emitted <c>(MockBehavior)</c> constructors so
+	///     subclasses of the generated mock can construct from a behavior without bypassing the FastMockInteractions
+	///     sizing. When <paramref name="setsMockRegistryProvider" /> is true, the helper also primes the
+	///     <c>MockRegistryProvider</c> AsyncLocal so virtual calls during base-class construction can resolve
+	///     the registry before the chained constructor body has run.
+	/// </summary>
+	private static void AppendCreateRegistryFromBehavior(StringBuilder sb, string indent,
+		bool setsMockRegistryProvider)
+	{
+		sb.Append(indent).Append("/// <summary>").AppendLine();
+		sb.Append(indent)
+			.Append("///     Builds a <see cref=\"global::Mockolate.MockRegistry\" /> backed by a typed-buffer-sized ")
+			.Append(
+				"<see cref=\"global::Mockolate.Interactions.FastMockInteractions\" /> from <paramref name=\"behavior\" />.")
+			.AppendLine();
+		sb.Append(indent).Append("/// </summary>").AppendLine();
+		sb.Append(indent)
+			.Append(
+				"private static global::Mockolate.MockRegistry MockolateCreateRegistryFromBehavior(global::Mockolate.MockBehavior behavior)")
+			.AppendLine();
+		sb.Append(indent).Append("{").AppendLine();
+		sb.Append(indent)
+			.Append(
+				"\tglobal::Mockolate.MockRegistry registry = new global::Mockolate.MockRegistry(behavior, CreateFastInteractions(behavior));")
+			.AppendLine();
+		if (setsMockRegistryProvider)
+		{
+			sb.Append(indent).Append("\tMockRegistryProvider.Value = registry;").AppendLine();
+		}
+
+		sb.Append(indent).Append("\treturn registry;").AppendLine();
+		sb.Append(indent).Append("}").AppendLine();
+	}
+
+	/// <summary>
+	///     Emits a public <c>(MockBehavior)</c> constructor on the generated mock for interface targets and class
+	///     targets without detected base-class constructors. Chains via <c>: this(...)</c> to the existing
+	///     <c>(MockRegistry)</c> constructor with a properly-sized registry.
+	/// </summary>
+	private static void AppendMockSubject_BehaviorConstructor(StringBuilder sb, string name)
+	{
+		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
+		sb.Append("\t\tpublic ").Append(name).Append("(global::Mockolate.MockBehavior behavior)").AppendLine();
+		sb.Append("\t\t\t: this(MockolateCreateRegistryFromBehavior(behavior))").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+	}
+
+	/// <summary>
+	///     Emits a public <c>(MockBehavior, ...baseCtorParams)</c> constructor sibling for each detected base-class
+	///     constructor. The chained <c>(MockRegistry, ...baseCtorParams)</c> constructor handles base invocation;
+	///     <c>MockolateCreateRegistryFromBehavior</c> primes the <c>MockRegistryProvider</c> AsyncLocal before that
+	///     chain so virtual calls during base construction resolve the registry.
+	/// </summary>
+	private static void AppendMockSubject_BehaviorBaseClassConstructor(StringBuilder sb, string name,
+		Method constructor, bool hasRequiredMembers)
+	{
+		string behavior = CreateUniqueParameterName(constructor.Parameters, "behavior");
+		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
+		sb.Append(constructor.Attributes, "\t\t");
+		if (hasRequiredMembers &&
+		    constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") !=
+		    true)
+		{
+			sb.Append("\t\t[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").AppendLine();
+		}
+
+		sb.Append("\t\tpublic ").Append(name).Append("(global::Mockolate.MockBehavior ").Append(behavior);
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			sb.Append(", ");
+			if (parameter.IsParams)
+			{
+				sb.Append("params ");
+			}
+
+			sb.Append(parameter.Type.Fullname).Append(' ').Append(parameter.Name);
+			if (parameter.HasExplicitDefaultValue)
+			{
+				sb.Append(" = ").Append(parameter.ExplicitDefaultValue);
+			}
+		}
+
+		sb.Append(")").AppendLine();
+		sb.Append("\t\t\t: this(MockolateCreateRegistryFromBehavior(").Append(behavior).Append(")");
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			sb.Append(", ").Append(parameter.Name);
+		}
+
+		sb.Append(")").AppendLine();
+		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 	}
@@ -1844,7 +2023,8 @@ internal static partial class Sources
 					                      (property.ExplicitImplementation ?? "") + "::" +
 					                      property.Type.Fullname + "->|" +
 					                      string.Join("|",
-						                      property.IndexerParameters.Value.Select(p => p.RefKind + " " + p.Type.Fullname));
+						                      property.IndexerParameters.Value.Select(p
+							                      => p.RefKind + " " + p.Type.Fullname));
 					if (!signatureIndices.TryGetValue(signatureKey, out signatureIndex))
 					{
 						signatureIndex = nextSignatureIndex[0]++;
@@ -2604,7 +2784,8 @@ internal static partial class Sources
 		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
 		{
 			bool isOverride = !isClassInterface && method.UseOverride;
-			bool isExplicitImplementation = explicitInterfaceImplementation || method.ExplicitImplementation is not null;
+			bool isExplicitImplementation =
+				explicitInterfaceImplementation || method.ExplicitImplementation is not null;
 			bool inheritsConstraints = isExplicitImplementation || isOverride || method.IsEquals() ||
 			                           method.IsGetHashCode() || method.IsToString();
 			foreach (GenericParameter gp in method.GenericParameters.Value)
@@ -2630,9 +2811,11 @@ internal static partial class Sources
 		string methodSetupType = (method.ReturnType == Type.Void, method.Parameters.Count) switch
 		{
 			(true, 0) => "global::Mockolate.Setup.VoidMethodSetup",
-			(true, _) => $"global::Mockolate.Setup.VoidMethodSetup<{string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
+			(true, _) =>
+				$"global::Mockolate.Setup.VoidMethodSetup<{string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
 			(_, 0) => $"global::Mockolate.Setup.ReturnMethodSetup<{method.ReturnType.ToTypeOrWrapper()}>",
-			(_, _) => $"global::Mockolate.Setup.ReturnMethodSetup<{method.ReturnType.ToTypeOrWrapper()}, {string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
+			(_, _) =>
+				$"global::Mockolate.Setup.ReturnMethodSetup<{method.ReturnType.ToTypeOrWrapper()}, {string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
 		};
 		bool hasOutParams = method.Parameters.Any(p => p.RefKind is RefKind.Out);
 		bool hasRefParams = method.Parameters.Any(p => p.RefKind is RefKind.Ref);
@@ -2699,7 +2882,8 @@ internal static partial class Sources
 			}
 		}
 
-		sb.Append("\t\t\tif (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append("\t\t\tif (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)")
+			.AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
 		if (useFastBuffers && IsFastBufferEligibleMethod(method))
 		{
@@ -2725,7 +2909,8 @@ internal static partial class Sources
 				.Append(".RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation");
 			if (method.Parameters.Count > 0)
 			{
-				sb.Append('<').Append(string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper()))).Append('>');
+				sb.Append('<').Append(string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper())))
+					.Append('>');
 			}
 
 			sb.Append("(").Append(method.GetUniqueNameString());
@@ -2816,7 +3001,8 @@ internal static partial class Sources
 		{
 			string outParamBase = Helpers.GetUniqueIndexedLocalVariableBase("outParam", method.Parameters);
 			string refParamBase = Helpers.GetUniqueIndexedLocalVariableBase("refParam", method.Parameters);
-			sb.Append("\t\t\t\tif (!").Append(hasWrappedResult).Append(" || ").Append(methodSetup).Append(" is ").Append(methodSetupType)
+			sb.Append("\t\t\t\tif (!").Append(hasWrappedResult).Append(" || ").Append(methodSetup).Append(" is ")
+				.Append(methodSetupType)
 				.Append(".WithParameterCollection)")
 				.AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
@@ -2831,7 +3017,8 @@ internal static partial class Sources
 				{
 					sb.Append("\t\t\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex)
 						.Append(" is not global::Mockolate.Parameters.IOutParameter<")
-						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(outParamBase).Append(parameterIndex)
+						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(outParamBase)
+						.Append(parameterIndex)
 						.Append(" || !").Append(outParamBase).Append(parameterIndex).Append(".TryGetValue(out ")
 						.Append(parameter.Name).Append("))").AppendLine();
 					sb.Append("\t\t\t\t\t\t{").AppendLine();
@@ -2844,10 +3031,12 @@ internal static partial class Sources
 				{
 					sb.Append("\t\t\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex)
 						.Append(" is global::Mockolate.Parameters.IRefParameter<")
-						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(refParamBase).Append(parameterIndex)
+						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(refParamBase)
+						.Append(parameterIndex)
 						.Append(")").AppendLine();
 					sb.Append("\t\t\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\t\t\t").Append(parameter.Name).Append(" = ").Append(refParamBase).Append(parameterIndex)
+					sb.Append("\t\t\t\t\t\t\t").Append(parameter.Name).Append(" = ").Append(refParamBase)
+						.Append(parameterIndex)
 						.Append(".GetValue(").Append(parameter.Name).Append(");").AppendLine();
 					sb.Append("\t\t\t\t\t\t}").AppendLine();
 				}
@@ -2873,16 +3062,20 @@ internal static partial class Sources
 		AppendTriggerCallbacks(sb, "\t\t\t\t", methodSetup, method.Parameters);
 		sb.Append("\t\t\t}").AppendLine();
 
-		string displayMethodName = $"{method.ContainingType}.{method.Name}({string.Join(", ", method.Parameters.Select(p => p.Type.DisplayName))})";
-		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && !").Append(hasWrappedResult).Append(" && ").Append(mockRegistry).Append(".Behavior.ThrowWhenNotSetup)").AppendLine();
+		string displayMethodName =
+			$"{method.ContainingType}.{method.Name}({string.Join(", ", method.Parameters.Select(p => p.Type.DisplayName))})";
+		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && !").Append(hasWrappedResult).Append(" && ")
+			.Append(mockRegistry).Append(".Behavior.ThrowWhenNotSetup)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockNotSetupException(\"The method '").Append(displayMethodName).Append("' was invoked without prior setup.\");").AppendLine();
+		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockNotSetupException(\"The method '")
+			.Append(displayMethodName).Append("' was invoked without prior setup.\");").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 
 		if (method.ReturnType != Type.Void)
 		{
 			string returnValue = Helpers.GetUniqueLocalVariableName("returnValue", method.Parameters);
-			sb.Append("\t\t\tif (").Append(methodSetup).Append("?.HasReturnCallbacks != true && ").Append(hasWrappedResult).Append(")").AppendLine();
+			sb.Append("\t\t\tif (").Append(methodSetup).Append("?.HasReturnCallbacks != true && ")
+				.Append(hasWrappedResult).Append(")").AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\treturn ").Append(wrappedResult).Append(";").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
@@ -2895,7 +3088,8 @@ internal static partial class Sources
 			}
 
 			sb.Append("out var ").Append(returnValue).Append(") == true ? ").Append(returnValue).Append(" : ")
-				.AppendDefaultValueGeneratorFor(method.ReturnType, $"{mockRegistry}.Behavior.DefaultValue", defaultValueGeneratorSuffix)
+				.AppendDefaultValueGeneratorFor(method.ReturnType, $"{mockRegistry}.Behavior.DefaultValue",
+					defaultValueGeneratorSuffix)
 				.Append(';').AppendLine();
 		}
 
@@ -3026,7 +3220,8 @@ internal static partial class Sources
 		string displayMethodName =
 			$"{method.ContainingType}.{method.Name}({string.Join(", ", method.Parameters.Select(p => p.Type.DisplayName))})";
 
-		sb.Append("\t\t\tif (!").Append(matchedVar).Append(" && ").Append(mockRegistry).Append(".Behavior.ThrowWhenNotSetup)")
+		sb.Append("\t\t\tif (!").Append(matchedVar).Append(" && ").Append(mockRegistry)
+			.Append(".Behavior.ThrowWhenNotSetup)")
 			.AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockNotSetupException(\"The method '")
@@ -3092,7 +3287,8 @@ internal static partial class Sources
 		// Iterate setups in latest-registered-first order; stop on the first matching setup.
 		string paramNames = string.Join(", ", property.IndexerParameters.Value.Select(p => p.Name));
 		string setupVar = Helpers.GetUniqueLocalVariableName("setup", property.IndexerParameters.Value);
-		sb.Append("\t\t\t\tforeach (").Append(setupType).Append(' ').Append(setupVar).Append(" in ").Append(mockRegistry)
+		sb.Append("\t\t\t\tforeach (").Append(setupType).Append(' ').Append(setupVar).Append(" in ")
+			.Append(mockRegistry)
 			.Append(".GetMethodSetups<").Append(setupType).Append(">(").Append(indexerName).Append("))")
 			.AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
@@ -3188,7 +3384,8 @@ internal static partial class Sources
 			: string.Empty;
 
 		string setupVar = Helpers.GetUniqueLocalVariableName("setup", property.IndexerParameters.Value);
-		sb.Append("\t\t\t\tforeach (").Append(setupType).Append(' ').Append(setupVar).Append(" in ").Append(mockRegistry)
+		sb.Append("\t\t\t\tforeach (").Append(setupType).Append(' ').Append(setupVar).Append(" in ")
+			.Append(mockRegistry)
 			.Append(".GetMethodSetups<").Append(setupType).Append(">(").Append(indexerName).Append("))")
 			.AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
@@ -3197,7 +3394,8 @@ internal static partial class Sources
 		sb.Append("\t\t\t\t\t\tcontinue;").AppendLine();
 		sb.Append("\t\t\t\t\t}").AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\t\t\t\t").Append(setupVar).Append(".Invoke(").Append(keyNames).Append(", value").Append(rawKeysArgs).Append(");").AppendLine();
+		sb.Append("\t\t\t\t\t").Append(setupVar).Append(".Invoke(").Append(keyNames).Append(", value")
+			.Append(rawKeysArgs).Append(");").AppendLine();
 		sb.Append("\t\t\t\t\treturn;").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
 
@@ -3222,13 +3420,17 @@ internal static partial class Sources
 	{
 		sb.AppendLine();
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("\tprivate sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>").AppendLine();
+		sb.Append(
+				"\tprivate sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>")
+			.AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.Append("\t\tpublic bool Matches(T value) => inner.Matches(value);").AppendLine();
 		sb.Append("\t\tpublic void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);").AppendLine();
 		sb.Append("\t\tpublic override string? ToString() => inner.ToString();").AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\tpublic static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)").AppendLine();
+		sb.Append(
+				"\t\tpublic static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)")
+			.AppendLine();
 		sb.Append("\t\t\t=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct").AppendLine();
 		sb.Append("\t\t\t\t? direct").AppendLine();
 		sb.Append("\t\t\t\t: new CovariantParameterAdapter<T>(parameter);").AppendLine();
@@ -3421,7 +3623,8 @@ internal static partial class Sources
 		}
 		else if (valueFlags is null)
 		{
-			text = "This overload takes <see cref=\"global::Mockolate.It\" /> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.";
+			text =
+				"This overload takes <see cref=\"global::Mockolate.It\" /> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.";
 		}
 		else if (valueFlags.All(x => x))
 		{
@@ -3506,7 +3709,8 @@ internal static partial class Sources
 
 		sb.Append(".").AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
-		AppendOverloadDifferentiatorRemark(sb, method.Parameters.Select(p => p.Name).ToArray(), useParameters, valueFlags);
+		AppendOverloadDifferentiatorRemark(sb, method.Parameters.Select(p => p.Name).ToArray(), useParameters,
+			valueFlags);
 		if (method.ReturnType != Type.Void)
 		{
 			if (valueFlags?.All(x => x) == true)
@@ -4719,7 +4923,8 @@ internal static partial class Sources
 		AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "g");
 		sb.Append(",").AppendLine();
 
-		sb.Append("\t\t\t\t\t(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<");
+		sb.Append(
+			"\t\t\t\t\t(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<");
 		ti = 0;
 		foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
 		{
@@ -5058,7 +5263,8 @@ internal static partial class Sources
 
 		sb.Append(".").AppendLine();
 		sb.Append("\t\t/// </summary>").AppendLine();
-		AppendOverloadDifferentiatorRemark(sb, method.Parameters.Select(p => p.Name).ToArray(), useParameters, valueFlags, true);
+		AppendOverloadDifferentiatorRemark(sb, method.Parameters.Select(p => p.Name).ToArray(), useParameters,
+			valueFlags, true);
 		if (valueFlags?.All(x => x) == true || (method.Parameters.Count == 0 && !useParameters))
 		{
 			sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<").Append(verifyName)
@@ -5369,7 +5575,9 @@ internal static partial class Sources
 		                         && method.Parameters.Count <= 4
 		                         && (method.GenericParameters is null || method.GenericParameters.Value.Count == 0)
 		                         && (valueFlags is null || !valueFlags.Any(x => x))
-		                         && !method.Parameters.Any(p => p.RefKind == RefKind.Out || p.RefKind == RefKind.Ref || p.RefKind == RefKind.RefReadOnlyParameter);
+		                         && !method.Parameters.Any(p
+			                         => p.RefKind == RefKind.Out || p.RefKind == RefKind.Ref ||
+			                            p.RefKind == RefKind.RefReadOnlyParameter);
 
 		if (canUseTypedVerify)
 		{
@@ -5384,11 +5592,14 @@ internal static partial class Sources
 			{
 				string paramType = parameter.ToTypeOrWrapper();
 				sb.Append(", ").Append(parameter.Name).Append(" is null ? ")
-					.Append("(global::Mockolate.Parameters.IParameterMatch<").Append(paramType).Append(">)global::Mockolate.It.Is<").Append(paramType).Append(">(default!) : ")
-					.Append("CovariantParameterAdapter<").Append(paramType).Append(">.Wrap(").Append(parameter.Name).Append(")");
+					.Append("(global::Mockolate.Parameters.IParameterMatch<").Append(paramType)
+					.Append(">)global::Mockolate.It.Is<").Append(paramType).Append(">(default!) : ")
+					.Append("CovariantParameterAdapter<").Append(paramType).Append(">.Wrap(").Append(parameter.Name)
+					.Append(")");
 			}
 
-			sb.Append(", () => $\"").Append(method.Name).Append("(").Append(string.Join(", ", method.Parameters.Select(p => $"{{{p.Name}}}"))).Append(")\");").AppendLine();
+			sb.Append(", () => $\"").Append(method.Name).Append("(")
+				.Append(string.Join(", ", method.Parameters.Select(p => $"{{{p.Name}}}"))).Append(")\");").AppendLine();
 			return;
 		}
 
@@ -5404,8 +5615,12 @@ internal static partial class Sources
 		{
 			sb.Append(", i => parameters switch").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t\tglobal::Mockolate.Parameters.IParametersMatch m => m.Matches([").Append(string.Join(", ", Enumerable.Range(1, method.Parameters.Count).Select(i => $"i.Parameter{i}"))).Append("]),").AppendLine();
-			sb.Append("\t\t\t\t\tglobal::Mockolate.Parameters.INamedParametersMatch m => m.Matches([").Append(string.Join(", ", method.Parameters.Select((p, i) => $"(\"{p.Name}\", i.Parameter{i + 1})"))).Append("]),").AppendLine();
+			sb.Append("\t\t\t\t\tglobal::Mockolate.Parameters.IParametersMatch m => m.Matches([")
+				.Append(string.Join(", ", Enumerable.Range(1, method.Parameters.Count).Select(i => $"i.Parameter{i}")))
+				.Append("]),").AppendLine();
+			sb.Append("\t\t\t\t\tglobal::Mockolate.Parameters.INamedParametersMatch m => m.Matches([")
+				.Append(string.Join(", ", method.Parameters.Select((p, i) => $"(\"{p.Name}\", i.Parameter{i + 1})")))
+				.Append("]),").AppendLine();
 			sb.Append("\t\t\t\t\t_ => true").AppendLine();
 			sb.Append("\t\t\t\t}");
 		}
@@ -5430,24 +5645,30 @@ internal static partial class Sources
 				bool isValueParam = valueFlags?[i] == true;
 				if (isValueParam)
 				{
-					sb.Append($"(global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals({parameter.Name}, i.Parameter{i + 1}))");
+					sb.Append(
+						$"(global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals({parameter.Name}, i.Parameter{i + 1}))");
 				}
-				else if (parameter.RefKind == RefKind.Out || parameter.RefKind == RefKind.Ref || parameter.RefKind == RefKind.RefReadOnlyParameter)
+				else if (parameter.RefKind == RefKind.Out || parameter.RefKind == RefKind.Ref ||
+				         parameter.RefKind == RefKind.RefReadOnlyParameter)
 				{
 					// out/ref verify parameters use IVerifyOutParameter<T> / IVerifyRefParameter<T>, which don't inherit
 					// from IParameter<T> — covariance isn't applicable, so keep the direct IParameterMatch<T> check.
-					sb.Append($"({parameter.Name} is global::Mockolate.Parameters.IParameterMatch<{parameter.ToTypeOrWrapper()}> {parameter.Name}Match ? {parameter.Name}Match.Matches(i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
+					sb.Append(
+						$"({parameter.Name} is global::Mockolate.Parameters.IParameterMatch<{parameter.ToTypeOrWrapper()}> {parameter.Name}Match ? {parameter.Name}Match.Matches(i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
 				}
 				else
 				{
-					sb.Append($"({parameter.Name} is not null ? CovariantParameterAdapter<{parameter.ToTypeOrWrapper()}>.Wrap({parameter.Name}).Matches(i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
+					sb.Append(
+						$"({parameter.Name} is not null ? CovariantParameterAdapter<{parameter.ToTypeOrWrapper()}>.Wrap({parameter.Name}).Matches(i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
 				}
 
 				i++;
 			}
 		}
 
-		sb.Append(", () => $\"").Append(method.Name).Append("(").Append(useParameters ? "{parameters}" : string.Join(", ", method.Parameters.Select(p => $"{{{p.Name}}}"))).Append(")\");").AppendLine();
+		sb.Append(", () => $\"").Append(method.Name).Append("(")
+			.Append(useParameters ? "{parameters}" : string.Join(", ", method.Parameters.Select(p => $"{{{p.Name}}}")))
+			.Append(")\");").AppendLine();
 	}
 
 	#endregion Verify Helpers

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -40,11 +40,13 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tget").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tif (mock.Target is global::Mockolate.Mock.IMockFor").Append(name).Append(" mockInterface)").AppendLine();
+		sb.Append("\t\t\t\tif (mock.Target is global::Mockolate.Mock.IMockFor").Append(name).Append(" mockInterface)")
+			.AppendLine();
 		sb.Append("\t\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t\treturn mockInterface;").AppendLine();
 		sb.Append("\t\t\t\t}").AppendLine();
-		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");").AppendLine();
+		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");")
+			.AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
@@ -53,14 +55,18 @@ internal static partial class Sources
 
 		#region CreateMock
 
-		sb.AppendXmlSummary($"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlSummary(
+			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
 		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock()").AppendLine();
 		sb.Append("\t\t\t=> CreateMock(null, []);").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary($"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlSummary(
+			$"Create a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
 		sb.AppendXmlRemarks("All provided <paramref name=\"setups\" /> are immediately applied to the mock.");
-		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(name).Append(">[] setups)").AppendLine();
+		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
+			.Append(" CreateMock(params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(name)
+			.Append(">[] setups)").AppendLine();
 		sb.Append("\t\t\t=> CreateMock(null, setups);").AppendLine();
 		sb.AppendLine();
 
@@ -73,7 +79,9 @@ internal static partial class Sources
 			.Append(name).Append(">[] setups)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tmockBehavior ??= global::Mockolate.MockBehavior.Default;").AppendLine();
-		sb.Append("\t\t\tvar mockRegistry = new global::Mockolate.MockRegistry(mockBehavior);").AppendLine();
+		sb.Append(
+				"\t\t\tvar mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, new global::Mockolate.Interactions.FastMockInteractions(0, mockBehavior.SkipInteractionRecording));")
+			.AppendLine();
 		sb.Append("\t\t\tglobal::Mockolate.Mock.").Append(name).Append(" mockTarget = new global::Mockolate.Mock.")
 			.Append(name).Append("(mockRegistry);")
 			.AppendLine();
@@ -100,9 +108,12 @@ internal static partial class Sources
 		sb.Append("internal static partial class Mock").AppendLine();
 		sb.Append("{").AppendLine();
 		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     A mock implementation for <see cref=\"").Append(escapedClassName).Append("\" />.").AppendLine();
+		sb.Append("\t///     A mock implementation for <see cref=\"").Append(escapedClassName).Append("\" />.")
+			.AppendLine();
 		sb.Append("\t/// </summary>").AppendLine();
-		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
+		sb.Append(
+				"\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]")
+			.AppendLine();
 #if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
@@ -115,9 +126,13 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.MockRegistry global::Mockolate.IMock.MockRegistry => this.").Append(mockRegistryName).Append(';').AppendLine();
-		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }").AppendLine();
+		sb.Append(
+				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
+			.AppendLine();
+		sb.Append("\t\tglobal::Mockolate.MockRegistry global::Mockolate.IMock.MockRegistry => this.")
+			.Append(mockRegistryName).Append(';').AppendLine();
+		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }")
+			.AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
@@ -141,9 +156,11 @@ internal static partial class Sources
 		string methodSetupType = (delegateMethod.ReturnType == Type.Void, delegateMethod.Parameters.Count) switch
 		{
 			(true, 0) => "global::Mockolate.Setup.VoidMethodSetup",
-			(true, _) => $"global::Mockolate.Setup.VoidMethodSetup<{string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
+			(true, _) =>
+				$"global::Mockolate.Setup.VoidMethodSetup<{string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
 			(_, 0) => $"global::Mockolate.Setup.ReturnMethodSetup<{delegateMethod.ReturnType.ToTypeOrWrapper()}>",
-			(_, _) => $"global::Mockolate.Setup.ReturnMethodSetup<{delegateMethod.ReturnType.ToTypeOrWrapper()}, {string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
+			(_, _) =>
+				$"global::Mockolate.Setup.ReturnMethodSetup<{delegateMethod.ReturnType.ToTypeOrWrapper()}, {string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
 		};
 		bool hasOutParams = delegateMethod.Parameters.Any(p => p.RefKind is RefKind.Out);
 		bool hasRefParams = delegateMethod.Parameters.Any(p => p.RefKind is RefKind.Ref);
@@ -186,7 +203,8 @@ internal static partial class Sources
 		}
 
 		string memberIdRef = memberIdPrefix + memberIds.GetMethodIdentifier(delegateMethod);
-		bool isGeneric = delegateMethod.GenericParameters is not null && delegateMethod.GenericParameters.Value.Count > 0;
+		bool isGeneric = delegateMethod.GenericParameters is not null &&
+		                 delegateMethod.GenericParameters.Value.Count > 0;
 		EmitFastMethodSetupLookup(sb, "\t\t\t", $"this.{mockRegistryName}", methodSetup, methodSetupType,
 			memberIdRef, delegateMethod.GetUniqueNameString(), sb2.ToString(), isGeneric);
 
@@ -213,12 +231,14 @@ internal static partial class Sources
 				{
 					sb.Append("\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex)
 						.Append(" is not global::Mockolate.Parameters.IOutParameter<")
-						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(outParamBase).Append(parameterIndex)
+						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(outParamBase)
+						.Append(parameterIndex)
 						.Append(" || !").Append(outParamBase).Append(parameterIndex).Append(".TryGetValue(out ")
 						.Append(parameter.Name).Append("))").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = ")
-						.AppendDefaultValueGeneratorFor(parameter.Type, $"this.{mockRegistryName}.Behavior.DefaultValue")
+						.AppendDefaultValueGeneratorFor(parameter.Type,
+							$"this.{mockRegistryName}.Behavior.DefaultValue")
 						.Append(';').AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
 				}
@@ -226,10 +246,12 @@ internal static partial class Sources
 				{
 					sb.Append("\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex)
 						.Append(" is global::Mockolate.Parameters.IRefParameter<")
-						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(refParamBase).Append(parameterIndex)
+						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(refParamBase)
+						.Append(parameterIndex)
 						.Append(")").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = ").Append(refParamBase).Append(parameterIndex)
+					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = ").Append(refParamBase)
+						.Append(parameterIndex)
 						.Append(".GetValue(").Append(parameter.Name).Append(");").AppendLine();
 					sb.Append("\t\t\t\t}").AppendLine();
 				}
@@ -238,13 +260,15 @@ internal static partial class Sources
 			sb.Append("\t\t\t}").AppendLine();
 		}
 
-		sb.Append("\t\t\tif (").Append(mockRegistryName).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append("\t\t\tif (").Append(mockRegistryName).Append(".Behavior.SkipInteractionRecording == false)")
+			.AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
 		sb.Append("\t\t\t\t").Append(mockRegistryName)
 			.Append(".RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation");
 		if (delegateMethod.Parameters.Count > 0)
 		{
-			sb.Append('<').Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))).Append('>');
+			sb.Append('<').Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper())))
+				.Append('>');
 		}
 
 		sb.Append("(").Append(delegateMethod.GetUniqueNameString());
@@ -256,10 +280,13 @@ internal static partial class Sources
 		sb.Append("));").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 
-		string displayDelegateName = $"{delegateMethod.ContainingType}.{delegateMethod.Name}({string.Join(", ", delegateMethod.Parameters.Select(p => p.Type.DisplayName))})";
-		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && this.").Append(mockRegistryName).Append(".Behavior.ThrowWhenNotSetup)").AppendLine();
+		string displayDelegateName =
+			$"{delegateMethod.ContainingType}.{delegateMethod.Name}({string.Join(", ", delegateMethod.Parameters.Select(p => p.Type.DisplayName))})";
+		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && this.").Append(mockRegistryName)
+			.Append(".Behavior.ThrowWhenNotSetup)").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockNotSetupException(\"The method '").Append(displayDelegateName).Append("' was invoked without prior setup.\");").AppendLine();
+		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockNotSetupException(\"The method '")
+			.Append(displayDelegateName).Append("' was invoked without prior setup.\");").AppendLine();
 		sb.Append("\t\t\t}").AppendLine();
 
 		AppendTriggerCallbacks(sb, "\t\t\t", methodSetup, delegateMethod.Parameters);
@@ -274,7 +301,8 @@ internal static partial class Sources
 			}
 
 			sb.Append("out var ").Append(returnValue).Append(") == true ? ").Append(returnValue).Append(" : ")
-				.AppendDefaultValueGeneratorFor(delegateMethod.ReturnType, $"this.{mockRegistryName}.Behavior.DefaultValue")
+				.AppendDefaultValueGeneratorFor(delegateMethod.ReturnType,
+					$"this.{mockRegistryName}.Behavior.DefaultValue")
 				.Append(';').AppendLine();
 		}
 
@@ -340,18 +368,22 @@ internal static partial class Sources
 		}
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> IMockFor").Append(name).Append(".VerifySetup(global::Mockolate.Setup.IMethodSetup setup)").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Method<IMockVerifyFor").Append(name).Append(">(this, setup);").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> IMockFor")
+			.Append(name).Append(".VerifySetup(global::Mockolate.Setup.IMethodSetup setup)").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Method<IMockVerifyFor").Append(name)
+			.Append(">(this, setup);").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
 		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllInteractionsAreVerified()").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Interactions.GetUnverifiedInteractions().Count == 0;").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName)
+			.Append(".Interactions.GetUnverifiedInteractions().Count == 0;").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
 		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllSetupsAreUsed()").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".GetUnusedSetups(this.").Append(mockRegistryName).Append(".Interactions).Count == 0;").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".GetUnusedSetups(this.").Append(mockRegistryName)
+			.Append(".Interactions).Count == 0;").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
@@ -360,8 +392,12 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> IMockFor").Append(name).Append(".Monitor()").AppendLine();
-		sb.Append("\t\t\t=> new global::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append(">(this.").Append(mockRegistryName).Append(".Interactions, interactions => new VerifyMonitor").Append(name).Append("(new global::Mockolate.MockRegistry(this.").Append(mockRegistryName).Append(", interactions)));").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> IMockFor")
+			.Append(name).Append(".Monitor()").AppendLine();
+		sb.Append("\t\t\t=> new global::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append(">(this.")
+			.Append(mockRegistryName).Append(".Interactions, interactions => new VerifyMonitor").Append(name)
+			.Append("(new global::Mockolate.MockRegistry(this.").Append(mockRegistryName).Append(", interactions)));")
+			.AppendLine();
 		sb.AppendLine("\t}");
 
 		sb.AppendLine();
@@ -369,9 +405,12 @@ internal static partial class Sources
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("\tprivate sealed class VerifyMonitor").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor").Append(name).AppendLine();
+		sb.Append("\tprivate sealed class VerifyMonitor").Append(name)
+			.Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor")
+			.Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; } = mockRegistry;").AppendLine();
+		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName)
+			.Append(" { get; } = mockRegistry;").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t\t#region IMockVerifyFor").Append(name).AppendLine();
 		sb.AppendLine();
@@ -416,7 +455,8 @@ internal static partial class Sources
 		sb.Append("\t\t IMockSetupFor").Append(name).Append(", IMockVerifyFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.AppendXmlSummary("Verifies the method invocations for the <paramref name=\"setup\" /> on the mock.");
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name)
+			.Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
 		sb.AppendLine();
 		sb.AppendXmlSummary("Gets a value indicating whether all expected interactions have been verified.");
 		sb.Append("\t\tbool VerifyThatAllInteractionsAreVerified();").AppendLine();
@@ -427,8 +467,10 @@ internal static partial class Sources
 		sb.AppendXmlSummary("Clears all interactions recorded by the mock object.");
 		sb.Append("\t\tvoid ClearAllInteractions();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary("Provides monitoring capabilities for a mocked instance of the specified type, allowing inspection of accessed properties, invoked methods, and event subscriptions.");
-		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();").AppendLine();
+		sb.AppendXmlSummary(
+			"Provides monitoring capabilities for a mocked instance of the specified type, allowing inspection of accessed properties, invoked methods, and event subscriptions.");
+		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();")
+			.AppendLine();
 		sb.Append("\t}").AppendLine();
 
 		#endregion IMockForXXX
@@ -438,7 +480,8 @@ internal static partial class Sources
 		#region IMockSetupForXXX
 
 		sb.AppendXmlSummary($"Set up the mock of <see cref=\"{escapedClassName}\" />.", "\t");
-		sb.Append("\tinternal interface IMockSetupFor").Append(name).Append(" : global::Mockolate.Setup.IMockSetup<").Append(@class.ClassFullName).Append(">").AppendLine();
+		sb.Append("\tinternal interface IMockSetupFor").Append(name).Append(" : global::Mockolate.Setup.IMockSetup<")
+			.Append(@class.ClassFullName).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
 		AppendMethodSetupDefinition(sb, @class, delegateMethod, false, "Setup");
 		if (delegateMethod.Parameters.Count > 0)
@@ -471,7 +514,8 @@ internal static partial class Sources
 		#region IMockVerifyForXXX
 
 		sb.AppendXmlSummary($"Verify interactions with the mock of <see cref=\"{escapedClassName}\" />.", "\t");
-		sb.Append("\tinternal interface IMockVerifyFor").Append(name).Append(" : global::Mockolate.Verify.IMockVerify<").Append(@class.ClassFullName).Append(">").AppendLine();
+		sb.Append("\tinternal interface IMockVerifyFor").Append(name).Append(" : global::Mockolate.Verify.IMockVerify<")
+			.Append(@class.ClassFullName).Append(">").AppendLine();
 		sb.Append("\t{").AppendLine();
 		AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify");
 		if (delegateMethod.Parameters.Count > 0)
@@ -491,7 +535,8 @@ internal static partial class Sources
 			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
 			if (allValueFlags.Any(f => f))
 			{
-				AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify", allValueFlags);
+				AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify",
+					allValueFlags);
 			}
 		}
 

--- a/Source/Mockolate/MockRegistry.cs
+++ b/Source/Mockolate/MockRegistry.cs
@@ -21,43 +21,26 @@ public partial class MockRegistry
 	private readonly ScenarioState _scenarioState;
 
 	/// <summary>
-	///     Creates a new <see cref="MockRegistry" /> with the given <paramref name="behavior" /> and, optionally,
-	///     <paramref name="constructorParameters" /> for a class mock's base-class constructor.
-	/// </summary>
-	/// <param name="behavior">The <see cref="MockBehavior" /> that governs how the mock responds without a matching setup.</param>
-	/// <param name="constructorParameters">Values forwarded to the base-class constructor, or <see langword="null" /> if no base constructor call is needed.</param>
-	public MockRegistry(MockBehavior behavior, object?[]? constructorParameters = null)
-		: this(behavior,
-			new FastMockInteractions(0, behavior.SkipInteractionRecording),
-			constructorParameters)
-	{
-	}
-
-	/// <summary>
 	///     Creates a new <see cref="MockRegistry" /> with the given <paramref name="behavior" />, a caller-provided
 	///     <paramref name="interactions" /> store, and optional <paramref name="constructorParameters" />.
 	/// </summary>
 	/// <remarks>
 	///     The generator-emitted <c>CreateMock</c> paths use this overload to install a
-	///     <see cref="FastMockInteractions" /> tailored to the mocked type. Pass any
-	///     <see cref="IMockInteractions" /> implementation (e.g. <c>new FastMockInteractions(0)</c>)
-	///     when constructing a registry by hand.
+	///     <see cref="FastMockInteractions" /> tailored to the mocked type.
 	/// </remarks>
 	/// <param name="behavior">The <see cref="MockBehavior" /> that governs how the mock responds without a matching setup.</param>
 	/// <param name="interactions">The interaction collection that new invocations should be appended to.</param>
-	/// <param name="constructorParameters">Values forwarded to the base-class constructor, or <see langword="null" /> if no base constructor call is needed.</param>
+	/// <param name="constructorParameters">
+	///     Values forwarded to the base-class constructor, or <see langword="null" /> if no
+	///     base constructor call is needed.
+	/// </param>
 	public MockRegistry(MockBehavior behavior, IMockInteractions interactions,
 		object?[]? constructorParameters = null)
 	{
 		if (behavior.SkipInteractionRecording != interactions.SkipInteractionRecording)
 		{
 			throw new ArgumentException(
-				$"{nameof(behavior)}.{nameof(MockBehavior.SkipInteractionRecording)} " +
-				$"({behavior.SkipInteractionRecording}) and " +
-				$"{nameof(interactions)}.{nameof(IMockInteractions.SkipInteractionRecording)} " +
-				$"({interactions.SkipInteractionRecording}) must agree; recording paths gate on the " +
-				"behavior flag while verification gates on the interactions flag, so a mismatch leaves " +
-				"the registry in an inconsistent state.",
+				$"""{nameof(behavior)}.{nameof(MockBehavior.SkipInteractionRecording)} ({behavior.SkipInteractionRecording}) and {nameof(interactions)}.{nameof(IMockInteractions.SkipInteractionRecording)} ({interactions.SkipInteractionRecording}) must agree; recording paths gate on the behavior flag while verification gates on the interactions flag, so a mismatch leaves the registry in an inconsistent state.""",
 				nameof(interactions));
 		}
 
@@ -105,19 +88,17 @@ public partial class MockRegistry
 	///     Creates a <see cref="MockRegistry" /> that shares all state with <paramref name="registry" /> but records
 	///     into the supplied <paramref name="interactions" /> collection. Used for scoped monitoring.
 	/// </summary>
-	/// <param name="registry">The source registry whose behavior, setups, constructor parameters, scenario state, and wrapped instance are reused.</param>
+	/// <param name="registry">
+	///     The source registry whose behavior, setups, constructor parameters, scenario state, and wrapped
+	///     instance are reused.
+	/// </param>
 	/// <param name="interactions">The interaction collection that new invocations should be appended to.</param>
 	public MockRegistry(MockRegistry registry, IMockInteractions interactions)
 	{
 		if (registry.Behavior.SkipInteractionRecording != interactions.SkipInteractionRecording)
 		{
 			throw new ArgumentException(
-				$"{nameof(registry)}.{nameof(Behavior)}.{nameof(MockBehavior.SkipInteractionRecording)} " +
-				$"({registry.Behavior.SkipInteractionRecording}) and " +
-				$"{nameof(interactions)}.{nameof(IMockInteractions.SkipInteractionRecording)} " +
-				$"({interactions.SkipInteractionRecording}) must agree; recording paths gate on the " +
-				"behavior flag while verification gates on the interactions flag, so a mismatch leaves " +
-				"the registry in an inconsistent state.",
+				$"""{nameof(registry)}.{nameof(Behavior)}.{nameof(MockBehavior.SkipInteractionRecording)} ({registry.Behavior.SkipInteractionRecording}) and {nameof(interactions)}.{nameof(IMockInteractions.SkipInteractionRecording)} ({interactions.SkipInteractionRecording}) must agree; recording paths gate on the behavior flag while verification gates on the interactions flag, so a mismatch leaves the registry in an inconsistent state.""",
 				nameof(interactions));
 		}
 
@@ -186,15 +167,6 @@ public partial class MockRegistry
 	/// </remarks>
 	public void TransitionTo(string scenario)
 		=> _scenarioState.Current = scenario;
-
-	/// <summary>
-	///     Implicitly converts a <see cref="MockBehavior" /> to a <see cref="MockRegistry" /> with the given behavior and an
-	///     empty interaction collection.
-	/// </summary>
-	public static implicit operator MockRegistry(MockBehavior behavior)
-	{
-		return new MockRegistry(behavior);
-	}
 
 	private sealed class ScenarioState
 	{

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -192,7 +192,6 @@ namespace Mockolate
     [System.Diagnostics.DebuggerDisplay("{Interactions} | {Setup}")]
     public class MockRegistry
     {
-        public MockRegistry(Mockolate.MockBehavior behavior, object?[]? constructorParameters = null) { }
         public MockRegistry(Mockolate.MockRegistry registry, Mockolate.Interactions.IMockInteractions interactions) { }
         public MockRegistry(Mockolate.MockRegistry registry, object wraps) { }
         public MockRegistry(Mockolate.MockRegistry registry, object?[] constructorParameters) { }
@@ -277,7 +276,6 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<TSubject> VerifyProperty<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
         public Mockolate.Verify.VerificationResult<T> VerifyPropertyTyped<T>(T subject, int memberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> VerifyPropertyTyped<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
-        public static Mockolate.MockRegistry op_Implicit(Mockolate.MockBehavior behavior) { }
     }
     public static class ParameterExtensions
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -185,7 +185,6 @@ namespace Mockolate
     [System.Diagnostics.DebuggerDisplay("{Interactions} | {Setup}")]
     public class MockRegistry
     {
-        public MockRegistry(Mockolate.MockBehavior behavior, object?[]? constructorParameters = null) { }
         public MockRegistry(Mockolate.MockRegistry registry, Mockolate.Interactions.IMockInteractions interactions) { }
         public MockRegistry(Mockolate.MockRegistry registry, object wraps) { }
         public MockRegistry(Mockolate.MockRegistry registry, object?[] constructorParameters) { }
@@ -270,7 +269,6 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<TSubject> VerifyProperty<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
         public Mockolate.Verify.VerificationResult<T> VerifyPropertyTyped<T>(T subject, int memberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> VerifyPropertyTyped<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
-        public static Mockolate.MockRegistry op_Implicit(Mockolate.MockBehavior behavior) { }
     }
     public static class ParameterExtensions
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -172,7 +172,6 @@ namespace Mockolate
     [System.Diagnostics.DebuggerDisplay("{Interactions} | {Setup}")]
     public class MockRegistry
     {
-        public MockRegistry(Mockolate.MockBehavior behavior, object?[]? constructorParameters = null) { }
         public MockRegistry(Mockolate.MockRegistry registry, Mockolate.Interactions.IMockInteractions interactions) { }
         public MockRegistry(Mockolate.MockRegistry registry, object wraps) { }
         public MockRegistry(Mockolate.MockRegistry registry, object?[] constructorParameters) { }
@@ -257,7 +256,6 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<TSubject> VerifyProperty<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
         public Mockolate.Verify.VerificationResult<T> VerifyPropertyTyped<T>(T subject, int memberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> VerifyPropertyTyped<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
-        public static Mockolate.MockRegistry op_Implicit(Mockolate.MockBehavior behavior) { }
     }
     public static class ParameterExtensions
     {

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
@@ -1,3 +1,4 @@
+using Mockolate.Interactions;
 using Mockolate.Internal.Tests.TestHelpers;
 using Mockolate.Setup;
 

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
@@ -10,7 +10,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupMethod_WithIncreasingMemberIds_GrowsTableLazily()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeMethodSetup setup0 = new();
 			FakeMethodSetup setup7 = new();
 			FakeMethodSetup setup3 = new();
@@ -33,7 +33,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupMethod_WithMemberId_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeMethodSetup setup = new();
 
 			registry.SetupMethod(5, setup);
@@ -47,7 +47,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupMethod_WithMemberIdAndDefaultScenario_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeMethodSetup setup = new();
 
 			registry.SetupMethod(5, "", setup);
@@ -61,7 +61,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupMethod_WithMemberIdAndNamedScenario_DoesNotPublishToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeMethodSetup setup = new();
 
 			registry.SetupMethod(5, "s1", setup);
@@ -72,7 +72,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupMethod_WithMemberIdAndNamedScenario_PreservesScenarioBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeMethodSetup setup = new();
 
 			registry.SetupMethod(4, "s1", setup);
@@ -85,7 +85,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupMethod_WithSameMemberIdTwice_AppendsToBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeMethodSetup setupA = new();
 			FakeMethodSetup setupB = new();
 
@@ -105,7 +105,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task PublishPropertyToMemberIdBucket_WithDefaultThenUserSetup_RetainsUserSetup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup defaultSetup = new PropertySetup.Default<int>("P1", 0);
 			FakePropertySetup userSetup = new("P1");
 
@@ -118,7 +118,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task PublishPropertyToMemberIdBucket_WithUserThenDefaultSetup_RetainsUserSetup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakePropertySetup userSetup = new("P1");
 			PropertySetup defaultSetup = new PropertySetup.Default<int>("P1", 0);
 
@@ -131,7 +131,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupProperty_WithIncreasingMemberIds_GrowsTableLazily()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakePropertySetup setup0 = new("P0");
 			FakePropertySetup setup7 = new("P7");
 			FakePropertySetup setup3 = new("P3");
@@ -148,7 +148,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupProperty_WithMemberId_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakePropertySetup setup = new("P5");
 
 			registry.SetupProperty(5, setup);
@@ -159,7 +159,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupProperty_WithMemberIdAndDefaultScenario_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakePropertySetup setup = new("P5");
 
 			registry.SetupProperty(5, "", setup);
@@ -170,7 +170,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupProperty_WithMemberIdAndNamedScenario_DoesNotPublishToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakePropertySetup setup = new("P5");
 
 			registry.SetupProperty(5, "s1", setup);
@@ -181,7 +181,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupProperty_WithMemberIdAndNamedScenario_PreservesScenarioBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakePropertySetup setup = new("P4");
 
 			registry.SetupProperty(4, "s1", setup);
@@ -195,7 +195,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupProperty_WithSameMemberIdTwice_RetainsLatestUserSetup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakePropertySetup setupA = new("P2");
 			FakePropertySetup setupB = new("P2");
 
@@ -211,7 +211,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupIndexer_WithIncreasingMemberIds_GrowsTableLazily()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup setup0 = new(true);
 			FakeIndexerSetup setup7 = new(true);
 			FakeIndexerSetup setup3 = new(true);
@@ -234,7 +234,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupIndexer_WithMemberId_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup setup = new(true);
 
 			registry.SetupIndexer(5, setup);
@@ -248,7 +248,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupIndexer_WithMemberIdAndDefaultScenario_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup setup = new(true);
 
 			registry.SetupIndexer(5, "", setup);
@@ -262,7 +262,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupIndexer_WithMemberIdAndNamedScenario_DoesNotPublishToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup setup = new(true);
 
 			registry.SetupIndexer(5, "s1", setup);
@@ -273,7 +273,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupIndexer_WithMemberIdAndNamedScenario_PreservesScenarioBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup setup = new(true);
 
 			registry.SetupIndexer(4, "s1", setup);
@@ -286,7 +286,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupIndexer_WithSameMemberIdTwice_AppendsToBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup setupA = new(true);
 			FakeIndexerSetup setupB = new(true);
 
@@ -306,7 +306,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupEvent_WithIncreasingMemberIds_GrowsTableLazily()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setup0 = new(registry, "E0");
 			EventSetup setup7 = new(registry, "E7");
 			EventSetup setup3 = new(registry, "E3");
@@ -329,7 +329,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupEvent_WithMemberId_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setup = new(registry, "Evt");
 
 			registry.SetupEvent(5, setup);
@@ -343,7 +343,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupEvent_WithMemberIdAndDefaultScenario_PublishesToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setup = new(registry, "Evt");
 
 			registry.SetupEvent(5, "", setup);
@@ -357,7 +357,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupEvent_WithMemberIdAndNamedScenario_DoesNotPublishToSnapshot()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setup = new(registry, "Evt");
 
 			registry.SetupEvent(5, "s1", setup);
@@ -368,7 +368,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupEvent_WithMemberIdAndNamedScenario_PreservesScenarioBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setup = new(registry, "Evt");
 
 			registry.SetupEvent(4, "s1", setup);
@@ -381,7 +381,7 @@ public sealed class MockRegistrySetupSnapshotTests
 		[Fact]
 		public async Task SetupEvent_WithSameMemberIdTwice_AppendsToBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setupA = new(registry, "Evt");
 			EventSetup setupB = new(registry, "Evt");
 

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -50,7 +50,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RegistryAndInteractions_WhenSkipFlagsDisagree_Throws()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FastMockInteractions skippingInteractions = new(0, true);
 
 			void Act()
@@ -84,7 +84,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithActiveScenario_ShouldReturnScopedSetupOverGlobalSetup()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup globalSetup = new(true);
 			FakeIndexerSetup scopedSetup = new(true);
 			registry.Setup.Indexers.Add(globalSetup);
@@ -99,7 +99,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithoutActiveScenario_ShouldFallBackToGlobalSetup()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			FakeIndexerSetup globalSetup = new(true);
 			FakeIndexerSetup scopedSetup = new(true);
 			registry.Setup.Indexers.Add(globalSetup);
@@ -116,7 +116,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task ApplyIndexerGetter_WithNullSetup_ShouldStoreBaseValueForLaterLookup()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			IndexerGetterAccess<int> access1 = new(1);
 			IndexerGetterAccess<int> access2 = new(1);
 
@@ -149,7 +149,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithNegative_ShouldThrowWithDescriptiveMessage()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -163,7 +163,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithZero_ShouldNotThrow()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -197,7 +197,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockGot_WhenNameDoesNotMatch_ShouldReturnNever()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.GetProperty("foo.bar", () => 0, null);
 
 			VerificationResult<object> result = registry.VerifyProperty<object>(this, "baz.bar");
@@ -208,7 +208,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockGot_WhenNameMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.GetProperty("foo.bar", () => 0, null);
 
 			VerificationResult<object> result = registry.VerifyProperty<object>(this, "foo.bar");
@@ -219,7 +219,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockGot_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			VerificationResult<object> result = registry.VerifyProperty<object>(this, "foo.bar");
 
@@ -230,7 +230,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WhenNameAndValueMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.SetProperty("foo.bar", 4);
 
 			VerificationResult<object> result =
@@ -242,7 +242,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WhenOnlyNameMatches_ShouldReturnNever()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.SetProperty("foo.bar", 4);
 
 			VerificationResult<object> result =
@@ -254,7 +254,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WhenOnlyValueMatches_ShouldReturnNever()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.SetProperty("foo.bar", 4);
 
 			VerificationResult<object> result =
@@ -266,7 +266,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			VerificationResult<object> result =
 				registry.VerifyProperty<object, int>(this, "foo.bar", (IParameterMatch<int>)It.IsAny<int>());
@@ -278,7 +278,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task VerifyProperty_WhenNameContainsNoDot_ShouldIncludeFullNameInExpectation()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			VerificationResult<int> result = registry.VerifyProperty(0, "SomeNameWithoutADot");
 
@@ -289,7 +289,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task VerifyProperty_WhenNameStartsWithDot_ShouldOmitDotInExpectation()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			VerificationResult<int> result = registry.VerifyProperty(0, ".bar");
 
@@ -303,7 +303,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Subscribed_WhenNameDoesNotMatch_ShouldReturnNever()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.AddEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.SubscribedTo<object>(this, "baz.bar");
@@ -314,7 +314,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Subscribed_WhenNameMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.AddEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.SubscribedTo<object>(this, "foo.bar");
@@ -325,7 +325,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Subscribed_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			VerificationResult<object> result = registry.SubscribedTo<object>(this, "baz.bar");
 
@@ -339,7 +339,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Unsubscribed_WhenNameDoesNotMatch_ShouldReturnNever()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.RemoveEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.UnsubscribedFrom<object>(this, "baz.bar");
@@ -350,7 +350,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Unsubscribed_WhenNameMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			registry.RemoveEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.UnsubscribedFrom<object>(this, "foo.bar");
@@ -361,7 +361,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Unsubscribed_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			VerificationResult<object> result = registry.UnsubscribedFrom<object>(this, "baz.bar");
 
@@ -375,7 +375,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			MethodSetup[]? result = registry.GetMethodSetupSnapshot(0);
 
@@ -385,8 +385,9 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheBucket()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
-			ReturnMethodSetup<int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Method");
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			ReturnMethodSetup<int>.WithParameterCollection setup =
+				new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Method");
 			registry.SetupMethod(5, setup);
 
 			MethodSetup[]? result = registry.GetMethodSetupSnapshot(5);
@@ -398,8 +399,9 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
-			ReturnMethodSetup<int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Method");
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			ReturnMethodSetup<int>.WithParameterCollection setup =
+				new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Method");
 			registry.SetupMethod(0, setup);
 
 			MethodSetup[]? result = registry.GetMethodSetupSnapshot(5);
@@ -413,7 +415,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			PropertySetup? result = registry.GetPropertySetupSnapshot(0);
 
@@ -423,7 +425,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheSetup()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> setup = new(registry, "P");
 			registry.SetupProperty(5, setup);
 
@@ -435,7 +437,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> setup = new(registry, "P");
 			registry.SetupProperty(0, setup);
 
@@ -450,7 +452,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			IndexerSetup[]? result = registry.GetIndexerSetupSnapshot(0);
 
@@ -460,7 +462,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheBucket()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			IndexerSetup<string, int> setup = new(registry, (IParameterMatch<int>)It.IsAny<int>());
 			registry.SetupIndexer(5, setup);
 
@@ -473,7 +475,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			IndexerSetup<string, int> setup = new(registry, (IParameterMatch<int>)It.IsAny<int>());
 			registry.SetupIndexer(0, setup);
 
@@ -488,7 +490,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			EventSetup[]? result = registry.GetEventSetupSnapshot(0);
 
@@ -498,7 +500,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheBucket()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setup = new(registry, "OnEvent");
 			registry.SetupEvent(5, setup);
 
@@ -511,7 +513,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			EventSetup setup = new(registry, "OnEvent");
 			registry.SetupEvent(0, setup);
 
@@ -526,7 +528,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithActiveScenario_ShouldAlwaysTakeColdPath()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> defaultSetup = new(registry, "P");
 			defaultSetup.InitializeWith(10);
 			registry.SetupProperty(2, defaultSetup);
@@ -544,7 +546,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithBaseValueAccessor_ShouldAlwaysTakeColdPath()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> snapshot = new(registry, "P");
 			registry.SetupProperty(2, snapshot);
 
@@ -565,7 +567,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithoutSnapshotSetup_ShouldFallBackToColdPath()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			int result = registry.GetPropertyFast(0, "P", _ => 7);
 
@@ -575,7 +577,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithSnapshotSetup_ShouldBypassSlowResolverAndReturnSetupValue()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> snapshot = new(registry, "P");
 			snapshot.InitializeWith(42);
 			registry.SetupProperty(2, snapshot);
@@ -602,7 +604,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithoutSnapshotSetup_ShouldFallBackToResolveSetup()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> setup = new(registry, "P");
 			setup.InitializeWith(10);
 			registry.SetupProperty(setup);
@@ -617,7 +619,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithSnapshotSetup_ShouldInvokeSetterAndStoreValue()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> snapshot = new(registry, "P");
 			snapshot.InitializeWith(0);
 			registry.SetupProperty(2, snapshot);
@@ -635,7 +637,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task AddEvent_WithMemberId_ShouldRecordAsEventSubscription()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			registry.AddEvent(0, "OnFoo", this, GetMethodInfo());
 
@@ -646,7 +648,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task AddEvent_WithMemberIdAndMatchingSnapshot_ShouldInvokeSubscribedCallback()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			int subscribedCount = 0;
 			EventSetup setup = new(registry, "OnFoo");
 			setup.OnSubscribed.Do(() => subscribedCount++);
@@ -660,7 +662,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task AddEvent_WithNullMethod_ShouldThrowMockException()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -676,7 +678,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RemoveEvent_WithMemberId_ShouldRecordAsEventUnsubscription()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			registry.RemoveEvent(0, "OnFoo", this, GetMethodInfo());
 
@@ -687,7 +689,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RemoveEvent_WithMemberIdAndMatchingSnapshot_ShouldInvokeUnsubscribedCallback()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			int unsubscribedCount = 0;
 			EventSetup setup = new(registry, "OnFoo");
 			setup.OnUnsubscribed.Do(() => unsubscribedCount++);
@@ -701,7 +703,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RemoveEvent_WithNullMethod_ShouldThrowMockException()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -728,7 +730,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task SetProperty_WithoutSnapshot_ShouldReturnFalseWhenBehaviorDoesNotSkip()
 		{
-			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 
 			bool result = registry.SetProperty("P", 42);
 

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -50,7 +50,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RegistryAndInteractions_WhenSkipFlagsDisagree_Throws()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			FastMockInteractions skippingInteractions = new(0, true);
 
 			void Act()
@@ -84,7 +84,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithActiveScenario_ShouldReturnScopedSetupOverGlobalSetup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			FakeIndexerSetup globalSetup = new(true);
 			FakeIndexerSetup scopedSetup = new(true);
 			registry.Setup.Indexers.Add(globalSetup);
@@ -99,7 +99,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithoutActiveScenario_ShouldFallBackToGlobalSetup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			FakeIndexerSetup globalSetup = new(true);
 			FakeIndexerSetup scopedSetup = new(true);
 			registry.Setup.Indexers.Add(globalSetup);
@@ -116,7 +116,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task ApplyIndexerGetter_WithNullSetup_ShouldStoreBaseValueForLaterLookup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			IndexerGetterAccess<int> access1 = new(1);
 			IndexerGetterAccess<int> access2 = new(1);
 
@@ -132,7 +132,7 @@ public sealed class MockRegistryTests
 		{
 			int counter = 0;
 			MockBehavior behavior = MockBehavior.Default.WithDefaultValueFor(() => ++counter);
-			MockRegistry registry = new(behavior);
+			MockRegistry registry = new(behavior, new FastMockInteractions(0, behavior.SkipInteractionRecording));
 			IndexerGetterAccess<int> access1 = new(1);
 			IndexerGetterAccess<int> access2 = new(1);
 
@@ -149,7 +149,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithNegative_ShouldThrowWithDescriptiveMessage()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -163,7 +163,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithZero_ShouldNotThrow()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -180,7 +180,7 @@ public sealed class MockRegistryTests
 		public async Task WhenBehaviorSkipsInteractionRecording_WrappedRegistryAlsoSkipsRecording()
 		{
 			MockBehavior behavior = MockBehavior.Default.SkippingInteractionRecording();
-			MockRegistry original = new(behavior);
+			MockRegistry original = new(behavior, new FastMockInteractions(0, behavior.SkipInteractionRecording));
 			object wrapped = new();
 
 			MockRegistry wrappingRegistry = new(original, wrapped);
@@ -197,7 +197,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockGot_WhenNameDoesNotMatch_ShouldReturnNever()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.GetProperty("foo.bar", () => 0, null);
 
 			VerificationResult<object> result = registry.VerifyProperty<object>(this, "baz.bar");
@@ -208,7 +208,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockGot_WhenNameMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.GetProperty("foo.bar", () => 0, null);
 
 			VerificationResult<object> result = registry.VerifyProperty<object>(this, "foo.bar");
@@ -219,7 +219,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockGot_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			VerificationResult<object> result = registry.VerifyProperty<object>(this, "foo.bar");
 
@@ -230,7 +230,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WhenNameAndValueMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.SetProperty("foo.bar", 4);
 
 			VerificationResult<object> result =
@@ -242,7 +242,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WhenOnlyNameMatches_ShouldReturnNever()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.SetProperty("foo.bar", 4);
 
 			VerificationResult<object> result =
@@ -254,7 +254,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WhenOnlyValueMatches_ShouldReturnNever()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.SetProperty("foo.bar", 4);
 
 			VerificationResult<object> result =
@@ -266,7 +266,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task MockSet_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			VerificationResult<object> result =
 				registry.VerifyProperty<object, int>(this, "foo.bar", (IParameterMatch<int>)It.IsAny<int>());
@@ -278,7 +278,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task VerifyProperty_WhenNameContainsNoDot_ShouldIncludeFullNameInExpectation()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			VerificationResult<int> result = registry.VerifyProperty(0, "SomeNameWithoutADot");
 
@@ -289,7 +289,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task VerifyProperty_WhenNameStartsWithDot_ShouldOmitDotInExpectation()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			VerificationResult<int> result = registry.VerifyProperty(0, ".bar");
 
@@ -303,7 +303,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Subscribed_WhenNameDoesNotMatch_ShouldReturnNever()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.AddEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.SubscribedTo<object>(this, "baz.bar");
@@ -314,7 +314,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Subscribed_WhenNameMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.AddEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.SubscribedTo<object>(this, "foo.bar");
@@ -325,7 +325,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Subscribed_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			VerificationResult<object> result = registry.SubscribedTo<object>(this, "baz.bar");
 
@@ -339,7 +339,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Unsubscribed_WhenNameDoesNotMatch_ShouldReturnNever()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.RemoveEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.UnsubscribedFrom<object>(this, "baz.bar");
@@ -350,7 +350,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Unsubscribed_WhenNameMatches_ShouldReturnOnce()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			registry.RemoveEvent("foo.bar", this, GetMethodInfo());
 
 			VerificationResult<object> result = registry.UnsubscribedFrom<object>(this, "foo.bar");
@@ -361,7 +361,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task Unsubscribed_WithoutInteractions_ShouldReturnNeverResultWithExpectation()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			VerificationResult<object> result = registry.UnsubscribedFrom<object>(this, "baz.bar");
 
@@ -375,7 +375,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			MethodSetup[]? result = registry.GetMethodSetupSnapshot(0);
 
@@ -385,8 +385,8 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
-			ReturnMethodSetup<int>.WithParameterCollection setup = new(MockBehavior.Default, "Method");
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			ReturnMethodSetup<int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Method");
 			registry.SetupMethod(5, setup);
 
 			MethodSetup[]? result = registry.GetMethodSetupSnapshot(5);
@@ -398,8 +398,8 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
-			ReturnMethodSetup<int>.WithParameterCollection setup = new(MockBehavior.Default, "Method");
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
+			ReturnMethodSetup<int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Method");
 			registry.SetupMethod(0, setup);
 
 			MethodSetup[]? result = registry.GetMethodSetupSnapshot(5);
@@ -413,7 +413,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			PropertySetup? result = registry.GetPropertySetupSnapshot(0);
 
@@ -423,7 +423,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheSetup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			PropertySetup<int> setup = new(registry, "P");
 			registry.SetupProperty(5, setup);
 
@@ -435,7 +435,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			PropertySetup<int> setup = new(registry, "P");
 			registry.SetupProperty(0, setup);
 
@@ -450,7 +450,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			IndexerSetup[]? result = registry.GetIndexerSetupSnapshot(0);
 
@@ -460,7 +460,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			IndexerSetup<string, int> setup = new(registry, (IParameterMatch<int>)It.IsAny<int>());
 			registry.SetupIndexer(5, setup);
 
@@ -473,7 +473,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			IndexerSetup<string, int> setup = new(registry, (IParameterMatch<int>)It.IsAny<int>());
 			registry.SetupIndexer(0, setup);
 
@@ -488,7 +488,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithEmptyTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			EventSetup[]? result = registry.GetEventSetupSnapshot(0);
 
@@ -498,7 +498,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdAtBoundary_ShouldReturnTheBucket()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			EventSetup setup = new(registry, "OnEvent");
 			registry.SetupEvent(5, setup);
 
@@ -511,7 +511,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			EventSetup setup = new(registry, "OnEvent");
 			registry.SetupEvent(0, setup);
 
@@ -526,7 +526,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithActiveScenario_ShouldAlwaysTakeColdPath()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			PropertySetup<int> defaultSetup = new(registry, "P");
 			defaultSetup.InitializeWith(10);
 			registry.SetupProperty(2, defaultSetup);
@@ -544,7 +544,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithBaseValueAccessor_ShouldAlwaysTakeColdPath()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			PropertySetup<int> snapshot = new(registry, "P");
 			registry.SetupProperty(2, snapshot);
 
@@ -565,7 +565,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithoutSnapshotSetup_ShouldFallBackToColdPath()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			int result = registry.GetPropertyFast(0, "P", _ => 7);
 
@@ -575,7 +575,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithSnapshotSetup_ShouldBypassSlowResolverAndReturnSetupValue()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			PropertySetup<int> snapshot = new(registry, "P");
 			snapshot.InitializeWith(42);
 			registry.SetupProperty(2, snapshot);
@@ -602,7 +602,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithoutSnapshotSetup_ShouldFallBackToResolveSetup()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			PropertySetup<int> setup = new(registry, "P");
 			setup.InitializeWith(10);
 			registry.SetupProperty(setup);
@@ -617,7 +617,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithSnapshotSetup_ShouldInvokeSetterAndStoreValue()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			PropertySetup<int> snapshot = new(registry, "P");
 			snapshot.InitializeWith(0);
 			registry.SetupProperty(2, snapshot);
@@ -635,7 +635,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task AddEvent_WithMemberId_ShouldRecordAsEventSubscription()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			registry.AddEvent(0, "OnFoo", this, GetMethodInfo());
 
@@ -646,7 +646,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task AddEvent_WithMemberIdAndMatchingSnapshot_ShouldInvokeSubscribedCallback()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			int subscribedCount = 0;
 			EventSetup setup = new(registry, "OnFoo");
 			setup.OnSubscribed.Do(() => subscribedCount++);
@@ -660,7 +660,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task AddEvent_WithNullMethod_ShouldThrowMockException()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -676,7 +676,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RemoveEvent_WithMemberId_ShouldRecordAsEventUnsubscription()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			registry.RemoveEvent(0, "OnFoo", this, GetMethodInfo());
 
@@ -687,7 +687,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RemoveEvent_WithMemberIdAndMatchingSnapshot_ShouldInvokeUnsubscribedCallback()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 			int unsubscribedCount = 0;
 			EventSetup setup = new(registry, "OnFoo");
 			setup.OnUnsubscribed.Do(() => unsubscribedCount++);
@@ -701,7 +701,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task RemoveEvent_WithNullMethod_ShouldThrowMockException()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			void Act()
 			{
@@ -718,7 +718,7 @@ public sealed class MockRegistryTests
 		public async Task SetProperty_WithoutSnapshot_ShouldReturnBehaviorSkipBaseClassWhenSetupAllowsBase()
 		{
 			MockBehavior behavior = MockBehavior.Default.SkippingBaseClass();
-			MockRegistry registry = new(behavior);
+			MockRegistry registry = new(behavior, new FastMockInteractions(0, behavior.SkipInteractionRecording));
 
 			bool result = registry.SetProperty("P", 42);
 
@@ -728,7 +728,7 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task SetProperty_WithoutSnapshot_ShouldReturnFalseWhenBehaviorDoesNotSkip()
 		{
-			MockRegistry registry = new(MockBehavior.Default);
+			MockRegistry registry = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), new FastMockInteractions(0));
 
 			bool result = registry.SetProperty("P", 42);
 

--- a/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
@@ -118,7 +118,7 @@ public sealed class IndexerSetupTests
 	public async Task GetResult_WithBaseValue_StoresComputedValueForLaterLookup()
 	{
 		IndexerSetup<string, int> setup = new(
-			new MockRegistry(MockBehavior.Default),
+			new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 			(IParameterMatch<int>)It.IsAny<int>());
 		IndexerValueStorage<string> storage = new();
 		IndexerGetterAccess<int> access1 = new(42)
@@ -143,7 +143,7 @@ public sealed class IndexerSetupTests
 	public async Task GetResult_WithDefaultValueGenerator_StoresComputedValueForLaterLookup()
 	{
 		IndexerSetup<string, int> setup = new(
-			new MockRegistry(MockBehavior.Default),
+			new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 			(IParameterMatch<int>)It.IsAny<int>());
 		IndexerValueStorage<string> storage = new();
 		IndexerGetterAccess<int> access1 = new(42)
@@ -294,7 +294,7 @@ public sealed class IndexerSetupTests
 		public async Task GetResult_WithBaseValue_StoresComputedValueForLaterLookup()
 		{
 			IndexerSetup<string, int, int> setup = new(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>());
 			IndexerValueStorage<string> storage = new();
@@ -318,7 +318,7 @@ public sealed class IndexerSetupTests
 
 		private sealed class MyIndexerSetup<T1, T2>()
 			: IndexerSetup<string, T1, T2>(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<T1>)It.IsAny<T1>(),
 				(IParameterMatch<T2>)It.IsAny<T2>())
 		{
@@ -453,7 +453,7 @@ public sealed class IndexerSetupTests
 		public async Task GetResult_WithBaseValue_StoresComputedValueForLaterLookup()
 		{
 			IndexerSetup<string, int, int, int> setup = new(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>());
@@ -480,7 +480,7 @@ public sealed class IndexerSetupTests
 
 		private sealed class MyIndexerSetup<T1, T2, T3>()
 			: IndexerSetup<string, T1, T2, T3>(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<T1>)It.IsAny<T1>(),
 				(IParameterMatch<T2>)It.IsAny<T2>(),
 				(IParameterMatch<T3>)It.IsAny<T3>())
@@ -623,7 +623,7 @@ public sealed class IndexerSetupTests
 		public async Task GetResult_WithBaseValue_StoresComputedValueForLaterLookup()
 		{
 			IndexerSetup<string, int, int, int, int> setup = new(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
@@ -651,7 +651,7 @@ public sealed class IndexerSetupTests
 
 		private sealed class MyIndexerSetup<T1, T2, T3, T4>()
 			: IndexerSetup<string, T1, T2, T3, T4>(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<T1>)It.IsAny<T1>(),
 				(IParameterMatch<T2>)It.IsAny<T2>(),
 				(IParameterMatch<T3>)It.IsAny<T3>(),
@@ -802,7 +802,7 @@ public sealed class IndexerSetupTests
 
 		private sealed class MyIndexerSetup<T1, T2, T3, T4, T5>()
 			: IndexerSetup<string, T1, T2, T3, T4, T5>(
-				new MockRegistry(MockBehavior.Default),
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 				(IParameterMatch<T1>)It.IsAny<T1>(),
 				(IParameterMatch<T2>)It.IsAny<T2>(),
 				(IParameterMatch<T3>)It.IsAny<T3>(),
@@ -829,7 +829,7 @@ public sealed class IndexerSetupTests
 
 	private sealed class MyIndexerSetup<T1>()
 		: IndexerSetup<string, T1>(
-			new MockRegistry(MockBehavior.Default),
+			new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
 			(IParameterMatch<T1>)It.IsAny<T1>())
 	{
 		private readonly IndexerValueStorage<string> _storage = new();

--- a/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.cs
@@ -9,7 +9,7 @@ public partial class MockSetupsTests
 	[Fact]
 	public async Task EventSetup_ToString_ShouldReturnEventName()
 	{
-		EventSetup setup = new(new MockRegistry(MockBehavior.Default), "global::MyCode.IMyService.SomeEvent");
+		EventSetup setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "global::MyCode.IMyService.SomeEvent");
 
 		string result = setup.ToString();
 
@@ -36,7 +36,7 @@ public partial class MockSetupsTests
 		for (int i = 0; i < methodCount; i++)
 		{
 			mock.MockRegistry.SetupMethod(
-				new ReturnMethodSetup<int>.WithParameterCollection(MockBehavior.Default, $"my.method{i}"));
+				new ReturnMethodSetup<int>.WithParameterCollection(mock.MockRegistry, $"my.method{i}"));
 		}
 
 		for (int i = 0; i < propertyCount; i++)

--- a/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Mockolate.Interactions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
 
@@ -9,7 +10,8 @@ public partial class MockSetupsTests
 	[Fact]
 	public async Task EventSetup_ToString_ShouldReturnEventName()
 	{
-		EventSetup setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "global::MyCode.IMyService.SomeEvent");
+		EventSetup setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
+			"global::MyCode.IMyService.SomeEvent");
 
 		string result = setup.ToString();
 

--- a/Tests/Mockolate.Internal.Tests/TestHelpers/FakeIndexerSetup.cs
+++ b/Tests/Mockolate.Internal.Tests/TestHelpers/FakeIndexerSetup.cs
@@ -5,7 +5,7 @@ namespace Mockolate.Internal.Tests.TestHelpers;
 
 internal sealed class FakeIndexerSetup : IndexerSetup
 {
-	internal FakeIndexerSetup(bool match) : base(new MockRegistry(MockBehavior.Default))
+	internal FakeIndexerSetup(bool match) : base(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)))
 	{
 		ShouldMatch = match;
 	}

--- a/Tests/Mockolate.Internal.Tests/TestHelpers/FakePropertySetup.cs
+++ b/Tests/Mockolate.Internal.Tests/TestHelpers/FakePropertySetup.cs
@@ -4,5 +4,5 @@ namespace Mockolate.Internal.Tests.TestHelpers;
 
 internal sealed class FakePropertySetup : PropertySetup<int>
 {
-	internal FakePropertySetup(string name) : base(new MockRegistry(MockBehavior.Default), name) { }
+	internal FakePropertySetup(string name) : base(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), name) { }
 }

--- a/Tests/Mockolate.Internal.Tests/TestHelpers/FakePropertySetup.cs
+++ b/Tests/Mockolate.Internal.Tests/TestHelpers/FakePropertySetup.cs
@@ -1,8 +1,12 @@
+using Mockolate.Interactions;
 using Mockolate.Setup;
 
 namespace Mockolate.Internal.Tests.TestHelpers;
 
 internal sealed class FakePropertySetup : PropertySetup<int>
 {
-	internal FakePropertySetup(string name) : base(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), name) { }
+	internal FakePropertySetup(string name) : base(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
+		name)
+	{
+	}
 }

--- a/Tests/Mockolate.Internal.Tests/Usings.cs
+++ b/Tests/Mockolate.Internal.Tests/Usings.cs
@@ -1,5 +1,6 @@
 ﻿global using System;
 global using System.Threading.Tasks;
+global using Mockolate.Interactions;
 global using Xunit;
 global using aweXpect;
 global using static aweXpect.Expect;

--- a/Tests/Mockolate.Internal.Tests/Usings.cs
+++ b/Tests/Mockolate.Internal.Tests/Usings.cs
@@ -1,6 +1,5 @@
 ﻿global using System;
 global using System.Threading.Tasks;
-global using Mockolate.Interactions;
 global using Xunit;
 global using aweXpect;
 global using static aweXpect.Expect;

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -68,8 +68,11 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Diagnostics).IsEmpty();
+			// One occurrence per generator-emitted public ctor: the (MockRegistry, ...) overload and
+			// the typed (MockBehavior, ...) overload that subclasses use. The base ctor already carries
+			// the attribute, and the dedup check still suppresses an injected duplicate on each.
 			await That(result.Sources).ContainsKey("Mock.AnnotatedShape.g.cs").WhoseValue
-				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").Once();
+				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").Exactly(2);
 		}
 
 		[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -28,13 +28,15 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.MyService.g.cs").WhoseValue
-				.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.MyService.ProcessData\"))")
+				.Contains(
+					"foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.MyService.ProcessData\"))")
 				.IgnoringNewlineStyle().And
 				.Contains("wrappedResult = base.ProcessData(baseResult);")
 				.IgnoringNewlineStyle().And
 				.Contains("methodSetup?.TriggerCallbacks(baseResult);")
 				.IgnoringNewlineStyle().And
-				.Contains("return methodSetup?.TryGetReturnValue(baseResult, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, baseResult);")
+				.Contains(
+					"return methodSetup?.TryGetReturnValue(baseResult, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, baseResult);")
 				.IgnoringNewlineStyle();
 		}
 
@@ -201,14 +203,27 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-				.Contains("Setup for the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\">BaseProperty</see>.").And
-				.Contains("Verify interactions with the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\">BaseProperty</see>.").And
-				.Contains("Setup for the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\">this[string]</see>").And
-				.Contains("Verify interactions with the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\">this[string]</see>.").And
-				.Contains("Setup for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\">BaseMethod()</see>.").And
-				.Contains("Verify invocations for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\">BaseMethod()</see>.").And
+				.Contains(
+					"Setup for the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\">BaseProperty</see>.")
+				.And
+				.Contains(
+					"Verify interactions with the int property <see cref=\"global::MyCode.IMyBaseService.BaseProperty\">BaseProperty</see>.")
+				.And
+				.Contains(
+					"Setup for the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\">this[string]</see>")
+				.And
+				.Contains(
+					"Verify interactions with the int indexer <see cref=\"global::MyCode.IMyBaseService.this[string]\">this[string]</see>.")
+				.And
+				.Contains(
+					"Setup for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\">BaseMethod()</see>.")
+				.And
+				.Contains(
+					"Verify invocations for the method <see cref=\"global::MyCode.IMyBaseService.BaseMethod()\">BaseMethod()</see>.")
+				.And
 				.Contains("Raise the <see cref=\"global::MyCode.IMyBaseService.BaseEvent\">BaseEvent</see> event.").And
-				.Contains("Verify subscriptions on the BaseEvent event of <see cref=\"global::MyCode.IMyBaseService.BaseEvent\">BaseEvent</see>.");
+				.Contains(
+					"Verify subscriptions on the BaseEvent event of <see cref=\"global::MyCode.IMyBaseService.BaseEvent\">BaseEvent</see>.");
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/Internals/TypeFormatterTests.cs
+++ b/Tests/Mockolate.Tests/Internals/TypeFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Mockolate.Setup;
 
@@ -13,7 +13,7 @@ public sealed class TypeFormatterTests
 
 	public static TheoryData<string, string> ProvideTestData()
 	{
-		MockRegistry registry = new(MockBehavior.Default);
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 		return new TheoryData<string, string>
 		{
 			{

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -544,7 +544,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int>.WithParameterCollection setup = new(MockBehavior.Default, "Foo");
+			ReturnMethodSetup<int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo");
 
 			string result = setup.ToString();
 
@@ -601,7 +601,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1");
+			ReturnMethodSetup<int, string>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1");
 
 			string result = setup.ToString();
 
@@ -624,7 +624,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string>.WithParameterCollection setup = new(MockBehavior.Default, "Foo", (IParameterMatch<string>)It.IsAny<string>());
+			ReturnMethodSetup<int, string>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", (IParameterMatch<string>)It.IsAny<string>());
 
 			string result = setup.ToString();
 
@@ -697,7 +697,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2");
+			ReturnMethodSetup<int, string, long>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2");
 
 			string result = setup.ToString();
 
@@ -720,8 +720,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long>.WithParameterCollection setup = new(
-				MockBehavior.Default, "Foo",
+			ReturnMethodSetup<int, string, long>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>());
 
@@ -828,7 +827,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2", "p3");
+			ReturnMethodSetup<int, string, long, int>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2", "p3");
 
 			string result = setup.ToString();
 
@@ -851,8 +850,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int>.WithParameterCollection setup = new(
-				MockBehavior.Default, "Foo",
+			ReturnMethodSetup<int, string, long, int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>(),
 				(IParameterMatch<int>)It.IsAny<int>());
@@ -1028,7 +1026,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int, int>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4");
+			ReturnMethodSetup<int, string, long, int, int>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4");
 
 			string result = setup.ToString();
 
@@ -1051,8 +1049,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int, int>.WithParameterCollection setup = new(
-				MockBehavior.Default, "Foo",
+			ReturnMethodSetup<int, string, long, int, int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
@@ -1375,7 +1372,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int, int, int>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4", "p5");
+			ReturnMethodSetup<int, string, long, int, int, int>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4", "p5");
 
 			string result = setup.ToString();
 
@@ -1398,8 +1395,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			ReturnMethodSetup<int, string, long, int, int, int>.WithParameterCollection setup = new(
-				MockBehavior.Default, "Foo",
+			ReturnMethodSetup<int, string, long, int, int, int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
@@ -1472,7 +1468,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup.WithParameterCollection setup = new(MockBehavior.Default, "Foo");
+			VoidMethodSetup.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo");
 
 			string result = setup.ToString();
 
@@ -1513,7 +1509,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1");
+			VoidMethodSetup<string>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1");
 
 			string result = setup.ToString();
 
@@ -1536,7 +1532,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string>.WithParameterCollection setup = new(MockBehavior.Default, "Foo",
+			VoidMethodSetup<string>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>());
 
 			string result = setup.ToString();
@@ -1579,7 +1575,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2");
+			VoidMethodSetup<string, long>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2");
 
 			string result = setup.ToString();
 
@@ -1602,7 +1598,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long>.WithParameterCollection setup = new(MockBehavior.Default, "Foo",
+			VoidMethodSetup<string, long>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>());
 
@@ -1646,7 +1642,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2", "p3");
+			VoidMethodSetup<string, long, int>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2", "p3");
 
 			string result = setup.ToString();
 
@@ -1669,7 +1665,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int>.WithParameterCollection setup = new(MockBehavior.Default, "Foo",
+			VoidMethodSetup<string, long, int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>(),
 				(IParameterMatch<int>)It.IsAny<int>());
@@ -1714,7 +1710,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int, int>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4");
+			VoidMethodSetup<string, long, int, int>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4");
 
 			string result = setup.ToString();
 
@@ -1737,7 +1733,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int, int>.WithParameterCollection setup = new(MockBehavior.Default, "Foo",
+			VoidMethodSetup<string, long, int, int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>(),
 				(IParameterMatch<int>)It.IsAny<int>(),
@@ -1785,7 +1781,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_AnyParameters_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int, int, int>.WithParameters setup = new(MockBehavior.Default, "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4", "p5");
+			VoidMethodSetup<string, long, int, int, int>.WithParameters setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo", Match.AnyParameters(), "p1", "p2", "p3", "p4", "p5");
 
 			string result = setup.ToString();
 
@@ -1808,8 +1804,7 @@ public sealed partial class SetupMethodTests
 		[Fact]
 		public async Task ToString_ShouldReturnMethodSignature()
 		{
-			VoidMethodSetup<string, long, int, int, int>.WithParameterCollection setup = new(
-				MockBehavior.Default, "Foo",
+			VoidMethodSetup<string, long, int, int, int>.WithParameterCollection setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo",
 				(IParameterMatch<string>)It.IsAny<string>(),
 				(IParameterMatch<long>)It.IsAny<long>(),
 				(IParameterMatch<int>)It.IsAny<int>(),

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate.Exceptions;
+using Mockolate.Exceptions;
 using Mockolate.Setup;
 
 namespace Mockolate.Tests.MockProperties;
@@ -132,7 +132,7 @@ public sealed partial class SetupPropertyTests
 	[Fact]
 	public async Task ToString_ShouldReturnType()
 	{
-		PropertySetup<int> setup = new(new MockRegistry(MockBehavior.Default), "Foo");
+		PropertySetup<int> setup = new(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "Foo");
 
 		string result = setup.ToString();
 
@@ -169,7 +169,7 @@ public sealed partial class SetupPropertyTests
 	}
 
 	private sealed class MyPropertySetup<T>()
-		: PropertySetup<T>(new MockRegistry(MockBehavior.Default), "My.Property")
+		: PropertySetup<T>(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "My.Property")
 	{
 		public void InvokeSetter<TValue>(TValue value)
 			=> InvokeSetter(value, MockBehavior.Default);
@@ -181,7 +181,7 @@ public sealed partial class SetupPropertyTests
 			=> InitializeValue(value);
 	}
 
-	private sealed class InitializeValueCountingPropertySetup<T>(string name) : PropertySetup<T>(MockBehavior.Default, name)
+	private sealed class InitializeValueCountingPropertySetup<T>(string name) : PropertySetup<T>(new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), name)
 	{
 		public int InitializeValueCallCount { get; private set; }
 

--- a/Tests/Mockolate.Tests/MockRegistryTests.cs
+++ b/Tests/Mockolate.Tests/MockRegistryTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using Mockolate.Interactions;
 using Mockolate.Setup;
@@ -61,20 +61,9 @@ public sealed class MockRegistryTests
 	}
 
 	[Fact]
-	public async Task ImplicitConversionFromMockBehavior()
-	{
-		MockBehavior behavior = MockBehavior.Default.ThrowingWhenNotSetup();
-
-		MockRegistry result = behavior;
-
-		await That(result.Behavior).IsSameAs(behavior);
-		await That(result.Interactions).IsEmpty();
-	}
-
-	[Fact]
 	public async Task RegisterInteraction_ShouldBeThreadSafe()
 	{
-		MockRegistry sut = new(MockBehavior.Default);
+		MockRegistry sut = new(MockBehavior.Default, new FastMockInteractions(0));
 		Task[] tasks = new Task[50];
 		for (int i = 0; i < 50; i++)
 		{

--- a/Tests/Mockolate.Tests/TestHelpers/Usings.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/Usings.cs
@@ -1,5 +1,6 @@
 ﻿global using System;
 global using System.Threading.Tasks;
+global using Mockolate.Interactions;
 global using Xunit;
 global using aweXpect;
 global using static aweXpect.Expect;


### PR DESCRIPTION
This PR introduces a breaking change to how `MockRegistry` is constructed so that generated mocks (and subclasses of generated mocks) always get a correctly sized `FastMockInteractions` instance, rather than relying on behavior-only registry construction.

**Changes:**
- Remove `MockRegistry(MockBehavior, ...)` and `MockBehavior -> MockRegistry` implicit conversion, requiring callers to provide an `IMockInteractions`.
- Update the source generator to emit `(MockBehavior)` (and `(MockBehavior, ...baseCtorParams)`) constructors that build a typed-buffer-sized registry and (when needed) prime `MockRegistryProvider` during base construction.
- Update tests and API baselines to use the new `MockRegistry(MockBehavior, IMockInteractions, ...)` construction model and add coverage for subclassing.