### PR TITLE
refactor: enhance AsArray method to return empty array for default-constructed values and update related interfaces

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/EquatableArray.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/EquatableArray.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Mockolate.SourceGenerators.Internals;
+namespace Mockolate.SourceGenerators.Entities;
 
 /// <summary>
 ///     An immutable, equatable array. This is equivalent to <see cref="Array" /> but with value equality support.
@@ -61,7 +61,7 @@ public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnume
 	/// <inheritdoc />
 	public override int GetHashCode()
 	{
-		if (_array is not T[] array)
+		if (_array is not { } array)
 		{
 			return 0;
 		}

--- a/Source/Mockolate.SourceGenerators/Entities/EquatableArray.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/EquatableArray.cs
@@ -85,10 +85,10 @@ public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnume
 	public ReadOnlySpan<T> AsSpan() => _array.AsSpan();
 
 	/// <summary>
-	///     Returns the underlying wrapped array.
+	///     Returns the underlying wrapped array, or an empty array when the value was default-constructed.
 	/// </summary>
-	/// <returns>Returns the underlying array.</returns>
-	public T[]? AsArray() => _array;
+	/// <returns>Returns the underlying array (never null).</returns>
+	public T[] AsArray() => _array ?? Array.Empty<T>();
 
 	/// <inheritdoc />
 	IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)(_array ?? Array.Empty<T>())).GetEnumerator();

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -131,8 +131,8 @@ internal record Method
 			}
 
 			// Compare parameters ignoring nullability annotations
