### PR TITLE
refactor: remove unused registry methods

### DIFF
--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -23,25 +23,6 @@ public partial class MockRegistry
 		=> Interactions.Clear();
 
 	/// <summary>
-	///     Optional pre-sizing hook for the mock's internal indexer value-storage array. When the total number
-	///     of distinct indexer signatures is known up front, calling this once avoids the lazy-grow allocation
-	///     on first access. Safe to skip — storage grows on demand otherwise.
-	/// </summary>
-	/// <param name="indexerCount">The number of distinct indexer signatures. Must be non-negative.</param>
-	/// <exception cref="ArgumentOutOfRangeException"><paramref name="indexerCount" /> is negative.</exception>
-	public void InitializeStorage(int indexerCount)
-	{
-		if (indexerCount < 0)
-		{
-			throw new ArgumentOutOfRangeException(nameof(indexerCount), indexerCount,
-				// ReSharper disable once LocalizableElement
-				"Indexer count must be non-negative.");
-		}
-
-		Setup.Indexers.InitializeStorageCount(indexerCount);
-	}
-
-	/// <summary>
 	///     Returns the current snapshot of default-scope method setups registered under the generator-emitted
 	///     <paramref name="memberId" />, or <see langword="null" /> when no setup has been registered.
 	/// </summary>
@@ -56,27 +37,6 @@ public partial class MockRegistry
 	public MethodSetup[]? GetMethodSetupSnapshot(int memberId)
 	{
 		MethodSetup[]?[]? table = Volatile.Read(ref _setupsByMemberId);
-		if (table is null || (uint)memberId >= (uint)table.Length)
-		{
-			return null;
-		}
-
-		return table[memberId];
-	}
-
-	/// <summary>
-	///     Returns the current default-scope property setup registered under the generator-emitted
-	///     <paramref name="memberId" />, or <see langword="null" /> when no setup has been registered.
-	/// </summary>
-	/// <remarks>
-	///     Reads are lock-free. Only sees setups registered via the <c>SetupProperty(int, ...)</c> overloads;
-	///     scenario-scoped registrations still go through the string-keyed fallback.
-	/// </remarks>
-	/// <param name="memberId">The generator-emitted member id.</param>
-	/// <returns>The property setup for the member, or <see langword="null" /> when none is registered.</returns>
-	public PropertySetup? GetPropertySetupSnapshot(int memberId)
-	{
-		PropertySetup?[]? table = Volatile.Read(ref _propertySetupsByMemberId);
 		if (table is null || (uint)memberId >= (uint)table.Length)
 		{
 			return null;
@@ -204,19 +164,6 @@ public partial class MockRegistry
 		}
 
 		return Setup.Indexers.GetMatching<T>(access);
-	}
-
-	/// <summary>
-	///     Stores <paramref name="value" /> in the indexer value slot identified by <paramref name="access" />.
-	/// </summary>
-	/// <typeparam name="TResult">The indexer's value type.</typeparam>
-	/// <param name="access">The indexer access whose arguments identify the slot.</param>
-	/// <param name="value">The value to store.</param>
-	/// <param name="signatureIndex">Index into the mock's indexer-signature table (emitted by the source generator).</param>
-	public void SetIndexerValue<TResult>(IndexerAccess access, TResult value, int signatureIndex)
-	{
-		access.AttachStorage(Setup.Indexers.GetOrCreateStorage<TResult>(signatureIndex));
-		access.StoreValue(value);
 	}
 
 	/// <summary>

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -225,9 +225,9 @@ public partial class MockRegistry
 	/// </summary>
 	/// <remarks>
 	///     The <paramref name="memberId" /> is a compile-time constant emitted by the source generator, one per
