### PR TITLE
perf: optimize property getter access handling in FastPropertyBuffer

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
@@ -132,10 +132,12 @@ internal static partial class Sources
 	{
 		private readonly List<string> _declarations = new();
 		private readonly Dictionary<string, int> _usedIdentifiers = new();
+		private readonly List<(Property Property, string FieldName)> _propertyGetterAccessFields = new();
 
 		internal Dictionary<Method, int> MethodIds { get; } = new();
 		internal Dictionary<Property, int> PropertyGetIds { get; } = new();
 		internal Dictionary<Property, int> PropertySetIds { get; } = new();
+		internal Dictionary<Property, string> PropertyGetterAccessFieldNames { get; } = new();
 		internal Dictionary<Property, int> IndexerGetIds { get; } = new();
 		internal Dictionary<Property, int> IndexerSetIds { get; } = new();
 		internal Dictionary<Event, int> EventSubscribeIds { get; } = new();
@@ -190,10 +192,21 @@ internal static partial class Sources
 			int getId = AllocateId("MemberId_" + identifierGet);
 			PropertyGetIds[property] = getId;
 
+			// PropertyGetterAccess is parameterless and identified solely by Name, so we can
+			// share one instance across every recorded access for a given property. The
+			// generator emits a static readonly field next to MemberId_<X>_Get; both the
+			// FastPropertyGetterBuffer and the legacy RecordPropertyGetter path use it.
+			string accessFieldName = "PropertyAccess_" + identifierGet;
+			PropertyGetterAccessFieldNames[property] = accessFieldName;
+			_propertyGetterAccessFields.Add((property, accessFieldName));
+
 			string identifierSet = UniqueIdentifier(property.Name + "_Set");
 			int setId = AllocateId("MemberId_" + identifierSet);
 			PropertySetIds[property] = setId;
 		}
+
+		internal string GetPropertyGetterAccessFieldName(Property property)
+			=> PropertyGetterAccessFieldNames[property];
 
 		internal void AddIndexer(Property indexer)
 		{
@@ -241,6 +254,16 @@ internal static partial class Sources
 
 			sb.Append(indent).Append("internal const int MemberCount = ").Append(_declarations.Count)
 				.Append(';').AppendLine();
+
+			foreach ((Property property, string fieldName) in _propertyGetterAccessFields)
+			{
+				sb.Append(indent)
+					.Append(
+						"internal static readonly global::Mockolate.Interactions.PropertyGetterAccess ")
+					.Append(fieldName)
+					.Append(" = new global::Mockolate.Interactions.PropertyGetterAccess(")
+					.Append(property.GetUniqueNameString()).Append(");").AppendLine();
+			}
 		}
 
 		private static string BuildIndexerSignatureSuffix(Property indexer)

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
@@ -192,10 +192,14 @@ internal static partial class Sources
 			int getId = AllocateId("MemberId_" + identifierGet);
 			PropertyGetIds[property] = getId;
 
-			// PropertyGetterAccess is parameterless and identified solely by Name, so we can
-			// share one instance across every recorded access for a given property. The
-			// generator emits a static readonly field next to MemberId_<X>_Get; both the
-			// FastPropertyGetterBuffer and the legacy RecordPropertyGetter path use it.
+			// PropertyGetterAccess is identified solely by Name, so the generator emits one
+			// static readonly per-property template next to MemberId_<X>_Get. The template is a
+			// cheap name source: FastPropertyGetterBuffer caches it once instead of storing the
+			// name on every record, and the cold-path RecordPropertyGetter constructs fresh
+			// PropertyGetterAccess instances from the template's Name. Per-record identity is
+			// preserved (every recorded interaction is still a distinct object) — reference-
+			// keyed bookkeeping like Then ordering and FastMockInteractions._verified depends
+			// on that.
 			string accessFieldName = "PropertyAccess_" + identifierGet;
 			PropertyGetterAccessFieldNames[property] = accessFieldName;
 			_propertyGetterAccessFields.Add((property, accessFieldName));

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
@@ -193,13 +193,13 @@ internal static partial class Sources
 			PropertyGetIds[property] = getId;
 
 			// PropertyGetterAccess is identified solely by Name, so the generator emits one
-			// static readonly per-property template next to MemberId_<X>_Get. The template is a
-			// cheap name source: FastPropertyGetterBuffer caches it once instead of storing the
-			// name on every record, and the cold-path RecordPropertyGetter constructs fresh
-			// PropertyGetterAccess instances from the template's Name. Per-record identity is
-			// preserved (every recorded interaction is still a distinct object) — reference-
-			// keyed bookkeeping like Then ordering and FastMockInteractions._verified depends
-			// on that.
+			// static readonly per-property singleton next to MemberId_<X>_Get and reuses it for
+			// every recorded access. Sharing one reference is safe because the only two
+			// reference-keyed verification paths in the codebase tolerate it: the
+			// FastMockInteractions._verified filter is all-or-nothing per matched property
+			// (every recording of a getter shares the same predicate result), and
+			// VerificationResultExtensions.Then walks the snapshot positionally so repeated
+			// occurrences of the same reference still resolve to distinct positions.
 			string accessFieldName = "PropertyAccess_" + identifierGet;
 			PropertyGetterAccessFieldNames[property] = accessFieldName;
 			_propertyGetterAccessFields.Add((property, accessFieldName));

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1331,9 +1331,10 @@ internal static partial class Sources
 			}
 
 			string getMemberIdRef = memberIdPrefix + memberIds.GetPropertyGetIdentifier(property);
+			string accessFieldRef = memberIdPrefix + memberIds.GetPropertyGetterAccessFieldName(property);
 			sb.Append(indent)
 				.Append("\tglobal::Mockolate.Interactions.FastPropertyBufferFactory.InstallPropertyGetter(fast, ")
-				.Append(getMemberIdRef).Append(");").AppendLine();
+				.Append(getMemberIdRef).Append(", ").Append(accessFieldRef).Append(");").AppendLine();
 
 			string setMemberIdRef = memberIdPrefix + memberIds.GetPropertySetIdentifier(property);
 			string propertyType = property.Type.ToTypeOrWrapper();
