### PR TITLE
perf: improve indexer performance

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Mockolate.SourceGenerators.Entities;
 using Event = Mockolate.SourceGenerators.Entities.Event;
@@ -165,6 +166,33 @@ internal static partial class Sources
 
 		internal string GetEventUnsubscribeIdentifier(Event @event)
 			=> _declarations[EventUnsubscribeIds[@event]];
+
+		/// <summary>
+		///     Returns the cached typed-buffer field name for the indexer's getter slot.
+		/// </summary>
+		internal string GetIndexerGetterBufferFieldName(Property indexer)
+			=> ToBufferFieldName(_declarations[IndexerGetIds[indexer]]);
+
+		/// <summary>
+		///     Returns the cached typed-buffer field name for the indexer's setter slot.
+		/// </summary>
+		internal string GetIndexerSetterBufferFieldName(Property indexer)
+			=> ToBufferFieldName(_declarations[IndexerSetIds[indexer]]);
+
+		/// <summary>
+		///     Returns the cached typed-buffer field name for the method's slot.
+		/// </summary>
+		internal string GetMethodBufferFieldName(Method method)
+			=> ToBufferFieldName(_declarations[MethodIds[method]]);
+
+		private static string ToBufferFieldName(string identifier)
+		{
+			const string Prefix = "MemberId_";
+			string suffix = identifier.StartsWith(Prefix, StringComparison.Ordinal)
+				? identifier.Substring(Prefix.Length)
+				: identifier;
+			return "MockolateBuffer_" + suffix;
+		}
 
 		private int AllocateId(string identifier)
 		{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -705,6 +705,8 @@ internal static partial class Sources
 		}
 
 		sb.AppendLine();
+		AppendCachedFieldDeclarations(sb, "\t\t", @class, memberIds, memberIdPrefix, mockRegistryName);
+		sb.AppendLine();
 		ImplementMockForInterface(sb, mockRegistryName, name, hasEvents, hasProtectedMembers, hasProtectedEvents,
 			hasStaticMembers, hasStaticEvents);
 
@@ -1382,6 +1384,115 @@ internal static partial class Sources
 
 		sb.Append(indent).Append("\treturn fast;").AppendLine();
 		sb.Append(indent).Append("}").AppendLine();
+	}
+
+	/// <summary>
+	///     Emits the declarations of the cached <c>MockolateSkipRecording</c> flag and per-member typed
+	///     buffer fields. These mirror values that <c>AppendCreateFastInteractions</c> writes into the
+	///     <c>FastMockInteractions.Buffers</c> array so the body emitters can read them as plain field
+	///     accesses instead of paying the cast / array-index / property-chain on every invocation. Static
+	///     members stay on the legacy path because the cached field would not flow through
+	///     <c>AsyncLocal</c>-resolved registries.
+	/// </summary>
+	/// <summary>
+	///     <see langword="true" /> when the class has at least one fast-eligible non-static indexer or
+	///     method, in which case the generator emits cached typed-buffer fields and a
+	///     <c>MockolateSkipRecording</c> flag that the recording hot paths read instead of paying the
+	///     per-call cast / array-index / property-chain.
+	/// </summary>
+	private static bool HasCachedBufferFields(Class @class)
+	{
+		foreach (Property property in @class.AllProperties())
+		{
+			if (property.IsIndexer && IsFastBufferEligibleIndexer(property))
+			{
+				return true;
+			}
+		}
+
+		foreach (Method method in @class.AllMethods())
+		{
+			if (!method.IsStatic && IsFastBufferEligibleMethod(method))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static void AppendCachedFieldDeclarations(StringBuilder sb, string indent, Class @class,
+		MemberIdTable memberIds, string memberIdPrefix, string mockRegistryName)
+	{
+		if (!HasCachedBufferFields(@class))
+		{
+			return;
+		}
+
+		string mockRegistryRef = "this." + mockRegistryName;
+
+		foreach (Property indexer in @class.AllProperties().Where(p => p.IsIndexer))
+		{
+			if (!IsFastBufferEligibleIndexer(indexer))
+			{
+				continue;
+			}
+
+			string indexerKeyTypeArgs =
+				string.Join(", ", indexer.IndexerParameters!.Value.Select(p => p.ToTypeOrWrapper()));
+			string indexerValueType = indexer.Type.ToTypeOrWrapper();
+			string getMemberIdRef = memberIdPrefix + memberIds.GetIndexerGetIdentifier(indexer);
+			string setMemberIdRef = memberIdPrefix + memberIds.GetIndexerSetIdentifier(indexer);
+
+			sb.Append(indent)
+				.Append(
+					"[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
+				.AppendLine();
+			sb.Append(indent).Append("private global::Mockolate.Interactions.FastIndexerGetterBuffer<")
+				.Append(indexerKeyTypeArgs).Append("> ")
+				.Append(memberIds.GetIndexerGetterBufferFieldName(indexer)).AppendLine();
+			sb.Append(indent).Append("\t=> field ?? (field = (global::Mockolate.Interactions.FastIndexerGetterBuffer<")
+				.Append(indexerKeyTypeArgs).Append(">)((global::Mockolate.Interactions.FastMockInteractions)")
+				.Append(mockRegistryRef).Append(".Interactions).Buffers[").Append(getMemberIdRef).Append("]!);")
+				.AppendLine();
+
+			sb.Append(indent)
+				.Append(
+					"[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
+				.AppendLine();
+			sb.Append(indent).Append("private global::Mockolate.Interactions.FastIndexerSetterBuffer<")
+				.Append(indexerKeyTypeArgs).Append(", ").Append(indexerValueType).Append("> ")
+				.Append(memberIds.GetIndexerSetterBufferFieldName(indexer)).AppendLine();
+			sb.Append(indent).Append("\t=> field ?? (field = (global::Mockolate.Interactions.FastIndexerSetterBuffer<")
+				.Append(indexerKeyTypeArgs).Append(", ").Append(indexerValueType)
+				.Append(">)((global::Mockolate.Interactions.FastMockInteractions)").Append(mockRegistryRef)
+				.Append(".Interactions).Buffers[").Append(setMemberIdRef).Append("]!);").AppendLine();
+		}
+
+		foreach (Method method in @class.AllMethods())
+		{
+			if (method.IsStatic || !IsFastBufferEligibleMethod(method))
+			{
+				continue;
+			}
+
+			int arity = method.Parameters.Count;
+			string typeArgs = arity == 0
+				? string.Empty
+				: "<" + string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper())) + ">";
+			string memberIdRef = memberIdPrefix + memberIds.GetMethodIdentifier(method);
+			sb.Append(indent)
+				.Append(
+					"[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
+				.AppendLine();
+			sb.Append(indent).Append("private global::Mockolate.Interactions.FastMethod").Append(arity)
+				.Append("Buffer").Append(typeArgs).Append(' ')
+				.Append(memberIds.GetMethodBufferFieldName(method)).AppendLine();
+			sb.Append(indent).Append("\t=> field ?? (field = (global::Mockolate.Interactions.FastMethod").Append(arity)
+				.Append("Buffer").Append(typeArgs).Append(")((global::Mockolate.Interactions.FastMockInteractions)")
+				.Append(mockRegistryRef).Append(".Interactions).Buffers[").Append(memberIdRef).Append("]!);")
+				.AppendLine();
+		}
 	}
 
 	/// <summary>
@@ -2220,6 +2331,12 @@ internal static partial class Sources
 		string indexerSetIdRef = property.IsIndexer
 			? memberIdPrefix + memberIds.GetIndexerSetIdentifier(property)
 			: string.Empty;
+		string? indexerGetCachedBufferRef = useFastForIndexer
+			? "this." + memberIds.GetIndexerGetterBufferFieldName(property)
+			: null;
+		string? indexerSetCachedBufferRef = useFastForIndexer
+			? "this." + memberIds.GetIndexerSetterBufferFieldName(property)
+			: null;
 		string propertyGetMemberArg = useFastForProperty
 			? memberIdPrefix + memberIds.GetPropertyGetIdentifier(property) + ", "
 			: string.Empty;
@@ -2316,7 +2433,8 @@ internal static partial class Sources
 
 					EmitIndexerGetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
-						useFastForIndexer ? indexerGetIdRef : null);
+						useFastForIndexer ? indexerGetIdRef : null,
+						cachedBufferRef: indexerGetCachedBufferRef);
 					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is not ").Append(className)
 						.Append(' ').Append(wrapsVarName).Append(')').AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
@@ -2391,7 +2509,8 @@ internal static partial class Sources
 
 					EmitIndexerGetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
-						useFastForIndexer ? indexerGetIdRef : null);
+						useFastForIndexer ? indexerGetIdRef : null,
+						cachedBufferRef: indexerGetCachedBufferRef);
 					sb.Append("\t\t\t\tif (!(").Append(setupVarName).Append("?.SkipBaseClass() ?? ")
 						.Append(mockRegistry).Append(".Behavior.SkipBaseClass))").AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
