### PR TITLE
fix: implement ConsumeAll method to mark all slots as verified in FastMethodBuffer

### DIFF
--- a/Source/Mockolate/Interactions/FastMethodBuffer.cs
+++ b/Source/Mockolate/Interactions/FastMethodBuffer.cs
@@ -213,6 +213,20 @@ public sealed class FastMethod1Buffer<T1> : IFastMemberBuffer
 		return matches;
 	}
 
+	internal int ConsumeAll()
+	{
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				_storage.VerifiedUnderLock(slot) = true;
+			}
+
+			return n;
+		}
+	}
+
 	internal struct Record
 	{
 		public long Seq;
@@ -322,6 +336,20 @@ public sealed class FastMethod2Buffer<T1, T2> : IFastMemberBuffer
 		}
 
 		return matches;
+	}
+
+	internal int ConsumeAll()
+	{
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				_storage.VerifiedUnderLock(slot) = true;
+			}
+
+			return n;
+		}
 	}
 
 	internal struct Record
@@ -436,6 +464,20 @@ public sealed class FastMethod3Buffer<T1, T2, T3> : IFastMemberBuffer
 		return matches;
 	}
 
+	internal int ConsumeAll()
+	{
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				_storage.VerifiedUnderLock(slot) = true;
+			}
+
+			return n;
+		}
+	}
+
 	internal struct Record
 	{
 		public long Seq;
@@ -548,6 +590,20 @@ public sealed class FastMethod4Buffer<T1, T2, T3, T4> : IFastMemberBuffer
 		}
 
 		return matches;
+	}
+
+	internal int ConsumeAll()
+	{
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				_storage.VerifiedUnderLock(slot) = true;
+			}
+
+			return n;
+		}
 	}
 
 	internal struct Record

--- a/Source/Mockolate/Verify/MethodCountSources.cs
+++ b/Source/Mockolate/Verify/MethodCountSources.cs
@@ -16,7 +16,7 @@ internal sealed class Method0CountSource : IFastMethodCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching();
-	public int CountAll() => _buffer.Count;
+	public int CountAll() => _buffer.ConsumeMatching();
 }
 
 /// <summary>
@@ -34,7 +34,7 @@ internal sealed class Method1CountSource<T1> : IFastMethodCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1);
-	public int CountAll() => _buffer.Count;
+	public int CountAll() => _buffer.ConsumeAll();
 }
 
 /// <summary>
@@ -55,7 +55,7 @@ internal sealed class Method2CountSource<T1, T2> : IFastMethodCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2);
-	public int CountAll() => _buffer.Count;
+	public int CountAll() => _buffer.ConsumeAll();
 }
 
 /// <summary>
@@ -78,7 +78,7 @@ internal sealed class Method3CountSource<T1, T2, T3> : IFastMethodCountSource
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _match3);
-	public int CountAll() => _buffer.Count;
+	public int CountAll() => _buffer.ConsumeAll();
 }
 
 /// <summary>
@@ -104,7 +104,7 @@ internal sealed class Method4CountSource<T1, T2, T3, T4> : IFastMethodCountSourc
 	}
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _match3, _match4);
-	public int CountAll() => _buffer.Count;
+	public int CountAll() => _buffer.ConsumeAll();
 }
 
 /// <summary>

--- a/Tests/Mockolate.Internal.Tests/Verify/MethodCountSourcesTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Verify/MethodCountSourcesTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Reflection;
 using Mockolate.Interactions;
 using Mockolate.Parameters;
@@ -248,6 +249,96 @@ public class MethodCountSourcesTests
 
 		await That(source.CountAll()).IsEqualTo(3);
 		await That(source.Count()).IsEqualTo(2);
+	}
+
+	[Fact]
+	public async Task Method0CountSource_CountAll_ShouldMarkSlotsVerified()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod0Buffer buffer = store.InstallMethod(0);
+		buffer.Append("M");
+		buffer.Append("M");
+
+		Method0CountSource source = new(buffer);
+		await That(source.CountAll()).IsEqualTo(2);
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+		await That(dest).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Method1CountSource_CountAll_ShouldMarkSlotsVerified()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+		buffer.Append("M", 1);
+		buffer.Append("M", 2);
+
+		Method1CountSource<int> source = new(buffer, (IParameterMatch<int>)It.Is(1));
+		await That(source.CountAll()).IsEqualTo(2);
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+		await That(dest).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Method2CountSource_CountAll_ShouldMarkSlotsVerified()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod2Buffer<int, string> buffer = store.InstallMethod<int, string>(0);
+		buffer.Append("M", 1, "a");
+		buffer.Append("M", 2, "b");
+
+		Method2CountSource<int, string> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"));
+		await That(source.CountAll()).IsEqualTo(2);
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+		await That(dest).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Method3CountSource_CountAll_ShouldMarkSlotsVerified()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+		buffer.Append("M", 1, "a", true);
+		buffer.Append("M", 2, "b", false);
+
+		Method3CountSource<int, string, bool> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true));
+		await That(source.CountAll()).IsEqualTo(2);
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+		await That(dest).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Method4CountSource_CountAll_ShouldMarkSlotsVerified()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+		buffer.Append("M", 1, "a", true, 0.5);
+		buffer.Append("M", 2, "b", false, 1.5);
+
+		Method4CountSource<int, string, bool, double> source = new(buffer,
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<string>)It.Is<string>("a"),
+			(IParameterMatch<bool>)It.Is(true),
+			(IParameterMatch<double>)It.Is(0.5));
+		await That(source.CountAll()).IsEqualTo(2);
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+		await That(dest).IsEmpty();
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR fixes method verification’s “AnyParameters()/CountAll” fast-path so it marks all recorded method-call slots as verified (preventing them from later showing up as “unverified interactions”), by adding a `ConsumeAll()` operation to the typed fast method buffers and using it from `Method*CountSource.CountAll()`.

**Changes:**
- Add `ConsumeAll()` to `FastMethod{1..4}Buffer` to mark all published slots as verified and return the published count.
- Update `Method{0..4}CountSource.CountAll()` to consume/verify interactions instead of reading `_buffer.Count`.
- Add regression tests ensuring `CountAll()` results in no remaining unverified boxed interactions.