### PR TITLE
test: add unit tests for caching behavior in FastIndexer and FastProperty buffers

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
@@ -610,20 +610,21 @@ public class FastBufferBoxingAndUnverifiedTests
 	[Fact]
 	public async Task FastPropertyGetterBuffer_AppendString_LazyInitsAccessOnce()
 	{
-		// Kills the `_access ??= new PropertyGetterAccess(name)` -> `_access = new ...` mutation.
-		// With the mutation, every Append(name) call would create a fresh PropertyGetterAccess,
-		// so successive AppendBoxed calls would surface DIFFERENT singletons across records.
 		FastMockInteractions store = new(1);
 		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
 
 		buffer.Append("P");
+		List<(long Seq, IInteraction Interaction)> firstSnapshot = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(firstSnapshot);
+
 		buffer.Append("P");
+		List<(long Seq, IInteraction Interaction)> secondSnapshot = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(secondSnapshot);
 
-		List<(long Seq, IInteraction Interaction)> dest = [];
-		((IFastMemberBuffer)buffer).AppendBoxed(dest);
-
-		await That(dest).HasCount(2);
-		await That(dest[1].Interaction).IsSameAs(dest[0].Interaction);
+		await That(firstSnapshot).HasCount(1);
+		await That(secondSnapshot).HasCount(2);
+		await That(secondSnapshot[0].Interaction).IsSameAs(firstSnapshot[0].Interaction);
+		await That(secondSnapshot[1].Interaction).IsSameAs(firstSnapshot[0].Interaction);
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
@@ -72,12 +72,84 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastIndexerGetterBuffer1_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+
+		buffer.Append(7);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer1_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+
+		buffer.Append(7);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastIndexerGetterBuffer2_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
 			FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
 			return () => buffer.Append(1, "a");
 		});
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer2_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
+
+		buffer.Append(7, "k");
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer2_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
+
+		buffer.Append(7, "k");
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
 
 	[Fact]
 	public async Task FastIndexerGetterBuffer3_Append_ShouldRaiseInteractionAdded()
@@ -89,6 +161,44 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastIndexerGetterBuffer3_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerGetter<int, string, bool>(0);
+
+		buffer.Append(7, "k", true);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer3_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerGetter<int, string, bool>(0);
+
+		buffer.Append(7, "k", true);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastIndexerGetterBuffer4_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -98,12 +208,86 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastIndexerGetterBuffer4_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+
+		buffer.Append(7, "k", true, 3.14);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer4_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+
+		buffer.Append(7, "k", true, 3.14);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastIndexerSetterBuffer1_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
 			FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
 			return () => buffer.Append(1, "a");
 		});
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer1_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+
+		buffer.Append(7, "k");
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer1_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+
+		buffer.Append(7, "k");
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
 
 	[Fact]
 	public async Task FastIndexerSetterBuffer2_Append_ShouldRaiseInteractionAdded()
@@ -115,6 +299,44 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastIndexerSetterBuffer2_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerSetter<int, string, bool>(0);
+
+		buffer.Append(7, "k", true);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer2_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerSetter<int, string, bool>(0);
+
+		buffer.Append(7, "k", true);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastIndexerSetterBuffer3_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -124,6 +346,44 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastIndexerSetterBuffer3_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+
+		buffer.Append(7, "k", true, 3.14);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer3_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+
+		buffer.Append(7, "k", true, 3.14);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastIndexerSetterBuffer4_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -131,6 +391,44 @@ public class FastBufferBoxingAndUnverifiedTests
 				store.InstallIndexerSetter<int, string, bool, double, char>(0);
 			return () => buffer.Append(1, "a", true, 1.0, 'x');
 		});
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer4_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+			store.InstallIndexerSetter<int, string, bool, double, char>(0);
+
+		buffer.Append(7, "k", true, 3.14, 'z');
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer4_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+			store.InstallIndexerSetter<int, string, bool, double, char>(0);
+
+		buffer.Append(7, "k", true, 3.14, 'z');
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
 
 	[Fact]
 	public async Task FastMethod1Buffer_Append_ShouldRaiseInteractionAdded()