@@ -2481,7 +2600,8 @@ internal static partial class Sources
 
 				EmitIndexerGetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 					property.Type, property.IndexerParameters.Value, useFastForIndexer,
-					useFastForIndexer ? indexerGetIdRef : null);
+					useFastForIndexer ? indexerGetIdRef : null,
+					cachedBufferRef: indexerGetCachedBufferRef);
 				sb.Append("\t\t\t\treturn ").Append(setupVarName).Append(" is null").AppendLine();
 				sb.Append("\t\t\t\t\t? ").Append(mockRegistry).Append(".GetIndexerFallback<")
 					.AppendTypeOrWrapper(property.Type).Append(">(").Append(accessVarName).Append(", ")
@@ -2549,7 +2669,8 @@ internal static partial class Sources
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
 						useFastForIndexer ? indexerSetIdRef : null,
-						useFastForIndexer ? indexerGetIdRef : null);
+						useFastForIndexer ? indexerGetIdRef : null,
+						cachedBufferRef: indexerSetCachedBufferRef);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append(");")
@@ -2605,7 +2726,8 @@ internal static partial class Sources
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
 						useFastForIndexer ? indexerSetIdRef : null,
-						useFastForIndexer ? indexerGetIdRef : null);
+						useFastForIndexer ? indexerGetIdRef : null,
+						cachedBufferRef: indexerSetCachedBufferRef);
 					sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append("))").AppendLine();
@@ -2640,7 +2762,8 @@ internal static partial class Sources
 					EmitIndexerSetterAccessAndSetup(sb, "\t\t\t\t", mockRegistry, accessVarName, setupVarName,
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
 						useFastForIndexer ? indexerSetIdRef : null,
-						useFastForIndexer ? indexerGetIdRef : null);
+						useFastForIndexer ? indexerGetIdRef : null,
+						cachedBufferRef: indexerSetCachedBufferRef);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append(");").AppendLine();
@@ -2891,10 +3014,22 @@ internal static partial class Sources
 			}
 		}
 
+		bool useCachedMethodBuffer = useFastBuffers && !method.IsStatic && IsFastBufferEligibleMethod(method);
 		sb.Append("\t\t\tif (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)")
 			.AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		if (useFastBuffers && IsFastBufferEligibleMethod(method))
+		if (useCachedMethodBuffer)
+		{
+			sb.Append("\t\t\t\tthis.").Append(memberIds.GetMethodBufferFieldName(method)).Append(".Append(")
+				.Append(method.GetUniqueNameString());
+			if (method.Parameters.Count > 0)
+			{
+				sb.Append(", ").Append(string.Join(", ", method.Parameters.Select(p => p.ToNameOrWrapper())));
+			}
+
+			sb.Append(");").AppendLine();
+		}
+		else if (useFastBuffers && IsFastBufferEligibleMethod(method))
 		{
 			int arity = method.Parameters.Count;
 			string typeArgs = arity == 0

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -5046,39 +5046,56 @@ internal static partial class Sources
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tget").AppendLine();
 		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName)
-			.Append(", ").AppendTypeOrWrapper(indexer.Type).Append(">(this, this.").Append(mockRegistryName)
-			.Append(", ").Append(indexerGetMemberId).Append(", ").Append(indexerSetMemberId).Append(",").AppendLine();
-
-		sb.Append("\t\t\t\t\tinteraction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<");
-		int ti = 0;
-		foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+		bool useTypedVerify = indexer.IndexerParameters.Value.Count is >= 1 and <= 4;
+		if (useTypedVerify)
 		{
-			if (ti > 0)
+			sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName);
+			foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
 			{
-				sb.Append(", ");
+				sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
 			}
 
-			sb.AppendTypeOrWrapper(parameter.Type);
-			ti++;
+			sb.Append(", ").AppendTypeOrWrapper(indexer.Type).Append(">(this, this.").Append(mockRegistryName)
+				.Append(", ").Append(indexerGetMemberId).Append(", ").Append(indexerSetMemberId).Append(",").AppendLine();
+
+			AppendIndexerVerifyTypedMatches(sb, indexer.IndexerParameters.Value, valueFlags);
 		}
-
-		sb.Append("> g");
-		AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "g");
-		sb.Append(",").AppendLine();
-
-		sb.Append(
-			"\t\t\t\t\t(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<");
-		ti = 0;
-		foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+		else
 		{
-			sb.AppendTypeOrWrapper(parameter.Type).Append(", ");
-			ti++;
-		}
+			sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName)
+				.Append(", ").AppendTypeOrWrapper(indexer.Type).Append(">(this, this.").Append(mockRegistryName)
+				.Append(", ").Append(indexerGetMemberId).Append(", ").Append(indexerSetMemberId).Append(",").AppendLine();
 
-		sb.AppendTypeOrWrapper(indexer.Type).Append("> s");
-		AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "s");
-		sb.Append(" && value.Matches(s.TypedValue),").AppendLine();
+			sb.Append("\t\t\t\t\tinteraction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<");
+			int ti = 0;
+			foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+			{
+				if (ti > 0)
+				{
+					sb.Append(", ");
+				}
+
+				sb.AppendTypeOrWrapper(parameter.Type);
+				ti++;
+			}
+
+			sb.Append("> g");
+			AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "g");
+			sb.Append(",").AppendLine();
+
+			sb.Append(
+				"\t\t\t\t\t(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<");
+			ti = 0;
+			foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+			{
+				sb.AppendTypeOrWrapper(parameter.Type).Append(", ");
+				ti++;
+			}
+
+			sb.AppendTypeOrWrapper(indexer.Type).Append("> s");
+			AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "s");
+			sb.Append(" && value.Matches(s.TypedValue),").AppendLine();
+		}
 
 		sb.Append("\t\t\t\t\t() => global::System.String.Format(\"[");
 
