### PR TITLE
fix: remove spurious `"` in exception message

### DIFF
--- a/Source/Mockolate/Verify/VerificationResult.cs
+++ b/Source/Mockolate/Verify/VerificationResult.cs
@@ -160,7 +160,7 @@ public class VerificationResult<TVerify> : IVerificationResult<TVerify>, IVerifi
 		{
 			throw new MockException(
 				"""
-				Cannot verify interactions because interaction recording is disabled. To re-enable verifications, set MockBehavior.SkipInteractionRecording to false."
+				Cannot verify interactions because interaction recording is disabled. To re-enable verifications, set MockBehavior.SkipInteractionRecording to false.
 				"""
 			);
 		}


### PR DESCRIPTION
This pull request makes a minor improvement to an exception message in the `VerificationResult.cs` file. The change removes an extraneous double quote at the end of the error message for clarity and correctness.