-			MethodParameter[] xParams = x.Parameters.AsArray()!;
-			MethodParameter[] yParams = y.Parameters.AsArray()!;
+			MethodParameter[] xParams = x.Parameters.AsArray();
+			MethodParameter[] yParams = y.Parameters.AsArray();
 
 			for (int i = 0; i < xParams.Length; i++)
 			{

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -145,7 +145,7 @@ public class MockGenerator : IIncrementalGenerator
 		// MockBehaviorExtensions: only depends on whether HttpClient appears as a mock target.
 		// Reduce to a bool so the aggregate cache holds across mock-set churn that doesn't toggle it.
 		IncrementalValueProvider<bool> includeHttpClient = collectedMocks
-			.Select(static (arr, _) => arr.AsArray()?.Any(m => m.ClassFullName == "global::System.Net.Http.HttpClient") ?? false);
+			.Select(static (arr, _) => arr.AsArray().Any(m => m.ClassFullName == "global::System.Net.Http.HttpClient"));
 
 		context.RegisterSourceOutput(includeHttpClient, static (spc, hasHttp) =>
 			spc.AddSource("MockBehaviorExtensions.g.cs",
@@ -189,19 +189,17 @@ public class MockGenerator : IIncrementalGenerator
 				return cmp;
 			}
 
-			Class[]? aAdds = a.AdditionalImplementations.AsArray();
-			Class[]? bAdds = b.AdditionalImplementations.AsArray();
-			int aLen = aAdds?.Length ?? 0;
-			int bLen = bAdds?.Length ?? 0;
-			cmp = aLen.CompareTo(bLen);
+			Class[] aAdds = a.AdditionalImplementations.AsArray();
+			Class[] bAdds = b.AdditionalImplementations.AsArray();
+			cmp = aAdds.Length.CompareTo(bAdds.Length);
 			if (cmp != 0)
 			{
 				return cmp;
 			}
 
-			for (int i = 0; i < aLen; i++)
+			for (int i = 0; i < aAdds.Length; i++)
 			{
-				cmp = StringComparer.Ordinal.Compare(aAdds![i].ClassFullName, bAdds![i].ClassFullName);
+				cmp = StringComparer.Ordinal.Compare(aAdds[i].ClassFullName, bAdds[i].ClassFullName);
 				if (cmp != 0)
 				{
 					return cmp;
@@ -216,7 +214,7 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static HashSet<int> ToHashSet(EquatableArray<int> arities)
 	{
-		int[] arr = arities.AsArray() ?? [];
+		int[] arr = arities.AsArray();
 		HashSet<int> set = new();
 		foreach (int item in arr)
 		{
@@ -228,7 +226,7 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static HashSet<(int, bool)> ToMethodSetupHashSet(EquatableArray<MethodSetupKey> keys)
 	{
-		MethodSetupKey[] arr = keys.AsArray() ?? [];
+		MethodSetupKey[] arr = keys.AsArray();
 		HashSet<(int, bool)> set = new();
 		foreach (MethodSetupKey item in arr)
 		{
@@ -240,7 +238,7 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static EquatableArray<int> CollectIndexerSetupArities(EquatableArray<MockClass> mocks)
 	{
-		MockClass[] arr = mocks.AsArray() ?? [];
+		MockClass[] arr = mocks.AsArray();
 		HashSet<int> set = new();
 		foreach (MockClass mc in arr)
 		{
@@ -260,7 +258,7 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static EquatableArray<MethodSetupKey> CollectMethodSetupKeys(EquatableArray<MockClass> mocks)
 	{
-		MockClass[] arr = mocks.AsArray() ?? [];
+		MockClass[] arr = mocks.AsArray();
 		HashSet<MethodSetupKey> set = new();
 		foreach (MockClass mc in arr)
 		{
@@ -289,7 +287,7 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static RefStructAggregate CollectRefStructAggregate(EquatableArray<MockClass> mocks)
 	{
-		MockClass[] arr = mocks.AsArray() ?? [];
+		MockClass[] arr = mocks.AsArray();
 		HashSet<MethodSetupKey> methods = new();
 		Dictionary<int, (bool HasGetter, bool HasSetter)> indexerMap = new();
 		foreach (MockClass mc in arr)
@@ -347,7 +345,7 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static EquatableArray<NamedMock> CreateNamedMocks(EquatableArray<MockClass> mocks)
 	{
-		MockClass[] arr = mocks.AsArray() ?? [];
+		MockClass[] arr = mocks.AsArray();
 		if (arr.Length == 0)
 		{
 			return new EquatableArray<NamedMock>([]);
@@ -417,7 +415,7 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static EquatableArray<MockAsExtensionPair> CollectAsExtensionPairs(EquatableArray<NamedMock> mocks)
 	{
-		NamedMock[] arr = mocks.AsArray() ?? [];
+		NamedMock[] arr = mocks.AsArray();
 		HashSet<MockAsExtensionPair> seen = new();
 		List<MockAsExtensionPair> ordered = new();
 		foreach (NamedMock nm in arr)
@@ -427,7 +425,7 @@ public class MockGenerator : IIncrementalGenerator
 				continue;
 			}
 
-			NamedClass[] additionalArr = additional.AsArray()!;
+			NamedClass[] additionalArr = additional.AsArray();
 			NamedClass last = additionalArr[additionalArr.Length - 1];
 
 			AddIfNew(seen, ordered, MockAsExtensionPair.Create(nm.ParentName, nm.Mock.ClassFullName, last.Name, last.Class.ClassFullName));
@@ -478,7 +476,7 @@ public class MockGenerator : IIncrementalGenerator
 			return;
 		}
 
-		NamedClass[] additionalNamed = additional.AsArray()!;
+		NamedClass[] additionalNamed = additional.AsArray();
 		(string Name, Class Class)[] additionalArr = new (string Name, Class Class)[additionalNamed.Length];
 		for (int i = 0; i < additionalNamed.Length; i++)
 		{

--- a/Source/Mockolate/Verify/IFastCountSource.cs
+++ b/Source/Mockolate/Verify/IFastCountSource.cs
@@ -12,7 +12,15 @@ internal interface IFastCountSource
 	///     Counts recorded interactions whose parameters satisfy the source's captured matchers.
 	/// </summary>
 	int Count();
+}
 
+/// <summary>
+///     Method-only extension to <see cref="IFastCountSource" />. The <c>AnyParameters()</c> widener is
+///     exposed by <see cref="VerificationResult{TVerify}.IgnoreParameters" />, which is only produced by
+///     <c>VerifyMethod*</c> overloads — so only method count sources need an unmatched-count path.
+/// </summary>
+internal interface IFastMethodCountSource : IFastCountSource
+{
 	/// <summary>
 	///     Counts every recorded interaction, ignoring captured matchers.
 	///     Used when <c>AnyParameters()</c> widens the verification to any argument list.

--- a/Source/Mockolate/Verify/MethodCountSources.cs
+++ b/Source/Mockolate/Verify/MethodCountSources.cs
@@ -6,7 +6,7 @@ namespace Mockolate.Verify;
 /// <summary>
 ///     Allocation-free count source backed by a parameterless method buffer.
 /// </summary>
-internal sealed class Method0CountSource : IFastCountSource
+internal sealed class Method0CountSource : IFastMethodCountSource
 {
 	private readonly FastMethod0Buffer _buffer;
 
@@ -22,7 +22,7 @@ internal sealed class Method0CountSource : IFastCountSource
 /// <summary>
 ///     Allocation-free count source backed by a 1-parameter method buffer and a typed matcher.
 /// </summary>
-internal sealed class Method1CountSource<T1> : IFastCountSource
+internal sealed class Method1CountSource<T1> : IFastMethodCountSource
 {
 	private readonly FastMethod1Buffer<T1> _buffer;
 	private readonly IParameterMatch<T1> _match1;
@@ -40,7 +40,7 @@ internal sealed class Method1CountSource<T1> : IFastCountSource
 /// <summary>
 ///     Allocation-free count source backed by a 2-parameter method buffer.
 /// </summary>
-internal sealed class Method2CountSource<T1, T2> : IFastCountSource
+internal sealed class Method2CountSource<T1, T2> : IFastMethodCountSource
 {
 	private readonly FastMethod2Buffer<T1, T2> _buffer;
 	private readonly IParameterMatch<T1> _match1;
@@ -61,7 +61,7 @@ internal sealed class Method2CountSource<T1, T2> : IFastCountSource
 /// <summary>
 ///     Allocation-free count source backed by a 3-parameter method buffer.
 /// </summary>
-internal sealed class Method3CountSource<T1, T2, T3> : IFastCountSource
+internal sealed class Method3CountSource<T1, T2, T3> : IFastMethodCountSource
 {
 	private readonly FastMethod3Buffer<T1, T2, T3> _buffer;
 	private readonly IParameterMatch<T1> _match1;
@@ -84,7 +84,7 @@ internal sealed class Method3CountSource<T1, T2, T3> : IFastCountSource
 /// <summary>
 ///     Allocation-free count source backed by a 4-parameter method buffer.
 /// </summary>
-internal sealed class Method4CountSource<T1, T2, T3, T4> : IFastCountSource
+internal sealed class Method4CountSource<T1, T2, T3, T4> : IFastMethodCountSource
 {
 	private readonly FastMethod4Buffer<T1, T2, T3, T4> _buffer;
 	private readonly IParameterMatch<T1> _match1;
@@ -120,7 +120,6 @@ internal sealed class PropertyGetterCountSource : IFastCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching();
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -138,7 +137,6 @@ internal sealed class PropertySetterCountSource<T> : IFastCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -156,7 +154,6 @@ internal sealed class IndexerGetter1CountSource<T1> : IFastCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -177,7 +174,6 @@ internal sealed class IndexerGetter2CountSource<T1, T2> : IFastCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -200,7 +196,6 @@ internal sealed class IndexerGetter3CountSource<T1, T2, T3> : IFastCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _match3);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -226,7 +221,6 @@ internal sealed class IndexerGetter4CountSource<T1, T2, T3, T4> : IFastCountSour
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _match3, _match4);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -247,7 +241,6 @@ internal sealed class IndexerSetter1CountSource<T1, TValue> : IFastCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _matchValue);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -270,7 +263,6 @@ internal sealed class IndexerSetter2CountSource<T1, T2, TValue> : IFastCountSour
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _matchValue);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -296,7 +288,6 @@ internal sealed class IndexerSetter3CountSource<T1, T2, T3, TValue> : IFastCount
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _match3, _matchValue);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -326,7 +317,6 @@ internal sealed class IndexerSetter4CountSource<T1, T2, T3, T4, TValue> : IFastC
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _match3, _match4, _matchValue);
-	public int CountAll() => _buffer.Count;
 }
 
 /// <summary>
@@ -342,5 +332,4 @@ internal sealed class EventCountSource : IFastCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching();
-	public int CountAll() => _buffer.Count;
 }

--- a/Source/Mockolate/Verify/VerificationIndexerResult.cs
+++ b/Source/Mockolate/Verify/VerificationIndexerResult.cs
@@ -15,7 +15,7 @@ public class VerificationIndexerResult<TSubject, TParameter>
 {
 	/// <summary>
 	///     Sentinel value used by the typed-match subclasses to indicate that the legacy predicate-based
-	///     <see cref="MockRegistry.IndexerGot{T}(T, int, Func{IInteraction, bool}, Func{string})" /> path is not used.
+	///     <see cref="MockRegistry.IndexerGot{T}(T, int, System.Func{Mockolate.Interactions.IInteraction,bool}, Func{string})" /> path is not used.
 	/// </summary>
 	private protected const int NoMemberId = -1;
 
@@ -24,12 +24,16 @@ public class VerificationIndexerResult<TSubject, TParameter>
 
 	/// <summary>The mock registry holding the recorded interactions.</summary>
 	private protected readonly MockRegistry MockRegistry;
+
 	/// <summary>Factory producing the indexer-argument description used in failure messages.</summary>
 	private protected readonly Func<string> ParametersDescription;
+
 	/// <summary>The verification facade the result is bound to.</summary>
 	private protected readonly TSubject Subject;
+
 	/// <summary>Member id of the indexer getter, or <c>-1</c> when unknown.</summary>
 	private protected readonly int GetMemberId;
+
 	/// <summary>Member id of the indexer setter, or <c>-1</c> when unknown.</summary>
 	private protected readonly int SetMemberId;
 
@@ -136,18 +140,18 @@ public sealed class VerificationIndexerResult<TSubject, T1, TParameter>
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Got()
-		=> MockRegistry.IndexerGotTyped<TSubject, T1>(Subject, GetMemberId, _match1, ParametersDescription);
+		=> MockRegistry.IndexerGotTyped(Subject, GetMemberId, _match1, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, (IParameterMatch<TParameter>)value, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(TParameter value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
 }
 
@@ -177,18 +181,18 @@ public sealed class VerificationIndexerResult<TSubject, T1, T2, TParameter>
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Got()
-		=> MockRegistry.IndexerGotTyped<TSubject, T1, T2>(Subject, GetMemberId, _match1, _match2, ParametersDescription);
+		=> MockRegistry.IndexerGotTyped(Subject, GetMemberId, _match1, _match2, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, _match2, (IParameterMatch<TParameter>)value, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(TParameter value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, _match2, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
 }
 
@@ -220,19 +224,19 @@ public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, TParameter>
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Got()
-		=> MockRegistry.IndexerGotTyped<TSubject, T1, T2, T3>(Subject, GetMemberId,
+		=> MockRegistry.IndexerGotTyped(Subject, GetMemberId,
 			_match1, _match2, _match3, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, _match2, _match3, (IParameterMatch<TParameter>)value, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(TParameter value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, _match2, _match3, (IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue),
 			ParametersDescription);
 }
@@ -268,19 +272,19 @@ public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, T4, TParamet
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Got()
-		=> MockRegistry.IndexerGotTyped<TSubject, T1, T2, T3, T4>(Subject, GetMemberId,
+		=> MockRegistry.IndexerGotTyped(Subject, GetMemberId,
 			_match1, _match2, _match3, _match4, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(IParameter<TParameter> value)
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, T4, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, _match2, _match3, _match4, (IParameterMatch<TParameter>)value, ParametersDescription);
 
 	/// <inheritdoc />
 	public override VerificationResult<TSubject> Set(TParameter value,
 		[CallerArgumentExpression(nameof(value))]
 		string doNotPopulateThisValue = "")
-		=> MockRegistry.IndexerSetTyped<TSubject, T1, T2, T3, T4, TParameter>(Subject, SetMemberId,
+		=> MockRegistry.IndexerSetTyped(Subject, SetMemberId,
 			_match1, _match2, _match3, _match4,
 			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
 }

--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -343,7 +343,9 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 			ThrowIfRecordingDisabled(_interactions);
 			if (_fastCountSource is not null)
 			{
-				int count = _useCountAll ? _fastCountSource.CountAll() : _fastCountSource.Count();
+				int count = _useCountAll
+					? ((IFastMethodCountSource)_fastCountSource).CountAll()
+					: _fastCountSource.Count();
 				if (countPredicate(count))
 				{
 					return true;
@@ -393,7 +395,9 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 					_interactions.InteractionAdded += OnInteractionAdded;
 					do
 					{
-						int count = _useCountAll ? _fastCountSource!.CountAll() : _fastCountSource!.Count();
+						int count = _useCountAll
+							? ((IFastMethodCountSource)_fastCountSource!).CountAll()
+							: _fastCountSource!.Count();
 						if (countPredicate(count))
 						{
 							return true;
@@ -472,7 +476,9 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 		ThrowIfRecordingDisabled(_interactions);
 		if (_fastCountSource is not null)
 		{
-			int count = _useCountAll ? _fastCountSource.CountAll() : _fastCountSource.Count();
+			int count = _useCountAll
+				? ((IFastMethodCountSource)_fastCountSource).CountAll()
+				: _fastCountSource.Count();
 			return countPredicate(count);
 		}
 

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryScenarioTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryScenarioTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using Mockolate.Interactions;
+using Mockolate.Internal.Tests.TestHelpers;
+using Mockolate.Setup;
+
+namespace Mockolate.Internal.Tests.Registry;
+
+/// <summary>
+///     Coverage for the scenario-scoped branches in <c>MockRegistry.Interactions.cs</c> — the
+///     <c>!string.IsNullOrEmpty(Scenario) &amp;&amp; Setup.TryGetScenario(...)</c> guards on
+///     <c>GetMethodSetups</c>, <c>GetIndexerSetup</c>, and the lazy-default <c>ApplyIndexerGetter</c>
+///     overload's <c>setup is not null</c> path.
+/// </summary>
+public sealed class MockRegistryScenarioTests
+{
+	[Fact]
+	public async Task GetMethodSetups_WithActiveScenarioAndScopedSetup_YieldsScopedThenGlobal()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeMethodSetup global = new();
+		FakeMethodSetup scoped = new();
+		registry.Setup.Methods.Add(global);
+		registry.Setup.GetOrCreateScenario("a").Methods.Add(scoped);
+
+		registry.TransitionTo("a");
+
+		List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+		await That(setups).HasCount(2);
+		await That(setups[0]).IsSameAs(scoped);
+		await That(setups[1]).IsSameAs(global);
+	}
+
+	[Fact]
+	public async Task GetMethodSetups_WithActiveScenarioButNoScopedBucket_FallsBackToGlobal()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeMethodSetup global = new();
+		registry.Setup.Methods.Add(global);
+
+		registry.TransitionTo("never-registered");
+
+		List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+		await That(setups).HasCount(1);
+		await That(setups[0]).IsSameAs(global);
+	}
+
+	[Fact]
+	public async Task GetIndexerSetup_ByPredicate_WithActiveScenarioButPredicateRejectsScoped_FallsBackToGlobal()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeIndexerSetup global = new(true);
+		FakeIndexerSetup scoped = new(true);
+		registry.Setup.Indexers.Add(global);
+		registry.Setup.GetOrCreateScenario("a").Indexers.Add(scoped);
+
+		registry.TransitionTo("a");
+
+		IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(s => ReferenceEquals(s, global));
+
+		await That(result).IsSameAs(global);
+	}
+
+	[Fact]
+	public async Task GetIndexerSetup_ByAccess_WithActiveScenarioAndScopedMatching_ReturnsScoped()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeIndexerSetup global = new(true);
+		FakeIndexerSetup scoped = new(true);
+		registry.Setup.Indexers.Add(global);
+		registry.Setup.GetOrCreateScenario("a").Indexers.Add(scoped);
+
+		registry.TransitionTo("a");
+
+		IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(new IndexerGetterAccess<int>(1));
+
+		await That(result).IsSameAs(scoped);
+	}
+
+	[Fact]
+	public async Task GetIndexerSetup_ByAccess_WithActiveScenarioButScopedDoesNotMatchAccess_FallsBackToGlobal()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeIndexerSetup global = new(true);
+		FakeIndexerSetup scopedNonMatching = new(false);
+		registry.Setup.Indexers.Add(global);
+		registry.Setup.GetOrCreateScenario("a").Indexers.Add(scopedNonMatching);
+
+		registry.TransitionTo("a");
+
+		IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(new IndexerGetterAccess<int>(1));
+
+		await That(result).IsSameAs(global);
+	}
+
+	[Fact]
+	public async Task ApplyIndexerGetter_WithLazyDefault_AndNonNullSetup_DispatchesToSetup()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeIndexerSetup setup = new(true);
+		IndexerGetterAccess<int> access = new(1);
+
+		int callCount = 0;
+		int result = registry.ApplyIndexerGetter(access, setup, () => ++callCount, 0);
+
+		// FakeIndexerSetup.GetResult<TResult>(access, behavior, defaultValueGenerator) returns the generator's value.
+		await That(result).IsEqualTo(1);
+		await That(callCount).IsEqualTo(1);
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryScenarioTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryScenarioTests.cs
@@ -6,61 +6,21 @@ using Mockolate.Setup;
 
 namespace Mockolate.Internal.Tests.Registry;
 
-/// <summary>
-///     Coverage for the scenario-scoped branches in <c>MockRegistry.Interactions.cs</c> — the
-///     <c>!string.IsNullOrEmpty(Scenario) &amp;&amp; Setup.TryGetScenario(...)</c> guards on
-///     <c>GetMethodSetups</c>, <c>GetIndexerSetup</c>, and the lazy-default <c>ApplyIndexerGetter</c>
-///     overload's <c>setup is not null</c> path.
-/// </summary>
 public sealed class MockRegistryScenarioTests
 {
 	[Fact]
-	public async Task GetMethodSetups_WithActiveScenarioAndScopedSetup_YieldsScopedThenGlobal()
+	public async Task ApplyIndexerGetter_WithLazyDefault_AndNonNullSetup_DispatchesToSetup()
 	{
 		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-		FakeMethodSetup global = new();
-		FakeMethodSetup scoped = new();
-		registry.Setup.Methods.Add(global);
-		registry.Setup.GetOrCreateScenario("a").Methods.Add(scoped);
+		FakeIndexerSetup setup = new(true);
+		IndexerGetterAccess<int> access = new(1);
 
-		registry.TransitionTo("a");
+		int callCount = 0;
+		int result = registry.ApplyIndexerGetter(access, setup, () => ++callCount, 0);
 
-		List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
-
-		await That(setups).HasCount(2);
-		await That(setups[0]).IsSameAs(scoped);
-		await That(setups[1]).IsSameAs(global);
-	}
-
-	[Fact]
-	public async Task GetMethodSetups_WithActiveScenarioButNoScopedBucket_FallsBackToGlobal()
-	{
-		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-		FakeMethodSetup global = new();
-		registry.Setup.Methods.Add(global);
-
-		registry.TransitionTo("never-registered");
-
-		List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
-
-		await That(setups).HasCount(1);
-		await That(setups[0]).IsSameAs(global);
-	}
-
-	[Fact]
-	public async Task GetIndexerSetup_ByPredicate_WithActiveScenarioButPredicateRejectsScoped_FallsBackToGlobal()
-	{
-		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-		FakeIndexerSetup global = new(true);
-		FakeIndexerSetup scoped = new(true);
-		registry.Setup.Indexers.Add(global);
-		registry.Setup.GetOrCreateScenario("a").Indexers.Add(scoped);
-
-		registry.TransitionTo("a");
-
-		IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(s => ReferenceEquals(s, global));
-
-		await That(result).IsSameAs(global);
+		// FakeIndexerSetup.GetResult<TResult>(access, behavior, defaultValueGenerator) returns the generator's value.
+		await That(result).IsEqualTo(1);
+		await That(callCount).IsEqualTo(1);
 	}
 
 	[Fact]
@@ -96,17 +56,51 @@ public sealed class MockRegistryScenarioTests
 	}
 
 	[Fact]
-	public async Task ApplyIndexerGetter_WithLazyDefault_AndNonNullSetup_DispatchesToSetup()
+	public async Task GetIndexerSetup_ByPredicate_WithActiveScenarioButPredicateRejectsScoped_FallsBackToGlobal()
 	{
 		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-		FakeIndexerSetup setup = new(true);
-		IndexerGetterAccess<int> access = new(1);
+		FakeIndexerSetup global = new(true);
+		FakeIndexerSetup scoped = new(true);
+		registry.Setup.Indexers.Add(global);
+		registry.Setup.GetOrCreateScenario("a").Indexers.Add(scoped);
 
-		int callCount = 0;
-		int result = registry.ApplyIndexerGetter(access, setup, () => ++callCount, 0);
+		registry.TransitionTo("a");
 
-		// FakeIndexerSetup.GetResult<TResult>(access, behavior, defaultValueGenerator) returns the generator's value.
-		await That(result).IsEqualTo(1);
-		await That(callCount).IsEqualTo(1);
+		IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(s => ReferenceEquals(s, global));
+
+		await That(result).IsSameAs(global);
+	}
+
+	[Fact]
+	public async Task GetMethodSetups_WithActiveScenarioAndScopedSetup_YieldsScopedThenGlobal()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeMethodSetup global = new();
+		FakeMethodSetup scoped = new();
+		registry.Setup.Methods.Add(global);
+		registry.Setup.GetOrCreateScenario("a").Methods.Add(scoped);
+
+		registry.TransitionTo("a");
+
+		List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+		await That(setups).HasCount(2);
+		await That(setups[0]).IsSameAs(scoped);
+		await That(setups[1]).IsSameAs(global);
+	}
+
+	[Fact]
+	public async Task GetMethodSetups_WithActiveScenarioButNoScopedBucket_FallsBackToGlobal()
+	{
+		MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+		FakeMethodSetup global = new();
+		registry.Setup.Methods.Add(global);
+
+		registry.TransitionTo("never-registered");
+
+		List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+		await That(setups).HasCount(1);
+		await That(setups[0]).IsSameAs(global);
 	}
 }

--- a/Tests/Mockolate.Internal.Tests/Verify/CountSourceTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Verify/CountSourceTests.cs
@@ -1,0 +1,352 @@
+using Mockolate.Interactions;
+using Mockolate.Parameters;
+using Mockolate.Verify;
+
+namespace Mockolate.Internal.Tests.Verify;
+
+/// <summary>
+///     Direct coverage for the count-source classes in <c>MethodCountSources.cs</c>. Each test takes a
+///     <see cref="MockRegistry" /> wired with a typed <c>FastMockInteractions</c> buffer, drives the
+///     allocation-free fast path via the registry's <c>Verify*Typed</c> helpers, and runs both the
+///     matching <c>Count()</c> path (via <c>.Once()</c>/<c>.Exactly(n)</c>) and, for method sources,
+///     the <c>CountAll()</c> path (via <c>.AnyParameters().Exactly(n)</c>).
+/// </summary>
+public class CountSourceTests
+{
+	[Fact]
+	public async Task Method0_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod0Buffer buffer = store.InstallMethod(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo");
+		buffer.Append("Foo");
+		buffer.Append("Foo");
+
+		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Exactly(3);
+		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").AnyParameters().Exactly(3);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task Method1_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo", 1);
+		buffer.Append("Foo", 2);
+
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1), () => "Foo(1)").Once();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99), () => "Foo(99)").AnyParameters().Exactly(2);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task Method2_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod2Buffer<int, string> buffer = store.InstallMethod<int, string>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo", 1, "a");
+		buffer.Append("Foo", 2, "b");
+
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"), () => "Foo(1, a)").Once();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.Is<string>("z"), () => "Foo(99, z)").AnyParameters().Exactly(2);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task Method3_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo", 1, "a", true);
+		buffer.Append("Foo", 2, "b", false);
+		buffer.Append("Foo", 1, "a", true);
+
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			() => "Foo(1, a, true)").Twice();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.Is<string>("z"),
+			(IParameterMatch<bool>)It.Is(false),
+			() => "Foo(99, z, false)").AnyParameters().Exactly(3);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task Method4_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo", 1, "a", true, 1.5);
+		buffer.Append("Foo", 2, "b", false, 2.5);
+
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(1.5),
+			() => "Foo(1, a, true, 1.5)").Once();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.Is<string>("z"),
+			(IParameterMatch<bool>)It.Is(false),
+			(IParameterMatch<double>)It.Is(0.0),
+			() => "Foo(99, z, false, 0.0)").AnyParameters().Exactly(2);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task PropertyGetter_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("P");
+		buffer.Append("P");
+
+		registry.VerifyPropertyTyped(new object(), 0, "P").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task PropertySetter_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("P", 1);
+		buffer.Append("P", 2);
+		buffer.Append("P", 1);
+
+		registry.VerifyPropertyTyped(new object(), 0, "P", (IParameterMatch<int>)It.Is(1)).Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerGetter1_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5);
+		buffer.Append(6);
+		buffer.Append(5);
+
+		registry.IndexerGotTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5), () => "(5)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerGetter2_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5, "a");
+		buffer.Append(6, "b");
+		buffer.Append(5, "a");
+
+		registry.IndexerGotTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			() => "(5, a)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerGetter3_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerGetter<int, string, bool>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5, "a", true);
+		buffer.Append(6, "b", false);
+		buffer.Append(5, "a", true);
+
+		registry.IndexerGotTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			() => "(5, a, true)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerGetter4_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5, "a", true, 1.5);
+		buffer.Append(6, "b", false, 2.5);
+		buffer.Append(5, "a", true, 1.5);
+
+		registry.IndexerGotTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(1.5),
+			() => "(5, a, true, 1.5)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerSetter1_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5, "v");
+		buffer.Append(6, "w");
+		buffer.Append(5, "v");
+
+		registry.IndexerSetTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			(IParameterMatch<string>)It.Is<string>("v"),
+			() => "(5)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerSetter2_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, double> buffer =
+			store.InstallIndexerSetter<int, string, double>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5, "a", 1.5);
+		buffer.Append(6, "b", 2.5);
+		buffer.Append(5, "a", 1.5);
+
+		registry.IndexerSetTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<double>)It.Is(1.5),
+			() => "(5, a)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerSetter3_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5, "a", true, 1.5);
+		buffer.Append(6, "b", false, 2.5);
+		buffer.Append(5, "a", true, 1.5);
+
+		registry.IndexerSetTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(1.5),
+			() => "(5, a, true)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task IndexerSetter4_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double, long> buffer =
+			store.InstallIndexerSetter<int, string, bool, double, long>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append(5, "a", true, 1.5, 100L);
+		buffer.Append(6, "b", false, 2.5, 200L);
+		buffer.Append(5, "a", true, 1.5, 100L);
+
+		registry.IndexerSetTyped(new object(), 0,
+			(IParameterMatch<int>)It.Is(5),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(1.5),
+			(IParameterMatch<long>)It.Is(100L),
+			() => "(5, a, true, 1.5)").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task EventCountSource_Subscribe_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventSubscribe(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		System.Reflection.MethodInfo m = typeof(CountSourceTests).GetMethod(
+			nameof(EventCountSource_Subscribe_Count_IsExercised))!;
+		buffer.Append("OnFoo", null, m);
+		buffer.Append("OnFoo", null, m);
+
+		registry.SubscribedToTyped(new object(), 0, "OnFoo").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task EventCountSource_Unsubscribe_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		System.Reflection.MethodInfo m = typeof(CountSourceTests).GetMethod(
+			nameof(EventCountSource_Unsubscribe_Count_IsExercised))!;
+		buffer.Append("OnFoo", null, m);
+		buffer.Append("OnFoo", null, m);
+		buffer.Append("OnFoo", null, m);
+
+		registry.UnsubscribedFromTyped(new object(), 0, "OnFoo").Exactly(3);
+
+		await That(true).IsTrue();
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Verify/CountSourceTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Verify/CountSourceTests.cs
@@ -1,152 +1,43 @@
+using System.Reflection;
 using Mockolate.Interactions;
 using Mockolate.Parameters;
 using Mockolate.Verify;
 
 namespace Mockolate.Internal.Tests.Verify;
 
-/// <summary>
-///     Direct coverage for the count-source classes in <c>MethodCountSources.cs</c>. Each test takes a
-///     <see cref="MockRegistry" /> wired with a typed <c>FastMockInteractions</c> buffer, drives the
-///     allocation-free fast path via the registry's <c>Verify*Typed</c> helpers, and runs both the
-///     matching <c>Count()</c> path (via <c>.Once()</c>/<c>.Exactly(n)</c>) and, for method sources,
-///     the <c>CountAll()</c> path (via <c>.AnyParameters().Exactly(n)</c>).
-/// </summary>
 public class CountSourceTests
 {
 	[Fact]
-	public async Task Method0_FastPath_Count_AndCountAll_AreExercised()
+	public async Task EventCountSource_Subscribe_Count_IsExercised()
 	{
 		FastMockInteractions store = new(1);
-		FastMethod0Buffer buffer = store.InstallMethod(0);
+		FastEventBuffer buffer = store.InstallEventSubscribe(0);
 		MockRegistry registry = new(MockBehavior.Default, store);
 
-		buffer.Append("Foo");
-		buffer.Append("Foo");
-		buffer.Append("Foo");
+		MethodInfo m = typeof(CountSourceTests).GetMethod(
+			nameof(EventCountSource_Subscribe_Count_IsExercised))!;
+		buffer.Append("OnFoo", null, m);
+		buffer.Append("OnFoo", null, m);
 
-		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Exactly(3);
-		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").AnyParameters().Exactly(3);
+		registry.SubscribedToTyped(new object(), 0, "OnFoo").Twice();
 
 		await That(true).IsTrue();
 	}
 
 	[Fact]
-	public async Task Method1_FastPath_Count_AndCountAll_AreExercised()
+	public async Task EventCountSource_Unsubscribe_Count_IsExercised()
 	{
 		FastMockInteractions store = new(1);
-		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+		FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
 		MockRegistry registry = new(MockBehavior.Default, store);
 
-		buffer.Append("Foo", 1);
-		buffer.Append("Foo", 2);
+		MethodInfo m = typeof(CountSourceTests).GetMethod(
+			nameof(EventCountSource_Unsubscribe_Count_IsExercised))!;
+		buffer.Append("OnFoo", null, m);
+		buffer.Append("OnFoo", null, m);
+		buffer.Append("OnFoo", null, m);
 
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(1), () => "Foo(1)").Once();
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(99), () => "Foo(99)").AnyParameters().Exactly(2);
-
-		await That(true).IsTrue();
-	}
-
-	[Fact]
-	public async Task Method2_FastPath_Count_AndCountAll_AreExercised()
-	{
-		FastMockInteractions store = new(1);
-		FastMethod2Buffer<int, string> buffer = store.InstallMethod<int, string>(0);
-		MockRegistry registry = new(MockBehavior.Default, store);
-
-		buffer.Append("Foo", 1, "a");
-		buffer.Append("Foo", 2, "b");
-
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(1),
-			(IParameterMatch<string>)It.Is<string>("a"), () => "Foo(1, a)").Once();
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(99),
-			(IParameterMatch<string>)It.Is<string>("z"), () => "Foo(99, z)").AnyParameters().Exactly(2);
-
-		await That(true).IsTrue();
-	}
-
-	[Fact]
-	public async Task Method3_FastPath_Count_AndCountAll_AreExercised()
-	{
-		FastMockInteractions store = new(1);
-		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
-		MockRegistry registry = new(MockBehavior.Default, store);
-
-		buffer.Append("Foo", 1, "a", true);
-		buffer.Append("Foo", 2, "b", false);
-		buffer.Append("Foo", 1, "a", true);
-
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(1),
-			(IParameterMatch<string>)It.Is<string>("a"),
-			(IParameterMatch<bool>)It.Is(true),
-			() => "Foo(1, a, true)").Twice();
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(99),
-			(IParameterMatch<string>)It.Is<string>("z"),
-			(IParameterMatch<bool>)It.Is(false),
-			() => "Foo(99, z, false)").AnyParameters().Exactly(3);
-
-		await That(true).IsTrue();
-	}
-
-	[Fact]
-	public async Task Method4_FastPath_Count_AndCountAll_AreExercised()
-	{
-		FastMockInteractions store = new(1);
-		FastMethod4Buffer<int, string, bool, double> buffer =
-			store.InstallMethod<int, string, bool, double>(0);
-		MockRegistry registry = new(MockBehavior.Default, store);
-
-		buffer.Append("Foo", 1, "a", true, 1.5);
-		buffer.Append("Foo", 2, "b", false, 2.5);
-
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(1),
-			(IParameterMatch<string>)It.Is<string>("a"),
-			(IParameterMatch<bool>)It.Is(true),
-			(IParameterMatch<double>)It.Is(1.5),
-			() => "Foo(1, a, true, 1.5)").Once();
-		registry.VerifyMethod(new object(), 0, "Foo",
-			(IParameterMatch<int>)It.Is(99),
-			(IParameterMatch<string>)It.Is<string>("z"),
-			(IParameterMatch<bool>)It.Is(false),
-			(IParameterMatch<double>)It.Is(0.0),
-			() => "Foo(99, z, false, 0.0)").AnyParameters().Exactly(2);
-
-		await That(true).IsTrue();
-	}
-
-	[Fact]
-	public async Task PropertyGetter_FastPath_Count_IsExercised()
-	{
-		FastMockInteractions store = new(1);
-		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
-		MockRegistry registry = new(MockBehavior.Default, store);
-
-		buffer.Append("P");
-		buffer.Append("P");
-
-		registry.VerifyPropertyTyped(new object(), 0, "P").Twice();
-
-		await That(true).IsTrue();
-	}
-
-	[Fact]
-	public async Task PropertySetter_FastPath_Count_IsExercised()
-	{
-		FastMockInteractions store = new(1);
-		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
-		MockRegistry registry = new(MockBehavior.Default, store);
-
-		buffer.Append("P", 1);
-		buffer.Append("P", 2);
-		buffer.Append("P", 1);
-
-		registry.VerifyPropertyTyped(new object(), 0, "P", (IParameterMatch<int>)It.Is(1)).Twice();
+		registry.UnsubscribedFromTyped(new object(), 0, "OnFoo").Exactly(3);
 
 		await That(true).IsTrue();
 	}