@@ -5114,6 +5131,44 @@ internal static partial class Sources
 		sb.Append("\t\t\t}").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
+	}
+
+	/// <summary>
+	///     Emits one comma-terminated <c>IParameterMatch&lt;T&gt;</c> argument per indexer key for the typed
+	///     <c>VerificationIndexerResult&lt;TSubject, T1, ..., TParameter&gt;</c> family. Each match is either
+	///     built via <c>CovariantParameterAdapter</c> (for the matcher overload) or via <c>It.Is</c> (for the
+	///     value overload).
+	/// </summary>
+	private static void AppendIndexerVerifyTypedMatches(StringBuilder sb,
+		EquatableArray<MethodParameter> parameters, bool[]? valueFlags)
+	{
+		int j = 0;
+		foreach (MethodParameter parameter in parameters)
+		{
+			sb.Append("\t\t\t\t\t");
+			bool isValueParam = valueFlags?[j] == true;
+			if (isValueParam)
+			{
+				sb.Append("(global::Mockolate.Parameters.IParameterMatch<").AppendTypeOrWrapper(parameter.Type)
+					.Append(">)global::Mockolate.It.Is<").AppendTypeOrWrapper(parameter.Type).Append(">(")
+					.Append(parameter.Name).Append(", \"").Append(parameter.Name).Append("\")");
+			}
+			else
+			{
+				sb.Append("CovariantParameterAdapter<").AppendTypeOrWrapper(parameter.Type)
+					.Append(">.Wrap(").Append(parameter.Name);
+				if (parameter.CanUseNullableParameterOverload())
+				{
+					sb.Append(" ?? global::Mockolate.It.IsNull<").Append(parameter.ToNullableType())
+						.Append(">(\"null\")");
+				}
+
+				sb.Append(")");
+			}
+
+			sb.Append(',').AppendLine();
+			j++;
+		}
 	}
 
 	private static void AppendIndexerVerifyParameterMatches(StringBuilder sb,

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -164,7 +164,7 @@ internal static partial class Sources
 		sb.Append(indent).Append("}").AppendLine();
 
 		EmitIndexerSetupLookup(sb, indent, mockRegistry, accessVarName, setupVarName, propertyType, parameters,
-			setupMemberIdRef ?? memberIdRef);
+			setupMemberIdRef ?? memberIdRef, isSetter: false);
 	}
 
 	/// <summary>
@@ -216,18 +216,23 @@ internal static partial class Sources
 		sb.Append(indent).Append("}").AppendLine();
 
 		EmitIndexerSetupLookup(sb, indent, mockRegistry, accessVarName, setupVarName, propertyType, parameters,
-			setupMemberIdRef);
+			setupMemberIdRef, isSetter: true);
 	}
 
 	/// <summary>
 	///     Emits the indexer-setup lookup variable. When <paramref name="memberIdRef" /> is provided the lookup
 	///     scans the lock-free <c>GetIndexerSetupSnapshot</c> array first (default-scope fast path), and falls back
 	///     to the closure-free <c>GetIndexerSetup&lt;T&gt;(access)</c> overload for scenario-scoped setups.
+	///     The snapshot match check uses the typed <c>Matches(p1, ...)</c> overload (and <c>access.TypedValue</c>
+	///     for setters) on the concrete <c>IndexerSetup&lt;TValue, T1, ...&gt;</c> instead of dispatching through
+	///     <c>IInteractiveIndexerSetup.Matches(IndexerAccess)</c>, which avoids the interface-cast and the
+	///     getter/setter type test on every snapshot entry.
 	/// </summary>
 #pragma warning disable S107 // Methods should not have too many parameters
 	private static void EmitIndexerSetupLookup(StringBuilder sb, string indent,
 		string mockRegistry, string accessVarName, string setupVarName,
-		Type propertyType, EquatableArray<MethodParameter> parameters, string? memberIdRef)
+		Type propertyType, EquatableArray<MethodParameter> parameters, string? memberIdRef,
+		bool isSetter)
 #pragma warning restore S107
 	{
 		StringBuilder typedSetup = new("global::Mockolate.Setup.IndexerSetup<");
@@ -264,8 +269,30 @@ internal static partial class Sources
 		sb.Append(indent).Append("\t\t{").AppendLine();
 		sb.Append(indent).Append("\t\t\tif (").Append(snapshotVar).Append('[').Append(indexVar)
 			.Append("] is ").Append(typedSetupName).Append(' ').Append(itemVar)
-			.Append(" && ((global::Mockolate.Setup.IInteractiveIndexerSetup)").Append(itemVar)
-			.Append(").Matches(").Append(accessVarName).Append("))").AppendLine();
+			.Append(" && ").Append(itemVar).Append(".Matches(");
+		bool firstArg = true;
+		for (int i = 1; i <= parameters.Count; i++)
+		{
+			if (!firstArg)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append(accessVarName).Append(".Parameter").Append(i);
+			firstArg = false;
+		}
+
+		if (isSetter)
+		{
+			if (!firstArg)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append(accessVarName).Append(".TypedValue");
+		}
+
+		sb.Append("))").AppendLine();
 		sb.Append(indent).Append("\t\t\t{").AppendLine();
 		sb.Append(indent).Append("\t\t\t\t").Append(setupVarName).Append(" = ").Append(itemVar)
 			.Append(';').AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -118,12 +118,18 @@ internal static partial class Sources
 	///     mockRegistry.RegisterInteraction(access);
 	///     var setup = mockRegistry.GetIndexerSetup&lt;IndexerSetup&lt;TValue, T...&gt;&gt;(access);</code>
 	/// </summary>
+	/// <remarks>
+	///     When <paramref name="cachedBufferRef" /> is provided, the recording branch reads from the
+	///     cached typed-buffer property on the mock instead of paying the per-call cast / array-index /
+	///     property-chain to reach the typed buffer.
+	/// </remarks>
 #pragma warning disable S107 // Methods should not have too many parameters
 	private static void EmitIndexerGetterAccessAndSetup(StringBuilder sb, string indent,
 		string mockRegistry, string accessVarName, string setupVarName,
 		Type propertyType, EquatableArray<MethodParameter> parameters,
 		bool useFastBuffers = false, string? memberIdRef = null,
-		string? setupMemberIdRef = null)
+		string? setupMemberIdRef = null,
+		string? cachedBufferRef = null)
 #pragma warning restore S107
 	{
 		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerGetterAccess<");
@@ -132,9 +138,15 @@ internal static partial class Sources
 		AppendIndexerParameterArguments(sb, parameters);
 		sb.Append(");").AppendLine();
 
-		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)")
+			.AppendLine();
 		sb.Append(indent).Append("{").AppendLine();
