### PR TITLE
refactor: streamline default value generation for tuples and tasks

### DIFF
--- a/Source/Mockolate.SourceGenerators/Helpers.cs
+++ b/Source/Mockolate.SourceGenerators/Helpers.cs
@@ -284,6 +284,25 @@ internal static class Helpers
 		public StringBuilder AppendDefaultValueGeneratorFor(Type type,
 			string defaultValueName, string suffix = "")
 		{
+			if (type.TupleTypes is not null)
+			{
+				sb.Append("(");
+				bool first = true;
+				foreach (Type? genericType in type.TupleTypes.Value)
+				{
+					if (!first)
+					{
+						sb.Append(", ");
+					}
+
+					first = false;
+					sb.AppendDefaultValueGeneratorFor(genericType, defaultValueName, suffix);
+				}
+
+				sb.Append(")");
+				return sb;
+			}
+
 			sb.Append(defaultValueName);
 			sb.Append(".Generate(default(");
 
@@ -301,23 +320,6 @@ internal static class Helpers
 			}
 
 			sb.Append(")!");
-
-			if (type.TupleTypes is not null)
-			{
-				foreach (Type? genericType in type.TupleTypes.Value)
-				{
-					sb.Append(", ").Append("() => ")
-						.AppendDefaultValueGeneratorFor(genericType, defaultValueName);
-				}
-
-				if (!string.IsNullOrWhiteSpace(suffix))
-				{
-					sb.Append(", ").Append(suffix);
-				}
-
-				sb.Append(")");
-				return sb;
-			}
 
 			if (type.SpecialGenericType != SpecialGenericType.None && type.GenericTypeParameters?.Count > 0)
 			{

--- a/Source/Mockolate.SourceGenerators/Helpers.cs
+++ b/Source/Mockolate.SourceGenerators/Helpers.cs
@@ -321,12 +321,13 @@ internal static class Helpers
 
 			sb.Append(")!");
 
-			if (type.SpecialGenericType != SpecialGenericType.None && type.GenericTypeParameters?.Count > 0)
+			if (type.SpecialGenericType is SpecialGenericType.Task or SpecialGenericType.ValueTask
+			    && type.GenericTypeParameters?.Count > 0)
 			{
 				foreach (Type? genericType in type.GenericTypeParameters.Value)
 				{
-					sb.Append(", ").Append("() => ")
-						.AppendDefaultValueGeneratorFor(genericType, defaultValueName);
+					sb.Append(", ")
+						.AppendDefaultValueGeneratorFor(genericType, defaultValueName, suffix);
 				}
 			}
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
@@ -235,7 +235,7 @@ internal static partial class Sources
 		          		///     Generates a <see cref="global::System.Threading.Tasks.Task" /> of <typeparamref name="T" />, with
 		          		///     the <paramref name="parameters" /> for context.
 		          		/// </summary>
-		          		public global::System.Threading.Tasks.Task<T> Generate<T>(global::System.Threading.Tasks.Task<T> nullValue, params object?[] parameters)
+		          		public global::System.Threading.Tasks.Task<T> Generate<T>(global::System.Threading.Tasks.Task<T> nullValue, T value, params object?[] parameters)
 		          		{
 		          			global::System.Threading.CancellationToken cancellationToken = global::System.Linq.Enumerable.FirstOrDefault(
 		          				global::System.Linq.Enumerable.OfType<global::System.Threading.CancellationToken?>(parameters)) ?? global::System.Threading.CancellationToken.None;
@@ -243,13 +243,8 @@ internal static partial class Sources
 		          			{
 		          				return global::System.Threading.Tasks.Task.FromCanceled<T>(cancellationToken);
 		          			}
-		          			
-		          			if (parameters.Length > 0 && parameters[0] is global::System.Func<T> func)
-		          			{
-		          				return global::System.Threading.Tasks.Task.FromResult(func());
-		          			}
-		          			
-		          			return global::System.Threading.Tasks.Task.FromResult(generator.Generate(default(T)!, parameters));
+
+		          			return global::System.Threading.Tasks.Task.FromResult(value);
 		          		}
 
 		          #if NET8_0_OR_GREATER
@@ -257,7 +252,7 @@ internal static partial class Sources
 		          		///     Generates a <see cref="global::System.Threading.Tasks.ValueTask" /> of <typeparamref name="T" />, with
 		          		///     the <paramref name="parameters" /> for context.
 		          		/// </summary>
-		          		public global::System.Threading.Tasks.ValueTask<T> Generate<T>(global::System.Threading.Tasks.ValueTask<T> nullValue, params object?[] parameters)
+		          		public global::System.Threading.Tasks.ValueTask<T> Generate<T>(global::System.Threading.Tasks.ValueTask<T> nullValue, T value, params object?[] parameters)
 		          		{
 		          			global::System.Threading.CancellationToken cancellationToken = global::System.Linq.Enumerable.FirstOrDefault(
 		          				global::System.Linq.Enumerable.OfType<global::System.Threading.CancellationToken?>(parameters)) ?? global::System.Threading.CancellationToken.None;
@@ -265,13 +260,8 @@ internal static partial class Sources
 		          			{
 		          				return global::System.Threading.Tasks.ValueTask.FromCanceled<T>(cancellationToken);
 		          			}
-		          			
-		          			if (parameters.Length > 0 && parameters[0] is global::System.Func<T> func)
-		          			{
-		          				return global::System.Threading.Tasks.ValueTask.FromResult(func());
-		          			}
-		          			
-		          			return global::System.Threading.Tasks.ValueTask.FromResult(generator.Generate(default(T)!, parameters));
+
+		          			return global::System.Threading.Tasks.ValueTask.FromResult(value);
 		          		}
 		          #endif
 

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockBehaviorExtensions.cs
@@ -276,41 +276,6 @@ internal static partial class Sources
 		          #endif
 
 		          		/// <summary>
-		          		///     Generates a tuple of (<typeparamref name="T1" />, <typeparamref name="T2" />), with
-		          		///     the <paramref name="parameters" /> for context.
-		          		/// </summary>
-		          		public (T1, T2) Generate<T1, T2>((T1, T2) nullValue, params object?[] parameters)
-		          		{
-		          			if (parameters.Length >= 2 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2)
-		          			{
-		          				return (func1(), func2());
-		          			}
-		          			
-		          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters));
-		          		}
-		          """).AppendLine();
-		for (int i = 3; i <= 8; i++)
-		{
-			string ts = string.Join(", ", Enumerable.Range(1, i).Select(x => $"T{x}"));
-			sb.Append($$"""
-			            		/// <summary>
-			            		///     Generates a tuple of ({{string.Join(", ", Enumerable.Range(1, i).Select(x => $"<typeparamref name=\"T{x}\" />"))}}), with
-			            		///     the <paramref name="parameters" /> for context.
-			            		/// </summary>
-			            		public ({{ts}}) Generate<{{ts}}>(({{ts}}) nullValue, params object?[] parameters)
-			            		{
-			            			if (parameters.Length >= {{i}} && {{string.Join(" && ", Enumerable.Range(1, i).Select(x => $"parameters[{x - 1}] is global::System.Func<T{x}> func{x}"))}})
-			            			{
-			            				return ({{string.Join(", ", Enumerable.Range(1, i).Select(x => $"func{x}()"))}});
-			            			}
-			            			
-			            			return ({{string.Join(", ", Enumerable.Range(1, i).Select(x => $"generator.Generate(default(T{x})!, parameters)"))}});
-			            		}
-			            """).AppendLine();
-		}
-
-		sb.Append("""
-		          		/// <summary>
 		          		///     Generates an empty enumerable of <typeparamref name="T" />, with
 		          		///     the <paramref name="parameters" /> for context.
 		          		/// </summary>