@@ -316,36 +207,139 @@ public class CountSourceTests
 	}
 
 	[Fact]
-	public async Task EventCountSource_Subscribe_Count_IsExercised()
+	public async Task Method0_FastPath_Count_AndCountAll_AreExercised()
 	{
 		FastMockInteractions store = new(1);
-		FastEventBuffer buffer = store.InstallEventSubscribe(0);
+		FastMethod0Buffer buffer = store.InstallMethod(0);
 		MockRegistry registry = new(MockBehavior.Default, store);
 
-		System.Reflection.MethodInfo m = typeof(CountSourceTests).GetMethod(
-			nameof(EventCountSource_Subscribe_Count_IsExercised))!;
-		buffer.Append("OnFoo", null, m);
-		buffer.Append("OnFoo", null, m);
+		buffer.Append("Foo");
+		buffer.Append("Foo");
+		buffer.Append("Foo");
 
-		registry.SubscribedToTyped(new object(), 0, "OnFoo").Twice();
+		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Exactly(3);
+		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").AnyParameters().Exactly(3);
 
 		await That(true).IsTrue();
 	}
 
 	[Fact]
-	public async Task EventCountSource_Unsubscribe_Count_IsExercised()
+	public async Task Method1_FastPath_Count_AndCountAll_AreExercised()
 	{
 		FastMockInteractions store = new(1);
-		FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
 		MockRegistry registry = new(MockBehavior.Default, store);
 
-		System.Reflection.MethodInfo m = typeof(CountSourceTests).GetMethod(
-			nameof(EventCountSource_Unsubscribe_Count_IsExercised))!;
-		buffer.Append("OnFoo", null, m);
-		buffer.Append("OnFoo", null, m);
-		buffer.Append("OnFoo", null, m);
+		buffer.Append("Foo", 1);
+		buffer.Append("Foo", 2);
 
-		registry.UnsubscribedFromTyped(new object(), 0, "OnFoo").Exactly(3);
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1), () => "Foo(1)").Once();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99), () => "Foo(99)").AnyParameters().Exactly(2);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task Method2_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod2Buffer<int, string> buffer = store.InstallMethod<int, string>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo", 1, "a");
+		buffer.Append("Foo", 2, "b");
+
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"), () => "Foo(1, a)").Once();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.Is<string>("z"), () => "Foo(99, z)").AnyParameters().Exactly(2);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task Method3_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo", 1, "a", true);
+		buffer.Append("Foo", 2, "b", false);
+		buffer.Append("Foo", 1, "a", true);
+
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			() => "Foo(1, a, true)").Twice();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.Is<string>("z"),
+			(IParameterMatch<bool>)It.Is(false),
+			() => "Foo(99, z, false)").AnyParameters().Exactly(3);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task Method4_FastPath_Count_AndCountAll_AreExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("Foo", 1, "a", true, 1.5);
+		buffer.Append("Foo", 2, "b", false, 2.5);
+
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(1.5),
+			() => "Foo(1, a, true, 1.5)").Once();
+		registry.VerifyMethod(new object(), 0, "Foo",
+			(IParameterMatch<int>)It.Is(99),
+			(IParameterMatch<string>)It.Is<string>("z"),
+			(IParameterMatch<bool>)It.Is(false),
+			(IParameterMatch<double>)It.Is(0.0),
+			() => "Foo(99, z, false, 0.0)").AnyParameters().Exactly(2);
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task PropertyGetter_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("P");
+		buffer.Append("P");
+
+		registry.VerifyPropertyTyped(new object(), 0, "P").Twice();
+
+		await That(true).IsTrue();
+	}
+
+	[Fact]
+	public async Task PropertySetter_FastPath_Count_IsExercised()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		buffer.Append("P", 1);
+		buffer.Append("P", 2);
+		buffer.Append("P", 1);
+
+		registry.VerifyPropertyTyped(new object(), 0, "P", (IParameterMatch<int>)It.Is(1)).Twice();
 
 		await That(true).IsTrue();
 	}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