-		if (useFastBuffers && memberIdRef is not null)
+		if (cachedBufferRef is not null)
+		{
+			sb.Append(indent).Append('\t').Append(cachedBufferRef).Append(".Append(").Append(accessVarName)
+				.Append(");").AppendLine();
+		}
+		else if (useFastBuffers && memberIdRef is not null)
 		{
 			sb.Append(indent).Append("\t((global::Mockolate.Interactions.FastIndexerGetterBuffer<");
 			AppendIndexerParameterTypes(sb, parameters);
@@ -157,12 +169,17 @@ internal static partial class Sources
 	/// <summary>
 	///     Emits variable declarations for the indexer setter access and matching setup.
 	/// </summary>
+	/// <remarks>
+	///     See <see cref="EmitIndexerGetterAccessAndSetup" /> for how <paramref name="cachedBufferRef" />
+	///     short-circuits the per-call buffer lookup.
+	/// </remarks>
 #pragma warning disable S107 // Methods should not have too many parameters
 	private static void EmitIndexerSetterAccessAndSetup(StringBuilder sb, string indent,
 		string mockRegistry, string accessVarName, string setupVarName,
 		Type propertyType, EquatableArray<MethodParameter> parameters,
 		bool useFastBuffers = false, string? memberIdRef = null,
-		string? setupMemberIdRef = null)
+		string? setupMemberIdRef = null,
+		string? cachedBufferRef = null)
 #pragma warning restore S107
 	{
 		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerSetterAccess<");
@@ -171,9 +188,15 @@ internal static partial class Sources
 		AppendIndexerParameterArguments(sb, parameters);
 		sb.Append(", value);").AppendLine();
 
-		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)")
+			.AppendLine();
 		sb.Append(indent).Append("{").AppendLine();
-		if (useFastBuffers && memberIdRef is not null)
+		if (cachedBufferRef is not null)
+		{
+			sb.Append(indent).Append('\t').Append(cachedBufferRef).Append(".Append(").Append(accessVarName)
+				.Append(");").AppendLine();
+		}
+		else if (useFastBuffers && memberIdRef is not null)
 		{
 			sb.Append(indent).Append("\t((global::Mockolate.Interactions.FastIndexerSetterBuffer<");
 			AppendIndexerParameterTypes(sb, parameters);

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -143,8 +143,9 @@ internal static partial class Sources
 		sb.Append(indent).Append("{").AppendLine();
 		if (cachedBufferRef is not null)
 		{
-			sb.Append(indent).Append('\t').Append(cachedBufferRef).Append(".Append(").Append(accessVarName)
-				.Append(");").AppendLine();
+			sb.Append(indent).Append('\t').Append(cachedBufferRef).Append(".Append(");
+			AppendIndexerParameterArguments(sb, parameters);
+			sb.Append(");").AppendLine();
 		}
 		else if (useFastBuffers && memberIdRef is not null)
 		{
@@ -193,8 +194,9 @@ internal static partial class Sources
 		sb.Append(indent).Append("{").AppendLine();
 		if (cachedBufferRef is not null)
 		{
-			sb.Append(indent).Append('\t').Append(cachedBufferRef).Append(".Append(").Append(accessVarName)
-				.Append(");").AppendLine();
+			sb.Append(indent).Append('\t').Append(cachedBufferRef).Append(".Append(");
+			AppendIndexerParameterArguments(sb, parameters);
+			sb.Append(", value);").AppendLine();
 		}
 		else if (useFastBuffers && memberIdRef is not null)
 		{

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -132,11 +132,12 @@ internal static partial class Sources
 		string? cachedBufferRef = null)
 #pragma warning restore S107
 	{
-		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerGetterAccess<");
-		AppendIndexerParameterTypes(sb, parameters);
-		sb.Append("> ").Append(accessVarName).Append(" = new(");
-		AppendIndexerParameterArguments(sb, parameters);
-		sb.Append(");").AppendLine();
+		bool deferAccess = CanDeferIndexerAccess(parameters, cachedBufferRef);
+
+		if (!deferAccess)
+		{
+			EmitIndexerGetterAccessDeclaration(sb, indent, accessVarName, parameters);
+		}
 
 		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)")
 			.AppendLine();
@@ -164,7 +165,47 @@ internal static partial class Sources
 		sb.Append(indent).Append("}").AppendLine();
 
 		EmitIndexerSetupLookup(sb, indent, mockRegistry, accessVarName, setupVarName, propertyType, parameters,
-			setupMemberIdRef ?? memberIdRef, isSetter: false);
+			setupMemberIdRef ?? memberIdRef, isSetter: false, deferAccess: deferAccess,
+			emitAccessDeclaration: deferAccess
+				? sbInner => EmitIndexerGetterAccessDeclaration(sbInner, indent, accessVarName, parameters)
+				: null);
+	}
+
+	/// <summary>
+	///     Emits the <c>IndexerGetterAccess&lt;T...&gt; access = new(...)</c> declaration line.
+	/// </summary>
+	private static void EmitIndexerGetterAccessDeclaration(StringBuilder sb, string indent, string accessVarName,
+		EquatableArray<MethodParameter> parameters)
+	{
+		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerGetterAccess<");
+		AppendIndexerParameterTypes(sb, parameters);
+		sb.Append("> ").Append(accessVarName).Append(" = new(");
+		AppendIndexerParameterArguments(sb, parameters);
+		sb.Append(");").AppendLine();
+	}
+
+	/// <summary>
+	///     Determines whether the access-struct allocation can be deferred past the snapshot-scan loop.
+	///     Only applied when the cached typed buffer is in use (so the recording branch never references the
+	///     access object) and when no parameter is a Span/ReadOnlySpan (whose wrapper allocation would otherwise
+	///     repeat per loop iteration).
+	/// </summary>
+	private static bool CanDeferIndexerAccess(EquatableArray<MethodParameter> parameters, string? cachedBufferRef)
+	{
+		if (cachedBufferRef is null)
+		{
+			return false;
+		}
+
+		foreach (MethodParameter p in parameters)
+		{
+			if (p.Type.SpecialGenericType is SpecialGenericType.Span or SpecialGenericType.ReadOnlySpan)
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/// <summary>
@@ -183,11 +224,12 @@ internal static partial class Sources
 		string? cachedBufferRef = null)
 #pragma warning restore S107
 	{
-		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerSetterAccess<");
-		AppendIndexerParameterTypes(sb, parameters);
-		sb.Append(", ").AppendTypeOrWrapper(propertyType).Append("> ").Append(accessVarName).Append(" = new(");
-		AppendIndexerParameterArguments(sb, parameters);
-		sb.Append(", value);").AppendLine();
+		bool deferAccess = CanDeferIndexerAccess(parameters, cachedBufferRef);
+
+		if (!deferAccess)
+		{
+			EmitIndexerSetterAccessDeclaration(sb, indent, accessVarName, propertyType, parameters);
+		}
 
 		sb.Append(indent).Append("if (").Append(mockRegistry).Append(".Behavior.SkipInteractionRecording == false)")
 			.AppendLine();
@@ -216,7 +258,23 @@ internal static partial class Sources
 		sb.Append(indent).Append("}").AppendLine();
 
 		EmitIndexerSetupLookup(sb, indent, mockRegistry, accessVarName, setupVarName, propertyType, parameters,
-			setupMemberIdRef, isSetter: true);
+			setupMemberIdRef, isSetter: true, deferAccess: deferAccess,
+			emitAccessDeclaration: deferAccess
+				? sbInner => EmitIndexerSetterAccessDeclaration(sbInner, indent, accessVarName, propertyType, parameters)
+				: null);
+	}
+
+	/// <summary>
+	///     Emits the <c>IndexerSetterAccess&lt;T..., TValue&gt; access = new(..., value)</c> declaration line.
+	/// </summary>
+	private static void EmitIndexerSetterAccessDeclaration(StringBuilder sb, string indent, string accessVarName,
+		Type propertyType, EquatableArray<MethodParameter> parameters)
+	{
+		sb.Append(indent).Append("global::Mockolate.Interactions.IndexerSetterAccess<");
+		AppendIndexerParameterTypes(sb, parameters);
+		sb.Append(", ").AppendTypeOrWrapper(propertyType).Append("> ").Append(accessVarName).Append(" = new(");
+		AppendIndexerParameterArguments(sb, parameters);
+		sb.Append(", value);").AppendLine();
 	}
 
 	/// <summary>