@@ -2334,12 +2335,13 @@ internal static partial class Sources
 				}
 				else
 				{
+					string accessFieldRef = memberIdPrefix + memberIds.GetPropertyGetterAccessFieldName(property);
 					if (useFastForProperty)
 					{
 						sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetPropertyFast<")
 							.AppendTypeOrWrapper(property.Type).Append(">(")
 							.Append(memberIdPrefix).Append(memberIds.GetPropertyGetIdentifier(property))
-							.Append(", ").Append(property.GetUniqueNameString()).Append(", static b => ")
+							.Append(", ").Append(accessFieldRef).Append(", static b => ")
 							.AppendDefaultValueGeneratorFor(property.Type, "b.DefaultValue");
 						if (!property.IsStatic)
 						{
@@ -2353,7 +2355,7 @@ internal static partial class Sources
 					{
 						sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetProperty<")
 							.AppendTypeOrWrapper(property.Type).Append(">(")
-							.Append(propertyGetMemberArg).Append(property.GetUniqueNameString()).Append(", () => ")
+							.Append(propertyGetMemberArg).Append(accessFieldRef).Append(", () => ")
 							.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue");
 						if (!property.IsStatic)
 						{
@@ -2423,12 +2425,13 @@ internal static partial class Sources
 				}
 				else
 				{
+					string accessFieldRef = memberIdPrefix + memberIds.GetPropertyGetterAccessFieldName(property);
 					if (useFastForProperty)
 					{
 						sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetPropertyFast<")
 							.AppendTypeOrWrapper(property.Type).Append(">(")
 							.Append(memberIdPrefix).Append(memberIds.GetPropertyGetIdentifier(property))
-							.Append(", ").Append(property.GetUniqueNameString()).Append(", static b => ")
+							.Append(", ").Append(accessFieldRef).Append(", static b => ")
 							.AppendDefaultValueGeneratorFor(property.Type, "b.DefaultValue");
 						if (property is { IsStatic: false, } && property.Getter?.IsProtected != true)
 						{
@@ -2447,7 +2450,7 @@ internal static partial class Sources
 					{
 						sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetProperty<")
 							.AppendTypeOrWrapper(property.Type).Append(">(")
-							.Append(propertyGetMemberArg).Append(property.GetUniqueNameString()).Append(", () => ")
+							.Append(propertyGetMemberArg).Append(accessFieldRef).Append(", () => ")
 							.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue");
 						if (property is { IsStatic: false, } && property.Getter?.IsProtected != true)
 						{
@@ -2485,12 +2488,13 @@ internal static partial class Sources
 			}
 			else
 			{
+				string accessFieldRef = memberIdPrefix + memberIds.GetPropertyGetterAccessFieldName(property);
 				if (useFastForProperty)
 				{
 					sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetPropertyFast<")
 						.AppendTypeOrWrapper(property.Type).Append(">(")
 						.Append(memberIdPrefix).Append(memberIds.GetPropertyGetIdentifier(property))
-						.Append(", ").Append(property.GetUniqueNameString())
+						.Append(", ").Append(accessFieldRef)
 						.Append(", static b => ")
 						.AppendDefaultValueGeneratorFor(property.Type, "b.DefaultValue")
 						.Append(");").AppendLine();
@@ -2499,7 +2503,7 @@ internal static partial class Sources
 				{
 					sb.Append("\t\t\t\treturn ").Append(mockRegistry).Append(".GetProperty<")
 						.AppendTypeOrWrapper(property.Type).Append(">(")
-						.Append(propertyGetMemberArg).Append(property.GetUniqueNameString())
+						.Append(propertyGetMemberArg).Append(accessFieldRef)
 						.Append(", () => ")
 						.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue")
 						.Append(", null);").AppendLine();

--- a/Source/Mockolate/Interactions/FastPropertyBuffer.cs
+++ b/Source/Mockolate/Interactions/FastPropertyBuffer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Mockolate.Parameters;
@@ -5,9 +6,12 @@ using Mockolate.Parameters;
 namespace Mockolate.Interactions;
 
 /// <summary>
-///     Per-member buffer for property getters. Records only a sequence number per call; the
-///     property identity is captured once via a shared <see cref="PropertyGetterAccess" /> that
-///     every record points at when boxed for verification.
+///     Per-member buffer for property getters. The buffer is bound to a single property and
+///     keeps the property name on a per-buffer <see cref="PropertyGetterAccess" /> template, so
+///     the per-call hot path only stores the sequence number. Verification still emits a fresh
+///     <see cref="PropertyGetterAccess" /> per recorded slot — the template is only used as a
+///     name source — because reference-keyed bookkeeping (Then ordering, the verified set)
+///     requires each recorded interaction to be a distinct object.
 /// </summary>
 [DebuggerDisplay("{Count} property gets")]
 #if !DEBUG
@@ -35,15 +39,23 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 
 	/// <summary>
 	///     Records a property getter access using the buffer's pre-seeded
-	///     <see cref="PropertyGetterAccess" /> singleton. Throws when the singleton has not been
+	///     <see cref="PropertyGetterAccess" /> template. Throws when the template has not been
 	///     installed — callers must use <see cref="Append(string)" /> in that case.
 	/// </summary>
+	/// <exception cref="InvalidOperationException">No template was supplied at install time.</exception>
 	public void Append()
 	{
+		if (_access is null)
+		{
+			throw new InvalidOperationException(
+				$"{nameof(Append)}() requires the buffer to be installed with a {nameof(PropertyGetterAccess)} template via {nameof(FastPropertyBufferFactory)}.{nameof(FastPropertyBufferFactory.InstallPropertyGetter)}(memberId, access). Use {nameof(Append)}(string) when no template is available.");
+		}
+
 		long seq = _owner.NextSequence();
 		int slot = _storage.Reserve();
 		ref Record r = ref _storage.SlotForWrite(slot);
 		r.Seq = seq;
+		r.Boxed = null;
 		_storage.Publish();
 
 		if (_owner.HasInteractionAddedSubscribers)
@@ -54,16 +66,17 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 
 	/// <summary>
 	///     Records a property getter access. Lazily installs the buffer's
-	///     <see cref="PropertyGetterAccess" /> singleton from <paramref name="name" /> on first
-	///     call so legacy callers (generated code that does not pass a pre-built access) keep
-	///     working without allocating one access object per record.
+	///     <see cref="PropertyGetterAccess" /> template from <paramref name="name" /> on first
+	///     call so legacy callers (generated code that does not pass a pre-built template) keep
+	///     working without allocating one template object per record.
 	/// </summary>
 	public void Append(string name)
 	{
-		// Lazy init: every record in this buffer addresses the same property, so a single
-		// PropertyGetterAccess covers all of them. The benign race here is acceptable — both
-		// instances are equivalent because PropertyGetterAccess is immutable and identified
-		// solely by Name; whichever assignment wins still satisfies the contract.
+		// Lazy init: the buffer is bound to a single property, so one template covers every
+		// record. The benign race here is acceptable — both instances are equivalent because
+		// PropertyGetterAccess is identified solely by Name; whichever assignment wins still
+		// satisfies the contract. The template is only a Name source; per-record identity is
+		// preserved by allocating a fresh PropertyGetterAccess in AppendBoxed.
 		_access ??= new PropertyGetterAccess(name);
 		Append();
 	}
@@ -81,11 +94,12 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 				return;
 			}
 
-			PropertyGetterAccess access = _access!;
+			string name = _access!.Name;
 			for (int slot = 0; slot < n; slot++)
 			{
 				ref Record r = ref _storage.SlotUnderLock(slot);
-				dest.Add((r.Seq, access));
+				r.Boxed ??= new PropertyGetterAccess(name);
+				dest.Add((r.Seq, r.Boxed));
 			}
 		}
 	}
@@ -100,7 +114,7 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 				return;
 			}
 
-			PropertyGetterAccess access = _access!;
+			string name = _access!.Name;
 			for (int slot = 0; slot < n; slot++)
 			{
 				if (_storage.VerifiedUnderLock(slot))
@@ -109,7 +123,8 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 				}
 
 				ref Record r = ref _storage.SlotUnderLock(slot);
-				dest.Add((r.Seq, access));
+				r.Boxed ??= new PropertyGetterAccess(name);
+				dest.Add((r.Seq, r.Boxed));
 			}
 		}
 	}
@@ -138,6 +153,7 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 	internal struct Record
 	{
 		public long Seq;
+		public IInteraction? Boxed;
 	}
 }
 

--- a/Source/Mockolate/Interactions/FastPropertyBuffer.cs
+++ b/Source/Mockolate/Interactions/FastPropertyBuffer.cs
@@ -6,12 +6,15 @@ using Mockolate.Parameters;
 namespace Mockolate.Interactions;
 
 /// <summary>
-///     Per-member buffer for property getters. The buffer is bound to a single property and
-///     keeps the property name on a per-buffer <see cref="PropertyGetterAccess" /> template, so
-///     the per-call hot path only stores the sequence number. Verification still emits a fresh
-///     <see cref="PropertyGetterAccess" /> per recorded slot — the template is only used as a
-///     name source — because reference-keyed bookkeeping (Then ordering, the verified set)
-///     requires each recorded interaction to be a distinct object.
+///     Per-member buffer for property getters. The buffer is bound to a single property; every
+///     recorded record stores only a sequence number and shares a single
+///     <see cref="PropertyGetterAccess" /> when boxed for verification. Sharing one reference
+///     across records is safe because property getters carry no parameters — every recorded
+///     access is semantically identical — and the two reference-keyed verification paths in
+///     this codebase tolerate it: <c>FastMockInteractions._verified</c> filters all-or-nothing
+///     per matched property, and <c>VerificationResultExtensions.Then</c> walks the snapshot
+///     positionally so repeated occurrences of the same reference still resolve to distinct
+///     positions.
 /// </summary>
 [DebuggerDisplay("{Count} property gets")]
 #if !DEBUG
@@ -39,23 +42,22 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 
 	/// <summary>
 	///     Records a property getter access using the buffer's pre-seeded
-	///     <see cref="PropertyGetterAccess" /> template. Throws when the template has not been
+	///     <see cref="PropertyGetterAccess" /> singleton. Throws when the singleton has not been
 	///     installed — callers must use <see cref="Append(string)" /> in that case.
 	/// </summary>
-	/// <exception cref="InvalidOperationException">No template was supplied at install time.</exception>
+	/// <exception cref="InvalidOperationException">No singleton was supplied at install time.</exception>
 	public void Append()
 	{
 		if (_access is null)
 		{
 			throw new InvalidOperationException(
-				$"{nameof(Append)}() requires the buffer to be installed with a {nameof(PropertyGetterAccess)} template via {nameof(FastPropertyBufferFactory)}.{nameof(FastPropertyBufferFactory.InstallPropertyGetter)}(memberId, access). Use {nameof(Append)}(string) when no template is available.");
+				$"{nameof(Append)}() requires the buffer to be installed with a {nameof(PropertyGetterAccess)} singleton via {nameof(FastPropertyBufferFactory)}.{nameof(FastPropertyBufferFactory.InstallPropertyGetter)}(memberId, access). Use {nameof(Append)}(string) when no singleton is available.");
 		}
 
 		long seq = _owner.NextSequence();
 		int slot = _storage.Reserve();
 		ref Record r = ref _storage.SlotForWrite(slot);
 		r.Seq = seq;
-		r.Boxed = null;
 		_storage.Publish();
 
 		if (_owner.HasInteractionAddedSubscribers)
@@ -66,17 +68,16 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 
 	/// <summary>
 	///     Records a property getter access. Lazily installs the buffer's
-	///     <see cref="PropertyGetterAccess" /> template from <paramref name="name" /> on first
-	///     call so legacy callers (generated code that does not pass a pre-built template) keep
-	///     working without allocating one template object per record.
+	///     <see cref="PropertyGetterAccess" /> singleton from <paramref name="name" /> on first
+	///     call so legacy callers (generated code that does not pass a pre-built singleton) keep
+	///     working without allocating one access object per record.
 	/// </summary>
 	public void Append(string name)
 	{
-		// Lazy init: the buffer is bound to a single property, so one template covers every
+		// Lazy init: the buffer is bound to a single property, so one singleton covers every
 		// record. The benign race here is acceptable — both instances are equivalent because
 		// PropertyGetterAccess is identified solely by Name; whichever assignment wins still
-		// satisfies the contract. The template is only a Name source; per-record identity is
-		// preserved by allocating a fresh PropertyGetterAccess in AppendBoxed.
+		// satisfies the contract.
 		_access ??= new PropertyGetterAccess(name);
 		Append();
 	}
@@ -94,12 +95,11 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 				return;
 			}
 
-			string name = _access!.Name;
+			PropertyGetterAccess access = _access!;
 			for (int slot = 0; slot < n; slot++)
 			{
 				ref Record r = ref _storage.SlotUnderLock(slot);
-				r.Boxed ??= new PropertyGetterAccess(name);
-				dest.Add((r.Seq, r.Boxed));
+				dest.Add((r.Seq, access));
 			}
 		}
 	}
@@ -114,7 +114,7 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 				return;
 			}
 
