### PR TITLE
perf: update property verification methods to use typed verification

### DIFF
--- a/Source/Mockolate/Verify/VerificationEventResult.cs
+++ b/Source/Mockolate/Verify/VerificationEventResult.cs
@@ -44,11 +44,11 @@ public class VerificationEventResult<TSubject>
 	///     Verifies the subscriptions for the event.
 	/// </summary>
 	public VerificationResult<TSubject> Subscribed()
-		=> _mockRegistry.SubscribedTo(_subject, _subscribeMemberId, _name);
+		=> _mockRegistry.SubscribedToTyped(_subject, _subscribeMemberId, _name);
 
 	/// <summary>
 	///     Verifies the unsubscriptions from the event.
 	/// </summary>
 	public VerificationResult<TSubject> Unsubscribed()
-		=> _mockRegistry.UnsubscribedFrom(_subject, _unsubscribeMemberId, _name);
+		=> _mockRegistry.UnsubscribedFromTyped(_subject, _unsubscribeMemberId, _name);
 }

--- a/Source/Mockolate/Verify/VerificationPropertyResult.cs
+++ b/Source/Mockolate/Verify/VerificationPropertyResult.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Mockolate.Parameters;
 
@@ -7,17 +8,17 @@ namespace Mockolate.Verify;
 ///     Verifications on a property of type <typeparamref name="TParameter" />.
 /// </summary>
 #if !DEBUG
-[System.Diagnostics.DebuggerNonUserCode]
+[DebuggerNonUserCode]
 #endif
 public class VerificationPropertyResult<TSubject, TParameter>
 {
 	private const int NoMemberId = -1;
+	private readonly int _getMemberId;
 
 	private readonly MockRegistry _mockRegistry;
 	private readonly string _propertyName;
-	private readonly TSubject _subject;
-	private readonly int _getMemberId;
 	private readonly int _setMemberId;
+	private readonly TSubject _subject;
 
 	/// <inheritdoc cref="VerificationPropertyResult{TSubject, TParameter}" />
 	public VerificationPropertyResult(TSubject subject, MockRegistry mockRegistry, string propertyName)
@@ -53,12 +54,14 @@ public class VerificationPropertyResult<TSubject, TParameter>
 	///     Verifies the property write access on the mock with the given <paramref name="value" />.
 	/// </summary>
 	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
-		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName, (IParameterMatch<TParameter>)value);
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName, value.AsParameterMatch());
 
 	/// <summary>
 	///     Verifies the property write access on the mock with the given <paramref name="value" />.
 	/// </summary>
 	[OverloadResolutionPriority(1)]
-	public VerificationResult<TSubject> Set(TParameter value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
-		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue));
+	public VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName,
+			It.Is(value, doNotPopulateThisValue).AsParameterMatch());
 }

--- a/Source/Mockolate/Verify/VerificationPropertyResult.cs
+++ b/Source/Mockolate/Verify/VerificationPropertyResult.cs
@@ -47,18 +47,18 @@ public class VerificationPropertyResult<TSubject, TParameter>
 	///     Verifies the property read access on the mock.
 	/// </summary>
 	public VerificationResult<TSubject> Got()
-		=> _mockRegistry.VerifyProperty(_subject, _getMemberId, _propertyName);
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _getMemberId, _propertyName);
 
 	/// <summary>
 	///     Verifies the property write access on the mock with the given <paramref name="value" />.
 	/// </summary>
 	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
-		=> _mockRegistry.VerifyProperty(_subject, _setMemberId, _propertyName, (IParameterMatch<TParameter>)value);
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName, (IParameterMatch<TParameter>)value);
 
 	/// <summary>
 	///     Verifies the property write access on the mock with the given <paramref name="value" />.
 	/// </summary>
 	[OverloadResolutionPriority(1)]
 	public VerificationResult<TSubject> Set(TParameter value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
-		=> _mockRegistry.VerifyProperty(_subject, _setMemberId, _propertyName, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue));
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue));
 }


### PR DESCRIPTION
This PR updates the property verification facade to route through the typed verification fast-paths in `MockRegistry`, aligning property verification with the newer typed-buffer verification approach for better performance and correctness.

**Changes:**
- Switch `VerificationPropertyResult.Got()` and `Set(...)` to call `MockRegistry.VerifyPropertyTyped(...)` instead of `VerifyProperty(...)`.