@@ -227,12 +285,16 @@ internal static partial class Sources
 	///     for setters) on the concrete <c>IndexerSetup&lt;TValue, T1, ...&gt;</c> instead of dispatching through
 	///     <c>IInteractiveIndexerSetup.Matches(IndexerAccess)</c>, which avoids the interface-cast and the
 	///     getter/setter type test on every snapshot entry.
+	///     When <paramref name="deferAccess" /> is <see langword="true" />, the snapshot scan references parameter
+	///     locals directly and <paramref name="emitAccessDeclaration" /> is invoked just before the scenario
+	///     fallback (which still consumes the access object). This keeps the access-struct allocation off the
+	///     snapshot-only fast path entirely.
 	/// </summary>
 #pragma warning disable S107 // Methods should not have too many parameters
 	private static void EmitIndexerSetupLookup(StringBuilder sb, string indent,
 		string mockRegistry, string accessVarName, string setupVarName,
 		Type propertyType, EquatableArray<MethodParameter> parameters, string? memberIdRef,
-		bool isSetter)
+		bool isSetter, bool deferAccess = false, Action<StringBuilder>? emitAccessDeclaration = null)
 #pragma warning restore S107
 	{
 		StringBuilder typedSetup = new("global::Mockolate.Setup.IndexerSetup<");
@@ -247,6 +309,11 @@ internal static partial class Sources
 
 		if (memberIdRef is null)
 		{
+			if (deferAccess)
+			{
+				emitAccessDeclaration?.Invoke(sb);
+			}
+
 			sb.Append(indent).Append(typedSetupName).Append("? ").Append(setupVarName).Append(" = ")
 				.Append(mockRegistry).Append(".GetIndexerSetup<").Append(typedSetupName).Append(">(")
 				.Append(accessVarName).Append(");").AppendLine();
@@ -271,15 +338,25 @@ internal static partial class Sources
 			.Append("] is ").Append(typedSetupName).Append(' ').Append(itemVar)
 			.Append(" && ").Append(itemVar).Append(".Matches(");
 		bool firstArg = true;
-		for (int i = 1; i <= parameters.Count; i++)
+		int paramIndex = 1;
+		foreach (MethodParameter p in parameters)
 		{
 			if (!firstArg)
 			{
 				sb.Append(", ");
 			}
 
-			sb.Append(accessVarName).Append(".Parameter").Append(i);
+			if (deferAccess)
+			{
+				sb.Append(p.Name);
+			}
+			else
+			{
+				sb.Append(accessVarName).Append(".Parameter").Append(paramIndex);
+			}
+
 			firstArg = false;
+			paramIndex++;
 		}
 
 		if (isSetter)
@@ -289,7 +366,7 @@ internal static partial class Sources
 				sb.Append(", ");
 			}
 
-			sb.Append(accessVarName).Append(".TypedValue");
+			sb.Append(deferAccess ? "value" : accessVarName + ".TypedValue");
 		}
 
 		sb.Append("))").AppendLine();
@@ -301,6 +378,11 @@ internal static partial class Sources
 		sb.Append(indent).Append("\t\t}").AppendLine();
 		sb.Append(indent).Append("\t}").AppendLine();
 		sb.Append(indent).Append('}').AppendLine();
+		if (deferAccess)
+		{
+			emitAccessDeclaration?.Invoke(sb);
+		}
+
 		sb.Append(indent).Append(setupVarName).Append(" ??= ").Append(mockRegistry)
 			.Append(".GetIndexerSetup<").Append(typedSetupName).Append(">(").Append(accessVarName).Append(");")
 			.AppendLine();

--- a/Source/Mockolate/Verify/VerificationIndexerResult.cs
+++ b/Source/Mockolate/Verify/VerificationIndexerResult.cs
@@ -13,15 +13,25 @@ namespace Mockolate.Verify;
 #endif
 public class VerificationIndexerResult<TSubject, TParameter>
 {
-	private const int NoMemberId = -1;
+	/// <summary>
+	///     Sentinel value used by the typed-match subclasses to indicate that the legacy predicate-based
+	///     <see cref="MockRegistry.IndexerGot{T}(T, int, Func{IInteraction, bool}, Func{string})" /> path is not used.
+	/// </summary>
+	private protected const int NoMemberId = -1;
 
-	private readonly MockRegistry _mockRegistry;
-	private readonly Func<IInteraction, bool> _gotPredicate;
-	private readonly Func<IInteraction, IParameterMatch<TParameter>, bool> _setPredicate;
-	private readonly Func<string> _parametersDescription;
-	private readonly TSubject _subject;
-	private readonly int _getMemberId;
-	private readonly int _setMemberId;
+	private readonly Func<IInteraction, bool>? _gotPredicate;
+	private readonly Func<IInteraction, IParameterMatch<TParameter>, bool>? _setPredicate;
+
+	/// <summary>The mock registry holding the recorded interactions.</summary>
+	private protected readonly MockRegistry MockRegistry;
+	/// <summary>Factory producing the indexer-argument description used in failure messages.</summary>
+	private protected readonly Func<string> ParametersDescription;
+	/// <summary>The verification facade the result is bound to.</summary>
+	private protected readonly TSubject Subject;
+	/// <summary>Member id of the indexer getter, or <c>-1</c> when unknown.</summary>
+	private protected readonly int GetMemberId;
+	/// <summary>Member id of the indexer setter, or <c>-1</c> when unknown.</summary>
+	private protected readonly int SetMemberId;
 
 	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}" />
 	public VerificationIndexerResult(TSubject subject, MockRegistry mockRegistry,
@@ -48,35 +58,229 @@ public class VerificationIndexerResult<TSubject, TParameter>
 		Func<IInteraction, IParameterMatch<TParameter>, bool> setPredicate,
 		Func<string> parametersDescription)
 	{
-		_subject = subject;
-		_mockRegistry = mockRegistry;
-		_getMemberId = getMemberId;
-		_setMemberId = setMemberId;
+		Subject = subject;
+		MockRegistry = mockRegistry;
+		GetMemberId = getMemberId;
+		SetMemberId = setMemberId;
 		_gotPredicate = gotPredicate;
 		_setPredicate = setPredicate;
-		_parametersDescription = parametersDescription;
+		ParametersDescription = parametersDescription;
+	}
+
+	/// <summary>
+	///     Predicate-free constructor used by the typed-match subclasses, which dispatch through
+	///     <see cref="MockRegistry.IndexerGotTyped{T, T1}" /> / <see cref="MockRegistry.IndexerSetTyped{T, T1, TValue}" />
+	///     and never consult the base predicates.
+	/// </summary>
+	private protected VerificationIndexerResult(TSubject subject, MockRegistry mockRegistry,
+		int getMemberId, int setMemberId,
+		Func<string> parametersDescription)
+	{
+		Subject = subject;
+		MockRegistry = mockRegistry;
+		GetMemberId = getMemberId;
+		SetMemberId = setMemberId;
+		_gotPredicate = null;
+		_setPredicate = null;
+		ParametersDescription = parametersDescription;
 	}
 
 	/// <summary>
 	///     Verifies the indexer read access on the mock.
 	/// </summary>