-			string name = _access!.Name;
+			PropertyGetterAccess access = _access!;
 			for (int slot = 0; slot < n; slot++)
 			{
 				if (_storage.VerifiedUnderLock(slot))
@@ -123,8 +123,7 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 				}
 
 				ref Record r = ref _storage.SlotUnderLock(slot);
-				r.Boxed ??= new PropertyGetterAccess(name);
-				dest.Add((r.Seq, r.Boxed));
+				dest.Add((r.Seq, access));
 			}
 		}
 	}
@@ -153,7 +152,6 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 	internal struct Record
 	{
 		public long Seq;
-		public IInteraction? Boxed;
 	}
 }
 

--- a/Source/Mockolate/Interactions/FastPropertyBuffer.cs
+++ b/Source/Mockolate/Interactions/FastPropertyBuffer.cs
@@ -5,7 +5,9 @@ using Mockolate.Parameters;
 namespace Mockolate.Interactions;
 
 /// <summary>
-///     Per-member buffer for property getters. Records only the property name + sequence number.
+///     Per-member buffer for property getters. Records only a sequence number per call; the
+///     property identity is captured once via a shared <see cref="PropertyGetterAccess" /> that
+///     every record points at when boxed for verification.
 /// </summary>
 [DebuggerDisplay("{Count} property gets")]
 #if !DEBUG
@@ -15,32 +17,55 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 {
 	private readonly FastMockInteractions _owner;
 	private readonly ChunkedSlotStorage<Record> _storage = new();
+	private PropertyGetterAccess? _access;
 
 	internal FastPropertyGetterBuffer(FastMockInteractions owner)
 	{
 		_owner = owner;
 	}
 
+	internal FastPropertyGetterBuffer(FastMockInteractions owner, PropertyGetterAccess access)
+	{
+		_owner = owner;
+		_access = access;
+	}
+
 	/// <inheritdoc cref="IFastMemberBuffer.Count" />
 	public int Count => _storage.Count;
 
 	/// <summary>
-	///     Records a property getter access.
+	///     Records a property getter access using the buffer's pre-seeded
+	///     <see cref="PropertyGetterAccess" /> singleton. Throws when the singleton has not been
+	///     installed — callers must use <see cref="Append(string)" /> in that case.
 	/// </summary>
-	public void Append(string name)
+	public void Append()
 	{
 		long seq = _owner.NextSequence();
 		int slot = _storage.Reserve();
 		ref Record r = ref _storage.SlotForWrite(slot);
 		r.Seq = seq;
-		r.Name = name;
-		r.Boxed = null;
 		_storage.Publish();
 
 		if (_owner.HasInteractionAddedSubscribers)
 		{
 			_owner.RaiseAdded();
 		}
+	}
+
+	/// <summary>
+	///     Records a property getter access. Lazily installs the buffer's
+	///     <see cref="PropertyGetterAccess" /> singleton from <paramref name="name" /> on first
+	///     call so legacy callers (generated code that does not pass a pre-built access) keep
+	///     working without allocating one access object per record.
+	/// </summary>
+	public void Append(string name)
+	{
+		// Lazy init: every record in this buffer addresses the same property, so a single
+		// PropertyGetterAccess covers all of them. The benign race here is acceptable — both
+		// instances are equivalent because PropertyGetterAccess is immutable and identified
+		// solely by Name; whichever assignment wins still satisfies the contract.
+		_access ??= new PropertyGetterAccess(name);
+		Append();
 	}
 
 	/// <inheritdoc cref="IFastMemberBuffer.Clear" />
@@ -51,11 +76,16 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 		lock (_storage.Lock)
 		{
 			int n = _storage.PublishedUnderLock;
+			if (n == 0)
+			{
+				return;
+			}
+
+			PropertyGetterAccess access = _access!;
 			for (int slot = 0; slot < n; slot++)
 			{
 				ref Record r = ref _storage.SlotUnderLock(slot);
-				r.Boxed ??= new PropertyGetterAccess(r.Name);
-				dest.Add((r.Seq, r.Boxed));
+				dest.Add((r.Seq, access));
 			}
 		}
 	}