-	///     mocked property accessor. Reads via <see cref="GetPropertySetupSnapshot(int)" /> are lock-free; writes
-	///     take an internal lock and publish via <see cref="Volatile.Write{T}(ref T, T)" />. A non-default setup
-	///     never overrides itself with a <see cref="PropertySetup.Default" /> placeholder — mirroring the rules in
+	///     mocked property accessor. Reads of the lock-free snapshot table are paired with writes that take an
+	///     internal lock and publish via <see cref="Volatile.Write{T}(ref T, T)" />. A non-default setup never
+	///     overrides itself with a <see cref="PropertySetup.Default" /> placeholder — mirroring the rules in
 	///     <see cref="MockSetups.PropertySetups.Add" />.
 	/// </remarks>
 	/// <param name="memberId">The generator-emitted member id for the setup's target property.</param>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -222,7 +222,6 @@ namespace Mockolate
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetPropertyFast<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public TResult GetPropertyFast<TResult>(int memberId, string propertyName, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
-        public Mockolate.Setup.PropertySetup? GetPropertySetupSnapshot(int memberId) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.IMockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, int memberId, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGotTyped<T, T1>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
@@ -234,12 +233,10 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, T3, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, T3, T4, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
-        public void InitializeStorage(int indexerCount) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public void RegisterInteraction(Mockolate.Interactions.IInteraction interaction) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void RemoveEvent(int memberId, string name, object? target, System.Reflection.MethodInfo? method) { }
-        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public bool SetProperty<T>(int memberId, string propertyName, T value) { }
         public bool SetPropertyFast<T>(int memberId, int setterMemberId, string propertyName, T value) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -215,7 +215,6 @@ namespace Mockolate
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetPropertyFast<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public TResult GetPropertyFast<TResult>(int memberId, string propertyName, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
-        public Mockolate.Setup.PropertySetup? GetPropertySetupSnapshot(int memberId) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.IMockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, int memberId, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGotTyped<T, T1>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
@@ -227,12 +226,10 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, T3, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, T3, T4, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
-        public void InitializeStorage(int indexerCount) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public void RegisterInteraction(Mockolate.Interactions.IInteraction interaction) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void RemoveEvent(int memberId, string name, object? target, System.Reflection.MethodInfo? method) { }
-        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public bool SetProperty<T>(int memberId, string propertyName, T value) { }
         public bool SetPropertyFast<T>(int memberId, int setterMemberId, string propertyName, T value) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -202,7 +202,6 @@ namespace Mockolate
         public TResult GetProperty<TResult>(string propertyName, System.Func<TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor) { }
         public TResult GetPropertyFast<TResult>(int memberId, Mockolate.Interactions.PropertyGetterAccess access, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
         public TResult GetPropertyFast<TResult>(int memberId, string propertyName, System.Func<Mockolate.MockBehavior, TResult> defaultValueGenerator, System.Func<TResult>? baseValueAccessor = null) { }
-        public Mockolate.Setup.PropertySetup? GetPropertySetupSnapshot(int memberId) { }
         public System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> GetUnusedSetups(Mockolate.Interactions.IMockInteractions interactions) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGot<T>(T subject, int memberId, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerGotTyped<T, T1>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
@@ -214,12 +213,10 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, T3, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
         public Mockolate.Verify.VerificationResult<T> IndexerSetTyped<T, T1, T2, T3, T4, TValue>(T subject, int memberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, Mockolate.Parameters.IParameterMatch<TValue> value, System.Func<string> parametersDescription) { }
-        public void InitializeStorage(int indexerCount) { }
         public Mockolate.Verify.VerificationResult<T> Method<T>(T subject, Mockolate.Setup.IMethodSetup methodSetup) { }
         public void RegisterInteraction(Mockolate.Interactions.IInteraction interaction) { }
         public void RemoveEvent(string name, object? target, System.Reflection.MethodInfo? method) { }
         public void RemoveEvent(int memberId, string name, object? target, System.Reflection.MethodInfo? method) { }
-        public void SetIndexerValue<TResult>(Mockolate.Interactions.IndexerAccess access, TResult value, int signatureIndex) { }
         public bool SetProperty<T>(string propertyName, T value) { }
         public bool SetProperty<T>(int memberId, string propertyName, T value) { }
         public bool SetPropertyFast<T>(int memberId, int setterMemberId, string propertyName, T value) { }

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
@@ -107,76 +107,89 @@ public sealed class MockRegistrySetupSnapshotTests
 		public async Task PublishPropertyToMemberIdBucket_WithDefaultThenUserSetup_RetainsUserSetup()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			PropertySetup defaultSetup = new PropertySetup.Default<int>("P1", 0);
-			FakePropertySetup userSetup = new("P1");
+			PropertySetup<int> defaultSetup = new(registry, "P1");
+			defaultSetup.InitializeWith(0);
+			PropertySetup<int> userSetup = new(registry, "P1");
+			userSetup.InitializeWith(99);
 
-			registry.SetupProperty(1, defaultSetup);
+			registry.SetupProperty(1, new PropertySetup.Default<int>("P1", 0));
 			registry.SetupProperty(1, userSetup);
 
-			await That(registry.GetPropertySetupSnapshot(1)).IsSameAs(userSetup);
+			int observed = registry.GetPropertyFast(1, "P1", _ => -1);
+			await That(observed).IsEqualTo(99);
 		}
 
 		[Fact]
 		public async Task PublishPropertyToMemberIdBucket_WithUserThenDefaultSetup_RetainsUserSetup()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			FakePropertySetup userSetup = new("P1");
-			PropertySetup defaultSetup = new PropertySetup.Default<int>("P1", 0);
+			PropertySetup<int> userSetup = new(registry, "P1");
+			userSetup.InitializeWith(99);
 
 			registry.SetupProperty(1, userSetup);
-			registry.SetupProperty(1, defaultSetup);
+			registry.SetupProperty(1, new PropertySetup.Default<int>("P1", 0));
 
-			await That(registry.GetPropertySetupSnapshot(1)).IsSameAs(userSetup);
+			int observed = registry.GetPropertyFast(1, "P1", _ => -1);
+			await That(observed).IsEqualTo(99);
 		}
 
 		[Fact]
 		public async Task SetupProperty_WithIncreasingMemberIds_GrowsTableLazily()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			FakePropertySetup setup0 = new("P0");
-			FakePropertySetup setup7 = new("P7");
-			FakePropertySetup setup3 = new("P3");
+			PropertySetup<int> setup0 = new(registry, "P0");
+			setup0.InitializeWith(10);
+			PropertySetup<int> setup7 = new(registry, "P7");
+			setup7.InitializeWith(70);
+			PropertySetup<int> setup3 = new(registry, "P3");
+			setup3.InitializeWith(30);
 
 			registry.SetupProperty(0, setup0);
 			registry.SetupProperty(7, setup7);
 			registry.SetupProperty(3, setup3);
 
-			await That(registry.GetPropertySetupSnapshot(0)).IsSameAs(setup0);
-			await That(registry.GetPropertySetupSnapshot(7)).IsSameAs(setup7);
-			await That(registry.GetPropertySetupSnapshot(3)).IsSameAs(setup3);
+			await That(registry.GetPropertyFast(0, "P0", _ => -1)).IsEqualTo(10);
+			await That(registry.GetPropertyFast(7, "P7", _ => -1)).IsEqualTo(70);
+			await That(registry.GetPropertyFast(3, "P3", _ => -1)).IsEqualTo(30);
 		}
 
 		[Fact]
 		public async Task SetupProperty_WithMemberId_PublishesToSnapshot()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			FakePropertySetup setup = new("P5");
+			PropertySetup<int> setup = new(registry, "P5");
+			setup.InitializeWith(50);
 
 			registry.SetupProperty(5, setup);
 
-			await That(registry.GetPropertySetupSnapshot(5)).IsSameAs(setup);
+			int observed = registry.GetPropertyFast(5, "P5", _ => -1);
+			await That(observed).IsEqualTo(50);
 		}
 
 		[Fact]
 		public async Task SetupProperty_WithMemberIdAndDefaultScenario_PublishesToSnapshot()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			FakePropertySetup setup = new("P5");
