### PR TITLE
refactor: improve equality comparison logic in Property classes

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -82,13 +82,24 @@ internal record Property
 	private sealed class PropertyEqualityComparer : IEqualityComparer<Property>
 	{
 		public bool Equals(Property? x, Property? y)
-			=> (x is null && y is null) ||
-			   (x is not null && y is not null &&
-			    (x.IsIndexer
-				    ? y.IsIndexer && x.IndexerParameters?.Count == y.IndexerParameters?.Count &&
-				      x.IndexerParameters!.Value.SequenceEqual(y.IndexerParameters!.Value) &&
-				      x.ContainingType.Equals(y.ContainingType)
-				    : !y.IsIndexer && x.Name.Equals(y.Name) && x.ContainingType.Equals(y.ContainingType)));
+		{
+			if (x is null)
+			{
+				return y is null;
+			}
+
+			if (y is null || x.IsIndexer != y.IsIndexer || !x.ContainingType.Equals(y.ContainingType))
+			{
+				return false;
+			}
+
+			if (x.IsIndexer)
+			{
+				return x.IndexerParameters!.Value.Equals(y.IndexerParameters!.Value);
+			}
+
+			return x.Name.Equals(y.Name);
+		}
 
 		public int GetHashCode(Property obj) => obj.Name.GetHashCode();
 	}
@@ -96,12 +107,24 @@ internal record Property
 	private sealed class ContainingTypeIndependentPropertyEqualityComparer : IEqualityComparer<Property>
 	{
 		public bool Equals(Property? x, Property? y)
-			=> (x is null && y is null) ||
-			   (x is not null && y is not null &&
-			    (x.IsIndexer
-				    ? y.IsIndexer && x.IndexerParameters?.Count == y.IndexerParameters?.Count &&
-				      x.IndexerParameters!.Value.SequenceEqual(y.IndexerParameters!.Value)
-				    : !y.IsIndexer && x.Name.Equals(y.Name)));
+		{
+			if (x is null)
+			{
+				return y is null;
+			}
+
+			if (y is null || x.IsIndexer != y.IsIndexer)
+			{
+				return false;
+			}
+
+			if (x.IsIndexer)
+			{
+				return x.IndexerParameters!.Value.Equals(y.IndexerParameters!.Value);
+			}
+
+			return x.Name.Equals(y.Name);
+		}
 
 		public int GetHashCode(Property obj) => obj.Name.GetHashCode();
 	}

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -194,14 +194,14 @@ public class MockGenerator : IIncrementalGenerator
 			int aLen = aAdds?.Length ?? 0;
 			int bLen = bAdds?.Length ?? 0;
 			cmp = aLen.CompareTo(bLen);
-			if (cmp != 0 || aAdds is null || bAdds is null)
+			if (cmp != 0)
 			{
 				return cmp;
 			}
 
 			for (int i = 0; i < aLen; i++)
 			{
-				cmp = StringComparer.Ordinal.Compare(aAdds[i].ClassFullName, bAdds[i].ClassFullName);
+				cmp = StringComparer.Ordinal.Compare(aAdds![i].ClassFullName, bAdds![i].ClassFullName);
 				if (cmp != 0)
 				{
 					return cmp;
@@ -406,18 +406,13 @@ public class MockGenerator : IIncrementalGenerator
 			}
 
 			NamedClass[] additionalNamed = mc.AdditionalImplementations
-				.Select(additional => new NamedClass(LookupName(baseClassNames, additional), additional))
+				.Select(additional => new NamedClass(baseClassNames[additional.ClassFullName], additional))
 				.ToArray();
 
-			result.Add(new NamedMock(actualName, LookupName(baseClassNames, mc), mc, new EquatableArray<NamedClass>(additionalNamed)));
+			result.Add(new NamedMock(actualName, baseClassNames[mc.ClassFullName], mc, new EquatableArray<NamedClass>(additionalNamed)));
 		}
 
 		return new EquatableArray<NamedMock>(result.ToArray());
-
-		static string LookupName(Dictionary<string, string> map, Class @class)
-		{
-			return map.TryGetValue(@class.ClassFullName, out string? v) ? v : "";
-		}
 	}
 
 	private static EquatableArray<MockAsExtensionPair> CollectAsExtensionPairs(EquatableArray<NamedMock> mocks)
@@ -432,12 +427,7 @@ public class MockGenerator : IIncrementalGenerator
 				continue;
 			}
 
-			NamedClass[] additionalArr = additional.AsArray() ?? [];
-			if (additionalArr.Length == 0)
-			{
-				continue;
-			}
-
+			NamedClass[] additionalArr = additional.AsArray()!;
 			NamedClass last = additionalArr[additionalArr.Length - 1];
 
 			AddIfNew(seen, ordered, MockAsExtensionPair.Create(nm.ParentName, nm.Mock.ClassFullName, last.Name, last.Class.ClassFullName));
@@ -488,7 +478,7 @@ public class MockGenerator : IIncrementalGenerator
 			return;
 		}
 
-		NamedClass[] additionalNamed = additional.AsArray() ?? [];
+		NamedClass[] additionalNamed = additional.AsArray()!;
 		(string Name, Class Class)[] additionalArr = new (string Name, Class Class)[additionalNamed.Length];
 		for (int i = 0; i < additionalNamed.Length; i++)
 		{


### PR DESCRIPTION
Refactors internal comparison and lookup logic in the source generator to make equality checks and array/dictionary access more direct and consistent, supporting stable incremental generation behavior.

**Changes:**
- Simplifies `Property` equality comparers by using early returns and `EquatableArray<T>.Equals` for indexer-parameter comparisons.
- Tightens `MockGenerator` naming/collection logic by replacing fallback lookups with direct dictionary indexing where keys are guaranteed to exist.
- Removes redundant null/empty array handling in a few generator paths by relying on `EquatableArray<T>.Count` guards.