### PR TITLE
test: add missing unit tests for source generation

### DIFF
--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/EventEqualityComparerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/EventEqualityComparerTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Event = Mockolate.SourceGenerators.Entities.Event;
+
+namespace Mockolate.SourceGenerators.Tests.Entities;
+
+public class EventEqualityComparerTests
+{
+	[Fact]
+	public async Task BothNull_ShouldReturnTrue()
+	{
+		await That(Event.EqualityComparer.Equals(null, null)).IsTrue();
+		await That(Event.ContainingTypeIndependentEqualityComparer.Equals(null, null)).IsTrue();
+	}
+
+	[Fact]
+	public async Task ContainingTypeIndependent_DifferentNames_ShouldReturnFalse()
+	{
+		IEqualityComparer<Event> comparer = Event.ContainingTypeIndependentEqualityComparer;
+		Event e1 = CreateEvent(
+			"using System; public class C { public event Action Foo; }",
+			"Foo");
+		Event e2 = CreateEvent(
+			"using System; public class D { public event Action Bar; }",
+			"Bar");
+
+		await That(comparer.Equals(e1, e2)).IsFalse();
+	}
+
+	[Fact]
+	public async Task ContainingTypeIndependent_SameNameDifferentContainingType_ShouldReturnTrue()
+	{
+		IEqualityComparer<Event> comparer = Event.ContainingTypeIndependentEqualityComparer;
+		Event fromC = CreateEvent(
+			"using System; public class C { public event Action Foo; }",
+			"Foo");
+		Event fromD = CreateEvent(
+			"using System; public class D { public event Action Foo; }",
+			"Foo");
+
+		await That(comparer.Equals(fromC, fromD)).IsTrue();
+	}
+
+	[Fact]
+	public async Task EventsWithDifferentContainingType_ShouldReturnFalse()
+	{
+		IEqualityComparer<Event> comparer = Event.EqualityComparer;
+		Event fromC = CreateEvent(
+			"using System; public class C { public event Action Foo; }",
+			"Foo");
+		Event fromD = CreateEvent(
+			"using System; public class D { public event Action Foo; }",
+			"Foo");
+
+		await That(comparer.Equals(fromC, fromD)).IsFalse();
+	}
+
+	[Fact]
+	public async Task EventsWithDifferentNames_ShouldReturnFalse()
+	{
+		IEqualityComparer<Event> comparer = Event.EqualityComparer;
+		Event e1 = CreateEvent(
+			"using System; public class C { public event Action Foo; }",
+			"Foo");
+		Event e2 = CreateEvent(
+			"using System; public class C { public event Action Bar; }",
+			"Bar");
+
+		await That(comparer.Equals(e1, e2)).IsFalse();
+	}
+
+	[Fact]
+	public async Task LeftOrRightNull_ShouldReturnFalse()
+	{
+		IEqualityComparer<Event> comparer = Event.EqualityComparer;
+		Event e = CreateEvent(
+			"using System; public class C { public event Action Foo; }",
+			"Foo");
+
+		await That(comparer.Equals(null, e)).IsFalse();
+		await That(comparer.Equals(e, null)).IsFalse();
+	}
+
+	private static Event CreateEvent(string source, string eventName)
+	{
+		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+		CSharpCompilation compilation = CSharpCompilation.Create(
+			"TestAssembly",
+			[tree,],
+			[
+				MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+				MetadataReference.CreateFromFile(typeof(Action).Assembly.Location),
+			],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+		SemanticModel model = compilation.GetSemanticModel(tree);
+		EventFieldDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+			.OfType<EventFieldDeclarationSyntax>()
+			.First(d => d.Declaration.Variables.Any(v => v.Identifier.Text == eventName));
+		VariableDeclaratorSyntax variable = declaration.Declaration.Variables
+			.First(v => v.Identifier.Text == eventName);
+		IEventSymbol symbol = (IEventSymbol)model.GetDeclaredSymbol(variable)!;
+		IMethodSymbol invoke = ((INamedTypeSymbol)symbol.Type).DelegateInvokeMethod!;
+		return new Event(symbol, invoke, null);
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/MethodEqualityComparerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/MethodEqualityComparerTests.cs
@@ -31,17 +31,6 @@ public class MethodEqualityComparerTests
 	}
 
 	[Fact]
-	public async Task WhenRightMethodIsNull_ShouldReturnFalse()
-	{
-		IEqualityComparer<Method> comparer = Method.ContainingTypeIndependentEqualityComparer;
-		Method left = CreateMethod("public class C { public void Foo() {} }", "Foo");
-
-		bool result = comparer.Equals(left, null);
-
-		await That(result).IsFalse();
-	}
-
-	[Fact]
 	public async Task WhenMethodsHaveDifferentNames_ShouldReturnFalse()
 	{
 		IEqualityComparer<Method> comparer = Method.ContainingTypeIndependentEqualityComparer;
@@ -65,6 +54,17 @@ public class MethodEqualityComparerTests
 		await That(result).IsFalse();
 	}
 
+	[Fact]
+	public async Task WhenRightMethodIsNull_ShouldReturnFalse()
+	{
+		IEqualityComparer<Method> comparer = Method.ContainingTypeIndependentEqualityComparer;
+		Method left = CreateMethod("public class C { public void Foo() {} }", "Foo");
+
+		bool result = comparer.Equals(left, null);
+
+		await That(result).IsFalse();
+	}
+
 	private static Method CreateMethod(string source, string methodName)
 	{
 		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
@@ -77,7 +77,7 @@ public class MethodEqualityComparerTests
 		MethodDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
 			.OfType<MethodDeclarationSyntax>()
 			.First(m => m.Identifier.Text == methodName);
-		IMethodSymbol symbol = (IMethodSymbol)model.GetDeclaredSymbol(declaration)!;
+		IMethodSymbol symbol = model.GetDeclaredSymbol(declaration)!;
 		return new Method(symbol, null);
 	}
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/MockClassEqualityTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/MockClassEqualityTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Mockolate.SourceGenerators.Entities;
+
+namespace Mockolate.SourceGenerators.Tests.Entities;
+
+public class MockClassEqualityTests
+{
+	[Fact]
+	public async Task ReferenceEqualMockClasses_ShouldBeEqual()
+	{
+		(Compilation compilation, INamedTypeSymbol[] symbols) = ParseSymbols(Source, "IBase");
+
+		MockClass a = new([symbols[0],], compilation.Assembly);
+
+		await That(a.Equals(a)).IsTrue();
+		await That(a.Equals(null)).IsFalse();
+	}
+
+	[Fact]
+	public async Task TwoMockClassesWithDifferentConstructors_ShouldNotBeEqual()
+	{
+		(Compilation compilation, INamedTypeSymbol[] symbols) = ParseSymbols(Source,
+			"BaseWithCtor", "BaseWithIntCtor");
+
+		MockClass a = new([symbols[0],], compilation.Assembly);
+		MockClass b = new([symbols[1],], compilation.Assembly);
+
+		await That(a.Equals(b)).IsFalse();
+	}
+
+	[Fact]
+	public async Task TwoMockClassesWithSameRootAndSameAdditionals_ShouldBeEqual()
+	{
+		(Compilation compilation, INamedTypeSymbol[] symbols) = ParseSymbols(Source,
+			"IBase", "IExtraA");
+
+		MockClass a = new([symbols[0], symbols[1],], compilation.Assembly);
+		MockClass b = new([symbols[0], symbols[1],], compilation.Assembly);
+
+		await That(a.Equals(b)).IsTrue();
+		await That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
+	}
+
+	[Fact]
+	public async Task TwoMockClassesWithSameRootButDifferentAdditionals_ShouldNotBeEqual()
+	{
+		(Compilation compilation, INamedTypeSymbol[] symbols) = ParseSymbols(Source,
+			"IBase", "IExtraA", "IExtraB");
+
+		MockClass a = new([symbols[0], symbols[1],], compilation.Assembly);
+		MockClass b = new([symbols[0], symbols[2],], compilation.Assembly);
+
+		await That(a.Equals(b)).IsFalse();
+		await That(a.Equals((object?)b)).IsFalse();
+	}
+
+	private const string Source = """
+	                              public interface IBase { }
+	                              public interface IExtraA { }
+	                              public interface IExtraB { }
+	                              public class BaseWithCtor
+	                              {
+	                                  public BaseWithCtor() { }
+	                              }
+	                              public class BaseWithIntCtor
+	                              {
+	                                  public BaseWithIntCtor(int v) { }
+	                              }
+	                              """;
+
+	private static (Compilation Compilation, INamedTypeSymbol[] Symbols) ParseSymbols(string source,
+		params string[] names)
+	{
+		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+		CSharpCompilation compilation = CSharpCompilation.Create(
+			"TestAssembly",
+			[tree,],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location),],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+		SemanticModel model = compilation.GetSemanticModel(tree);
+		INamedTypeSymbol[] symbols = names.Select(name =>
+		{
+			BaseTypeDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+				.OfType<BaseTypeDeclarationSyntax>()
+				.First(t => t.Identifier.Text == name);
+			return model.GetDeclaredSymbol(declaration)!;
+		}).ToArray();
+		return (compilation, symbols);
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/PropertyEqualityComparerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/PropertyEqualityComparerTests.cs
@@ -79,19 +79,12 @@ public class PropertyEqualityComparerTests
 	}
 
 	private static Property CreateProperty(string source, string propertyName)
-	{
-		(IPropertySymbol symbol, _) = ParsePropertySymbol(source, propertyName, false);
-		return new Property(symbol, null);
-	}
+		=> new Property(ParsePropertySymbol(source, propertyName, false), null);
 
 	private static Property CreateIndexer(string source)
-	{
-		(IPropertySymbol symbol, _) = ParsePropertySymbol(source, null, true);
-		return new Property(symbol, null);
-	}
+		=> new Property(ParsePropertySymbol(source, null, true), null);
 
-	private static (IPropertySymbol Symbol, SemanticModel Model) ParsePropertySymbol(string source,
-		string? propertyName, bool isIndexer)
+	private static IPropertySymbol ParsePropertySymbol(string source, string? propertyName, bool isIndexer)
 	{
 		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
 		CSharpCompilation compilation = CSharpCompilation.Create(
@@ -105,16 +98,12 @@ public class PropertyEqualityComparerTests
 			IndexerDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
 				.OfType<IndexerDeclarationSyntax>()
 				.First();
-			IPropertySymbol symbol = model.GetDeclaredSymbol(declaration)!;
-			return (symbol, model);
+			return model.GetDeclaredSymbol(declaration)!;
 		}
-		else
-		{
-			PropertyDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
-				.OfType<PropertyDeclarationSyntax>()
-				.First(p => p.Identifier.Text == propertyName);
-			IPropertySymbol symbol = model.GetDeclaredSymbol(declaration)!;
-			return (symbol, model);
-		}
+
+		PropertyDeclarationSyntax propertyDeclaration = tree.GetRoot().DescendantNodes()
+			.OfType<PropertyDeclarationSyntax>()
+			.First(p => p.Identifier.Text == propertyName);
+		return model.GetDeclaredSymbol(propertyDeclaration)!;
 	}
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/PropertyEqualityComparerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/PropertyEqualityComparerTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Mockolate.SourceGenerators.Entities;
+
+namespace Mockolate.SourceGenerators.Tests.Entities;
+
+public class PropertyEqualityComparerTests
+{
+	[Fact]
+	public async Task BothNull_ShouldReturnTrue()
+	{
+		await That(Property.EqualityComparer.Equals(null, null)).IsTrue();
+		await That(Property.ContainingTypeIndependentEqualityComparer.Equals(null, null)).IsTrue();
+	}
+
+	[Fact]
+	public async Task ContainingTypeIndependent_IndexersWithDifferentArity_ShouldReturnFalse()
+	{
+		IEqualityComparer<Property> comparer = Property.ContainingTypeIndependentEqualityComparer;
+		Property arity1 = CreateIndexer("public class C { public int this[int i] => 0; }");
+		Property arity2 = CreateIndexer("public class D { public int this[int i, int j] => 0; }");
+
+		await That(comparer.Equals(arity1, arity2)).IsFalse();
+	}
+
+	[Fact]
+	public async Task ContainingTypeIndependent_IndexerVsNonIndexer_ShouldReturnFalse()
+	{
+		IEqualityComparer<Property> comparer = Property.ContainingTypeIndependentEqualityComparer;
+		Property indexer = CreateIndexer("public class C { public int this[int i] => 0; }");
+		Property nonIndexer = CreateProperty("public class C { public int Foo => 0; }", "Foo");
+
+		await That(comparer.Equals(indexer, nonIndexer)).IsFalse();
+		await That(comparer.Equals(nonIndexer, indexer)).IsFalse();
+	}
+
+	[Fact]
+	public async Task IndexersWithDifferentArity_ShouldReturnFalse()
+	{
+		IEqualityComparer<Property> comparer = Property.EqualityComparer;
+		Property arity1 = CreateIndexer("public class C { public int this[int i] => 0; }");
+		Property arity2 = CreateIndexer("public class C { public int this[int i, int j] => 0; }");
+
+		await That(comparer.Equals(arity1, arity2)).IsFalse();
+	}
+
+	[Fact]
+	public async Task IndexersWithDifferentContainingType_ShouldReturnFalse()
+	{
+		IEqualityComparer<Property> comparer = Property.EqualityComparer;
+		Property fromC = CreateIndexer("public class C { public int this[int i] => 0; }");
+		Property fromD = CreateIndexer("public class D { public int this[int i] => 0; }");
+
+		await That(comparer.Equals(fromC, fromD)).IsFalse();
+	}
+
+	[Fact]
+	public async Task IndexerVsNonIndexer_ShouldReturnFalse()
+	{
+		IEqualityComparer<Property> comparer = Property.EqualityComparer;
+		Property indexer = CreateIndexer("public class C { public int this[int i] => 0; }");
+		Property nonIndexer = CreateProperty("public class C { public int Foo => 0; }", "Foo");
+
+		await That(comparer.Equals(indexer, nonIndexer)).IsFalse();
+		await That(comparer.Equals(nonIndexer, indexer)).IsFalse();
+	}
+
+	[Fact]
+	public async Task NonIndexersWithDifferentContainingType_ShouldReturnFalse()
+	{
+		IEqualityComparer<Property> comparer = Property.EqualityComparer;
+		Property fromC = CreateProperty("public class C { public int Foo => 0; }", "Foo");
+		Property fromD = CreateProperty("public class D { public int Foo => 0; }", "Foo");
+
+		await That(comparer.Equals(fromC, fromD)).IsFalse();
+	}
+
+	private static Property CreateProperty(string source, string propertyName)
+	{
+		(IPropertySymbol symbol, _) = ParsePropertySymbol(source, propertyName, false);
+		return new Property(symbol, null);
+	}
+
+	private static Property CreateIndexer(string source)
+	{
+		(IPropertySymbol symbol, _) = ParsePropertySymbol(source, null, true);
+		return new Property(symbol, null);
+	}
+
+	private static (IPropertySymbol Symbol, SemanticModel Model) ParsePropertySymbol(string source,
+		string? propertyName, bool isIndexer)
+	{
+		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+		CSharpCompilation compilation = CSharpCompilation.Create(
+			"TestAssembly",
+			[tree,],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location),],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+		SemanticModel model = compilation.GetSemanticModel(tree);
+		if (isIndexer)
+		{
+			IndexerDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+				.OfType<IndexerDeclarationSyntax>()
+				.First();
+			IPropertySymbol symbol = model.GetDeclaredSymbol(declaration)!;
+			return (symbol, model);
+		}
+		else
+		{
+			PropertyDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+				.OfType<PropertyDeclarationSyntax>()
+				.First(p => p.Identifier.Text == propertyName);
+			IPropertySymbol symbol = model.GetDeclaredSymbol(declaration)!;
+			return (symbol, model);
+		}
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/TypeIsFormattableTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/TypeIsFormattableTests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Type = Mockolate.SourceGenerators.Entities.Type;
+
+namespace Mockolate.SourceGenerators.Tests.Entities;
+
+public class TypeIsFormattableTests
+{
+	[Fact]
+	public async Task WhenSymbolIsObject_ShouldNotReportFormattable()
+	{
+		const string source = "public class Holder { public object Value; }";
+		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+		CSharpCompilation compilation = CSharpCompilation.Create(
+			"TestAssembly",
+			[tree,],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location),],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+		SemanticModel model = compilation.GetSemanticModel(tree);
+		FieldDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+			.OfType<FieldDeclarationSyntax>()
+			.First();
+		VariableDeclaratorSyntax variable = declaration.Declaration.Variables.Single();
+		IFieldSymbol fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(variable)!;
+
+		Type type = Type.From(fieldSymbol.Type);
+
+		await That(type.IsFormattable).IsFalse();
+	}
+
+	[Fact]
+	public async Task WhenSymbolIsSystemIFormattableItself_ShouldReportFormattable()
+	{
+		// The IsFormattable self-check (Type.cs:87-94) handles the case where the symbol IS
+		// System.IFormattable - AllInterfaces excludes the type itself, so the explicit
+		// Containing-Namespace check is the only path that catches this.
+		const string source = """
+		                      using System;
+		                      public class Holder
+		                      {
+		                          public IFormattable Value;
+		                      }
+		                      """;
+		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+		CSharpCompilation compilation = CSharpCompilation.Create(
+			"TestAssembly",
+			[tree,],
+			[
+				MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+				MetadataReference.CreateFromFile(typeof(IFormattable).Assembly.Location),
+			],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+		SemanticModel model = compilation.GetSemanticModel(tree);
+		FieldDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+			.OfType<FieldDeclarationSyntax>()
+			.First();
+		VariableDeclaratorSyntax variable = declaration.Declaration.Variables.Single();
+		IFieldSymbol fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(variable)!;
+		ITypeSymbol typeSymbol = fieldSymbol.Type;
+
+		Type type = Type.From(typeSymbol);
+
+		await That(type.IsFormattable).IsTrue();
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -893,7 +893,8 @@ public class GeneralTests
 			          		{
 			          			global::Mockolate.Setup.ReturnMethodSetup<string, string>? methodSetup = null;
 			          """).IgnoringNewlineStyle().And
-			.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<string, string> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<string, string>>(\"global::MyCode.IMyService.MyMethod\"))")
+			.Contains(
+				"foreach (global::Mockolate.Setup.ReturnMethodSetup<string, string> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<string, string>>(\"global::MyCode.IMyService.MyMethod\"))")
 			.IgnoringNewlineStyle().And
 			.Contains("""
 			          			bool hasWrappedResult = false;

--- a/Tests/Mockolate.SourceGenerators.Tests/MockBehaviorExtensionsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockBehaviorExtensionsTests.cs
@@ -5,6 +5,47 @@ namespace Mockolate.SourceGenerators.Tests;
 public sealed class MockBehaviorExtensionsTests
 {
 	[Fact]
+	public async Task DefaultValueGenerator_ForValueTuples_ShouldEmitInlineExpressions()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using Mockolate;
+
+			     namespace MyCode
+			     {
+			         public class Program
+			         {
+			             public static void Main(string[] args)
+			             {
+			     			_ = IMyInterface.CreateMock();
+			             }
+			         }
+
+			         public interface IMyInterface
+			         {
+			             (int V1, string V2) NamedValueTuple { get; }
+			             (int, string, int, string, int, string, int, string) ValueTuple8 { get; }
+			             (int, T1, T2) GenericValueTuple<T1, T2>();
+			         }
+			     }
+			     """);
+
+		await That(result.Sources).ContainsKey("Mock.IMyInterface.g.cs").WhoseValue
+			.Contains("(b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!))").And
+			.Contains(
+				"(b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!))")
+			.And
+			.Contains(
+				"(this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Behavior.DefaultValue.Generate(default(T1)!), this.MockRegistry.Behavior.DefaultValue.Generate(default(T2)!))");
+
+		await That(result.Sources).ContainsKey("MockBehaviorExtensions.g.cs").WhoseValue
+			.DoesNotContain("Generate<T1, T2>((T1, T2)").And
+			.DoesNotContain("Generate<T1, T2, T3>((T1, T2, T3)").And
+			.DoesNotContain("Generate<T1, T2, T3, T4, T5, T6, T7, T8>");
+	}
+
+	[Fact]
 	public async Task DefaultValueGenerator_ShouldRegisterArrays()
 	{
 		GeneratorResult result = Generator
@@ -177,43 +218,5 @@ public sealed class MockBehaviorExtensionsTests
 			          		}
 			          """).IgnoringNewlineStyle().And
 			.DoesNotContain("global::System.Func<T>");
-	}
-
-	[Fact]
-	public async Task DefaultValueGenerator_ForValueTuples_ShouldEmitInlineExpressions()
-	{
-		GeneratorResult result = Generator
-			.Run("""
-			     using System;
-			     using Mockolate;
-
-			     namespace MyCode
-			     {
-			         public class Program
-			         {
-			             public static void Main(string[] args)
-			             {
-			     			_ = IMyInterface.CreateMock();
-			             }
-			         }
-
-			         public interface IMyInterface
-			         {
-			             (int V1, string V2) NamedValueTuple { get; }
-			             (int, string, int, string, int, string, int, string) ValueTuple8 { get; }
-			             (int, T1, T2) GenericValueTuple<T1, T2>();
-			         }
-			     }
-			     """);
-
-		await That(result.Sources).ContainsKey("Mock.IMyInterface.g.cs").WhoseValue
-			.Contains("(b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!))").And
-			.Contains("(b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!), b.DefaultValue.Generate(default(int)!), b.DefaultValue.Generate(default(string)!))").And
-			.Contains("(this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!), this.MockRegistry.Behavior.DefaultValue.Generate(default(T1)!), this.MockRegistry.Behavior.DefaultValue.Generate(default(T2)!))");
-
-		await That(result.Sources).ContainsKey("MockBehaviorExtensions.g.cs").WhoseValue
-			.DoesNotContain("Generate<T1, T2>((T1, T2)").And
-			.DoesNotContain("Generate<T1, T2, T3>((T1, T2, T3)").And
-			.DoesNotContain("Generate<T1, T2, T3, T4, T5, T6, T7, T8>");
 	}
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.AggregationTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.AggregationTests.cs
@@ -1,0 +1,223 @@
+using System.Linq;
+using System.Net.Http;
+
+namespace Mockolate.SourceGenerators.Tests;
+
+public sealed class MockGeneratorAggregationTests
+{
+	[Fact]
+	public async Task AllVoidMethods_ShouldNotEmitReturnsThrowsAsyncExtensions()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IService.CreateMock();
+			         }
+			     }
+
+			     public interface IService
+			     {
+			         void DoWork(int v1, int v2, int v3, int v4, int v5);
+			         void DoMore(int v1, int v2, int v3, int v4, int v5, int v6);
+			     }
+			     """);
+
+		await That(result.Sources).DoesNotContainKey("ReturnsThrowsAsyncExtensions.g.cs");
+	}
+
+	[Fact]
+	public async Task AsExtensionsForChainOfTwoAdditionalInterfaces_ShouldEmitBothPairs()
+	{
+		// Implementing<IA>().Implementing<IB>() must register two pairs in Mock.AsExtensions.g.cs:
+		// the (parent, last) pair (IBase ↔ IB) and the (intermediate, last) pair (IA ↔ IB).
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IBase.CreateMock().Implementing<IA>().Implementing<IB>();
+			         }
+			     }
+
+			     public interface IBase { }
+			     public interface IA { }
+			     public interface IB { }
+			     """);
+
+		await That(result.Sources).ContainsKey("Mock.AsExtensions.g.cs").WhoseValue
+			// (IBase ↔ IB): bridge from a typed-as-IBase mock to IMockForIB.
+			.Contains("internal static partial class MockExtensionsForIB").And
+			.Contains("extension(global::Mockolate.Mock.IMockForIBase mock)").And
+			// (IA ↔ IB): bridge from a typed-as-IA mock to IMockForIB.
+			.Contains("extension(global::Mockolate.Mock.IMockForIA mock)").And
+			// Reverse direction is also emitted.
+			.Contains("internal static partial class MockExtensionsForIBase").And
+			.Contains("internal static partial class MockExtensionsForIA");
+	}
+
+	[Fact]
+	public async Task HttpClientMock_ShouldEmitHttpResponseMessageFactoryInBehaviorExtensions()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Net.Http;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = HttpClient.CreateMock();
+			         }
+			     }
+			     """, typeof(HttpClient));
+
+		await That(result.Sources).ContainsKey("MockBehaviorExtensions.g.cs").WhoseValue
+			.Contains("HttpResponseMessageFactory").And
+			.Contains("new HttpResponseMessageFactory(global::System.Net.HttpStatusCode.NotImplemented)");
+	}
+
+	[Fact]
+	public async Task NonHttpClientMock_ShouldNotEmitHttpResponseMessageFactoryInBehaviorExtensions()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IService.CreateMock();
+			         }
+			     }
+
+			     public interface IService
+			     {
+			         void DoWork();
+			     }
+			     """);
+
+		await That(result.Sources).ContainsKey("MockBehaviorExtensions.g.cs").WhoseValue
+			.DoesNotContain("HttpResponseMessageFactory");
+	}
+
+	[Fact]
+	public async Task NonVoidMethodWithArity5_ShouldEmitReturnsThrowsAsyncExtensions()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IService.CreateMock();
+			         }
+			     }
+
+			     public interface IService
+			     {
+			         int Compute(int v1, int v2, int v3, int v4, int v5);
+			     }
+			     """);
+
+		await That(result.Sources).ContainsKey("ReturnsThrowsAsyncExtensions.g.cs");
+	}
+
+	[Fact]
+	public async Task SameRootWithDifferentAdditionalImplementations_ShouldEmitBothCombinations()
+	{
+		// Two MockClass entries have identical ClassFullName (IBase) but different
+		// AdditionalImplementations. The Distinct comparator's per-element tie-break must order
+		// them deterministically rather than collapsing them.
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = IBase.CreateMock().Implementing<IExtraA>();
+			     		_ = IBase.CreateMock().Implementing<IExtraB>();
+			         }
+			     }
+
+			     public interface IBase { }
+			     public interface IExtraA { }
+			     public interface IExtraB { }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources)
+			.ContainsKey("Mock.IBase__IExtraA.g.cs").And
+			.ContainsKey("Mock.IBase__IExtraB.g.cs");
+	}
+
+	[Fact]
+	public async Task TwoCombinationsWithCollidingCombinedName_ShouldSuffixSecondCombination()
+	{
+		// Each combination resolves to combinedName "IBase__IExtra" because GetClassNameWithoutDots
+		// uses the simple class name (no namespace), so pass 2 of CreateNamedMocks must increment
+		// the suffix counter to disambiguate the second combination's emitted file.
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode
+			     {
+			         public class Program
+			         {
+			             public static void Main(string[] args)
+			             {
+			                 _ = Foo.IBase.CreateMock().Implementing<Foo.IExtra>();
+			                 _ = Bar.IBase.CreateMock().Implementing<Bar.IExtra>();
+			             }
+			         }
+			     }
+
+			     namespace Foo
+			     {
+			         public interface IBase { }
+			         public interface IExtra { }
+			     }
+
+			     namespace Bar
+			     {
+			         public interface IBase { }
+			         public interface IExtra { }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+
+		string[] combinationKeys = result.Sources.Keys
+			.Where(k => k.Contains("__"))
+			.ToArray();
+
+		await That(combinationKeys).Contains("Mock.IBase__IExtra.g.cs").And
+			.Contains("Mock.IBase__IExtra_1.g.cs");
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -106,7 +106,8 @@ public partial class MockGeneratorTests
 			.IgnoringNewlineStyle().And
 			.Contains("public static global::MyCode.MyService CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForMyService> setup, int value)")
 			.IgnoringNewlineStyle().And
-			.Contains("public static global::MyCode.MyService CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyService> setup, int value)")
+			.Contains(
+				"public static global::MyCode.MyService CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyService> setup, int value)")
 			.IgnoringNewlineStyle();
 	}
 

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -201,11 +201,13 @@ public sealed partial class MockTests
 					     """);
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.ProcessData\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.ProcessData\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("methodSetup?.TriggerCallbacks(methodExecution);")
 					.IgnoringNewlineStyle().And