@@ -1,0 +1,199 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Mockolate.SourceGenerators.Entities;
+using Mockolate.SourceGenerators.Internals;
+
+namespace Mockolate.SourceGenerators.Tests;
+
+/// <summary>
+///     Direct coverage for the <c>Equals</c>/<c>GetHashCode</c> implementations on
+///     <see cref="RefStructAggregate" /> and <see cref="NamedMock" />. Roslyn's incremental
+///     generator pipeline does invoke these (during cache lookup), but coverage instrumentation
+///     of those internal Roslyn calls is unreliable — these unit tests pin the contract.
+/// </summary>
+public sealed class MockGeneratorEqualityTests
+{
+	public sealed class RefStructAggregateTests
+	{
+		[Fact]
+		public async Task Equals_WithEqualMethodAndIndexerSetups_IsTrue()
+		{
+			RefStructAggregate a = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false), new MethodSetupKey(6, true)]),
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false)]));
+			RefStructAggregate b = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false), new MethodSetupKey(6, true)]),
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false)]));
+
+			await That(a.Equals(b)).IsTrue();
+			await That(a.Equals((object)b)).IsTrue();
+			await That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferingMethodSetups_IsFalse()
+		{
+			RefStructAggregate a = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false)]),
+				new EquatableArray<RefStructIndexerSetup>([]));
+			RefStructAggregate b = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(6, false)]),
+				new EquatableArray<RefStructIndexerSetup>([]));
+
+			await That(a.Equals(b)).IsFalse();
+			await That(a.Equals((object)b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferingIndexerSetups_IsFalse()
+		{
+			RefStructAggregate a = new(
+				new EquatableArray<MethodSetupKey>([]),
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false)]));
+			RefStructAggregate b = new(
+				new EquatableArray<MethodSetupKey>([]),
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, false, true)]));
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithNull_IsFalse()
+		{
+			RefStructAggregate a = new(
+				new EquatableArray<MethodSetupKey>([]),
+				new EquatableArray<RefStructIndexerSetup>([]));
+
+			await That(a.Equals(null)).IsFalse();
+			await That(a.Equals((object?)null)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferentType_IsFalse()
+		{
+			RefStructAggregate a = new(
+				new EquatableArray<MethodSetupKey>([]),
+				new EquatableArray<RefStructIndexerSetup>([]));
+
+			await That(a.Equals((object)"not an aggregate")).IsFalse();
+		}
+	}
+
+	public sealed class NamedMockTests
+	{
+		private static MockClass CreateMockClass(string source = "public interface IFoo { void M(); }",
+			string typeName = "IFoo")
+		{
+			SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+			CSharpCompilation compilation = CSharpCompilation.Create("test",
+				[tree],
+				[MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+			INamedTypeSymbol symbol = compilation.GetTypeByMetadataName(typeName)!;
+			return new MockClass([symbol], compilation.Assembly);
+		}
+
+		[Fact]
+		public async Task Equals_WithIdenticalNamedMock_IsTrue()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("File1", "Parent1", mc, null);
+			NamedMock b = new("File1", "Parent1", mc, null);
+
+			await That(a.Equals(b)).IsTrue();
+			await That(a.Equals((object)b)).IsTrue();
+			await That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
+		}
+
+		[Fact]
+		public async Task Equals_WithNullOther_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("F", "P", mc, null);
+
+			await That(a.Equals((NamedMock?)null)).IsFalse();
+			await That(a.Equals((object?)null)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferentFileName_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("File1", "Parent", mc, null);
+			NamedMock b = new("File2", "Parent", mc, null);
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferentParentName_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("File", "Parent1", mc, null);
+			NamedMock b = new("File", "Parent2", mc, null);
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferentMockClass_IsFalse()
+		{
+			MockClass mcA = CreateMockClass();
+			MockClass mcB = CreateMockClass(
+				"public interface IBar { void M(); }",
+				"IBar");
+			NamedMock a = new("File", "Parent", mcA, null);
+			NamedMock b = new("File", "Parent", mcB, null);
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WhenAdditionalClassesPresentOnOneAndNullOnOther_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock withAdditional = new("F", "P", mc,
+				new EquatableArray<NamedClass>([new NamedClass("X", mc)]));
+			NamedMock withNull = new("F", "P", mc, null);
+
+			await That(withAdditional.Equals(withNull)).IsFalse();
+			await That(withNull.Equals(withAdditional)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WhenBothAdditionalClassesNull_IsTrue()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("F", "P", mc, null);
+			NamedMock b = new("F", "P", mc, null);
+
+			await That(a.Equals(b)).IsTrue();
+		}
+
+		[Fact]
+		public async Task Equals_WhenAdditionalClassesDiffer_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("F", "P", mc,
+				new EquatableArray<NamedClass>([new NamedClass("A", mc)]));
+			NamedMock b = new("F", "P", mc,
+				new EquatableArray<NamedClass>([new NamedClass("B", mc)]));
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task GetHashCode_IncludesAdditionalClasses()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock withAdditional = new("F", "P", mc,
+				new EquatableArray<NamedClass>([new NamedClass("X", mc)]));
+			NamedMock withNull = new("F", "P", mc, null);
+
+			// Different additionalClasses should produce different hash codes — can't guarantee
+			// strict inequality, but the field is part of the hash so at minimum it must run.
+			_ = withAdditional.GetHashCode();
+			_ = withNull.GetHashCode();
+			await That(true).IsTrue();
+		}
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
@@ -16,32 +16,14 @@ public sealed class MockGeneratorEqualityTests
 	public sealed class RefStructAggregateTests
 	{
 		[Fact]
-		public async Task Equals_WithEqualMethodAndIndexerSetups_IsTrue()
+		public async Task Equals_WithDifferentType_IsFalse()
 		{
 			RefStructAggregate a = new(
-				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false), new MethodSetupKey(6, true)]),
-				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false)]));
-			RefStructAggregate b = new(
-				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false), new MethodSetupKey(6, true)]),
-				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false)]));
-
-			await That(a.Equals(b)).IsTrue();
-			await That(a.Equals((object)b)).IsTrue();
-			await That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
-		}
-
-		[Fact]
-		public async Task Equals_WithDifferingMethodSetups_IsFalse()
-		{
-			RefStructAggregate a = new(
-				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false)]),
-				new EquatableArray<RefStructIndexerSetup>([]));
-			RefStructAggregate b = new(
-				new EquatableArray<MethodSetupKey>([new MethodSetupKey(6, false)]),
+				new EquatableArray<MethodSetupKey>([]),
 				new EquatableArray<RefStructIndexerSetup>([]));
 