+			PropertySetup<int> setup = new(registry, "P5");
+			setup.InitializeWith(50);
 
 			registry.SetupProperty(5, "", setup);
 
-			await That(registry.GetPropertySetupSnapshot(5)).IsSameAs(setup);
+			int observed = registry.GetPropertyFast(5, "P5", _ => -1);
+			await That(observed).IsEqualTo(50);
 		}
 
 		[Fact]
 		public async Task SetupProperty_WithMemberIdAndNamedScenario_DoesNotPublishToSnapshot()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			FakePropertySetup setup = new("P5");
+			PropertySetup<int> setup = new(registry, "P5");
+			setup.InitializeWith(50);
 
 			registry.SetupProperty(5, "s1", setup);
 
-			await That(registry.GetPropertySetupSnapshot(5)).IsNull();
+			int observed = registry.GetPropertyFast(5, "P5", _ => -1);
+			await That(observed).IsEqualTo(-1);
 		}
 
 		[Fact]
@@ -187,7 +200,6 @@ public sealed class MockRegistrySetupSnapshotTests
 
 			registry.SetupProperty(4, "s1", setup);
 
-			await That(registry.GetPropertySetupSnapshot(4)).IsNull();
 			await That(registry.Setup.TryGetScenario("s1", out MockScenarioSetup? scoped)).IsTrue();
 			await That(scoped!.Properties.TryGetValue("P4", out PropertySetup? scopedSetup)).IsTrue();
 			await That(scopedSetup).IsSameAs(setup);