-					.Contains("return methodSetup?.TryGetReturnValue(methodExecution, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, methodExecution);")
+					.Contains(
+						"return methodSetup?.TryGetReturnValue(methodExecution, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, methodExecution);")
 					.IgnoringNewlineStyle();
 			}
 
@@ -266,7 +268,8 @@ public sealed partial class MockTests
 					     """);
 
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").WhoseValue
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.ProcessResult\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.ProcessResult\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("methodSetup?.TriggerCallbacks(result);")
 					.IgnoringNewlineStyle().And
@@ -438,7 +441,8 @@ public sealed partial class MockTests
 					          		public bool MyMethod1(int index)
 					          		{
 					          """).IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int>>(\"global::MyCode.IMyService.MyMethod1\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int>>(\"global::MyCode.IMyService.MyMethod1\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -476,7 +480,8 @@ public sealed partial class MockTests
 					          		{
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.VoidMethodSetup<int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<int, bool>>(\"global::MyCode.IMyService.MyMethod2\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.VoidMethodSetup<int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<int, bool>>(\"global::MyCode.IMyService.MyMethod2\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -549,7 +554,8 @@ public sealed partial class MockTests
 					          		{
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.MyDirectMethod\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyService.MyDirectMethod\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -587,7 +593,8 @@ public sealed partial class MockTests
 					          		{
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyServiceBase1.MyBaseMethod1\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyServiceBase1.MyBaseMethod1\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -625,7 +632,8 @@ public sealed partial class MockTests
 					          		{
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyServiceBase2.MyBaseMethod2\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyServiceBase2.MyBaseMethod2\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -663,7 +671,8 @@ public sealed partial class MockTests
 					          		{
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyServiceBase3.MyBaseMethod3\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int>>(\"global::MyCode.IMyServiceBase3.MyBaseMethod3\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -750,7 +759,8 @@ public sealed partial class MockTests
 					          			var ref_value1 = value1;
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.VoidMethodSetup<int, int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<int, int, bool>>(\"global::MyCode.MyService.MyMethod1\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.VoidMethodSetup<int, int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<int, int, bool>>(\"global::MyCode.MyService.MyMethod1\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -807,7 +817,8 @@ public sealed partial class MockTests
 					          			var ref_value1 = value1;
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool, int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool, int, bool>>(\"global::MyCode.MyService.MyMethod2\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool, int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool, int, bool>>(\"global::MyCode.MyService.MyMethod2\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -865,7 +876,8 @@ public sealed partial class MockTests
 					          		{
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int>>(\"global::MyCode.IMyOtherService.SomeOtherMethod\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int>>(\"global::MyCode.IMyOtherService.SomeOtherMethod\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -1009,7 +1021,8 @@ public sealed partial class MockTests
 					          			var ref_index = index;
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.VoidMethodSetup<int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<int>>(\"global::MyCode.IMyService.MyMethod1\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.VoidMethodSetup<int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<int>>(\"global::MyCode.IMyService.MyMethod1\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -1054,7 +1067,8 @@ public sealed partial class MockTests
 					          		{
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool>>(\"global::MyCode.IMyService.MyMethod2\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int, bool>>(\"global::MyCode.IMyService.MyMethod2\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -1108,7 +1122,8 @@ public sealed partial class MockTests
 					          			var ref_p1 = p1;
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>>(\"global::MyCode.IMyService.MyMethod3\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>>(\"global::MyCode.IMyService.MyMethod3\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -1141,7 +1156,8 @@ public sealed partial class MockTests
 					          			var ref_p1 = p1;
 					          """)
 					.IgnoringNewlineStyle().And
-					.Contains("foreach (global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>>(\"global::MyCode.IMyService.MyMethod4\"))")
+					.Contains(
+						"foreach (global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<global::MyCode.MyReadonlyStruct>>(\"global::MyCode.IMyService.MyMethod4\"))")
 					.IgnoringNewlineStyle().And
 					.Contains("""
 					          			bool hasWrappedResult = false;
@@ -1255,7 +1271,8 @@ public sealed partial class MockTests
 					          		public override bool MyMethod<T>(T entity)
 					          		{
 					          """).IgnoringNewlineStyle().And
-					.DoesNotContain("public override bool MyMethod<T>(T entity)\n\t\t\twhere T :").IgnoringNewlineStyle().Because("CS0460: constraints on override methods are inherited from the base method");
+					.DoesNotContain("public override bool MyMethod<T>(T entity)\n\t\t\twhere T :").IgnoringNewlineStyle()
+					.Because("CS0460: constraints on override methods are inherited from the base method");
 			}
 		}
 	}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CombinationTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CombinationTests.cs
@@ -1,0 +1,228 @@
+namespace Mockolate.SourceGenerators.Tests;
+
+public sealed partial class MockTests
+{
+	public sealed class CombinationTests
+	{
+		[Fact]
+		public async Task AbstractBaseWithParameterlessAndMixedConstructor_ShouldEmitBothTryCastHelpers()
+		{
+			// A constructor with a required parameter sets useTryCast; a defaulted parameter sets
+			// useTryCastWithDefaultValue. Mixing both flips both flags so the extension method ends
+			// up with both helper functions and the constructor-arity dispatch 'else if' chain.
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = MyService.CreateMock([42]).Implementing<IMyInterface>();
+				         }
+				     }
+
+				     public abstract class MyService
+				     {
+				         protected MyService() { }
+				         protected MyService(int required, string text = "hi") { }
+				     }
+
+				     public interface IMyInterface
+				     {
+				         void DoWork();
+				     }
+				     """);
+
+			await That(result.Diagnostics).IsEmpty();
+
+			await That(result.Sources).ContainsKey("Mock.MyService__IMyInterface.g.cs").WhoseValue
+				.Contains("static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)").And
+				.Contains("static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)").And
+				// Parameterless dispatch.
+				.Contains("if (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)").And
+				// 'else if' arity dispatch chain (mixed-required + defaulted ctor produces the optional-range branch).
+				.Contains("else if (mock.MockRegistry.ConstructorParameters.Length >= 1 && mock.MockRegistry.ConstructorParameters.Length <= 2");
+		}
+
+		[Fact]
+		public async Task AbstractBaseWithRequiredOnlyConstructor_ShouldThrowNoParameterlessConstructorMessage()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = MyService.CreateMock([42]).Implementing<IMyInterface>();
+				         }
+				     }
+
+				     public abstract class MyService
+				     {
+				         protected MyService(int value) { }
+				     }
+
+				     public interface IMyInterface
+				     {
+				         void DoWork();
+				     }
+				     """);
+
+			await That(result.Diagnostics).IsEmpty();
+
+			await That(result.Sources).ContainsKey("Mock.MyService__IMyInterface.g.cs").WhoseValue
+				.Contains("No parameterless constructor found for 'MyCode.MyService'").And
+				.Contains("static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)").And
+				.DoesNotContain("static bool TryCastWithDefaultValue<TValue>");
+		}
+
+		[Fact]
+		public async Task CombinationWithProtectedEventOnBaseClass_ShouldEmitProtectedRaiseRegion()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = MyService.CreateMock().Implementing<IExtra>();
+				         }
+				     }
+
+				     public class MyService
+				     {
+				         protected virtual event EventHandler? Pinged;
+				     }
+
+				     public interface IExtra
+				     {
+				         void DoWork();
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.MyService__IExtra.g.cs").WhoseValue
+				.Contains("IMockProtectedRaiseOnMyService").And
+				.Contains("#region IMockProtectedRaiseOnMyService");
+		}
+
+		[Fact]
+		public async Task CombinationWithRequiredMemberOnBase_ShouldEmitSetsRequiredMembersAttribute()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = MyService.CreateMock().Implementing<IExtra>();
+				         }
+				     }
+
+				     public class MyService
+				     {
+				         public required int Value { get; init; }
+				         public MyService() { }
+				     }
+
+				     public interface IExtra
+				     {
+				         void DoWork();
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.MyService__IExtra.g.cs").WhoseValue
+				// AppendMockSubject_BaseClassConstructor stamps SetsRequiredMembers on the generated
+				// constructor when the base class declares any `required` member.
+				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
+		}
+
+		[Fact]
+		public async Task CombinationWithStaticInterfaceEvents_ShouldEmitStaticRaiseRegion()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = IBase.CreateMock().Implementing<IStaticEvents>();
+				         }
+				     }
+
+				     public interface IBase
+				     {
+				         void DoWork();
+				     }
+
+				     public interface IStaticEvents
+				     {
+				         static abstract event EventHandler Pinged;
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.IBase__IStaticEvents.g.cs").WhoseValue
+				.Contains("IMockStaticRaiseOnIStaticEvents").And
+				.Contains("#region IMockStaticRaiseOnIStaticEvents").And
+				.Contains("internal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider");
+		}
+
+		[Fact]
+		public async Task CombinationWithStaticInterfaceMembers_ShouldEmitStaticSetupAndVerifyRegions()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = IBase.CreateMock().Implementing<IStaticAware>();
+				         }
+				     }
+
+				     public interface IBase
+				     {
+				         void DoWork();
+				     }
+
+				     public interface IStaticAware
+				     {
+				         static abstract int Counter { get; }
+				         static abstract void Reset();
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.IBase__IStaticAware.g.cs").WhoseValue
+				.Contains("IMockStaticSetupForIStaticAware").And
+				.Contains("IMockStaticVerifyForIStaticAware").And
+				.Contains("#region IMockStaticSetupForIStaticAware").And
+				.Contains("#region IMockStaticVerifyForIStaticAware").And
+				// AsyncLocal field is required so static accessors can find the registry.
+				.Contains("internal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider");
+		}
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.DelegateTests.cs
@@ -82,7 +82,8 @@ public sealed partial class MockTests
 				          		{
 				          """)
 				.IgnoringNewlineStyle().And
-				.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>>(\"global::MyCode.Program.DoSomething1.Invoke\"))")
+				.Contains(
+					"foreach (global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>>(\"global::MyCode.Program.DoSomething1.Invoke\"))")
 				.IgnoringNewlineStyle().And
 				.Contains("""
 				          			if (MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -105,7 +106,8 @@ public sealed partial class MockTests
 				          		{
 				          """)
 				.IgnoringNewlineStyle().And
-				.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>>(\"global::MyCode.Program.DoSomething2.Invoke\"))")
+				.Contains(
+					"foreach (global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>>(\"global::MyCode.Program.DoSomething2.Invoke\"))")
 				.IgnoringNewlineStyle().And
 				.Contains("""
 				          			if (MockRegistry.Behavior.SkipInteractionRecording == false)
@@ -216,7 +218,8 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Sources).ContainsKey("Mock.Func_int_bool.g.cs").WhoseValue
-				.Contains("foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int>>(\"global::System.Func<int, bool>.Invoke\"))")
+				.Contains(
+					"foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, int> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, int>>(\"global::System.Func<int, bool>.Invoke\"))")
 				.IgnoringNewlineStyle().And
 				.Contains("global::System.Func<int, bool> Object").IgnoringNewlineStyle();
 		}
@@ -247,7 +250,8 @@ public sealed partial class MockTests
 				.IgnoringNewlineStyle().And
 				.Contains("Verify(int a, int b, int c, int d, int e)")
 				.IgnoringNewlineStyle().And
-				.Contains("Setup(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<int>? c, global::Mockolate.Parameters.IParameter<int>? d, global::Mockolate.Parameters.IParameter<int>? e)")
+				.Contains(
+					"Setup(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<int>? c, global::Mockolate.Parameters.IParameter<int>? d, global::Mockolate.Parameters.IParameter<int>? e)")
 				.IgnoringNewlineStyle();
 		}
 
@@ -273,7 +277,8 @@ public sealed partial class MockTests
 
 			await That(result.Sources)
 				.ContainsKey("Mock.Program_ProcessAll.g.cs").WhoseValue
-				.Contains("Setup(global::Mockolate.Parameters.IOutParameter<int> a, global::Mockolate.Parameters.IOutParameter<int> b, global::Mockolate.Parameters.IOutParameter<int> c, global::Mockolate.Parameters.IOutParameter<int> d, global::Mockolate.Parameters.IOutParameter<int> e)")
+				.Contains(
+					"Setup(global::Mockolate.Parameters.IOutParameter<int> a, global::Mockolate.Parameters.IOutParameter<int> b, global::Mockolate.Parameters.IOutParameter<int> c, global::Mockolate.Parameters.IOutParameter<int> d, global::Mockolate.Parameters.IOutParameter<int> e)")
 				.IgnoringNewlineStyle().And
 				.DoesNotContain("Setup(int")
 				.IgnoringNewlineStyle();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.RefStructTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.RefStructTests.cs
@@ -5,6 +5,187 @@ public sealed partial class MockTests
 	public sealed class RefStructTests
 	{
 		[Fact]
+		public async Task Arity16VoidMethod_EmitsGeneratedRefStructSetupAtArity16()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Packet(int id) { public int Id { get; } = id; }
+
+				     public interface IBigSink16
+				     {
+				         void Consume(Packet p1, Packet p2, Packet p3, Packet p4, Packet p5, Packet p6, Packet p7, Packet p8, Packet p9, Packet p10, Packet p11, Packet p12, Packet p13, Packet p14, Packet p15, Packet p16);
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IBigSink16.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructVoidMethodSetup<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>").And
+				.Contains("public sealed class RefStructVoidMethodSetup<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>").And
+				.Contains("where T16 : allows ref struct").And
+				.Contains("where T1 : allows ref struct");
+		}
+
+		[Fact]
+		public async Task Arity5IndexerGetAndSet_WithRefStructKey_EmitsCombinedSetup()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Key(int id) { public int Id { get; } = id; }
+
+				     public interface IRefStructStore5
+				     {
+				         string this[Key k1, int k2, Key k3, int k4, Key k5] { get; set; }
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IRefStructStore5.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructIndexerSetup<TValue, T1, T2, T3, T4, T5>").And
+				.Contains("public sealed class RefStructIndexerSetup<TValue, T1, T2, T3, T4, T5>").And
+				// Combined facade exposes the inner Getter / Setter properties.
+				.Contains("Getter { get; }").And
+				.Contains("Setter { get; }").And
+				// Storage plumbing visible on the getter-only emission.
+				.Contains("TryResolveKey").And
+				.Contains("GetChildDispatch").And
+				.Contains("StoreValue").And
+				.Contains("BoundGetter");
+		}
+
+		[Fact]
+		public async Task Arity5IndexerGetterOnly_WithRefStructKey_EmitsGetterSetupOnly()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Key(int id) { public int Id { get; } = id; }
+
+				     public interface IRefStructLookup5
+				     {
+				         string this[Key k1, int k2, Key k3, int k4, Key k5] { get; }
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IRefStructLookup5.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructIndexerGetterSetup<TValue, T1, T2, T3, T4, T5>").And
+				.Contains("public sealed class RefStructIndexerGetterSetup<TValue, T1, T2, T3, T4, T5>").And
+				// Storage / projection plumbing must be present at arity 5.
+				.Contains("TryResolveKey").And
+				.Contains("GetChildDispatch").And
+				// Setter-only and combined surfaces must NOT be emitted for a getter-only indexer.
+				.DoesNotContain("public sealed class RefStructIndexerSetterSetup<TValue, T1, T2, T3, T4, T5>").And
+				.DoesNotContain("public sealed class RefStructIndexerSetup<TValue, T1, T2, T3, T4, T5>");
+		}
+
+		[Fact]
+		public async Task Arity5IndexerSetterOnly_WithRefStructKey_EmitsSetterSetupOnly()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Key(int id) { public int Id { get; } = id; }
+
+				     public interface IRefStructWriter5
+				     {
+				         string this[Key k1, int k2, Key k3, int k4, Key k5] { set; }
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IRefStructWriter5.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructIndexerSetterSetup<TValue, T1, T2, T3, T4, T5>").And
+				.Contains("public sealed class RefStructIndexerSetterSetup<TValue, T1, T2, T3, T4, T5>").And
+				// BoundGetter property is emitted on the setter so combined setups can forward writes.
+				.Contains("BoundGetter").And
+				// No getter-only or combined surface for a setter-only indexer.
+				.DoesNotContain("public sealed class RefStructIndexerGetterSetup<TValue, T1, T2, T3, T4, T5>").And
+				.DoesNotContain("public sealed class RefStructIndexerSetup<TValue, T1, T2, T3, T4, T5>");
+		}
+
+		[Fact]
+		public async Task Arity5ReturnMethod_EmitsGeneratedRefStructReturnSetup()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Packet(int id) { public int Id { get; } = id; }
+
+				     public interface IBigParser5
+				     {
+				         int TryParse(Packet p1, int p2, Packet p3, Packet p4, string p5);
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IBigParser5.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructReturnMethodSetup<TReturn, T1, T2, T3, T4, T5>").And
+				.Contains("public sealed class RefStructReturnMethodSetup<TReturn, T1, T2, T3, T4, T5>").And
+				.Contains("public bool HasReturnValue => _returnFactory is not null;").And
+				.Contains(".Returns(TReturn returnValue)").And
+				.Contains(".Returns(global::System.Func<TReturn> returnFactory)").And
+				// default! fallback when neither return factory nor defaultFactory is present.
+				.Contains("return defaultFactory is not null ? defaultFactory() : default!;");
+		}
+
+		[Fact]
 		public async Task Arity5VoidMethod_EmitsGeneratedRefStructSetup()
 		{
 			// Arity 5 exceeds the hand-written ceiling (1-4); the generator must emit
@@ -75,6 +256,109 @@ public sealed partial class MockTests
 				.Contains("public interface IRefStructReturnMethodSetup<TReturn, T1, T2, T3, T4, T5, T6>").And
 				.Contains("public sealed class RefStructReturnMethodSetup<TReturn, T1, T2, T3, T4, T5, T6>").And
 				.Contains("public bool HasReturnValue");
+		}
+
+		[Fact]
+		public async Task Arity6VoidMethod_EmitsGeneratedRefStructSetupAtArity6()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Packet(int id) { public int Id { get; } = id; }
+
+				     public interface IBigSink6
+				     {
+				         void Consume(Packet p1, Packet p2, Packet p3, Packet p4, Packet p5, Packet p6);
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IBigSink6.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructVoidMethodSetup<T1, T2, T3, T4, T5, T6>").And
+				.Contains("public sealed class RefStructVoidMethodSetup<T1, T2, T3, T4, T5, T6>").And
+				.Contains("where T1 : allows ref struct").And
+				.Contains("where T6 : allows ref struct").And
+				// _returnAction body present (matches the emitted void-setup throw machinery).
+				.Contains("private global::System.Func<global::System.Exception?>? _returnAction;").And
+				.Contains("_returnAction = static () => new TException();");
+		}
+
+		[Fact]
+		public async Task Arity7ReturnMethod_MixedRefStructAndValueTypes_EmitsRefStructReturnSetup()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Packet(int id) { public int Id { get; } = id; }
+
+				     public interface IBigParser7
+				     {
+				         int TryParse(Packet p1, Packet p2, int p3, Packet p4, Packet p5, string p6, double p7);
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IBigParser7.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructReturnMethodSetup<TReturn, T1, T2, T3, T4, T5, T6, T7>").And
+				.Contains("public sealed class RefStructReturnMethodSetup<TReturn, T1, T2, T3, T4, T5, T6, T7>").And
+				.Contains("public bool HasReturnValue => _returnFactory is not null;").And
+				.Contains("return defaultFactory is not null ? defaultFactory() : default!;").And
+				.Contains("where T7 : allows ref struct");
+		}
+
+		[Fact]
+		public async Task Arity8VoidMethod_EmitsGeneratedRefStructSetupAtArity8()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Packet(int id) { public int Id { get; } = id; }
+
+				     public interface IBigSink8
+				     {
+				         void Consume(Packet p1, Packet p2, Packet p3, Packet p4, Packet p5, Packet p6, Packet p7, Packet p8);
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IBigSink8.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("RefStructMethodSetups.g.cs").WhoseValue
+				.Contains("public interface IRefStructVoidMethodSetup<T1, T2, T3, T4, T5, T6, T7, T8>").And
+				.Contains("public sealed class RefStructVoidMethodSetup<T1, T2, T3, T4, T5, T6, T7, T8>").And
+				.Contains("where T8 : allows ref struct").And
+				.Contains("_returnAction = exceptionFactory;");
 		}
 
 		[Fact]
@@ -246,6 +530,34 @@ public sealed partial class MockTests
 				// Must NOT use the ref-struct pipeline.
 				.DoesNotContain("RefStructMethodInvocation").And
 				.DoesNotContain("RefStructVoidMethodSetup");
+		}
+
+		[Fact]
+		public async Task NoRefStructSurface_ShouldNotEmitRefStructMethodSetupsFile()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public interface IPlainService
+				     {
+				         void DoWork(int v1, int v2, int v3, int v4, int v5, int v6);
+				         int Compute(int v1, int v2, int v3, int v4, int v5, int v6);
+				         int this[int v1, int v2, int v3, int v4, int v5] { get; set; }
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IPlainService.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).DoesNotContainKey("RefStructMethodSetups.g.cs");
 		}
 
 		[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -268,7 +268,8 @@ public sealed partial class MockTests
 			.DoesNotContain("CreateMock(object?[] constructorParameters)").And
 			.DoesNotContain("CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)").And
 			.DoesNotContain("object?[] constructorParameters)").And
-			.Contains("private static global::MyCode.MyBaseClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyBaseClass>? setup, object?[]? constructorParameters)");
+			.Contains(
+				"private static global::MyCode.MyBaseClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyBaseClass>? setup, object?[]? constructorParameters)");
 	}
 
 	[Fact]
@@ -296,7 +297,8 @@ public sealed partial class MockTests
 		await That(result.Sources).ContainsKey("Mock.MyBaseClass.g.cs").WhoseValue
 			.DoesNotContain("CreateMock(object?[] constructorParameters)").And
 			.DoesNotContain("object?[] constructorParameters)").And
-			.Contains("private static global::MyCode.MyBaseClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyBaseClass>? setup, object?[]? constructorParameters)");
+			.Contains(
+				"private static global::MyCode.MyBaseClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForMyBaseClass>? setup, object?[]? constructorParameters)");
 	}
 
 	[Fact]
@@ -710,7 +712,8 @@ public sealed partial class MockTests
 			          		{
 			          """)
 			.IgnoringNewlineStyle().And
-			.Contains("foreach (global::Mockolate.Setup.VoidMethodSetup<object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal>>(\"global::MyCode.IMyService.MyMethod\"))")
+			.Contains(
+				"foreach (global::Mockolate.Setup.VoidMethodSetup<object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.VoidMethodSetup<object, bool, string, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal>>(\"global::MyCode.IMyService.MyMethod\"))")
 			.IgnoringNewlineStyle().And
 			.Contains("""
 			          			bool hasWrappedResult = false;


### PR DESCRIPTION
This PR expands the Mockolate source-generator test suite, adding new unit tests that validate entity equality behavior (Event/Property/MockClass) and several additional generator-emission scenarios (ref-struct surfaces, mock combinations, and aggregation behaviors).

**Changes:**
- Add new entity-focused tests for Event/Property equality comparers and MockClass equality/hash behavior.
- Add new generator tests for ref-struct setup emissions across higher arities, plus combination/aggregation scenarios.
- Minor test assertion formatting tweaks (wrapping long `.Contains(...)` strings) and a small reordering/cleanup in existing tests.