--- a/Source/Mockolate/IDefaultValueGenerator.cs
+++ b/Source/Mockolate/IDefaultValueGenerator.cs
@@ -15,8 +15,7 @@ public interface IDefaultValueGenerator
 	/// </summary>
 	/// <param name="type">The runtime type to produce a default value for.</param>
 	/// <param name="parameters">
-	///     The runtime arguments of the mocked invocation, in declaration order (for tuple defaults, nested
-	///     <c>Func&lt;T&gt;</c> factories for each tuple element are appended). Implementations can inspect this
+	///     The runtime arguments of the mocked invocation, in declaration order. Implementations can inspect this
 	///     array to return a more appropriate default - for example, the built-in cancellable-task factory scans it
 	///     for a cancelled <see cref="System.Threading.CancellationToken" /> and returns
 	///     <see cref="System.Threading.Tasks.Task.FromCanceled(System.Threading.CancellationToken)" /> instead of

--- a/Tests/Mockolate.SourceGenerators.Tests/MockBehaviorExtensionsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockBehaviorExtensionsTests.cs
@@ -192,7 +192,7 @@ public sealed class MockBehaviorExtensionsTests
 	}
 
 	[Fact]
-	public async Task DefaultValueGenerator_ShouldRegisterValueTuples()
+	public async Task DefaultValueGenerator_ForValueTuples_ShouldEmitInlineExpressions()
 	{
 		GeneratorResult result = Generator
 			.Run("""
@@ -218,90 +218,14 @@ public sealed class MockBehaviorExtensionsTests
 			     }
 			     """);
 
+		await That(result.Sources).ContainsKey("Mock.IMyInterface.g.cs").WhoseValue
+			.Contains("(b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!))").And
+			.Contains("(b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!))").And
+			.Contains("(this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Behavior.DefaultValue.Generate(default(T1)!), this.MockRegistry.Behavior.DefaultValue.Generate(default(T2)!))");
+
 		await That(result.Sources).ContainsKey("MockBehaviorExtensions.g.cs").WhoseValue
-			.Contains("""
-			          		public (T1, T2) Generate<T1, T2>((T1, T2) nullValue, params object?[] parameters)
-			          		{
-			          			if (parameters.Length >= 2 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2)
-			          			{
-			          				return (func1(), func2());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters));
-			          		}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          		public (T1, T2, T3) Generate<T1, T2, T3>((T1, T2, T3) nullValue, params object?[] parameters)
-			          		{
-			          			if (parameters.Length >= 3 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2 && parameters[2] is global::System.Func<T3> func3)
-			          			{
-			          				return (func1(), func2(), func3());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters), generator.Generate(default(T3)!, parameters));
-			          		}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          		public (T1, T2, T3, T4) Generate<T1, T2, T3, T4>((T1, T2, T3, T4) nullValue, params object?[] parameters)
-			          		{
-			          			if (parameters.Length >= 4 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2 && parameters[2] is global::System.Func<T3> func3 && parameters[3] is global::System.Func<T4> func4)
-			          			{
-			          				return (func1(), func2(), func3(), func4());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters), generator.Generate(default(T3)!, parameters), generator.Generate(default(T4)!, parameters));
-			          		}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          		public (T1, T2, T3, T4, T5) Generate<T1, T2, T3, T4, T5>((T1, T2, T3, T4, T5) nullValue, params object?[] parameters)
-			          		{
-			          			if (parameters.Length >= 5 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2 && parameters[2] is global::System.Func<T3> func3 && parameters[3] is global::System.Func<T4> func4 && parameters[4] is global::System.Func<T5> func5)
-			          			{
-			          				return (func1(), func2(), func3(), func4(), func5());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters), generator.Generate(default(T3)!, parameters), generator.Generate(default(T4)!, parameters), generator.Generate(default(T5)!, parameters));
-			          		}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          		public (T1, T2, T3, T4, T5, T6) Generate<T1, T2, T3, T4, T5, T6>((T1, T2, T3, T4, T5, T6) nullValue, params object?[] parameters)
-			          		{
-			          			if (parameters.Length >= 6 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2 && parameters[2] is global::System.Func<T3> func3 && parameters[3] is global::System.Func<T4> func4 && parameters[4] is global::System.Func<T5> func5 && parameters[5] is global::System.Func<T6> func6)
-			          			{
-			          				return (func1(), func2(), func3(), func4(), func5(), func6());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters), generator.Generate(default(T3)!, parameters), generator.Generate(default(T4)!, parameters), generator.Generate(default(T5)!, parameters), generator.Generate(default(T6)!, parameters));
-			          		}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          		public (T1, T2, T3, T4, T5, T6, T7) Generate<T1, T2, T3, T4, T5, T6, T7>((T1, T2, T3, T4, T5, T6, T7) nullValue, params object?[] parameters)
-			          		{
-			          			if (parameters.Length >= 7 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2 && parameters[2] is global::System.Func<T3> func3 && parameters[3] is global::System.Func<T4> func4 && parameters[4] is global::System.Func<T5> func5 && parameters[5] is global::System.Func<T6> func6 && parameters[6] is global::System.Func<T7> func7)
-			          			{
-			          				return (func1(), func2(), func3(), func4(), func5(), func6(), func7());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters), generator.Generate(default(T3)!, parameters), generator.Generate(default(T4)!, parameters), generator.Generate(default(T5)!, parameters), generator.Generate(default(T6)!, parameters), generator.Generate(default(T7)!, parameters));
-			          		}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          		public (T1, T2, T3, T4, T5, T6, T7, T8) Generate<T1, T2, T3, T4, T5, T6, T7, T8>((T1, T2, T3, T4, T5, T6, T7, T8) nullValue, params object?[] parameters)
-			          		{
-			          			if (parameters.Length >= 8 && parameters[0] is global::System.Func<T1> func1 && parameters[1] is global::System.Func<T2> func2 && parameters[2] is global::System.Func<T3> func3 && parameters[3] is global::System.Func<T4> func4 && parameters[4] is global::System.Func<T5> func5 && parameters[5] is global::System.Func<T6> func6 && parameters[6] is global::System.Func<T7> func7 && parameters[7] is global::System.Func<T8> func8)
-			          			{
-			          				return (func1(), func2(), func3(), func4(), func5(), func6(), func7(), func8());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return (generator.Generate(default(T1)!, parameters), generator.Generate(default(T2)!, parameters), generator.Generate(default(T3)!, parameters), generator.Generate(default(T4)!, parameters), generator.Generate(default(T5)!, parameters), generator.Generate(default(T6)!, parameters), generator.Generate(default(T7)!, parameters), generator.Generate(default(T8)!, parameters));
-			          		}
-			          """).IgnoringNewlineStyle();
+			.DoesNotContain("Generate<T1, T2>((T1, T2)").And
+			.DoesNotContain("Generate<T1, T2, T3>((T1, T2, T3)").And
+			.DoesNotContain("Generate<T1, T2, T3, T4, T5, T6, T7, T8>");
 	}
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/MockBehaviorExtensionsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockBehaviorExtensionsTests.cs
@@ -119,7 +119,7 @@ public sealed class MockBehaviorExtensionsTests
 
 		await That(result.Sources).ContainsKey("MockBehaviorExtensions.g.cs").WhoseValue
 			.Contains("""
-			          		public global::System.Threading.Tasks.Task<T> Generate<T>(global::System.Threading.Tasks.Task<T> nullValue, params object?[] parameters)
+			          		public global::System.Threading.Tasks.Task<T> Generate<T>(global::System.Threading.Tasks.Task<T> nullValue, T value, params object?[] parameters)
 			          		{
 			          			global::System.Threading.CancellationToken cancellationToken = global::System.Linq.Enumerable.FirstOrDefault(
 			          				global::System.Linq.Enumerable.OfType<global::System.Threading.CancellationToken?>(parameters)) ?? global::System.Threading.CancellationToken.None;
@@ -127,17 +127,11 @@ public sealed class MockBehaviorExtensionsTests
 			          			{
 			          				return global::System.Threading.Tasks.Task.FromCanceled<T>(cancellationToken);
 			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			if (parameters.Length > 0 && parameters[0] is global::System.Func<T> func)
-			          			{
-			          				return global::System.Threading.Tasks.Task.FromResult(func());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return global::System.Threading.Tasks.Task.FromResult(generator.Generate(default(T)!, parameters));
+
+			          			return global::System.Threading.Tasks.Task.FromResult(value);
 			          		}
-			          """).IgnoringNewlineStyle();
+			          """).IgnoringNewlineStyle().And
+			.DoesNotContain("global::System.Func<T>");
 	}
 
 	[Fact]
@@ -170,7 +164,7 @@ public sealed class MockBehaviorExtensionsTests
 
 		await That(result.Sources).ContainsKey("MockBehaviorExtensions.g.cs").WhoseValue
 			.Contains("""
