### PR TITLE
fix: preserve init accessor on init-only properties

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -12,6 +12,7 @@ internal record Method
 		UseOverride = methodSymbol.IsVirtual || methodSymbol.IsAbstract;
 		IsAbstract = methodSymbol.IsAbstract;
 		IsStatic = methodSymbol.IsStatic;
+		IsInitOnly = methodSymbol.IsInitOnly;
 		ReturnType = methodSymbol.ReturnsVoid ? Type.Void : Type.From(methodSymbol.ReturnType);
 		Name = Helpers.EscapeIfKeyword(methodSymbol.ExplicitInterfaceImplementations.Length > 0 ? methodSymbol.ExplicitInterfaceImplementations[0].Name : methodSymbol.Name);
 		ContainingType = methodSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
@@ -51,6 +52,7 @@ internal record Method
 	public bool UseOverride { get; }
 	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
+	public bool IsInitOnly { get; }
 	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal;
 
 	public MemberType MemberType => (IsStatic, IsProtected) switch

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2646,7 +2646,7 @@ internal static partial class Sources
 				sb.Append(property.Setter.Accessibility.ToVisibilityString()).Append(' ');
 			}
 
-			sb.AppendLine("set");
+			sb.AppendLine(property.Setter.IsInitOnly ? "init" : "set");
 			sb.AppendLine("\t\t\t{");
 
 			// Ref-struct-keyed indexer setter: dispatches through
@@ -2702,7 +2702,7 @@ internal static partial class Sources
 							.Append(", value);").AppendLine();
 					}
 
-					if (!property.IsStatic)
+					if (!property.IsStatic && !property.Setter.IsInitOnly)
 					{
 						sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className)
 							.Append(" wraps)").AppendLine();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -7,6 +7,45 @@ public sealed partial class MockTests
 		public sealed class PropertiesTests
 		{
 			[Fact]
+			public async Task InitOnlyProperty_ShouldEmitInitAccessorAndCompile()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyService
+					     {
+					         string Name { get; init; }
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+				await That(result.Sources["Mock.IMyService.g.cs"])
+					.Contains("""
+					          		public string Name
+					          		{
+					          			get
+					          			{
+					          				return this.MockRegistry.GetPropertyFast<string>(global::Mockolate.Mock.IMyService.MemberId_Name_Get, global::Mockolate.Mock.IMyService.PropertyAccess_Name_Get, static b => b.DefaultValue.Generate(default(string)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.Name);
+					          			}
+					          			init
+					          			{
+					          				this.MockRegistry.SetPropertyFast<string>(global::Mockolate.Mock.IMyService.MemberId_Name_Get, global::Mockolate.Mock.IMyService.MemberId_Name_Set, "global::MyCode.IMyService.Name", value);
+					          			}
+					          		}
+					          """).IgnoringNewlineStyle();
+			}
+
+			[Fact]
 			public async Task MultipleImplementations_ShouldOnlyHaveOneExplicitImplementation()
 			{
 				GeneratorResult result = Generator


### PR DESCRIPTION
This pull request adds support for C# `init`-only properties in the source generator, ensuring that properties declared with the `init` accessor are correctly recognized and emitted in generated code. The changes update both the code generation logic and the method/property metadata, and include a new test to verify this functionality.

**Support for init-only properties:**

* Added an `IsInitOnly` property to the `Method` entity to track whether a method or property accessor is `init`-only. 
* Updated property code generation to emit `init` instead of `set` for `init`-only setters in generated mock classes. 
* Modified the logic for generating property setters to skip certain code paths for `init`-only properties, ensuring correct behavior.