### PR TITLE
refactor: update property getter to use default value generator for unsupported types

### DIFF
--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -300,14 +300,42 @@ public class PropertySetup<T> : PropertySetup,
 
 	/// <inheritdoc cref="PropertySetup.InvokeGetter{TResult}(MockBehavior, Func{TResult})" />
 	protected override TResult InvokeGetter<TResult>(MockBehavior behavior, Func<TResult> defaultValueGenerator)
-		=> InvokeGetterCore<TResult>();
+	{
+		RunGetterCallbacks();
+
+		if (typeof(TResult) == typeof(T))
+		{
+			return Unsafe.As<T, TResult>(ref _value);
+		}
+
+		if (_value is TResult typedValue)
+		{
+			return typedValue;
+		}
+
+		return defaultValueGenerator();
+	}
 
 	/// <inheritdoc cref="PropertySetup.InvokeGetterFast{TResult}(MockBehavior, Func{MockBehavior, TResult})" />
 	internal override TResult InvokeGetterFast<TResult>(MockBehavior behavior,
 		Func<MockBehavior, TResult> defaultValueGenerator)
-		=> InvokeGetterCore<TResult>();
+	{
+		RunGetterCallbacks();
 
-	private TResult InvokeGetterCore<TResult>()
+		if (typeof(TResult) == typeof(T))
+		{
+			return Unsafe.As<T, TResult>(ref _value);
+		}
+
+		if (_value is TResult typedValue)
+		{
+			return typedValue;
+		}
+
+		return defaultValueGenerator(behavior);
+	}
+
+	private void RunGetterCallbacks()
 	{
 		if (_getterCallbacks is not null)
 		{
@@ -341,19 +369,6 @@ public class PropertySetup<T> : PropertySetup,
 				}
 			}
 		}
-
-		if (typeof(TResult) == typeof(T))
-		{
-			return Unsafe.As<T, TResult>(ref _value);
-		}
-
-		if (_value is null && default(TResult) is null)
-		{
-			return default!;
-		}
-
-		throw new MockException(
-			$"The property only supports '{typeof(T).FormatType()}' and not '{typeof(TResult).FormatType()}'.");
 	}
 
 	/// <inheritdoc cref="PropertySetup.InvokeSetter{TValue}(TValue, MockBehavior)" />

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.cs
@@ -6,19 +6,13 @@ namespace Mockolate.Tests.MockProperties;
 public sealed partial class SetupPropertyTests
 {
 	[Fact]
-	public async Task InvokeGetter_InvalidType_ShouldThrowMockException()
+	public async Task InvokeGetter_InvalidType_ShouldFallBackToDefaultValueGenerator()
 	{
 		MyPropertySetup<int> setup = new();
 
-		void Act()
-		{
-			setup.InvokeGetter<string>();
-		}
+		string? result = setup.InvokeGetter<string?>(() => "fallback");
 
-		await That(Act).Throws<MockException>()
-			.WithMessage("""
-			             The property only supports 'int' and not 'string'.
-			             """);
+		await That(result).IsEqualTo("fallback");
 	}
 
 	[Fact]
@@ -176,6 +170,9 @@ public sealed partial class SetupPropertyTests
 
 		public TResult InvokeGetter<TResult>()
 			=> InvokeGetter<TResult>(MockBehavior.Default, () => default!);
+
+		public TResult InvokeGetter<TResult>(Func<TResult> defaultValueGenerator)
+			=> InvokeGetter(MockBehavior.Default, defaultValueGenerator);
 
 		public void MyInitializeValue(object? value)
 			=> InitializeValue(value);


### PR DESCRIPTION
This pull request updates the behavior of property getter invocations in the `PropertySetup` class, specifically improving type handling and fallback logic. The core change is that when a property is accessed with a type that doesn't match the originally set type, the getter now falls back to a provided default value generator instead of throwing a `MockException`. Corresponding tests have been updated to reflect this new behavior.

**Behavioral changes to property getter logic:**

* Refactored `InvokeGetter` and `InvokeGetterFast` to return the stored value if types match, attempt a type cast if possible, and otherwise use the provided default value generator instead of throwing a `MockException` for unsupported types. The old `InvokeGetterCore` method and its exception logic were removed.