@@ -65,6 +95,12 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 		lock (_storage.Lock)
 		{
 			int n = _storage.PublishedUnderLock;
+			if (n == 0)
+			{
+				return;
+			}
+
+			PropertyGetterAccess access = _access!;
 			for (int slot = 0; slot < n; slot++)
 			{
 				if (_storage.VerifiedUnderLock(slot))
@@ -73,8 +109,7 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 				}
 
 				ref Record r = ref _storage.SlotUnderLock(slot);
-				r.Boxed ??= new PropertyGetterAccess(r.Name);
-				dest.Add((r.Seq, r.Boxed));
+				dest.Add((r.Seq, access));
 			}
 		}
 	}
@@ -103,8 +138,6 @@ public sealed class FastPropertyGetterBuffer : IFastMemberBuffer
 	internal struct Record
 	{
 		public long Seq;
-		public string Name;
-		public IInteraction? Boxed;
 	}
 }
 
@@ -230,6 +263,20 @@ public static class FastPropertyBufferFactory
 	public static FastPropertyGetterBuffer InstallPropertyGetter(this FastMockInteractions interactions, int memberId)
 	{
 		FastPropertyGetterBuffer buffer = new(interactions);
+		interactions.InstallBuffer(memberId, buffer);
+		return buffer;
+	}
+
+	/// <summary>
+	///     Creates and installs a property getter buffer at the given <paramref name="memberId" /> with
+	///     a pre-built shared <paramref name="access" /> singleton. Used by the source generator so the
+	///     buffer never has to allocate a <see cref="PropertyGetterAccess" /> on the first record or on
+	///     verification.
+	/// </summary>
+	public static FastPropertyGetterBuffer InstallPropertyGetter(this FastMockInteractions interactions,
+		int memberId, PropertyGetterAccess access)
+	{
+		FastPropertyGetterBuffer buffer = new(interactions, access);
 		interactions.InstallBuffer(memberId, buffer);
 		return buffer;
 	}

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -422,23 +422,32 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Template-aware overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" />.
-	///     Reads the property name from <paramref name="access" /> and delegates to the string-keyed
-	///     overload so each recorded interaction stays a unique <see cref="IInteraction" /> reference —
-	///     reference-keyed bookkeeping such as <c>Then</c> ordering and the verified set requires
-	///     distinct objects per call. The source generator emits one static
-	///     <see cref="PropertyGetterAccess" /> per non-indexer property and passes it here so the cold
-	///     path can derive the property name without an extra string literal.
+	///     Singleton-aware overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" />.
+	///     Records the shared <paramref name="access" /> singleton emitted by the source generator
+	///     (one static instance per non-indexer property), avoiding the per-call
+	///     <see cref="PropertyGetterAccess" /> allocation. Sharing one reference across recorded
+	///     accesses is safe because the only reference-keyed bookkeeping in the codebase tolerates
+	///     it — the <c>_verified</c> filter is all-or-nothing per matched property, and
+	///     <c>Then</c> walks the snapshot positionally rather than mapping interactions to a
+	///     position via a dictionary.
 	/// </summary>
 	/// <typeparam name="TResult">The property's value type.</typeparam>
-	/// <param name="access">The per-property <see cref="PropertyGetterAccess" /> template.</param>
+	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> singleton for the property.</param>
 	/// <param name="defaultValueGenerator">Producer of the default value when no setup supplies one.</param>
 	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered.</param>
 	/// <returns>The resolved getter value.</returns>
 	/// <exception cref="MockNotSetupException">No setup exists for the property and <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />.</exception>
 	public TResult GetProperty<TResult>(PropertyGetterAccess access, Func<TResult> defaultValueGenerator,
 		Func<TResult>? baseValueAccessor)
-		=> GetProperty(access.Name, defaultValueGenerator, baseValueAccessor);
+	{
+		IInteraction? interaction = null;
+		if (!Behavior.SkipInteractionRecording)
+		{
+			interaction = Interactions.RegisterInteraction(access);
+		}
+
+		return ResolveGetterInternal(access.Name, defaultValueGenerator, baseValueAccessor, interaction);
+	}
 
 	/// <summary>
 	///     Member-id-keyed overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" /> that
@@ -464,17 +473,14 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Template-aware overload of <see cref="GetProperty{TResult}(int, string, Func{TResult}, Func{TResult}?)" />
-	///     that uses <paramref name="access" /> as a per-property name source and dispatches through the
-	///     fast buffer when available. The fast buffer's <see cref="FastPropertyGetterBuffer.Append()" />
-	///     stores only a sequence number; verification still emits a fresh
-	///     <see cref="PropertyGetterAccess" /> per slot so reference-keyed bookkeeping stays correct.
-	///     When no fast buffer is installed, the cold path allocates a fresh
-	///     <see cref="PropertyGetterAccess" /> per call.
+	///     Singleton-aware overload of <see cref="GetProperty{TResult}(int, string, Func{TResult}, Func{TResult}?)" />
+	///     that records the supplied <paramref name="access" /> directly. The source generator emits one shared
+	///     <see cref="PropertyGetterAccess" /> per non-indexer property; reusing it keeps every recorded access
+	///     in the matching <see cref="FastPropertyGetterBuffer" /> pointing at the same singleton.
 	/// </summary>
 	/// <typeparam name="TResult">The property's value type.</typeparam>
 	/// <param name="memberId">The generator-emitted member id for the property getter.</param>
-	/// <param name="access">The per-property <see cref="PropertyGetterAccess" /> template.</param>
+	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> singleton for the property.</param>
 	/// <param name="defaultValueGenerator">Producer of the default value when no setup supplies one.</param>
 	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered.</param>
 	/// <returns>The resolved getter value.</returns>
@@ -515,17 +521,17 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Template-aware overload of
+	///     Singleton-aware overload of
 	///     <see cref="GetPropertyFast{TResult}(int, string, Func{MockBehavior, TResult}, Func{TResult}?)" />