-	public VerificationResult<TSubject> Got()
-		=> _mockRegistry.IndexerGot(_subject, _getMemberId, _gotPredicate, _parametersDescription);
+	public virtual VerificationResult<TSubject> Got()
+		=> MockRegistry.IndexerGot(Subject, GetMemberId, _gotPredicate!, ParametersDescription);
 
 	/// <summary>
 	///     Verifies the indexer write access on the mock with the given <paramref name="value" />.
 	/// </summary>
-	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
-		=> _mockRegistry.IndexerSet(_subject, _setMemberId, _setPredicate,
-			(IParameterMatch<TParameter>)value, _parametersDescription);
+	public virtual VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> MockRegistry.IndexerSet(Subject, SetMemberId, _setPredicate!,
+			(IParameterMatch<TParameter>)value, ParametersDescription);
 
 	/// <summary>
 	///     Verifies the indexer write access on the mock with the given <paramref name="value" />.
 	/// </summary>
 	[OverloadResolutionPriority(1)]
-	public VerificationResult<TSubject> Set(TParameter value,
+	public virtual VerificationResult<TSubject> Set(TParameter value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
-		=> _mockRegistry.IndexerSet(_subject, _setMemberId, _setPredicate,
-			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), _parametersDescription);
+		=> MockRegistry.IndexerSet(Subject, SetMemberId, _setPredicate!,
+			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 1-key indexer of type <typeparamref name="TParameter" />.
+///     Bypasses the predicate-based <see cref="VerificationIndexerResult{TSubject, TParameter}" />
+///     hot path and dispatches through the typed
+///     <see cref="MockRegistry.IndexerGotTyped{T, T1}" /> /
+///     <see cref="MockRegistry.IndexerSetTyped{T, T1, TValue}" /> overloads.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public sealed class VerificationIndexerResult<TSubject, T1, TParameter>
+	: VerificationIndexerResult<TSubject, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, T1, TParameter}" />
+	public VerificationIndexerResult(TSubject subject, MockRegistry mockRegistry,
+		int getMemberId, int setMemberId,
+		IParameterMatch<T1> match1,
+		Func<string> parametersDescription)
+		: base(subject, mockRegistry, getMemberId, setMemberId, parametersDescription)
+	{
+		_match1 = match1;
+	}
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Got()
+		=> MockRegistry.IndexerGotTyped<TSubject, T1>(Subject, GetMemberId, _match1, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, TParameter>(Subject, SetMemberId,
+			_match1, (IParameterMatch<TParameter>)value, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, TParameter>(Subject, SetMemberId,
+			_match1, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 2-key indexer of type <typeparamref name="TParameter" />. See
+///     <see cref="VerificationIndexerResult{TSubject, T1, TParameter}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public sealed class VerificationIndexerResult<TSubject, T1, T2, TParameter>
+	: VerificationIndexerResult<TSubject, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, T1, T2, TParameter}" />
+	public VerificationIndexerResult(TSubject subject, MockRegistry mockRegistry,
+		int getMemberId, int setMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2,
+		Func<string> parametersDescription)
+		: base(subject, mockRegistry, getMemberId, setMemberId, parametersDescription)
+	{
+		_match1 = match1;
+		_match2 = match2;
+	}
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Got()
+		=> MockRegistry.IndexerGotTyped<TSubject, T1, T2>(Subject, GetMemberId, _match1, _match2, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, TParameter>(Subject, SetMemberId,
+			_match1, _match2, (IParameterMatch<TParameter>)value, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, TParameter>(Subject, SetMemberId,
+			_match1, _match2, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 3-key indexer of type <typeparamref name="TParameter" />. See
+///     <see cref="VerificationIndexerResult{TSubject, T1, TParameter}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, TParameter>
+	: VerificationIndexerResult<TSubject, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly IParameterMatch<T3> _match3;
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, T1, T2, T3, TParameter}" />
+	public VerificationIndexerResult(TSubject subject, MockRegistry mockRegistry,
+		int getMemberId, int setMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2, IParameterMatch<T3> match3,
+		Func<string> parametersDescription)
+		: base(subject, mockRegistry, getMemberId, setMemberId, parametersDescription)
+	{
+		_match1 = match1;
+		_match2 = match2;
+		_match3 = match3;
+	}
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Got()
+		=> MockRegistry.IndexerGotTyped<TSubject, T1, T2, T3>(Subject, GetMemberId,
+			_match1, _match2, _match3, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, TParameter>(Subject, SetMemberId,
+			_match1, _match2, _match3, (IParameterMatch<TParameter>)value, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, TParameter>(Subject, SetMemberId,
+			_match1, _match2, _match3, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue),
+			ParametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 4-key indexer of type <typeparamref name="TParameter" />. See
+///     <see cref="VerificationIndexerResult{TSubject, T1, TParameter}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, T4, TParameter>
+	: VerificationIndexerResult<TSubject, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly IParameterMatch<T3> _match3;
+	private readonly IParameterMatch<T4> _match4;
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, T1, T2, T3, T4, TParameter}" />
+	public VerificationIndexerResult(TSubject subject, MockRegistry mockRegistry,
+		int getMemberId, int setMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2,
+		IParameterMatch<T3> match3, IParameterMatch<T4> match4,
+		Func<string> parametersDescription)
+		: base(subject, mockRegistry, getMemberId, setMemberId, parametersDescription)
+	{
+		_match1 = match1;
+		_match2 = match2;
+		_match3 = match3;
+		_match4 = match4;
+	}
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Got()
+		=> MockRegistry.IndexerGotTyped<TSubject, T1, T2, T3, T4>(Subject, GetMemberId,
+			_match1, _match2, _match3, _match4, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, T4, TParameter>(Subject, SetMemberId,
+			_match1, _match2, _match3, _match4, (IParameterMatch<TParameter>)value, ParametersDescription);
+
+	/// <inheritdoc />
+	public override VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, T4, TParameter>(Subject, SetMemberId,
+			_match1, _match2, _match3, _match4,
+			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
 }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -2856,9 +2856,37 @@ namespace Mockolate.Verify
     {
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
-        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
-        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
-        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, T4, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
     public class VerificationPropertyResult<TSubject, TParameter>
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -2446,9 +2446,37 @@ namespace Mockolate.Verify
     {
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
-        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
-        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
-        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, T4, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
     public class VerificationPropertyResult<TSubject, TParameter>
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -2387,9 +2387,37 @@ namespace Mockolate.Verify
     {
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
-        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
-        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
-        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public virtual Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, T4, TParameter> : Mockolate.Verify.VerificationIndexerResult<TSubject, TParameter>
+    {
+        public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
     public class VerificationPropertyResult<TSubject, TParameter>
     {

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -900,7 +900,7 @@ public class GeneralTests
 			          			string wrappedResult = default!;
 			          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 			          			{
-			          				((global::Mockolate.Interactions.FastMethod1Buffer<string>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod]!).Append("global::MyCode.IMyService.MyMethod", message);
+			          				this.MockolateBuffer_MyMethod.Append("global::MyCode.IMyService.MyMethod", message);
 			          			}
 			          			try
 			          			{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -113,7 +113,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && s_setup.Matches(access.Parameter1))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -146,7 +146,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && s_setup.Matches(access.Parameter1, access.TypedValue))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -182,7 +182,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, bool?> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, bool?> s_setup && s_setup.Matches(access.Parameter1, access.Parameter2))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -221,7 +221,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, string> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, string> s_setup && s_setup.Matches(access.Parameter1, access.Parameter2, access.TypedValue))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -438,7 +438,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>> s_setup && s_setup.Matches(access.Parameter1))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -471,7 +471,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>> s_setup && s_setup.Matches(access.Parameter1, access.TypedValue))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -507,7 +507,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>> s_setup && s_setup.Matches(access.Parameter1))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -540,7 +540,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>> s_setup && ((global::Mockolate.Setup.IInteractiveIndexerSetup)s_setup).Matches(access))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>> s_setup && s_setup.Matches(access.Parameter1, access.TypedValue))
 					          							{
 					          								setup = s_setup;
 					          								break;

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -100,7 +100,6 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				global::Mockolate.Interactions.IndexerGetterAccess<int> access = new(index);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
 					          					this.MockolateBuffer_Indexer_int_Get.Append(index);
@@ -113,7 +112,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && s_setup.Matches(access.Parameter1))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && s_setup.Matches(index))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -121,6 +120,7 @@ public sealed partial class MockTests
 					          						}
 					          					}
 					          				}
