### PR TITLE
coverage: add missing tests for MockRegistry

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -817,4 +817,288 @@ public sealed class MockRegistryTests
 			IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
 		}
 	}
+
+	public sealed class GetIndexerSetupSnapshotBoundaryTests
+	{
+		[Fact]
+		public async Task WithMemberIdEqualToTableLength_ShouldReturnNullWithoutThrowing()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			IndexerSetup<string, int> setup = new(registry, (IParameterMatch<int>)It.IsAny<int>());
+			registry.SetupIndexer(0, setup);
+
+			IndexerSetup[]? result = registry.GetIndexerSetupSnapshot(1);
+
+			await That(result).IsNull();
+		}
+	}
+
+	public sealed class GetPropertyFastInteractionRecordingTests
+	{
+		[Fact]
+		public async Task WithSharedAccessSingleton_AndMatchingFastBuffer_ShouldAppendToBuffer()
+		{
+			FastMockInteractions store = new(1);
+			PropertyGetterAccess access = new("P");
+			FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0, access);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			int result = registry.GetPropertyFast(0, access, _ => 7);
+
+			await That(buffer.Count).IsEqualTo(1);
+			await That(result).IsEqualTo(7);
+		}
+
+		[Fact]
+		public async Task WithSharedAccessSingleton_WithoutMatchingBuffer_ShouldRegisterTheSingleton()
+		{
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+			PropertyGetterAccess access = new("P");
+
+			registry.GetPropertyFast(0, access, _ => 7);
+
+			IInteraction recorded = registry.Interactions.Single();
+			await That(recorded).IsSameAs(access);
+		}
+
+		[Fact]
+		public async Task WithStringName_AndMatchingFastBuffer_ShouldAppendToBuffer()
+		{
+			FastMockInteractions store = new(1);
+			FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			int result = registry.GetPropertyFast(0, "P", _ => 7);
+
+			await That(buffer.Count).IsEqualTo(1);
+			await That(result).IsEqualTo(7);
+		}
+
+		[Fact]
+		public async Task WithStringName_AtBufferLengthBoundary_ShouldFallBackWithoutThrowing()
+		{
+			FastMockInteractions store = new(1);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			int result = registry.GetPropertyFast(1, "P", _ => 7);
+
+			await That(result).IsEqualTo(7);
+			await That(registry.Interactions.Count).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task WithStringName_AtTableLengthBoundary_ShouldFallToColdPathWithoutThrowing()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> snapshot = new(registry, "P");
+			snapshot.InitializeWith(42);
+			registry.SetupProperty(0, snapshot);
+
+			int result = registry.GetPropertyFast(1, "Q", _ => 7);
+
+			await That(result).IsEqualTo(7);
+		}
+
+		[Fact]
+		public async Task WithStringName_WhenBehaviorSkipsInteractionRecording_ShouldNotRecord()
+		{
+			MockBehavior behavior = MockBehavior.Default.SkippingInteractionRecording();
+			FastMockInteractions store = new(1, behavior.SkipInteractionRecording);
+			FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+			MockRegistry registry = new(behavior, store);
+
+			registry.GetPropertyFast(0, "P", _ => 7);
+
+			await That(buffer.Count).IsEqualTo(0);
+			await That(registry.Interactions.Count).IsEqualTo(0);
+		}
+
+		[Fact]
+		public async Task WithStringName_WithoutMatchingBuffer_ShouldFallBackToRegisterPropertyGetterAccess()
+		{
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			registry.GetPropertyFast(0, "P", _ => 7);
+
+			IInteraction recorded = registry.Interactions.Single();
+			await That(recorded).IsExactly<PropertyGetterAccess>()
+				.Whose(x => x.Name, x => x.IsEqualTo("P"));
+		}
+	}
+
+	public sealed class SetPropertyMemberIdTests
+	{
+		[Fact]
+		public async Task SetProperty_WithMemberId_AndSetupOverridesSkipBaseClass_ShouldReturnSetupOverride()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P");
+			setup.InitializeWith(0);
+			((IPropertySetup<int>)setup).SkippingBaseClass();
+			registry.SetupProperty(setup);
+
+			bool skipBase = registry.SetProperty(7, "P", 42);
+
+			await That(skipBase).IsTrue();
+		}
+
+		[Fact]
+		public async Task SetProperty_WithMemberId_AtBufferLengthBoundary_ShouldFallBackWithoutThrowing()
+		{
+			FastMockInteractions store = new(1);
+			MockRegistry registry = new(MockBehavior.Default, store);
+			PropertySetup<int> setup = new(registry, "P");
+			setup.InitializeWith(0);
+			registry.SetupProperty(setup);
+
+			registry.SetProperty(1, "P", 42);
+
+			IInteraction recorded = registry.Interactions.Single();
+			await That(recorded).IsExactly<PropertySetterAccess<int>>();
+		}
+
+		[Fact]
+		public async Task SetProperty_WithMemberId_ShouldInvokeSetterAndStoreValue()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P");
+			setup.InitializeWith(0);
+			registry.SetupProperty(setup);
+
+			registry.SetProperty(7, "P", 42);
+
+			int after = registry.GetProperty("P", () => -1, null);
+			await That(after).IsEqualTo(42);
+		}
+
+		[Fact]
+		public async Task SetProperty_WithoutMemberId_AndSetupOverridesSkipBaseClass_ShouldReturnSetupOverride()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P");
+			setup.InitializeWith(0);
+			((IPropertySetup<int>)setup).SkippingBaseClass();
+			registry.SetupProperty(setup);
+
+			bool skipBase = registry.SetProperty("P", 42);
+
+			await That(skipBase).IsTrue();
+		}
+	}
+
+	public sealed class SetPropertyFastTableBoundaryTests
+	{
+		[Fact]
+		public async Task SetPropertyFast_AtTableLengthBoundary_ShouldFallToColdPathWithoutThrowing()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> snapshot = new(registry, "P");
+			snapshot.InitializeWith(0);
+			registry.SetupProperty(0, snapshot);
+
+			bool skipBase = registry.SetPropertyFast(1, 2, "P", 42);
+
+			await That(skipBase).IsFalse();
+		}
+	}
+
+	public sealed class AddRemoveEventErrorMessageTests
+	{
+		[Fact]
+		public async Task AddEvent_WithMemberId_AndNullMethod_ShouldThrowSubscriptionMessage()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+
+			void Act()
+			{
+				registry.AddEvent(0, "OnFoo", this, null);
+			}
+
+			await That(Act).Throws<MockException>()
+				.WithMessage("The method of an event subscription may not be null.");
+		}
+
+		[Fact]
+		public async Task AddEvent_WithStringName_AndNullMethod_ShouldThrowSubscriptionMessage()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+
+			void Act()
+			{
+				registry.AddEvent("OnFoo", this, null);
+			}
+
+			await That(Act).Throws<MockException>()
+				.WithMessage("The method of an event subscription may not be null.");
+		}
+
+		[Fact]
+		public async Task RemoveEvent_WithMemberId_AndNullMethod_ShouldThrowUnsubscriptionMessage()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+
+			void Act()
+			{
+				registry.RemoveEvent(0, "OnFoo", this, null);
+			}
+
+			await That(Act).Throws<MockException>()
+				.WithMessage("The method of an event unsubscription may not be null.");
+		}
+
+		[Fact]
+		public async Task RemoveEvent_WithStringName_AndNullMethod_ShouldThrowUnsubscriptionMessage()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+
+			void Act()
+			{
+				registry.RemoveEvent("OnFoo", this, null);
+			}
+
+			await That(Act).Throws<MockException>()
+				.WithMessage("The method of an event unsubscription may not be null.");
+		}
+	}
+
+	public sealed class RemoveEventScenarioRoutingTests
+	{
+		[Fact]
+		public async Task AddEvent_WithMemberId_AndActiveScenario_ShouldRouteToScenarioSetup()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			EventSetup defaultSetup = new(registry, "OnFoo");
+			registry.SetupEvent(7, defaultSetup);
+
+			int scenarioCallbackCount = 0;
+			EventSetup scenarioSetup = new(registry, "OnFoo");
+			scenarioSetup.OnSubscribed.Do(() => scenarioCallbackCount++);
+			registry.SetupEvent(7, "myScenario", scenarioSetup);
+
+			registry.TransitionTo("myScenario");
+			registry.AddEvent(7, "OnFoo", this, GetMethodInfo());
+
+			await That(scenarioCallbackCount).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task RemoveEvent_WithMemberId_AndActiveScenario_ShouldRouteToScenarioSetup()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			EventSetup defaultSetup = new(registry, "OnFoo");
+			registry.SetupEvent(7, defaultSetup);
+
+			int scenarioCallbackCount = 0;
+			EventSetup scenarioSetup = new(registry, "OnFoo");
+			scenarioSetup.OnUnsubscribed.Do(() => scenarioCallbackCount++);
+			registry.SetupEvent(7, "myScenario", scenarioSetup);
+
+			registry.TransitionTo("myScenario");
+			registry.RemoveEvent(7, "OnFoo", this, GetMethodInfo());
+
+			await That(scenarioCallbackCount).IsEqualTo(1);
+		}
+	}
 }