-	///     that uses <paramref name="access" /> as a per-property name source. Recording goes through
-	///     <see cref="FastPropertyGetterBuffer.Append()" /> (sequence-only) when a fast buffer is wired
-	///     up; verification still allocates a fresh <see cref="PropertyGetterAccess" /> per slot so
-	///     reference-keyed bookkeeping stays correct. The cold-path fall-through allocates a fresh
-	///     <see cref="PropertyGetterAccess" /> per call from <paramref name="access" />'s name.
+	///     that records the shared <paramref name="access" /> singleton emitted by the source generator,
+	///     avoiding the per-call <see cref="PropertyGetterAccess" /> allocation. The
+	///     <see cref="FastPropertyGetterBuffer" /> stores only a sequence number per call and emits the
+	///     same singleton for every recorded record on verification; the cold-path fall-through likewise
+	///     registers the singleton.
 	/// </summary>
 	/// <typeparam name="TResult">The property's value type.</typeparam>
 	/// <param name="memberId">The generator-emitted member id for the property getter.</param>
-	/// <param name="access">The per-property <see cref="PropertyGetterAccess" /> template.</param>
+	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> singleton for the property.</param>
 	/// <param name="defaultValueGenerator">Cached factory invoked with the active <see cref="MockBehavior" /> when a default value is needed.</param>
 	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered. Pass <see langword="null" /> for the no-wrapping fast path.</param>
 	/// <returns>The resolved getter value.</returns>
@@ -603,11 +609,7 @@ public partial class MockRegistry
 			}
 		}
 
-		// Cold path: each recorded interaction must be a unique IInteraction reference so
-		// reference-keyed bookkeeping (Then ordering, FastMockInteractions._verified) stays
-		// correct, so allocate a fresh PropertyGetterAccess per call rather than registering
-		// the per-property template.
-		Interactions.RegisterInteraction(new PropertyGetterAccess(access.Name));
+		Interactions.RegisterInteraction(access);
 	}
 
 	private TResult ResolveGetterInternal<TResult>(string propertyName, Func<TResult> defaultValueGenerator,

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -422,29 +422,23 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Singleton-aware overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" />.
-	///     Records <paramref name="access" /> directly so the per-call allocation of a fresh
-	///     <see cref="PropertyGetterAccess" /> is eliminated. The source generator emits one shared
-	///     <see cref="PropertyGetterAccess" /> per non-indexer property and routes both the fast and
-	///     legacy paths through the singleton.
+	///     Template-aware overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" />.
+	///     Reads the property name from <paramref name="access" /> and delegates to the string-keyed
+	///     overload so each recorded interaction stays a unique <see cref="IInteraction" /> reference —
+	///     reference-keyed bookkeeping such as <c>Then</c> ordering and the verified set requires
+	///     distinct objects per call. The source generator emits one static
+	///     <see cref="PropertyGetterAccess" /> per non-indexer property and passes it here so the cold
+	///     path can derive the property name without an extra string literal.
 	/// </summary>
 	/// <typeparam name="TResult">The property's value type.</typeparam>
-	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> for the property.</param>
+	/// <param name="access">The per-property <see cref="PropertyGetterAccess" /> template.</param>
 	/// <param name="defaultValueGenerator">Producer of the default value when no setup supplies one.</param>
 	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered.</param>
 	/// <returns>The resolved getter value.</returns>
 	/// <exception cref="MockNotSetupException">No setup exists for the property and <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />.</exception>
 	public TResult GetProperty<TResult>(PropertyGetterAccess access, Func<TResult> defaultValueGenerator,
 		Func<TResult>? baseValueAccessor)
-	{
-		IInteraction? interaction = null;
-		if (!Behavior.SkipInteractionRecording)
-		{
-			interaction = Interactions.RegisterInteraction(access);
-		}
-
-		return ResolveGetterInternal(access.Name, defaultValueGenerator, baseValueAccessor, interaction);
-	}
+		=> GetProperty(access.Name, defaultValueGenerator, baseValueAccessor);
 
 	/// <summary>
 	///     Member-id-keyed overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" /> that
@@ -470,14 +464,17 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Singleton-aware overload of <see cref="GetProperty{TResult}(int, string, Func{TResult}, Func{TResult}?)" />
-	///     that records the supplied <paramref name="access" /> directly. The source generator emits one shared
-	///     <see cref="PropertyGetterAccess" /> per non-indexer property; reusing it keeps every recorded record
-	///     in the matching <see cref="FastPropertyGetterBuffer" /> pointing at the same access object.
+	///     Template-aware overload of <see cref="GetProperty{TResult}(int, string, Func{TResult}, Func{TResult}?)" />
+	///     that uses <paramref name="access" /> as a per-property name source and dispatches through the
+	///     fast buffer when available. The fast buffer's <see cref="FastPropertyGetterBuffer.Append()" />
+	///     stores only a sequence number; verification still emits a fresh
+	///     <see cref="PropertyGetterAccess" /> per slot so reference-keyed bookkeeping stays correct.
+	///     When no fast buffer is installed, the cold path allocates a fresh
+	///     <see cref="PropertyGetterAccess" /> per call.
 	/// </summary>
 	/// <typeparam name="TResult">The property's value type.</typeparam>
 	/// <param name="memberId">The generator-emitted member id for the property getter.</param>
-	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> for the property.</param>
+	/// <param name="access">The per-property <see cref="PropertyGetterAccess" /> template.</param>
 	/// <param name="defaultValueGenerator">Producer of the default value when no setup supplies one.</param>
 	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered.</param>
 	/// <returns>The resolved getter value.</returns>
@@ -518,14 +515,17 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
-	///     Singleton-aware overload of
+	///     Template-aware overload of
 	///     <see cref="GetPropertyFast{TResult}(int, string, Func{MockBehavior, TResult}, Func{TResult}?)" />
-	///     that records the shared <paramref name="access" /> singleton emitted by the source generator,
-	///     avoiding the per-call <see cref="PropertyGetterAccess" /> allocation.
+	///     that uses <paramref name="access" /> as a per-property name source. Recording goes through
+	///     <see cref="FastPropertyGetterBuffer.Append()" /> (sequence-only) when a fast buffer is wired
+	///     up; verification still allocates a fresh <see cref="PropertyGetterAccess" /> per slot so
+	///     reference-keyed bookkeeping stays correct. The cold-path fall-through allocates a fresh
+	///     <see cref="PropertyGetterAccess" /> per call from <paramref name="access" />'s name.
 	/// </summary>
 	/// <typeparam name="TResult">The property's value type.</typeparam>
 	/// <param name="memberId">The generator-emitted member id for the property getter.</param>
-	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> for the property.</param>
+	/// <param name="access">The per-property <see cref="PropertyGetterAccess" /> template.</param>
 	/// <param name="defaultValueGenerator">Cached factory invoked with the active <see cref="MockBehavior" /> when a default value is needed.</param>
 	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered. Pass <see langword="null" /> for the no-wrapping fast path.</param>
 	/// <returns>The resolved getter value.</returns>
@@ -603,7 +603,11 @@ public partial class MockRegistry
 			}
 		}
 