-			await That(a.Equals(b)).IsFalse();
-			await That(a.Equals((object)b)).IsFalse();
+			// ReSharper disable once SuspiciousTypeConversion.Global
+			await That(a.Equals("not an aggregate")).IsFalse();
 		}
 
 		[Fact]
@@ -49,12 +31,41 @@ public sealed class MockGeneratorEqualityTests
 		{
 			RefStructAggregate a = new(
 				new EquatableArray<MethodSetupKey>([]),
-				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false)]));
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false),]));
 			RefStructAggregate b = new(
 				new EquatableArray<MethodSetupKey>([]),
-				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, false, true)]));
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, false, true),]));
 
 			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferingMethodSetups_IsFalse()
+		{
+			RefStructAggregate a = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false),]),
+				new EquatableArray<RefStructIndexerSetup>([]));
+			RefStructAggregate b = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(6, false),]),
+				new EquatableArray<RefStructIndexerSetup>([]));
+
+			await That(a.Equals(b)).IsFalse();
+			await That(a.Equals((object)b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithEqualMethodAndIndexerSetups_IsTrue()
+		{
+			RefStructAggregate a = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false), new MethodSetupKey(6, true),]),
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false),]));
+			RefStructAggregate b = new(
+				new EquatableArray<MethodSetupKey>([new MethodSetupKey(5, false), new MethodSetupKey(6, true),]),
+				new EquatableArray<RefStructIndexerSetup>([new RefStructIndexerSetup(5, true, false),]));
+
+			await That(a.Equals(b)).IsTrue();
+			await That(a.Equals((object)b)).IsTrue();
+			await That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
 		}
 
 		[Fact]