@@ -197,13 +209,16 @@ public sealed class MockRegistrySetupSnapshotTests
 		public async Task SetupProperty_WithSameMemberIdTwice_RetainsLatestUserSetup()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			FakePropertySetup setupA = new("P2");
-			FakePropertySetup setupB = new("P2");
+			PropertySetup<int> setupA = new(registry, "P2");
+			setupA.InitializeWith(20);
+			PropertySetup<int> setupB = new(registry, "P2");
+			setupB.InitializeWith(99);
 
 			registry.SetupProperty(2, setupA);
 			registry.SetupProperty(2, setupB);
 
-			await That(registry.GetPropertySetupSnapshot(2)).IsSameAs(setupB);
+			int observed = registry.GetPropertyFast(2, "P2", _ => -1);
+			await That(observed).IsEqualTo(99);
 		}
 	}
 

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -188,7 +188,7 @@ public sealed class MockRegistryTests
 			IndexerSetterAccess<int, int> setterAccess = new(1, 7);
 			IndexerGetterAccess<int> getterAccess = new(1);
 
-			registry.SetIndexerValue(setterAccess, 7, 0);
+			registry.ApplyIndexerSetter(setterAccess, null, 7, 0);
 			int result = registry.ApplyIndexerGetter(getterAccess, null, () => 99, 0);
 
 			await That(result).IsEqualTo(7);
@@ -222,78 +222,11 @@ public sealed class MockRegistryTests
 			IndexerSetterAccess<int, int> setterAccess = new(1, 42);
 			IndexerGetterAccess<int> getterAccess = new(1);
 
-			registry.SetIndexerValue(setterAccess, 42, 0);
+			registry.ApplyIndexerSetter(setterAccess, null, 42, 0);
 			int result = registry.GetIndexerFallback<int>(getterAccess, 0);
 
 			await That(result).IsEqualTo(42);
 			await That(counter).IsEqualTo(0);
-		}
-	}
-
-	public sealed class SetIndexerValueTests
-	{
-		[Fact]
-		public async Task ShouldStoreValueRetrievableViaApplyIndexerGetter()
-		{
-			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			IndexerSetterAccess<int, string> setterAccess = new(7, "stored");
-			IndexerGetterAccess<int> getterAccess = new(7);
-
-			registry.SetIndexerValue(setterAccess, "stored", 0);
-			string result = registry.ApplyIndexerGetter<string>(getterAccess, null, () => "default", 0);
-
-			await That(result).IsEqualTo("stored");
-		}
-
-		[Fact]
-		public async Task WithMultiKeyAccess_ShouldStorePerKeyTuple()
-		{
-			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			IndexerSetterAccess<int, int, string> setA = new(1, 2, "a");
-			IndexerSetterAccess<int, int, string> setB = new(3, 4, "b");
-			IndexerGetterAccess<int, int> getA = new(1, 2);
-			IndexerGetterAccess<int, int> getB = new(3, 4);
-			IndexerGetterAccess<int, int> miss = new(5, 6);
-
-			registry.SetIndexerValue(setA, "a", 0);
-			registry.SetIndexerValue(setB, "b", 0);
-			string a = registry.ApplyIndexerGetter<string>(getA, null, () => "default", 0);
-			string b = registry.ApplyIndexerGetter<string>(getB, null, () => "default", 0);
-			string m = registry.ApplyIndexerGetter<string>(miss, null, () => "default", 0);
-
-			await That(a).IsEqualTo("a");
-			await That(b).IsEqualTo("b");
-			await That(m).IsEqualTo("default");
-		}
-	}
-
-	public sealed class InitializeStorageTests
-	{
-		[Fact]
-		public async Task WithNegative_ShouldThrowWithDescriptiveMessage()
-		{
-			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-
-			void Act()
-			{
-				registry.InitializeStorage(-1);
-			}
-
-			await That(Act).Throws<ArgumentOutOfRangeException>()
-				.WithMessage("*non-negative*").AsWildcard();
-		}
-
-		[Fact]
-		public async Task WithZero_ShouldNotThrow()
-		{
-			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-
-			void Act()
-			{
-				registry.InitializeStorage(0);
-			}
-
-			await That(Act).DoesNotThrow();
 		}
 	}
 