--- a/Tests/Mockolate.Internal.Tests/Verify/TypedVerifyFastPathTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Verify/TypedVerifyFastPathTests.cs
@@ -8,6 +8,25 @@ namespace Mockolate.Internal.Tests.Verify;
 public class TypedVerifyFastPathTests
 {
 	[Fact]
+	public async Task IndexerGot_WithMemberIdAndInstalledBuffer_OnlyWalksBuffer()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallPropertyGetter(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new IndexerGetterAccess<int>(5));
+		interactions.RegisterInteraction(new IndexerGetterAccess<int>(5));
+
+		VerificationResult<object> result = registry.IndexerGot(
+			new object(), 0,
+			static i => i is IndexerGetterAccess<int> g && g.Parameter1 == 5,
+			() => "[5]");
+
+		await That(((IVerificationResult)result).Verify(arr => arr.Length == 0)).IsTrue();
+	}
+
+	[Fact]
 	public async Task IndexerGot_WithoutBuffer_ProducesParametersDescriptionInExpectation()
 	{
 		FastMockInteractions store = new(0);
@@ -34,6 +53,27 @@ public class TypedVerifyFastPathTests
 			() => "(5)");
 
 		await That(((IVerificationResult)result).Expectation).IsEqualTo("got indexer (5)");