@@ -238,6 +536,24 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastPropertyGetterBuffer_Append_WithoutInstalledSingleton_ShouldIncludeFactoryGuidanceInMessage()
+	{
+		// Kills the `$"..."` -> `$""` string mutation on the InvalidOperationException message.
+		// The message points callers at the correct factory overload — without it, the failure
+		// is just an empty-string IOE, which is useless guidance.
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+
+		void Act()
+		{
+			buffer.Append();
+		}
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("*InstallPropertyGetter*").AsWildcard();
+	}
+
+	[Fact]
 	public async Task FastPropertyGetterBuffer_Append_WithoutInstalledSingleton_ShouldThrow()
 	{
 		FastMockInteractions store = new(1);
@@ -292,6 +608,25 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
+	public async Task FastPropertyGetterBuffer_AppendString_LazyInitsAccessOnce()
+	{
+		// Kills the `_access ??= new PropertyGetterAccess(name)` -> `_access = new ...` mutation.
+		// With the mutation, every Append(name) call would create a fresh PropertyGetterAccess,
+		// so successive AppendBoxed calls would surface DIFFERENT singletons across records.
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+
+		buffer.Append("P");
+		buffer.Append("P");
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(dest);
+
+		await That(dest).HasCount(2);
+		await That(dest[1].Interaction).IsSameAs(dest[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastPropertySetterBuffer_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -315,6 +650,66 @@ public class FastBufferBoxingAndUnverifiedTests
 		await That(first).HasCount(1);
 		await That(second).HasCount(1);
 		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastPropertySetterBuffer_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Mirrors the AppendBoxed caching test for the Unverified path so the `r.Boxed ??= new
+		// PropertySetterAccess<T>(...)` mutation is killed there as well.
+		FastMockInteractions store = new(1);
+		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+
+		buffer.Append("P", 5);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastPropertySetterBuffer_AppendBoxedUnverified_ShouldSkipMatchedSlots()
+	{
+		// Covers the AppendBoxedUnverified branch on the setter buffer (NoCoverage cluster).
+		FastMockInteractions store = new(1);
+		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+		buffer.Append("P", 1);
+		buffer.Append("P", 2);
+		buffer.Append("P", 3);
+
+		_ = buffer.ConsumeMatching((IParameterMatch<int>)It.Is(2));
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(2);
+		await That(((PropertySetterAccess<int>)dest[0].Interaction).Value).IsEqualTo(1);
+		await That(((PropertySetterAccess<int>)dest[1].Interaction).Value).IsEqualTo(3);
+	}
+
+	[Fact]
+	public async Task FastPropertySetterBuffer_ConsumeMatching_ShouldMarkSlotsVerified()
+	{
+		// Pins the `_storage.VerifiedUnderLock(slot) = true` write. With the mutation flipped
+		// to `false`, ConsumeMatching would still report matches but the slots would never be
+		// marked verified — so a second ConsumeMatching call would re-count the same records.
+		FastMockInteractions store = new(1);
+		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+		buffer.Append("P", 1);
+		buffer.Append("P", 1);
+
+		int firstPass = buffer.ConsumeMatching((IParameterMatch<int>)It.Is(1));
+		await That(firstPass).IsEqualTo(2);
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).IsEmpty();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
@@ -220,6 +220,32 @@ public class FastMockInteractionsTests
 	}
 
 	[Fact]
+	public async Task GetUnverifiedInteractions_AcrossBuffersWithInterleavedAppends_ReturnsInSequenceOrder()
+	{
+		// Pins the `unverified.Count > 1` boundary that gates the defensive Sort by Seq inside
+		// GetUnverifiedInteractions. With multiple buffers contributing in non-Seq order (each
+		// buffer is iterated in install order, but appends are interleaved across the global
+		// sequence), the Sort step is what restores chronological order. Mutations that skip the
+		// Sort (`< 1`, `<= 1`, `!(>1)`) leave the snapshot grouped by buffer, not by Seq.
+		FastMockInteractions sut = new(2);
+		FastMethod1Buffer<int> bufA = sut.InstallMethod<int>(0);
+		FastMethod1Buffer<int> bufB = sut.InstallMethod<int>(1);
+
+		bufA.Append("A", 0);
+		bufB.Append("B", 1);
+		bufA.Append("A", 2);
+		bufB.Append("B", 3);
+
+		IInteraction[] unverified = sut.GetUnverifiedInteractions().ToArray();
+
+		await That(unverified).HasCount(4);
+		await That(((MethodInvocation<int>)unverified[0]).Parameter1).IsEqualTo(0);
+		await That(((MethodInvocation<int>)unverified[1]).Parameter1).IsEqualTo(1);
+		await That(((MethodInvocation<int>)unverified[2]).Parameter1).IsEqualTo(2);
+		await That(((MethodInvocation<int>)unverified[3]).Parameter1).IsEqualTo(3);
+	}
+
+	[Fact]
 	public async Task GetUnverifiedInteractions_AcrossMultipleBuffers_ShouldUnionFastAndSlowVerifications()
 	{
 		FastMockInteractions sut = new(2);
@@ -457,6 +483,24 @@ public class FastMockInteractionsTests
 		buffer.Append("Foo");
 		MethodInvocation appended = (MethodInvocation)sut.Single();
 		((IMockInteractions)sut).Verified([appended,]);
+
+		await That(sut.GetUnverifiedInteractions()).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Verified_OnSecondCallWithDifferentItems_PreservesPreviouslyVerifiedItems()
+	{
+		// Pins the `_verified ??= []` lazy-init in Verified(). With the assignment turned into a
+		// plain `_verified = []`, the second call would reset the verified set, so the first
+		// call's entry would re-surface as "unverified".
+		FastMockInteractions sut = new(1);
+		FastMethod0Buffer buffer = sut.InstallMethod(0);
+		buffer.Append("first");
+		buffer.Append("second");
+		List<IInteraction> all = [..sut,];
+
+		((IMockInteractions)sut).Verified([all[0],]);
+		((IMockInteractions)sut).Verified([all[1],]);
 
 		await That(sut.GetUnverifiedInteractions()).IsEmpty();
 	}

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Mockolate.Exceptions;
@@ -856,6 +858,67 @@ public sealed class MockRegistryTests
 			bool result = registry.SetProperty("P", 42);
 
 			await That(result).IsFalse();
+		}
+	}
+
+	public sealed class TryGetBufferTests
+	{
+		[Fact]
+		public async Task VerifyMethodTyped_WithNonFastInteractions_ShouldFallToSlowPath()
+		{
+			// Pins the `Interactions is FastMockInteractions` type-pattern guard at the top of
+			// TryGetBuffer. With a non-fast IMockInteractions implementation, the fast-path branch
+			// must short-circuit and the verification must succeed via the slow path. (Lives in the
+			// internal test project because the custom IMockInteractions implementation needs to
+			// satisfy the internal `Verified` contract.)
+			NonFastInteractions store = new();
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Never();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		private sealed class NonFastInteractions : IMockInteractions
+		{
+			private readonly List<IInteraction> _items = new();
+
+			public bool SkipInteractionRecording => false;
+
+			public int Count => _items.Count;
+
+			public event EventHandler? InteractionAdded
+			{
+				add { }
+				remove { }
+			}
+
+			public event EventHandler? OnClearing
+			{
+				add { }
+				remove { }
+			}
+
+			public TInteraction RegisterInteraction<TInteraction>(TInteraction interaction)
+				where TInteraction : IInteraction
+			{
+				_items.Add(interaction);
+				return interaction;
+			}
+
+			public IReadOnlyCollection<IInteraction> GetUnverifiedInteractions()
+				=> _items;
+
+			void IMockInteractions.Verified(IEnumerable<IInteraction> interactions) { }
+
+			public void Clear() => _items.Clear();
+
+			public IEnumerator<IInteraction> GetEnumerator() => _items.GetEnumerator();
+
+			IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
 		}
 	}
 }

--- a/Tests/Mockolate.Internal.Tests/Verify/MethodCountSourcesTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Verify/MethodCountSourcesTests.cs
@@ -1,0 +1,291 @@
+using System.Reflection;
+using Mockolate.Interactions;
+using Mockolate.Parameters;
+using Mockolate.Verify;
+
+namespace Mockolate.Internal.Tests.Verify;
+
+public class MethodCountSourcesTests
+{
+	[Fact]
+	public async Task EventCountSource_ShouldReturnSubscribeCount()
+	{
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventSubscribe(0);
+		MethodInfo handler = typeof(MethodCountSourcesTests).GetMethod(
+			nameof(EventCountSource_ShouldReturnSubscribeCount))!;
+		buffer.Append("E", null, handler);
+		buffer.Append("E", null, handler);
+
+		EventCountSource source = new(buffer);
+
+		await That(source.CountAll()).IsEqualTo(2);
+		await That(source.Count()).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerGetter1CountSource_ShouldHonorKeyMatcher()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+		buffer.Append(1);
+		buffer.Append(2);
+		buffer.Append(1);
+
+		IndexerGetter1CountSource<int> source = new(buffer, (IParameterMatch<int>)It.Is(1));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task IndexerGetter2CountSource_ShouldHonorBothMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
+		buffer.Append(1, "a");
+		buffer.Append(2, "a");
+		buffer.Append(1, "b");
+
+		IndexerGetter2CountSource<int, string> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task IndexerGetter3CountSource_ShouldHonorAllThreeMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerGetter<int, string, bool>(0);
+		buffer.Append(1, "a", true);
+		buffer.Append(1, "a", false);
+		buffer.Append(2, "a", true);
+
+		IndexerGetter3CountSource<int, string, bool> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task IndexerGetter4CountSource_ShouldHonorAllFourMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+		buffer.Append(1, "a", true, 0.5);
+		buffer.Append(1, "a", true, 1.5);
+		buffer.Append(2, "a", true, 0.5);
+
+		IndexerGetter4CountSource<int, string, bool, double> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(0.5));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task IndexerSetter1CountSource_ShouldHonorKeyAndValueMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+		buffer.Append(1, "a");
+		buffer.Append(1, "b");
+		buffer.Append(2, "a");
+
+		IndexerSetter1CountSource<int, string> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task IndexerSetter2CountSource_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool> buffer =
+			store.InstallIndexerSetter<int, string, bool>(0);
+		buffer.Append(1, "a", true);
+		buffer.Append(1, "a", false);
+		buffer.Append(2, "a", true);
+
+		IndexerSetter2CountSource<int, string, bool> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task IndexerSetter3CountSource_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double> buffer =
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+		buffer.Append(1, "a", true, 0.5);
+		buffer.Append(1, "a", true, 1.5);
+		buffer.Append(2, "a", true, 0.5);
+
+		IndexerSetter3CountSource<int, string, bool, double> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(0.5));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task IndexerSetter4CountSource_ShouldHonorAllMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+			store.InstallIndexerSetter<int, string, bool, double, char>(0);
+		buffer.Append(1, "a", true, 0.5, 'x');
+		buffer.Append(1, "a", true, 0.5, 'y');
+		buffer.Append(2, "a", true, 0.5, 'x');
+
+		IndexerSetter4CountSource<int, string, bool, double, char> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(0.5),
+			(IParameterMatch<char>)It.Is('x'));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task Method0CountSource_ShouldRouteCountAndCountAllThroughBuffer()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod0Buffer buffer = store.InstallMethod(0);
+		buffer.Append("M");
+		buffer.Append("M");
+
+		Method0CountSource source = new(buffer);
+
+		await That(source.CountAll()).IsEqualTo(2);
+		await That(source.Count()).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task Method1CountSource_ShouldHonorMatcher()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+		buffer.Append("M", 1);
+		buffer.Append("M", 2);
+		buffer.Append("M", 1);
+
+		Method1CountSource<int> matchAny = new(buffer, (IParameterMatch<int>)It.IsAny<int>());
+		await That(matchAny.CountAll()).IsEqualTo(3);
+
+		Method1CountSource<int> matchOne = new(buffer, (IParameterMatch<int>)It.Is(1));
+		await That(matchOne.Count()).IsEqualTo(2);
+
+		Method1CountSource<int> matchNone = new(buffer, (IParameterMatch<int>)It.Is(99));
+		await That(matchNone.Count()).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task Method2CountSource_ShouldHonorBothMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod2Buffer<int, string> buffer = store.InstallMethod<int, string>(0);
+		buffer.Append("M", 1, "a");
+		buffer.Append("M", 2, "a");
+		buffer.Append("M", 1, "b");
+
+		Method2CountSource<int, string> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(1);
+	}
+
+	[Fact]
+	public async Task Method3CountSource_ShouldHonorAllThreeMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+		buffer.Append("M", 1, "a", true);
+		buffer.Append("M", 2, "a", false);
+		buffer.Append("M", 1, "b", true);
+
+		Method3CountSource<int, string, bool> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.IsAny<string>(),
+			(IParameterMatch<bool>)It.Is(true));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task Method4CountSource_ShouldHonorAllFourMatchers()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+		buffer.Append("M", 1, "a", true, 0.5);
+		buffer.Append("M", 2, "a", false, 1.5);
+		buffer.Append("M", 1, "a", true, 2.5);
+
+		Method4CountSource<int, string, bool, double> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.IsAny<double>());
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task PropertyGetterCountSource_ShouldReturnRecordedCount()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+		buffer.Append("P");
+		buffer.Append("P");
+		buffer.Append("P");
+
+		PropertyGetterCountSource source = new(buffer);
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(3);
+	}
+
+	[Fact]
+	public async Task PropertySetterCountSource_ShouldHonorValueMatcher()
+	{
+		FastMockInteractions store = new(1);
+		FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+		buffer.Append("P", 1);
+		buffer.Append("P", 2);
+		buffer.Append("P", 1);
+
+		PropertySetterCountSource<int> source = new(buffer, (IParameterMatch<int>)It.Is(1));
+
+		await That(source.CountAll()).IsEqualTo(3);
+		await That(source.Count()).IsEqualTo(2);
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Verify/VerificationResultTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using aweXpect.Chronology;
 using Mockolate.Exceptions;
@@ -47,6 +48,38 @@ public class VerificationResultTests
 
 			await That(Act).Throws<MockVerificationException>()
 				.WithMessage("*timed out*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyCount_WithUseCountAll_ShouldPickCountAllNotFilteredCount()
+		{
+			// Pins the `_useCountAll ? CountAll() : Count()` conditional in Awaitable.VerifyCount.
+			// Buffer holds 3 records, the matcher accepts only 1 of them, AnyParameters() flips
+			// _useCountAll = true. With the original code, CountAll()=3 satisfies Exactly(3) — but
+			// here we assert against Exactly(1), which is the *filtered* count: only the false-branch
+			// (Count()) of the mutated conditional satisfies it synchronously, then short-circuits
+			// before the async loop can re-evaluate via the unmutated CountAll().
+			FastMockInteractions store = new(1);
+			FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			buffer.Append("Foo", 1);
+			buffer.Append("Foo", 2);
+			buffer.Append("Foo", 3);
+
+			VerificationResult<object>.IgnoreParameters typed = registry.VerifyMethod(
+				new object(), 0, "Foo",
+				(IParameterMatch<int>)It.Is(1),
+				() => "Foo(1)");
+
+			VerificationResult<object> widened = typed.AnyParameters();
+
+			void Act()
+			{
+				widened.Within(50.Milliseconds()).Exactly(1);
+			}
+
+			await That(Act).Throws<MockVerificationException>();
 		}
 
 		[Fact]
@@ -105,6 +138,61 @@ public class VerificationResultTests
 	public sealed class MapTests
 	{
 		[Fact]
+		public async Task Map_WhenBufferAndFastSourceBothNull_DropsToSimpleConstructor()
+		{
+			// Mirrors the buffer-only case from the other side: with neither buffer nor source, the
+			// only valid Map output is the simple constructor. Asserts via reflection that _buffer
+			// stays null after Map so the equality-mutation that would force the buffer-carrying
+			// constructor (and crash on the null buffer) is killed.
+			FastMockInteractions store = new(0);
+			VerificationResult<object> source = new(
+				new object(), store, _ => true, "expected");
+
+			VerificationResult<int> mapped = source.Map(42);
+
+			FieldInfo bufferField = typeof(VerificationResult<int>).GetField(
+				"_buffer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+			FieldInfo fastSourceField = typeof(VerificationResult<int>).GetField(
+				"_fastCountSource", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+			await That(bufferField.GetValue(mapped)).IsNull();
+			await That(fastSourceField.GetValue(mapped)).IsNull();
+		}
+
+		[Fact]
+		public async Task Map_WhenBufferOnlyAndFastSourceNull_PreservesBuffer()
+		{
+			// The buffer-only IgnoreParameters constructor is wired with no fast source. Map must
+			// take the buffer-preserving branch — if it slips into the simple constructor, the next
+			// CollectMatching falls back to a global Where over _interactions, which would pick up
+			// records from OTHER buffers that satisfy the (un-name-filtered) predicate.
+			FastMockInteractions store = new(2);
+			FastMethod1Buffer<int> bufA = store.InstallMethod<int>(0);
+			FastMethod1Buffer<int> bufB = store.InstallMethod<int>(1);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			bufA.Append("Foo", 1);
+			bufA.Append("Foo", 2);
+			bufB.Append("Bar", 99);
+
+			VerificationResult<object>.IgnoreParameters result =
+				registry.VerifyMethod<object, MethodInvocation<int>>(
+					new object(), 0, "Foo", _ => true, () => "Foo()");
+
+			VerificationResult<string> mapped = result.Map("newMock");
+
+			int observedLength = -1;
+			bool verified = ((IVerificationResult)mapped).Verify(arr =>
+			{
+				observedLength = arr.Length;
+				return true;
+			});
+
+			await That(verified).IsTrue();
+			await That(observedLength).IsEqualTo(2);
+		}
+
+		[Fact]
 		public async Task Map_WithBuffer_PreservesFastPathSource()
 		{
 			FastMockInteractions store = new(1);
@@ -150,6 +238,38 @@ public class VerificationResultTests
 
 	public sealed class CollectMatchingTests
 	{
+		[Fact]
+		public async Task WithBufferAndExactlyTwoRecords_PreservesSequenceOrder()
+		{
+			// Crosses the `records.Count > 1` boundary in CollectMatching at exactly N=2. Combined
+			// with the existing N=1 / N=3 / N=0 cases, this pins the boundary so flipping `> 1` to
+			// `>= 1` is no longer a silent rewrite of the sort path.
+			FastMockInteractions store = new(1);
+			FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			buffer.Append("Foo", 10);
+			buffer.Append("Foo", 20);
+
+			VerificationResult<object>.IgnoreParameters result =
+				registry.VerifyMethod<object, MethodInvocation<int>>(
+					new object(), 0, "Foo", _ => true, () => "Foo()");
+
+			List<int> values = new();
+			bool verified = ((IVerificationResult)result).Verify(arr =>
+			{
+				foreach (IInteraction interaction in arr)
+				{
+					values.Add(((MethodInvocation<int>)interaction).Parameter1);
+				}
+
+				return arr.Length == 2;
+			});
+
+			await That(verified).IsTrue();
+			await That(values).IsEqualTo([10, 20,]);
+		}
+
 		[Fact]
 		public async Task WithBufferAndMultipleRecords_PreservesSequenceOrder()
 		{
@@ -244,6 +364,72 @@ public class VerificationResultTests
 
 			await That(verified).IsTrue();
 			await That(observed).IsEqualTo(0);
+		}
+	}
+
+	public sealed class SkipInteractionRecordingTests
+	{
+		[Fact]
+		public async Task Verify_WhenRecordingDisabled_AndAwaitableViaWithin_ShouldThrowMockException()
+		{
+			// Same guard, Awaitable Verify (records-array) path. Constructed with a predicate-based
+			// VR (not a typed CountSource) so we exercise the slow CollectMatching branch.
+			FastMockInteractions store = new(0, true);
+			VerificationResult<object> result = new(
+				new object(), store, _ => true, "expected");
+
+			VerificationResult<object> awaitable = result.Within(50.Milliseconds());
+
+			void Act()
+			{
+				((IVerificationResult)awaitable).Verify(_ => true);
+			}
+
+			await That(Act).Throws<MockException>()
+				.WithMessage("*recording is disabled*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyCount_WhenRecordingDisabled_AndAwaitableViaWithin_ShouldThrowMockException()
+		{
+			// Same guard, Awaitable path (via Within). Distinct mutation site.
+			FastMockInteractions store = new(1, true);
+			store.InstallMethod(0);
+			MockRegistry registry = new(MockBehavior.Default with
+			{
+				SkipInteractionRecording = true,
+			}, store);
+
+			void Act()
+			{
+				registry.VerifyMethod<object>(new object(), 0, "Foo", () => "Foo()")
+					.Within(50.Milliseconds()).Once();
+			}
+
+			await That(Act).Throws<MockException>()
+				.WithMessage("*recording is disabled*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyCount_WhenRecordingDisabled_ShouldThrowMockException()
+		{
+			// Kills the ThrowIfRecordingDisabled statement-removal mutation on the non-Awaitable
+			// IFastVerifyCountResult.VerifyCount path. Without the guard, Once() would silently
+			// report a (probably false) count and never throw.
+			FastMockInteractions store = new(1, true);
+			store.InstallMethod(0);
+			MockRegistry registry = new(MockBehavior.Default with
+			{
+				SkipInteractionRecording = true,
+			}, store);
+
+			void Act()
+			{
+				registry.VerifyMethod<object>(new object(), 0, "Foo", () => "Foo()").Once();
+			}
+
+			await That(Act).Throws<MockException>()
+				.WithMessage("*recording is disabled*").AsWildcard();
 		}
 	}
 

--- a/Tests/Mockolate.Tests/Verify/MockRegistryVerifyTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockRegistryVerifyTests.cs
@@ -1,0 +1,482 @@
+using Mockolate.Exceptions;
+using Mockolate.Parameters;
+using Mockolate.Verify;
+
+namespace Mockolate.Tests.Verify;
+
+public class MockRegistryVerifyTests
+{
+	public sealed class FailureMessageTests
+	{
+		[Fact]
+		public async Task IndexerGotTyped_FourKeys_FailureMessageIncludesGotIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerGetter<int, string, bool, double>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerGotTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					(IParameterMatch<bool>)It.Is(true),
+					(IParameterMatch<double>)It.Is(1.0),
+					() => "[1, \"a\", true, 1.0]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*got indexer [1, \"a\", true, 1.0]*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task IndexerGotTyped_OneKey_FailureMessageIncludesGotIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerGetter<int>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerGotTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					() => "[1]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*got indexer [1]*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task IndexerGotTyped_ThreeKeys_FailureMessageIncludesGotIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerGetter<int, string, bool>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerGotTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					(IParameterMatch<bool>)It.Is(true),
+					() => "[1, \"a\", true]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*got indexer [1, \"a\", true]*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task IndexerGotTyped_TwoKeys_FailureMessageIncludesGotIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerGetter<int, string>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerGotTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					() => "[1, \"a\"]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*got indexer [1, \"a\"]*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task IndexerSetTyped_FourKeys_FailureMessageIncludesSetIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerSetter<int, string, bool, double, char>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerSetTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					(IParameterMatch<bool>)It.Is(true),
+					(IParameterMatch<double>)It.Is(1.0),
+					(IParameterMatch<char>)It.Is('z'),
+					() => "[1, \"a\", true, 1.0]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*set indexer [1, \"a\", true, 1.0] to *z*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task IndexerSetTyped_OneKey_FailureMessageIncludesSetIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerSetter<int, string>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerSetTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					() => "[1]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*set indexer [1] to *a*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task IndexerSetTyped_ThreeKeys_FailureMessageIncludesSetIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerSetter<int, string, bool, double>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerSetTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					(IParameterMatch<bool>)It.Is(true),
+					(IParameterMatch<double>)It.Is(1.0),
+					() => "[1, \"a\", true]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*set indexer [1, \"a\", true] to *1*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task IndexerSetTyped_TwoKeys_FailureMessageIncludesSetIndexerPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallIndexerSetter<int, string, bool>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerSetTyped(new object(), 0,
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					(IParameterMatch<bool>)It.Is(true),
+					() => "[1, \"a\"]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*set indexer [1, \"a\"] to *true*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task SubscribedToTyped_FailureMessageIncludesSubscribedToEventPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallEventSubscribe(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.SubscribedToTyped(new object(), 0, "Tick").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*subscribed to event Tick*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task UnsubscribedFromTyped_FailureMessageIncludesUnsubscribedFromEventPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallEventUnsubscribe(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.UnsubscribedFromTyped(new object(), 0, "Tick").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*unsubscribed from event Tick*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_FourParameters_FailureMessageIncludesInvokedMethodPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallMethod<int, string, bool, double>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					(IParameterMatch<bool>)It.Is(true),
+					(IParameterMatch<double>)It.Is(1.0),
+					() => "Foo(1, \"a\", true, 1.0)").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*invoked method Foo(1, \"a\", true, 1.0)*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_OneParameter_FailureMessageIncludesInvokedMethodPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallMethod<int>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					() => "Foo(1)").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*invoked method Foo(1)*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_Parameterless_FailureMessageIncludesInvokedMethodPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallMethod(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*invoked method Foo()*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_ThreeParameters_FailureMessageIncludesInvokedMethodPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallMethod<int, string, bool>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					(IParameterMatch<bool>)It.Is(true),
+					() => "Foo(1, \"a\", true)").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*invoked method Foo(1, \"a\", true)*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_TwoParameters_FailureMessageIncludesInvokedMethodPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallMethod<int, string>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("a"),
+					() => "Foo(1, \"a\")").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*invoked method Foo(1, \"a\")*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyPropertyTyped_Getter_FailureMessageIncludesGotPropertyPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallPropertyGetter(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyPropertyTyped(new object(), 0, "X").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*got property X*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task VerifyPropertyTyped_Setter_FailureMessageIncludesSetPropertyPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallPropertySetter<int>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyPropertyTyped(new object(), 0, "X",
+					(IParameterMatch<int>)It.Is(7)).Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*set property X to *7*").AsWildcard();
+		}
+	}
+
+	public sealed class TryGetBufferBoundaryTests
+	{
+		[Fact]
+		public async Task VerifyMethodTyped_WithMemberIdEqualToBufferLength_ShouldFallToSlowPath()
+		{
+			// Pins the `(uint)memberId < (uint)buffers.Length` boundary in TryGetBuffer.
+			// Mutation `<=` would let memberId == buffers.Length pass the bounds check and
+			// IndexOutOfRangeException-crash on `buffers[memberId]`. Asserting the verify
+			// resolves cleanly via the slow-path fallback documents the boundary.
+			FastMockInteractions store = new(1);
+			store.InstallMethod(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 1, "Foo", () => "Foo()").Never();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_WithMemberIdFarOutOfRange_ShouldFallToSlowPath()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallMethod(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 99, "Foo", () => "Foo()").Never();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+
+	public sealed class SlowPathPredicateTests
+	{
+		[Fact]
+		public async Task VerifyMethodTyped_FourParam_SlowPath_AllMatchersTrue_Counts()
+		{
+			// Positive case for the same slow-path lambda — the matched record must be counted.
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(
+				new MethodInvocation<int, string, bool, double>("Foo", 1, "ok", true, 1.0));
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("ok"),
+					(IParameterMatch<bool>)It.Is(true),
+					(IParameterMatch<double>)It.Is(1.0),
+					() => "Foo(1, \"ok\", true, 1.0)").Once();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_FourParam_SlowPath_RejectsWhenLastMatcherFails()
+		{
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(
+				new MethodInvocation<int, string, bool, double>("Foo", 1, "ok", true, 9.9));
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("ok"),
+					(IParameterMatch<bool>)It.Is(true),
+					(IParameterMatch<double>)It.Is(1.0),
+					() => "Foo(1, \"ok\", true, 1.0)").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_ThreeParam_SlowPath_RejectsWhenLastMatcherFails()
+		{
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(new MethodInvocation<int, string, bool>("Foo", 1, "ok", false));
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("ok"),
+					(IParameterMatch<bool>)It.Is(true),
+					() => "Foo(1, \"ok\", true)").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_TwoParam_SlowPath_RejectsWhenFirstMatcherFails()
+		{
+			// The "logical mutation" survivors live in the slow-path lambda used when TryGetBuffer
+			// returns null. With an out-of-range memberId we force that branch; then we record an
+			// interaction that satisfies match2 but NOT match1, and verify it is correctly excluded.
+			// This kills the mutation that drops the `&& match1` term from the AND-chain.
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(new MethodInvocation<int, string>("Foo", 99, "ok"));
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("ok"),
+					() => "Foo(1, \"ok\")").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>();
+		}
+
+		[Fact]
+		public async Task VerifyMethodTyped_TwoParam_SlowPath_RejectsWhenSecondMatcherFails()
+		{
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(new MethodInvocation<int, string>("Foo", 1, "no"));
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo",
+					(IParameterMatch<int>)It.Is(1),
+					(IParameterMatch<string>)It.Is<string>("ok"),
+					() => "Foo(1, \"ok\")").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>();
+		}
+	}
+}


### PR DESCRIPTION
Adds/expands unit tests around Mockolate’s fast interaction buffers and verification logic (including fast/slow-path boundaries), aiming to lock in caching behavior and improve mutation-test resilience.

**Changes:**
- Added new verification-focused test coverage for failure message prefixes, slow-path predicates, and TryGetBuffer boundary behavior.
- Expanded internal verification tests to cover `VerificationResult` mapping/counting edge cases and skip-recording guards.
- Added a new internal test suite for `*CountSource` implementations and expanded fast-buffer boxing/unverified tests to validate boxing cache reuse and ordering.