-			          		public global::System.Threading.Tasks.ValueTask<T> Generate<T>(global::System.Threading.Tasks.ValueTask<T> nullValue, params object?[] parameters)
+			          		public global::System.Threading.Tasks.ValueTask<T> Generate<T>(global::System.Threading.Tasks.ValueTask<T> nullValue, T value, params object?[] parameters)
 			          		{
 			          			global::System.Threading.CancellationToken cancellationToken = global::System.Linq.Enumerable.FirstOrDefault(
 			          				global::System.Linq.Enumerable.OfType<global::System.Threading.CancellationToken?>(parameters)) ?? global::System.Threading.CancellationToken.None;
@@ -178,17 +172,11 @@ public sealed class MockBehaviorExtensionsTests
 			          			{
 			          				return global::System.Threading.Tasks.ValueTask.FromCanceled<T>(cancellationToken);
 			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			if (parameters.Length > 0 && parameters[0] is global::System.Func<T> func)
-			          			{
-			          				return global::System.Threading.Tasks.ValueTask.FromResult(func());
-			          			}
-			          """).IgnoringNewlineStyle().And
-			.Contains("""
-			          			return global::System.Threading.Tasks.ValueTask.FromResult(generator.Generate(default(T)!, parameters));
+
+			          			return global::System.Threading.Tasks.ValueTask.FromResult(value);
 			          		}
-			          """).IgnoringNewlineStyle();
+			          """).IgnoringNewlineStyle().And
+			.DoesNotContain("global::System.Func<T>");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -94,7 +94,7 @@ public sealed partial class MockTests
 				          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.Program.DoSomething1.Invoke(int)' was invoked without prior setup.");
 				          			}
 				          			methodSetup?.TriggerCallbacks(x);