+	}
+
+	[Fact]
+	public async Task IndexerSet_WithMemberIdAndInstalledBuffer_OnlyWalksBuffer()
+	{
+		FastMockInteractions store = new(1);
+		store.InstallPropertyGetter(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new IndexerSetterAccess<int, string>(5, "v"));
+		interactions.RegisterInteraction(new IndexerSetterAccess<int, string>(5, "v"));
+
+		IParameterMatch<string> value = (IParameterMatch<string>)It.IsAny<string>();
+		VerificationResult<object> result = registry.IndexerSet(
+			new object(), 0,
+			static (i, v) => i is IndexerSetterAccess<int, string> s && s.Parameter1 == 5 && v.Matches(s.TypedValue),
+			value,
+			() => "[5]");
+
+		await That(((IVerificationResult)result).Verify(arr => arr.Length == 0)).IsTrue();
 	}
 
 	[Fact]
@@ -92,6 +132,24 @@ public class TypedVerifyFastPathTests
 		VerificationResult<object> result = registry.SubscribedToTyped(new object(), 5, "OnFoo");
 
 		await That(((IVerificationResult)result).Expectation).IsEqualTo("subscribed to event OnFoo");
+	}
+
+	[Fact]
+	public async Task TryGetBuffer_WhenBufferReturned_TypedFastPathIgnoresOtherInteractions()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod0Buffer buffer = store.InstallMethod(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		buffer.Append("Foo");
+
+		interactions.RegisterInteraction(new MethodInvocation("Foo"));
+		interactions.RegisterInteraction(new MethodInvocation("Foo"));
+
+		registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Once();
+
+		await That(true).IsTrue();
 	}
 
 	[Fact]
@@ -208,6 +266,68 @@ public class TypedVerifyFastPathTests
 	}
 
 	[Fact]