-		Interactions.RegisterInteraction(access);
+		// Cold path: each recorded interaction must be a unique IInteraction reference so
+		// reference-keyed bookkeeping (Then ordering, FastMockInteractions._verified) stays
+		// correct, so allocate a fresh PropertyGetterAccess per call rather than registering
+		// the per-property template.
+		Interactions.RegisterInteraction(new PropertyGetterAccess(access.Name));
 	}
 
 	private TResult ResolveGetterInternal<TResult>(string propertyName, Func<TResult> defaultValueGenerator,

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -422,6 +422,31 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Singleton-aware overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" />.
+	///     Records <paramref name="access" /> directly so the per-call allocation of a fresh
+	///     <see cref="PropertyGetterAccess" /> is eliminated. The source generator emits one shared
+	///     <see cref="PropertyGetterAccess" /> per non-indexer property and routes both the fast and
+	///     legacy paths through the singleton.
+	/// </summary>
+	/// <typeparam name="TResult">The property's value type.</typeparam>
+	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> for the property.</param>
+	/// <param name="defaultValueGenerator">Producer of the default value when no setup supplies one.</param>
+	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered.</param>
+	/// <returns>The resolved getter value.</returns>
+	/// <exception cref="MockNotSetupException">No setup exists for the property and <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />.</exception>
+	public TResult GetProperty<TResult>(PropertyGetterAccess access, Func<TResult> defaultValueGenerator,
+		Func<TResult>? baseValueAccessor)
+	{
+		IInteraction? interaction = null;
+		if (!Behavior.SkipInteractionRecording)
+		{
+			interaction = Interactions.RegisterInteraction(access);
+		}
+
+		return ResolveGetterInternal(access.Name, defaultValueGenerator, baseValueAccessor, interaction);
+	}
+
+	/// <summary>
 	///     Member-id-keyed overload of <see cref="GetProperty{TResult}(string, Func{TResult}, Func{TResult}?)" /> that
 	///     records via the typed <see cref="FastPropertyGetterBuffer" /> when the mock is wired to a
 	///     <see cref="FastMockInteractions" />, falling back to the legacy list otherwise.
@@ -445,6 +470,30 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Singleton-aware overload of <see cref="GetProperty{TResult}(int, string, Func{TResult}, Func{TResult}?)" />
+	///     that records the supplied <paramref name="access" /> directly. The source generator emits one shared
+	///     <see cref="PropertyGetterAccess" /> per non-indexer property; reusing it keeps every recorded record
+	///     in the matching <see cref="FastPropertyGetterBuffer" /> pointing at the same access object.
+	/// </summary>
+	/// <typeparam name="TResult">The property's value type.</typeparam>
+	/// <param name="memberId">The generator-emitted member id for the property getter.</param>
+	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> for the property.</param>
+	/// <param name="defaultValueGenerator">Producer of the default value when no setup supplies one.</param>
+	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered.</param>
+	/// <returns>The resolved getter value.</returns>
+	/// <exception cref="MockNotSetupException">No setup exists for the property and <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />.</exception>
+	public TResult GetProperty<TResult>(int memberId, PropertyGetterAccess access,
+		Func<TResult> defaultValueGenerator, Func<TResult>? baseValueAccessor)
+	{
+		if (!Behavior.SkipInteractionRecording)
+		{
+			RecordPropertyGetter(memberId, access);
+		}
+
+		return ResolveGetterInternal(access.Name, defaultValueGenerator, baseValueAccessor, null);
+	}
+
+	/// <summary>
 	///     Allocation-free fast-path overload of <see cref="GetProperty{TResult}(int, string, Func{TResult}, Func{TResult}?)" />.
 	///     Avoids the per-call closure allocation by accepting a static <see cref="Func{T, TResult}" /> that takes the
 	///     active <see cref="MockBehavior" /> as its argument — the source generator emits a <c>static</c> lambda so
@@ -465,6 +514,36 @@ public partial class MockRegistry
 			RecordPropertyGetter(memberId, propertyName);
 		}
 