@@ -528,43 +461,6 @@ public sealed class MockRegistryTests
 			registry.SetupMethod(0, setup);
 
 			MethodSetup[]? result = registry.GetMethodSetupSnapshot(5);
-
-			await That(result).IsNull();
-		}
-	}
-
-	public sealed class GetPropertySetupSnapshotTests
-	{
-		[Fact]
-		public async Task WithEmptyTable_ShouldReturnNull()
-		{
-			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-
-			PropertySetup? result = registry.GetPropertySetupSnapshot(0);
-
-			await That(result).IsNull();
-		}
-
-		[Fact]
-		public async Task WithMemberIdAtBoundary_ShouldReturnTheSetup()
-		{
-			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			PropertySetup<int> setup = new(registry, "P");
-			registry.SetupProperty(5, setup);
-
-			PropertySetup? result = registry.GetPropertySetupSnapshot(5);
-
-			await That(result).IsSameAs(setup);
-		}
-
-		[Fact]
-		public async Task WithMemberIdBeyondTable_ShouldReturnNull()
-		{
-			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
-			PropertySetup<int> setup = new(registry, "P");
-			registry.SetupProperty(0, setup);
-
-			PropertySetup? result = registry.GetPropertySetupSnapshot(5);
 
 			await That(result).IsNull();
 		}

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -519,36 +519,6 @@ public sealed partial class SetupIndexerTests
 				.WithParamName("signatureIndex");
 		}
 
-		[Fact]
-		public async Task InitializeStorage_WithNegativeCount_ShouldThrow()
-		{
-			IIndexerService sut = IIndexerService.CreateMock();
-			MockRegistry registry = ((IMock)sut).MockRegistry;
-
-			void Act()
-			{
-				registry.InitializeStorage(-1);
-			}
-
-			await That(Act).Throws<ArgumentOutOfRangeException>()
-				.WithParamName("indexerCount");
-		}
-
-		[Fact]
-		public async Task SetIndexerValue_WithNegativeSignatureIndex_ShouldThrow()
-		{
-			IIndexerService sut = IIndexerService.CreateMock();
-			MockRegistry registry = ((IMock)sut).MockRegistry;
-			IndexerGetterAccess<int> access = new(1);
-
-			void Act()
-			{
-				registry.SetIndexerValue(access, "foo", -1);
-			}
-
-			await That(Act).Throws<ArgumentOutOfRangeException>()
-				.WithParamName("signatureIndex");
-		}
 	}
 
 


### PR DESCRIPTION
This pull request removes several internal methods from the `MockRegistry` class that were previously used for advanced or low-level manipulation of property and indexer setups. The public API surface is reduced, and tests are updated to use higher-level accessors. This streamlines the codebase and encourages usage of the more robust, intended APIs for property and indexer access.

**API Surface Reduction and Internal Refactoring**

* Removed the `GetPropertySetupSnapshot(int memberId)`, `InitializeStorage(int indexerCount)`, and `SetIndexerValue<TResult>(IndexerAccess, TResult, int)` methods from `MockRegistry`, along with their documentation and all public API surface references. These were internal hooks or advanced usage points that are now superseded by higher-level APIs.
* Clarified remarks in the documentation for `SetupProperty(int, PropertySetup)` to reflect the new lock-free read/write behavior after the internal refactor.