+					          				global::Mockolate.Interactions.IndexerGetterAccess<int> access = new(index);
 					          				setup ??= this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
@@ -133,7 +133,6 @@ public sealed partial class MockTests
 					          			}
 					          			set
 					          			{
-					          				global::Mockolate.Interactions.IndexerSetterAccess<int, int> access = new(index, value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
 					          					this.MockolateBuffer_Indexer_int_Set.Append(index, value);
@@ -146,7 +145,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && s_setup.Matches(access.Parameter1, access.TypedValue))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int> s_setup && s_setup.Matches(index, value))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -154,6 +153,7 @@ public sealed partial class MockTests
 					          						}
 					          					}
 					          				}
+					          				global::Mockolate.Interactions.IndexerSetterAccess<int, int> access = new(index, value);
 					          				setup ??= this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int>>(access);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 0);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
@@ -169,7 +169,6 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				global::Mockolate.Interactions.IndexerGetterAccess<int, bool?> access = new(index, isReadOnly);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
 					          					this.MockolateBuffer_Indexer_int_bool__Get.Append(index, isReadOnly);
@@ -182,7 +181,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, bool?> s_setup && s_setup.Matches(access.Parameter1, access.Parameter2))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, bool?> s_setup && s_setup.Matches(index, isReadOnly))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -190,6 +189,7 @@ public sealed partial class MockTests
 					          						}
 					          					}
 					          				}
+					          				global::Mockolate.Interactions.IndexerGetterAccess<int, bool?> access = new(index, isReadOnly);
 					          				setup ??= this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, bool?>>(access);
 					          				if (this.MockRegistry.Wraps is not global::MyCode.IMyService wraps)
 					          				{
@@ -208,7 +208,6 @@ public sealed partial class MockTests
 					          		{
 					          			set
 					          			{
-					          				global::Mockolate.Interactions.IndexerSetterAccess<int, string, int> access = new(index, isWriteOnly, value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
 					          					this.MockolateBuffer_Indexer_int_string_Set.Append(index, isWriteOnly, value);
@@ -221,7 +220,7 @@ public sealed partial class MockTests
 					          					{
 					          						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
 					          						{
-					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, string> s_setup && s_setup.Matches(access.Parameter1, access.Parameter2, access.TypedValue))
+					          							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<int, int, string> s_setup && s_setup.Matches(index, isWriteOnly, value))
 					          							{
 					          								setup = s_setup;
 					          								break;
@@ -229,6 +228,7 @@ public sealed partial class MockTests
 					          						}
 					          					}
 					          				}
+					          				global::Mockolate.Interactions.IndexerSetterAccess<int, string, int> access = new(index, isWriteOnly, value);
 					          				setup ??= this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<int, int, string>>(access);
 					          				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 2);
 					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -103,7 +103,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int> access = new(index);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_int_Get.Append(access);
+					          					this.MockolateBuffer_Indexer_int_Get.Append(index);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -136,7 +136,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, int> access = new(index, value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_int_Set.Append(access);
+					          					this.MockolateBuffer_Indexer_int_Set.Append(index, value);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -172,7 +172,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int, bool?> access = new(index, isReadOnly);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_int_bool__Get.Append(access);
+					          					this.MockolateBuffer_Indexer_int_bool__Get.Append(index, isReadOnly);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, bool?>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -211,7 +211,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, string, int> access = new(index, isWriteOnly, value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_int_string_Set.Append(access);
+					          					this.MockolateBuffer_Indexer_int_string_Set.Append(index, isWriteOnly, value);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -428,7 +428,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<global::Mockolate.Setup.SpanWrapper<char>> access = new(new global::Mockolate.Setup.SpanWrapper<char>(buffer));
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_global__System_Span_char__Get.Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_Span_char__Get.Append(new global::Mockolate.Setup.SpanWrapper<char>(buffer));
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -461,7 +461,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<global::Mockolate.Setup.SpanWrapper<char>, int> access = new(new global::Mockolate.Setup.SpanWrapper<char>(buffer), value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_global__System_Span_char__Set.Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_Span_char__Set.Append(new global::Mockolate.Setup.SpanWrapper<char>(buffer), value);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -497,7 +497,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<global::Mockolate.Setup.ReadOnlySpanWrapper<int>> access = new(new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values));
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_global__System_ReadOnlySpan_int__Get.Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_ReadOnlySpan_int__Get.Append(new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values));
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -530,7 +530,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<global::Mockolate.Setup.ReadOnlySpanWrapper<int>, int> access = new(new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values), value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					this.MockolateBuffer_Indexer_global__System_ReadOnlySpan_int__Set.Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_ReadOnlySpan_int__Set.Append(new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values), value);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -103,7 +103,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int> access = new(index);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerGetterBuffer<int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_int_Get]!).Append(access);
+					          					this.MockolateBuffer_Indexer_int_Get.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -136,7 +136,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, int> access = new(index, value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerSetterBuffer<int, int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_int_Set]!).Append(access);
+					          					this.MockolateBuffer_Indexer_int_Set.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -172,7 +172,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<int, bool?> access = new(index, isReadOnly);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerGetterBuffer<int, bool?>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_int_bool__Get]!).Append(access);
+					          					this.MockolateBuffer_Indexer_int_bool__Get.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, bool?>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -211,7 +211,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<int, string, int> access = new(index, isWriteOnly, value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerSetterBuffer<int, string, int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_int_string_Set]!).Append(access);
+					          					this.MockolateBuffer_Indexer_int_string_Set.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, int, string>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -428,7 +428,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<global::Mockolate.Setup.SpanWrapper<char>> access = new(new global::Mockolate.Setup.SpanWrapper<char>(buffer));
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerGetterBuffer<global::Mockolate.Setup.SpanWrapper<char>>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_global__System_Span_char__Get]!).Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_Span_char__Get.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -461,7 +461,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<global::Mockolate.Setup.SpanWrapper<char>, int> access = new(new global::Mockolate.Setup.SpanWrapper<char>(buffer), value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerSetterBuffer<global::Mockolate.Setup.SpanWrapper<char>, int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_global__System_Span_char__Set]!).Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_Span_char__Set.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.SpanWrapper<char>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -497,7 +497,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerGetterAccess<global::Mockolate.Setup.ReadOnlySpanWrapper<int>> access = new(new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values));
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerGetterBuffer<global::Mockolate.Setup.ReadOnlySpanWrapper<int>>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_global__System_ReadOnlySpan_int__Get]!).Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_ReadOnlySpan_int__Get.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
@@ -530,7 +530,7 @@ public sealed partial class MockTests
 					          				global::Mockolate.Interactions.IndexerSetterAccess<global::Mockolate.Setup.ReadOnlySpanWrapper<int>, int> access = new(new global::Mockolate.Setup.ReadOnlySpanWrapper<int>(values), value);
 					          				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          				{
-					          					((global::Mockolate.Interactions.FastIndexerSetterBuffer<global::Mockolate.Setup.ReadOnlySpanWrapper<int>, int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_Indexer_global__System_ReadOnlySpan_int__Set]!).Append(access);
+					          					this.MockolateBuffer_Indexer_global__System_ReadOnlySpan_int__Set.Append(access);
 					          				}
 					          				global::Mockolate.Setup.IndexerSetup<int, global::Mockolate.Setup.ReadOnlySpanWrapper<int>>? setup = null;
 					          				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Mockolate.SourceGenerators.Tests;