+		return ResolvePropertyFast(memberId, propertyName, defaultValueGenerator, baseValueAccessor);
+	}
+
+	/// <summary>
+	///     Singleton-aware overload of
+	///     <see cref="GetPropertyFast{TResult}(int, string, Func{MockBehavior, TResult}, Func{TResult}?)" />
+	///     that records the shared <paramref name="access" /> singleton emitted by the source generator,
+	///     avoiding the per-call <see cref="PropertyGetterAccess" /> allocation.
+	/// </summary>
+	/// <typeparam name="TResult">The property's value type.</typeparam>
+	/// <param name="memberId">The generator-emitted member id for the property getter.</param>
+	/// <param name="access">The shared <see cref="PropertyGetterAccess" /> for the property.</param>
+	/// <param name="defaultValueGenerator">Cached factory invoked with the active <see cref="MockBehavior" /> when a default value is needed.</param>
+	/// <param name="baseValueAccessor">Optional accessor for the base-class getter; when <see langword="null" /> only the default/initial value is considered. Pass <see langword="null" /> for the no-wrapping fast path.</param>
+	/// <returns>The resolved getter value.</returns>
+	/// <exception cref="MockNotSetupException">No setup exists for the property and <see cref="MockBehavior.ThrowWhenNotSetup" /> is <see langword="true" />.</exception>
+	public TResult GetPropertyFast<TResult>(int memberId, PropertyGetterAccess access,
+		Func<MockBehavior, TResult> defaultValueGenerator, Func<TResult>? baseValueAccessor = null)
+	{
+		if (!Behavior.SkipInteractionRecording)
+		{
+			RecordPropertyGetter(memberId, access);
+		}
+
+		return ResolvePropertyFast(memberId, access.Name, defaultValueGenerator, baseValueAccessor);
+	}
+
+	private TResult ResolvePropertyFast<TResult>(int memberId, string propertyName,
+		Func<MockBehavior, TResult> defaultValueGenerator, Func<TResult>? baseValueAccessor)
+	{
 		// Hot path: setup registered via SetupProperty(int, ...), no scenario active, no base accessor.
 		if (baseValueAccessor is null && string.IsNullOrEmpty(Scenario))
 		{
@@ -509,6 +588,22 @@ public partial class MockRegistry
 		}
 
 		Interactions.RegisterInteraction(new PropertyGetterAccess(propertyName));
+	}
+
+	private void RecordPropertyGetter(int memberId, PropertyGetterAccess access)
+	{
+		if (Interactions is FastMockInteractions fast)
+		{
+			IFastMemberBuffer?[] buffers = fast.Buffers;
+			if ((uint)memberId < (uint)buffers.Length &&
+			    buffers[memberId] is FastPropertyGetterBuffer buffer)
+			{
+				buffer.Append();
+				return;
+			}
+		}
+
+		Interactions.RegisterInteraction(access);
 	}
 
 	private TResult ResolveGetterInternal<TResult>(string propertyName, Func<TResult> defaultValueGenerator,

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -441,11 +441,6 @@ public static class VerificationResultExtensions
 			IVerificationResult result = verificationResult;
 			TMock mockVerify = ((IVerificationResult<TMock>)verificationResult).Object;
 			IInteraction[] snapshot = result.Interactions.ToArray();
-			Dictionary<IInteraction, int> positions = new(snapshot.Length);
-			for (int i = 0; i < snapshot.Length; i++)
-			{
-				positions[snapshot[i]] = i;
-			}
 
 			int after = -1;
 			foreach (Func<TMock, VerificationResult<TMock>> check in orderedChecks)
@@ -467,23 +462,31 @@ public static class VerificationResultExtensions
 
 			bool VerifyInteractions(IInteraction[] interactions, IVerificationResult currentResult)
 			{
-				int bestPosition = int.MaxValue;
-				IInteraction? firstInteraction = null;
-				foreach (IInteraction candidate in interactions)
+				// Walk the snapshot from `after + 1` and stop on the first slot whose interaction
+				// is in the verification's matched set. The membership check uses reference
+				// equality, but the search is positional — repeated entries with the same
+				// reference (e.g. shared property-getter access singletons) still resolve to
+				// distinct positions because each call to this lambda picks up where the
+				// previous one stopped.
+				int firstPos = -1;
+				// `after == int.MaxValue` is the "earlier step already failed" signal — skip the
+				// walk so subsequent steps cascade to failure without going through the loop
+				// (and without triggering int overflow on `after + 1`).
+				if (after < snapshot.Length)
 				{
-					// Stryker disable once Equality : positions are unique per interaction, so position <= bestPosition can only differ from position < bestPosition on exact equality, which never occurs.
-					if (positions.TryGetValue(candidate, out int position) &&
-					    position > after &&
-					    position < bestPosition)
+					HashSet<IInteraction> matched = new(interactions);
+					for (int i = after + 1; i < snapshot.Length; i++)
 					{
-						bestPosition = position;
-						firstInteraction = candidate;
+						if (matched.Contains(snapshot[i]))
+						{
+							firstPos = i;
+							break;
+						}
 					}
 				}
 
-				bool hasInteractionAfter = firstInteraction is not null;
-				// Stryker disable once Conditional : when hasInteractionAfter is false, bestPosition is still the int.MaxValue seed, so the ternary branches produce identical values.
-				after = hasInteractionAfter ? bestPosition : int.MaxValue;
+				bool hasInteractionAfter = firstPos >= 0;
+				after = hasInteractionAfter ? firstPos : int.MaxValue;
 				if (!hasInteractionAfter && error is null)
 				{
 					error = interactions.Length > 0

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -218,8 +218,11 @@ namespace Mockolate
         public Mockolate.Setup.MethodSetup[]? GetMethodSetupSnapshot(int memberId) { }
         public System.Collections.Generic.IEnumerable<T> GetMethodSetups<T>(string methodName)
             where T : Mockolate.Setup.MethodSetup { }
+        public TResult GetProperty<TResult>(Mockolate.Interactions.PropertyGetterAccess access, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetProperty<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetProperty<TResult>(int memberId, string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetPropertyFast<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public TResult GetPropertyFast<TResult>(int memberId, string propertyName, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public Mockolate.Setup.PropertySetup? GetPropertySetupSnapshot(int memberId) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.IMockInteractions interactions) { }
@@ -820,12 +823,14 @@ namespace Mockolate.Interactions
     public static class FastPropertyBufferFactory
     {
         public static Mockolate.Interactions.FastPropertyGetterBuffer InstallPropertyGetter(this Mockolate.Interactions.FastMockInteractions interactions, int memberId) { }
+        public static Mockolate.Interactions.FastPropertyGetterBuffer InstallPropertyGetter(this Mockolate.Interactions.FastMockInteractions interactions, int memberId, Mockolate.Interactions.PropertyGetterAccess access) { }
         public static Mockolate.Interactions.FastPropertySetterBuffer<T> InstallPropertySetter<T>(this Mockolate.Interactions.FastMockInteractions interactions, int memberId) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} property gets")]
     public sealed class FastPropertyGetterBuffer : Mockolate.Interactions.IFastMemberBuffer
     {
         public int Count { get; }
+        public void Append() { }
         public void Append(string name) { }
         public void Clear() { }
         public int ConsumeMatching() { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -211,8 +211,11 @@ namespace Mockolate
         public Mockolate.Setup.MethodSetup[]? GetMethodSetupSnapshot(int memberId) { }
         public System.Collections.Generic.IEnumerable<T> GetMethodSetups<T>(string methodName)
             where T : Mockolate.Setup.MethodSetup { }
+        public TResult GetProperty<TResult>(Mockolate.Interactions.PropertyGetterAccess access, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetProperty<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetProperty<TResult>(int memberId, string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetPropertyFast<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public TResult GetPropertyFast<TResult>(int memberId, string propertyName, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public Mockolate.Setup.PropertySetup? GetPropertySetupSnapshot(int memberId) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.IMockInteractions interactions) { }
@@ -811,12 +814,14 @@ namespace Mockolate.Interactions
     public static class FastPropertyBufferFactory
     {
         public static Mockolate.Interactions.FastPropertyGetterBuffer InstallPropertyGetter(this Mockolate.Interactions.FastMockInteractions interactions, int memberId) { }
+        public static Mockolate.Interactions.FastPropertyGetterBuffer InstallPropertyGetter(this Mockolate.Interactions.FastMockInteractions interactions, int memberId, Mockolate.Interactions.PropertyGetterAccess access) { }
         public static Mockolate.Interactions.FastPropertySetterBuffer<T> InstallPropertySetter<T>(this Mockolate.Interactions.FastMockInteractions interactions, int memberId) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} property gets")]
     public sealed class FastPropertyGetterBuffer : Mockolate.Interactions.IFastMemberBuffer
     {
         public int Count { get; }
+        public void Append() { }
         public void Append(string name) { }
         public void Clear() { }
         public int ConsumeMatching() { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -198,8 +198,11 @@ namespace Mockolate
         public Mockolate.Setup.MethodSetup[]? GetMethodSetupSnapshot(int memberId) { }
         public System.Collections.Generic.IEnumerable<T> GetMethodSetups<T>(string methodName)
             where T : Mockolate.Setup.MethodSetup { }
+        public TResult GetProperty<TResult>(Mockolate.Interactions.PropertyGetterAccess access, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetProperty<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetProperty<TResult>(int memberId, string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
+        public TResult GetPropertyFast<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public TResult GetPropertyFast<TResult>(int memberId, string propertyName, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public Mockolate.Setup.PropertySetup? GetPropertySetupSnapshot(int memberId) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.IMockInteractions interactions) { }
@@ -770,12 +773,14 @@ namespace Mockolate.Interactions
     public static class FastPropertyBufferFactory
     {
         public static Mockolate.Interactions.FastPropertyGetterBuffer InstallPropertyGetter(this Mockolate.Interactions.FastMockInteractions interactions, int memberId) { }
+        public static Mockolate.Interactions.FastPropertyGetterBuffer InstallPropertyGetter(this Mockolate.Interactions.FastMockInteractions interactions, int memberId, Mockolate.Interactions.PropertyGetterAccess access) { }
         public static Mockolate.Interactions.FastPropertySetterBuffer<T> InstallPropertySetter<T>(this Mockolate.Interactions.FastMockInteractions interactions, int memberId) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} property gets")]
     public sealed class FastPropertyGetterBuffer : Mockolate.Interactions.IFastMemberBuffer
     {
         public int Count { get; }
+        public void Append() { }
         public void Append(string name) { }
         public void Clear() { }
         public int ConsumeMatching() { }

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
@@ -238,6 +238,20 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastPropertyGetterBuffer_Append_WithoutInstalledTemplate_ShouldThrow()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+
+		void Act()
+		{
+			buffer.Append();
+		}
+
+		await That(Act).Throws<InvalidOperationException>();
+	}
+
+	[Fact]
 	public async Task FastPropertyGetterBuffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
 	{
 		FastMockInteractions store = new(1);
@@ -253,6 +267,22 @@ public class FastBufferBoxingAndUnverifiedTests
 		await That(first).HasCount(1);
 		await That(second).HasCount(1);
 		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastPropertyGetterBuffer_AppendBoxed_DistinctSlotsProduceDistinctInteractions()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+
+		buffer.Append("P");
+		buffer.Append("P");
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(dest);
+
+		await That(dest).HasCount(2);
+		await That(dest[0].Interaction).IsNotSameAs(dest[1].Interaction);
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
@@ -238,7 +238,7 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
-	public async Task FastPropertyGetterBuffer_Append_WithoutInstalledTemplate_ShouldThrow()
+	public async Task FastPropertyGetterBuffer_Append_WithoutInstalledSingleton_ShouldThrow()
 	{
 		FastMockInteractions store = new(1);
 		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
@@ -252,7 +252,7 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
-	public async Task FastPropertyGetterBuffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	public async Task FastPropertyGetterBuffer_AppendBoxed_RepeatedCallsReturnSameSingleton()
 	{
 		FastMockInteractions store = new(1);
 		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
@@ -270,8 +270,14 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
-	public async Task FastPropertyGetterBuffer_AppendBoxed_DistinctSlotsProduceDistinctInteractions()
+	public async Task FastPropertyGetterBuffer_AppendBoxed_SharesSingletonAcrossRecords()
 	{
+		// All recorded getter accesses for the same property surface as one PropertyGetterAccess
+		// reference. This is intentional — getters carry no parameters, so every record is
+		// semantically identical, and the two reference-keyed verification paths
+		// (FastMockInteractions._verified and VerificationResultExtensions.Then) tolerate
+		// shared identity (the Then walker is positional, the verified filter is
+		// all-or-nothing per matched property).
 		FastMockInteractions store = new(1);
 		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
 
@@ -282,7 +288,7 @@ public class FastBufferBoxingAndUnverifiedTests
 		((IFastMemberBuffer)buffer).AppendBoxed(dest);
 
 		await That(dest).HasCount(2);
-		await That(dest[0].Interaction).IsNotSameAs(dest[1].Interaction);
+		await That(dest[0].Interaction).IsSameAs(dest[1].Interaction);
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -80,7 +80,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomeProperty_Get, "global::MyCode.IMyService.SomeProperty", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeProperty);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomeProperty_Get, global::Mockolate.Mock.IMyService.PropertyAccess_SomeProperty_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeProperty);
 					          			}
 					          			set
 					          			{
@@ -98,7 +98,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<bool?>(global::Mockolate.Mock.IMyService.MemberId_SomeReadOnlyProperty_Get, "global::MyCode.IMyService.SomeReadOnlyProperty", static b => b.DefaultValue.Generate(default(bool?)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeReadOnlyProperty);
+					          				return this.MockRegistry.GetPropertyFast<bool?>(global::Mockolate.Mock.IMyService.MemberId_SomeReadOnlyProperty_Get, global::Mockolate.Mock.IMyService.PropertyAccess_SomeReadOnlyProperty_Get, static b => b.DefaultValue.Generate(default(bool?)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeReadOnlyProperty);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -122,7 +122,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomeInternalProperty_Get, "global::MyCode.IMyService.SomeInternalProperty", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeInternalProperty);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomeInternalProperty_Get, global::Mockolate.Mock.IMyService.PropertyAccess_SomeInternalProperty_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomeInternalProperty);
 					          			}
 					          			set
 					          			{
@@ -140,7 +140,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomePrivateProperty_Get, "global::MyCode.IMyService.SomePrivateProperty", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProperty);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomePrivateProperty_Get, global::Mockolate.Mock.IMyService.PropertyAccess_SomePrivateProperty_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProperty);
 					          			}
 					          			set
 					          			{
@@ -158,7 +158,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomePrivateProtectedProperty_Get, "global::MyCode.IMyService.SomePrivateProtectedProperty", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProtectedProperty);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_SomePrivateProtectedProperty_Get, global::Mockolate.Mock.IMyService.PropertyAccess_SomePrivateProtectedProperty_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.SomePrivateProtectedProperty);
 					          			}
 					          			set
 					          			{
@@ -217,7 +217,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyDirectProperty_Get, "global::MyCode.IMyService.MyDirectProperty", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyDirectProperty);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyDirectProperty_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyDirectProperty_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyDirectProperty);
 					          			}
 					          			set
 					          			{
@@ -235,7 +235,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty1_Get, "global::MyCode.IMyServiceBase1.MyBaseProperty1", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty1);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty1_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty1_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty1);
 					          			}
 					          			set
 					          			{
@@ -253,7 +253,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty2_Get, "global::MyCode.IMyServiceBase2.MyBaseProperty2", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty2);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty2_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty2_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty2);
 					          			}
 					          			set
 					          			{
@@ -271,7 +271,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty3_Get, "global::MyCode.IMyServiceBase3.MyBaseProperty3", static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty3);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty3_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty3_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty3);
 					          			}
 					          			set
 					          			{
@@ -331,7 +331,7 @@ public sealed partial class MockTests
 					          		{
 					          			protected get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.MyService.SomeProperty1", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), () => base.SomeProperty1);
+					          				return this.MockRegistry.GetProperty<int>(global::Mockolate.Mock.MyService__IMyOtherService.PropertyAccess_SomeProperty1_Get, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), () => base.SomeProperty1);
 					          			}
 					          			set
 					          			{
@@ -355,7 +355,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.MyService.SomeProperty2", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is global::MyCode.MyService wraps ? () => wraps.SomeProperty2 : () => base.SomeProperty2);
+					          				return this.MockRegistry.GetProperty<int>(global::Mockolate.Mock.MyService__IMyOtherService.PropertyAccess_SomeProperty2_Get, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is global::MyCode.MyService wraps ? () => wraps.SomeProperty2 : () => base.SomeProperty2);
 					          			}
 					          			protected set
 					          			{
@@ -372,7 +372,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<bool?>("global::MyCode.MyService.SomeReadOnlyProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool?)!), () => base.SomeReadOnlyProperty);
+					          				return this.MockRegistry.GetProperty<bool?>(global::Mockolate.Mock.MyService__IMyOtherService.PropertyAccess_SomeReadOnlyProperty_Get, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(bool?)!), () => base.SomeReadOnlyProperty);
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle().And
@@ -396,7 +396,7 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetProperty<int>("global::MyCode.IMyOtherService.SomeAdditionalProperty", () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), null);
+					          				return this.MockRegistry.GetProperty<int>(global::Mockolate.Mock.MyService__IMyOtherService.PropertyAccess_SomeAdditionalProperty_Get, () => this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), null);
 					          			}
 					          			set
 					          			{

--- a/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
@@ -437,6 +437,18 @@ public class VerificationResultExtensionsTests
 			.Then(m => m.Dispense(It.IsAny<string>(), It.Is(2)));
 	}
 
+	[Fact]
+	public void Then_RepeatedPropertyGetter_ShouldNotCollapseIntoOnePosition()
+	{
+		IChocolateDispenser sut = IChocolateDispenser.CreateMock();
+		_ = sut.TotalDispensed;
+		sut.Dispense("Dark", 1);
+		_ = sut.TotalDispensed;
+
+		sut.Mock.Verify.TotalDispensed.Got()
+			.Then(m => m.TotalDispensed.Got());
+	}
+
 	[Theory]
 	[InlineData(false, 1, 2, 3, 4)]
 	[InlineData(true, 1, 2, 2, 4)]


### PR DESCRIPTION
This PR aims to optimize property-getter interaction recording by reusing a generator-emitted `PropertyGetterAccess` singleton (instead of allocating a new `PropertyGetterAccess` per getter call), and updating the source generator + tests to use the new access constants.

**Changes:**
- Added `MockRegistry.GetProperty*` overloads that accept a `PropertyGetterAccess` instance for recording.
- Updated `FastPropertyGetterBuffer` to record only sequence numbers and reuse a shared `PropertyGetterAccess` when boxing.
- Updated source generation to emit and use `PropertyAccess_*` fields and to install getter buffers with the shared access.