### PR TITLE
feat: update benchmarks to verify getter and setter calls

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -13,7 +13,7 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with an indexer, setup the indexer and verify
-///     the getter was called exactly <see cref="N" /> times.
+///     that both the getter and the setter were called exactly <see cref="N" /> times.
 /// </summary>
 public class CompleteIndexerBenchmarks : BenchmarksBase
 {
@@ -32,9 +32,11 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = sut[42];
+			sut[42] = "bar";
 		}
 
 		sut.Mock.Verify[It.IsAny<int>()].Got().Exactly(N);
+		sut.Mock.Verify[It.IsAny<int>()].Set(It.IsAny<string>()).Exactly(N);
 	}
 
 	/// <summary>
@@ -50,9 +52,11 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = sut[42];
+			sut[42] = "bar";
 		}
 
 		mock.Verify(x => x[Moq.It.IsAny<int>()], Times.Exactly(N));
+		mock.VerifySet(x => x[Moq.It.IsAny<int>()] = Moq.It.IsAny<string>(), Times.Exactly(N));
 	}
 
 	/// <summary>
@@ -67,9 +71,11 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = mock[42];
+			mock[42] = "bar";
 		}
 
 		_ = mock.Received(N)[Arg.Any<int>()];
+		mock.Received(N)[Arg.Any<int>()] = Arg.Any<string>();
 	}
 
 	/// <summary>
@@ -84,9 +90,11 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = mock[42];
+			mock[42] = "bar";
 		}
 
 		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(N, FakeItEasy.Times.Exactly);
+		A.CallToSet(() => mock[A<int>.Ignored]).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -102,9 +110,11 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = sut[42];
+			sut[42] = "bar";
 		}
 
 		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(N));
+		imposter[Imposter.Abstractions.Arg<int>.Any()].Setter().Called(Count.Exactly(N));
 	}
 
 	/* Indexers not supported on TUnit.Mocks
@@ -120,6 +130,7 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = mock.Object[42];
+			mock.Object[42] = "bar";
 		}
 
 		mock[Any<int>()].WasCalled(TUnit.Mocks.Times.Exactly(N));

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -12,7 +12,7 @@ namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
 /// <summary>
 ///     In this benchmark we check the case of an interface mock with a property, setup the property and verify
-///     the getter was called exactly <see cref="N" /> times.
+///     that both the getter and the setter were called exactly <see cref="N" /> times.
 /// </summary>
 public class CompletePropertyBenchmarks : BenchmarksBase
 {
@@ -31,9 +31,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
+			sut.Counter = i;
 		}
 
 		sut.Mock.Verify.Counter.Got().Exactly(N);
+		sut.Mock.Verify.Counter.Set(It.IsAny<int>()).Exactly(N);
 	}
 
 	/// <summary>
@@ -49,9 +51,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
+			sut.Counter = i;
 		}
 
 		mock.VerifyGet(x => x.Counter, Times.Exactly(N));
+		mock.VerifySet(x => x.Counter = Moq.It.IsAny<int>(), Times.Exactly(N));
 	}
 
 	/// <summary>
@@ -66,9 +70,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = mock.Counter;
+			mock.Counter = i;
 		}
 
 		_ = mock.Received(N).Counter;
+		mock.Received(N).Counter = NSubstitute.Arg.Any<int>();
 	}
 
 	/// <summary>
@@ -83,9 +89,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = mock.Counter;
+			mock.Counter = i;
 		}
 
 		A.CallTo(() => mock.Counter).MustHaveHappened(N, FakeItEasy.Times.Exactly);
+		A.CallToSet(() => mock.Counter).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 	}
 
 	/// <summary>
@@ -101,9 +109,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
+			sut.Counter = i;
 		}
 
 		imposter.Counter.Getter().Called(Count.Exactly(N));
+		imposter.Counter.Setter(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(N));
 	}
 
 	/// <summary>
@@ -119,9 +129,11 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		for (int i = 0; i < N; i++)
 		{
 			_ = sut.Counter;
+			sut.Counter = i;
 		}
 
 		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(N));
+		mock.Counter.Setter.WasCalled(TUnit.Mocks.Times.Exactly(N));
 	}
 
 	public interface IMyPropertyInterface


### PR DESCRIPTION
Updates Mockolate’s benchmark suite to measure and validate both read and write interactions for property and indexer scenarios, aligning the benchmark intent with full accessor usage across supported mocking libraries.

**Changes:**
- Extend property benchmarks to perform a setter call per iteration and verify setter invocation counts.
- Extend indexer benchmarks to perform a setter call per iteration and verify setter invocation counts.
- Update benchmark XML summaries to reflect getter + setter verification.