+namespace Mockolate.SourceGenerators.Tests;
 
 public sealed partial class MockTests
 {
@@ -445,7 +445,7 @@ public sealed partial class MockTests
 					          			bool wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod1]!).Append("global::MyCode.IMyService.MyMethod1", index);
+					          				this.MockolateBuffer_MyMethod1.Append("global::MyCode.IMyService.MyMethod1", index);
 					          			}
 					          			try
 					          			{
@@ -482,7 +482,7 @@ public sealed partial class MockTests
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod2Buffer<int, bool>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod2]!).Append("global::MyCode.IMyService.MyMethod2", index, isReadOnly);
+					          				this.MockolateBuffer_MyMethod2.Append("global::MyCode.IMyService.MyMethod2", index, isReadOnly);
 					          			}
 					          			try
 					          			{
@@ -556,7 +556,7 @@ public sealed partial class MockTests
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyDirectMethod]!).Append("global::MyCode.IMyService.MyDirectMethod", value);
+					          				this.MockolateBuffer_MyDirectMethod.Append("global::MyCode.IMyService.MyDirectMethod", value);
 					          			}
 					          			try
 					          			{
@@ -594,7 +594,7 @@ public sealed partial class MockTests
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyBaseMethod1]!).Append("global::MyCode.IMyServiceBase1.MyBaseMethod1", value);
+					          				this.MockolateBuffer_MyBaseMethod1.Append("global::MyCode.IMyServiceBase1.MyBaseMethod1", value);
 					          			}
 					          			try
 					          			{
@@ -632,7 +632,7 @@ public sealed partial class MockTests
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyBaseMethod2]!).Append("global::MyCode.IMyServiceBase2.MyBaseMethod2", value);
+					          				this.MockolateBuffer_MyBaseMethod2.Append("global::MyCode.IMyServiceBase2.MyBaseMethod2", value);
 					          			}
 					          			try
 					          			{
@@ -670,7 +670,7 @@ public sealed partial class MockTests
 					          			int wrappedResult = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyBaseMethod3]!).Append("global::MyCode.IMyServiceBase3.MyBaseMethod3", value);
+					          				this.MockolateBuffer_MyBaseMethod3.Append("global::MyCode.IMyServiceBase3.MyBaseMethod3", value);
 					          			}
 					          			try
 					          			{
@@ -1015,7 +1015,7 @@ public sealed partial class MockTests
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<int>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod1]!).Append("global::MyCode.IMyService.MyMethod1", index);
+					          				this.MockolateBuffer_MyMethod1.Append("global::MyCode.IMyService.MyMethod1", index);
 					          			}
 					          			try
 					          			{
@@ -1062,7 +1062,7 @@ public sealed partial class MockTests
 					          			isReadOnly = default!;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod2Buffer<int, bool>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod2]!).Append("global::MyCode.IMyService.MyMethod2", index, isReadOnly);
+					          				this.MockolateBuffer_MyMethod2.Append("global::MyCode.IMyService.MyMethod2", index, isReadOnly);
 					          			}
 					          			try
 					          			{
@@ -1114,7 +1114,7 @@ public sealed partial class MockTests
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<global::MyCode.MyReadonlyStruct>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod3]!).Append("global::MyCode.IMyService.MyMethod3", p1);
+					          				this.MockolateBuffer_MyMethod3.Append("global::MyCode.IMyService.MyMethod3", p1);
 					          			}
 					          			try
 					          			{
@@ -1147,7 +1147,7 @@ public sealed partial class MockTests
 					          			bool hasWrappedResult = false;
 					          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 					          			{
-					          				((global::Mockolate.Interactions.FastMethod1Buffer<global::MyCode.MyReadonlyStruct>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod4]!).Append("global::MyCode.IMyService.MyMethod4", p1);
+					          				this.MockolateBuffer_MyMethod4.Append("global::MyCode.IMyService.MyMethod4", p1);
 					          			}
 					          			try
 					          			{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Mockolate.SourceGenerators.Tests;
@@ -716,7 +716,7 @@ public sealed partial class MockTests
 			          			bool hasWrappedResult = false;
 			          			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
 			          			{
-			          				((global::Mockolate.Interactions.FastMethod15Buffer<object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal>)((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).Buffers[global::Mockolate.Mock.IMyService.MemberId_MyMethod]!).Append("global::MyCode.IMyService.MyMethod", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+			          				this.MockolateBuffer_MyMethod.Append("global::MyCode.IMyService.MyMethod", v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
 			          			}
 			          			try
 			          			{


### PR DESCRIPTION
This pull request introduces significant optimizations to how the source generator emits code for fast mock interaction recording, especially for indexers and methods. The main improvement is the introduction of cached, typed-buffer fields on generated mock classes, allowing hot paths to bypass repeated casts and property chains. Additionally, the verification logic for indexers is enhanced to emit more strongly-typed overloads for up to four indexer parameters, and code generation is refactored for improved clarity and efficiency.

### Key changes:

**Performance Optimizations:**

* Added logic to generate per-member cached, typed-buffer fields (e.g., `MockolateBuffer_*`) for eligible indexers and methods in generated mock classes, avoiding repeated lookup and casting during interaction recording. 
* Modified the code generation for method and indexer recording to use these cached buffer fields when available, further reducing overhead on hot paths.

**Indexer and Method Handling Improvements:**

* Extended the code generator to pass references to the new cached buffer fields into the relevant code paths for indexer getter and setter implementations. (`Sources.MockClass.cs`, `Sources.cs`)
* Improved the verification code generation for indexers: for indexers with 1-4 parameters, the generator now emits strongly-typed `VerificationIndexerResult<TSubject, T1, ...>` overloads, providing better type safety and IntelliSense. (`Sources.MockClass.cs`)

**Refactoring and Documentation:**

* Refactored and documented utility methods for buffer field naming and allocation, and clarified the logic for when cached fields are emitted. (`Sources.MemberIds.cs`, `Sources.MockClass.cs`)

These changes collectively improve the performance of generated mocks, especially in scenarios with frequent indexer and method invocations, and enhance the developer experience when verifying indexer interactions.