-				          			return methodSetup?.TryGetReturnValue(x, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.SpanWrapper<char>)!, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!));
+				          			return methodSetup?.TryGetReturnValue(x, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.SpanWrapper<char>)!);
 				          		}
 				          """).IgnoringNewlineStyle();
 			await That(result.Sources)
@@ -117,7 +117,7 @@ public sealed partial class MockTests
 				          				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::MyCode.Program.DoSomething2.Invoke(int)' was invoked without prior setup.");
 				          			}
 				          			methodSetup?.TriggerCallbacks(x);
-				          			return methodSetup?.TryGetReturnValue(x, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.ReadOnlySpanWrapper<char>)!, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(char)!));
+				          			return methodSetup?.TryGetReturnValue(x, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(global::Mockolate.Setup.ReadOnlySpanWrapper<char>)!);
 				          		}
 				          """).IgnoringNewlineStyle();
 		}

--- a/Tests/Mockolate.Tests/MockMethods/InteractionsTests.CancellationTokenTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/InteractionsTests.CancellationTokenTests.cs
@@ -101,6 +101,18 @@ public sealed partial class InteractionsTests
 			await That(result.IsCanceled).IsTrue();
 		}
 #endif
+
+		[Fact]
+		public async Task WithTupleContainingTask_ShouldCancelTaskElement()
+		{
+			IMockWithCancellationToken sut = IMockWithCancellationToken.CreateMock();
+			CancellationToken canceledToken = new(true);
+
+			(Task task, string text) result = sut.TupleWithTaskMethod(canceledToken);
+
+			await That(result.task.IsCanceled).IsTrue();
+			await That(result.text).IsEqualTo(string.Empty);
+		}
 	}
 
 	public interface IMockWithCancellationToken
@@ -111,5 +123,6 @@ public sealed partial class InteractionsTests
 		ValueTask ValueTaskMethod(CancellationToken cancellationToken);
 		ValueTask<int> ValueTaskOfIntMethod(CancellationToken cancellationToken);
 		Task<int> MultipleParametersMethod(string param1, int param2, CancellationToken cancellationToken);
+		(Task, string) TupleWithTaskMethod(CancellationToken cancellationToken);
 	}
 }


### PR DESCRIPTION
Refactors tuple and `Task`/`ValueTask` default-value generation in the source generator so their defaults are emitted inline (per-element) rather than relying on generated specific `IDefaultValueGenerator.Generate<T1..Tn>` overloads, and adds regression coverage for cancellation behavior when tuples contain cancellable tasks.

**Changes:**
- Emit inline tuple default expressions from the generator (and stop generating tuple `Generate<T1..Tn>` extension overloads).
- Update generator tests to assert inline tuple expressions and absence of tuple overloads.
- Add a runtime test ensuring a canceled `CancellationToken` cancels `Task` elements inside a returned tuple.