@@ -65,31 +76,77 @@ public sealed class MockGeneratorEqualityTests
 				new EquatableArray<RefStructIndexerSetup>([]));
 
 			await That(a.Equals(null)).IsFalse();
-			await That(a.Equals((object?)null)).IsFalse();
-		}
-
-		[Fact]
-		public async Task Equals_WithDifferentType_IsFalse()
-		{
-			RefStructAggregate a = new(
-				new EquatableArray<MethodSetupKey>([]),
-				new EquatableArray<RefStructIndexerSetup>([]));
-
-			await That(a.Equals((object)"not an aggregate")).IsFalse();
+			await That(a!.Equals((object?)null)).IsFalse();
 		}
 	}
 
 	public sealed class NamedMockTests
 	{
-		private static MockClass CreateMockClass(string source = "public interface IFoo { void M(); }",
-			string typeName = "IFoo")
+		[Fact]
+		public async Task Equals_WhenAdditionalClassesDiffer_IsFalse()
 		{
-			SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
-			CSharpCompilation compilation = CSharpCompilation.Create("test",
-				[tree],
-				[MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
-			INamedTypeSymbol symbol = compilation.GetTypeByMetadataName(typeName)!;
-			return new MockClass([symbol], compilation.Assembly);
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("F", "P", mc,
+				new EquatableArray<NamedClass>([new NamedClass("A", mc),]));
+			NamedMock b = new("F", "P", mc,
+				new EquatableArray<NamedClass>([new NamedClass("B", mc),]));
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WhenAdditionalClassesPresentOnOneAndNullOnOther_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock withAdditional = new("F", "P", mc,
+				new EquatableArray<NamedClass>([new NamedClass("X", mc),]));
+			NamedMock withNull = new("F", "P", mc, null);
+
+			await That(withAdditional.Equals(withNull)).IsFalse();
+			await That(withNull.Equals(withAdditional)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WhenBothAdditionalClassesNull_IsTrue()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("F", "P", mc, null);
+			NamedMock b = new("F", "P", mc, null);
+
+			await That(a.Equals(b)).IsTrue();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferentFileName_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("File1", "Parent", mc, null);
+			NamedMock b = new("File2", "Parent", mc, null);
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferentMockClass_IsFalse()
+		{
+			MockClass mcA = CreateMockClass();
+			MockClass mcB = CreateMockClass(
+				"public interface IBar { void M(); }",
+				"IBar");
+			NamedMock a = new("File", "Parent", mcA, null);
+			NamedMock b = new("File", "Parent", mcB, null);
+
+			await That(a.Equals(b)).IsFalse();
+		}
+
+		[Fact]
+		public async Task Equals_WithDifferentParentName_IsFalse()
+		{
+			MockClass mc = CreateMockClass();
+			NamedMock a = new("File", "Parent1", mc, null);
+			NamedMock b = new("File", "Parent2", mc, null);
+
+			await That(a.Equals(b)).IsFalse();
 		}
 
 		[Fact]
@@ -110,75 +167,8 @@ public sealed class MockGeneratorEqualityTests
 			MockClass mc = CreateMockClass();
 			NamedMock a = new("F", "P", mc, null);
 
-			await That(a.Equals((NamedMock?)null)).IsFalse();
-			await That(a.Equals((object?)null)).IsFalse();
-		}
-
-		[Fact]
-		public async Task Equals_WithDifferentFileName_IsFalse()
-		{
-			MockClass mc = CreateMockClass();
-			NamedMock a = new("File1", "Parent", mc, null);
-			NamedMock b = new("File2", "Parent", mc, null);
-
-			await That(a.Equals(b)).IsFalse();
-		}
-
-		[Fact]
-		public async Task Equals_WithDifferentParentName_IsFalse()
-		{
-			MockClass mc = CreateMockClass();
-			NamedMock a = new("File", "Parent1", mc, null);
-			NamedMock b = new("File", "Parent2", mc, null);
-
-			await That(a.Equals(b)).IsFalse();
-		}
-
-		[Fact]
-		public async Task Equals_WithDifferentMockClass_IsFalse()
-		{
-			MockClass mcA = CreateMockClass();
-			MockClass mcB = CreateMockClass(
-				"public interface IBar { void M(); }",
-				"IBar");
-			NamedMock a = new("File", "Parent", mcA, null);
-			NamedMock b = new("File", "Parent", mcB, null);
-
-			await That(a.Equals(b)).IsFalse();
-		}
-
-		[Fact]
-		public async Task Equals_WhenAdditionalClassesPresentOnOneAndNullOnOther_IsFalse()
-		{
-			MockClass mc = CreateMockClass();
-			NamedMock withAdditional = new("F", "P", mc,
-				new EquatableArray<NamedClass>([new NamedClass("X", mc)]));
-			NamedMock withNull = new("F", "P", mc, null);
-
-			await That(withAdditional.Equals(withNull)).IsFalse();
-			await That(withNull.Equals(withAdditional)).IsFalse();
-		}
-
-		[Fact]
-		public async Task Equals_WhenBothAdditionalClassesNull_IsTrue()
-		{
-			MockClass mc = CreateMockClass();
-			NamedMock a = new("F", "P", mc, null);
-			NamedMock b = new("F", "P", mc, null);
-
-			await That(a.Equals(b)).IsTrue();
-		}
-
-		[Fact]
-		public async Task Equals_WhenAdditionalClassesDiffer_IsFalse()
-		{
-			MockClass mc = CreateMockClass();
-			NamedMock a = new("F", "P", mc,
-				new EquatableArray<NamedClass>([new NamedClass("A", mc)]));
-			NamedMock b = new("F", "P", mc,
-				new EquatableArray<NamedClass>([new NamedClass("B", mc)]));
-
-			await That(a.Equals(b)).IsFalse();
+			await That(a.Equals(null)).IsFalse();
+			await That(a!.Equals((object?)null)).IsFalse();
 		}
 
 		[Fact]
@@ -186,7 +176,7 @@ public sealed class MockGeneratorEqualityTests
 		{
 			MockClass mc = CreateMockClass();
 			NamedMock withAdditional = new("F", "P", mc,
-				new EquatableArray<NamedClass>([new NamedClass("X", mc)]));
+				new EquatableArray<NamedClass>([new NamedClass("X", mc),]));
 			NamedMock withNull = new("F", "P", mc, null);
 
 			// Different additionalClasses should produce different hash codes — can't guarantee
@@ -194,6 +184,17 @@ public sealed class MockGeneratorEqualityTests
 			_ = withAdditional.GetHashCode();
 			_ = withNull.GetHashCode();
 			await That(true).IsTrue();
+		}
+
+		private static MockClass CreateMockClass(string source = "public interface IFoo { void M(); }",
+			string typeName = "IFoo")
+		{
+			SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+			CSharpCompilation compilation = CSharpCompilation.Create("test",
+				[tree,],
+				[MetadataReference.CreateFromFile(typeof(object).Assembly.Location),]);
+			INamedTypeSymbol symbol = compilation.GetTypeByMetadataName(typeName)!;
+			return new MockClass([symbol,], compilation.Assembly);
 		}
 	}
 }


### PR DESCRIPTION
This pull request refactors and improves the handling of equatable arrays and verification count sources in the codebase. The main focus is on simplifying the usage of `EquatableArray<T>` by ensuring that its `AsArray()` method never returns null, and on clarifying the distinction between method and property/event count sources by introducing a new interface. Several code cleanups and namespace corrections are also included.

**EquatableArray improvements:**

* Changed the `AsArray()` method in `EquatableArray<T>` to always return a non-null array, returning `Array.Empty<T>()` when default-constructed. This eliminates the need for null checks throughout the codebase.
* Updated all usages of `AsArray()` to remove null-forgiveness operators and null checks, simplifying code in `MockGenerator.cs` and `Method.cs`.
* Corrected the namespace of `EquatableArray` from `Internals` to `Entities`.

**Verification count source refactoring:**

* Introduced a new interface `IFastMethodCountSource` for method-only count sources, separating them from property/event count sources.
* Updated all method count source classes to implement `IFastMethodCountSource` instead of `IFastCountSource`, clarifying their intended usage.
* Removed the `CountAll()` method from property, indexer, and event count source classes, as this method is now only relevant for method count sources.

**Other improvements:**

* Minor documentation and namespace cleanups, including a more explicit XML doc reference and removal of an unused using directive.
* Simplified logic in the generator to take advantage of the new `AsArray()` behavior.

These changes improve code safety, clarity, and maintainability by eliminating unnecessary null checks and clarifying interface responsibilities.