+	public async Task VerifyMethod3_FallbackPath_RequiresAllParametersToMatch()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int>("M", 1, 2, 3));
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int>("M", 1, 2, 99));
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int>("M", 1, 99, 3));
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int>("M", 99, 2, 3));
+
+		VerificationResult<object>.IgnoreParameters result = registry.VerifyMethod(
+			new object(), 0, "M",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<int>)It.Is(2),
+			(IParameterMatch<int>)It.Is(3),
+			() => "M(1, 2, 3)");
+
+		await That(((IVerificationResult)result).Verify(arr => arr.Length == 1)).IsTrue();
+	}
+
+	[Fact]
+	public async Task VerifyMethod4_FallbackPath_RequiresAllParametersToMatch()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int, int>("M", 1, 2, 3, 4));
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int, int>("M", 1, 2, 3, 99));
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int, int>("M", 1, 2, 99, 4));
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int, int>("M", 1, 99, 3, 4));
+		interactions.RegisterInteraction(new MethodInvocation<int, int, int, int>("M", 99, 2, 3, 4));
+
+		VerificationResult<object>.IgnoreParameters result = registry.VerifyMethod(
+			new object(), 0, "M",
+			(IParameterMatch<int>)It.Is(1),
+			(IParameterMatch<int>)It.Is(2),
+			(IParameterMatch<int>)It.Is(3),
+			(IParameterMatch<int>)It.Is(4),
+			() => "M(1, 2, 3, 4)");
+
+		await That(((IVerificationResult)result).Verify(arr => arr.Length == 1)).IsTrue();
+	}
+
+	[Fact]
+	public async Task VerifyProperty_WithMemberIdButNoBuffer_FallbackPredicateFiltersByName()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new PropertyGetterAccess("P"));
+		interactions.RegisterInteraction(new PropertyGetterAccess("P"));
+		interactions.RegisterInteraction(new PropertyGetterAccess("Q"));
+
+		VerificationResult<object> result = registry.VerifyProperty(new object(), 5, "P");
+
+		await That(((IVerificationResult)result).Verify(arr => arr.Length == 2)).IsTrue();
+	}
+
+	[Fact]
 	public async Task VerifyProperty_WithMemberIdButNoBuffer_FallsBackToStringKeyedPath()
 	{
 		FastMockInteractions store = new(0);
@@ -221,6 +341,23 @@ public class TypedVerifyFastPathTests
 
 		await That(((IVerificationResult)result).Expectation).IsEqualTo("got property P");
 		((IVerificationResult)result).Verify(arr => arr.Length == 2);
+	}
+
+	[Fact]
+	public async Task VerifyPropertySetter_WithMemberIdButNoBuffer_FallbackPredicateFiltersByName()
+	{
+		FastMockInteractions store = new(0);
+		MockRegistry registry = new(MockBehavior.Default, store);
+		IMockInteractions interactions = store;
+
+		interactions.RegisterInteraction(new PropertySetterAccess<int>("P", 1));
+		interactions.RegisterInteraction(new PropertySetterAccess<int>("P", 2));
+		interactions.RegisterInteraction(new PropertySetterAccess<int>("Q", 3));
+
+		VerificationResult<object> result = registry.VerifyProperty(
+			new object(), 5, "P", (IParameterMatch<int>)It.IsAny<int>());
+
+		await That(((IVerificationResult)result).Verify(arr => arr.Length == 2)).IsTrue();
 	}
 
 	[Fact]


### PR DESCRIPTION
This pull request adds comprehensive new unit tests for the `MockRegistry` and its fast-path/fallback behavior in various scenarios, focusing on indexer, property, method, and event interactions. The new tests ensure correct handling of table/buffer boundaries, fallback logic, and scenario routing, significantly improving test coverage and confidence in the registry's edge-case behavior.

**Major additions and improvements:**

*Fast-path and fallback behavior for indexers, properties, and methods:*
- Added tests to verify that indexer and property getter/setter methods correctly use fast-path buffers when available, and properly fall back to slower, name-based or cold-path logic at buffer/table boundaries or when buffers are missing. This includes validation that only matching interactions are considered and that fallback predicates filter by name as expected.
- Added tests to ensure that, in fallback paths for multi-parameter methods, all parameters must match for verification to succeed.

*Event subscription/unsubscription and scenario routing:*
- Introduced tests to verify correct error messages when adding/removing events with null methods, and to ensure scenario-specific event setups are correctly routed when scenarios are active.

*Edge-case and boundary condition handling:*
- Added tests to cover table and buffer length boundaries for indexers, properties, and events, confirming that no exceptions are thrown and correct fallback logic is executed.

*Interaction recording and behavior skipping:*
- Included tests to check that interaction recording is correctly skipped when the mock behavior is configured to do so, ensuring no unintended side effects.