### PR TITLE
fix: rename verify lambda variable to avoid collision with parameter named i

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -5812,24 +5812,24 @@ internal static partial class Sources
 		sb.Append(">(this, ").Append(methodMemberId).Append(", ").Append(method.GetUniqueNameString());
 		if (useParameters)
 		{
-			sb.Append(", i => parameters switch").AppendLine();
+			sb.Append(", __i => parameters switch").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\t\tglobal::Mockolate.Parameters.IParametersMatch m => m.Matches([")
-				.Append(string.Join(", ", Enumerable.Range(1, method.Parameters.Count).Select(i => $"i.Parameter{i}")))
+				.Append(string.Join(", ", Enumerable.Range(1, method.Parameters.Count).Select(i => $"__i.Parameter{i}")))
 				.Append("]),").AppendLine();
 			sb.Append("\t\t\t\t\tglobal::Mockolate.Parameters.INamedParametersMatch m => m.Matches([")
-				.Append(string.Join(", ", method.Parameters.Select((p, i) => $"(\"{p.Name}\", i.Parameter{i + 1})")))
+				.Append(string.Join(", ", method.Parameters.Select((p, i) => $"(\"{p.Name}\", __i.Parameter{i + 1})")))
 				.Append("]),").AppendLine();
 			sb.Append("\t\t\t\t\t_ => true").AppendLine();
 			sb.Append("\t\t\t\t}");
 		}
 		else if (method.Parameters.Count == 0)
 		{
-			sb.Append(", i => true");
+			sb.Append(", __i => true");
 		}
 		else
 		{
-			sb.Append(", i => ");
+			sb.Append(", __i => ");
 
 			int i = 0;
 			foreach (MethodParameter parameter in method.Parameters)
@@ -5845,7 +5845,7 @@ internal static partial class Sources
 				if (isValueParam)
 				{
 					sb.Append(
-						$"(global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals({parameter.Name}, i.Parameter{i + 1}))");
+						$"(global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals({parameter.Name}, __i.Parameter{i + 1}))");
 				}
 				else if (parameter.RefKind == RefKind.Out || parameter.RefKind == RefKind.Ref ||
 				         parameter.RefKind == RefKind.RefReadOnlyParameter)
@@ -5853,12 +5853,12 @@ internal static partial class Sources
 					// out/ref verify parameters use IVerifyOutParameter<T> / IVerifyRefParameter<T>, which don't inherit
 					// from IParameter<T> — covariance isn't applicable, so keep the direct IParameterMatch<T> check.
 					sb.Append(
-						$"({parameter.Name} is global::Mockolate.Parameters.IParameterMatch<{parameter.ToTypeOrWrapper()}> {parameter.Name}Match ? {parameter.Name}Match.Matches(i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
+						$"({parameter.Name} is global::Mockolate.Parameters.IParameterMatch<{parameter.ToTypeOrWrapper()}> {parameter.Name}Match ? {parameter.Name}Match.Matches(__i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(__i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
 				}
 				else
 				{
 					sb.Append(
-						$"({parameter.Name} is not null ? CovariantParameterAdapter<{parameter.ToTypeOrWrapper()}>.Wrap({parameter.Name}).Matches(i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
+						$"({parameter.Name} is not null ? CovariantParameterAdapter<{parameter.ToTypeOrWrapper()}>.Wrap({parameter.Name}).Matches(__i.Parameter{i + 1}) : global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals(__i.Parameter{i + 1}, default({parameter.ToTypeOrWrapper()})))");
 				}
 
 				i++;

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -1290,6 +1290,32 @@ public sealed partial class MockTests
 					.DoesNotContain("public override bool MyMethod<T>(T entity)\n\t\t\twhere T :").IgnoringNewlineStyle()
 					.Because("CS0460: constraints on override methods are inherited from the base method");
 			}
+
+			[Fact]
+			public async Task ParameterNamedI_ShouldNotCollideWithVerifyLambdaVariable()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyService
+					     {
+					         void Do(int i, string s);
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request addresses a potential variable naming collision in the mock class source generator and adds a corresponding unit test to ensure correct behavior. The main change is to avoid conflicts between user-defined parameter names (such as `i`) and internal lambda variables used in generated code, by renaming the internal variable. Additionally, a test is added to verify this fix.

**Mock source generator improvements:**

* Updated the mock class generator in `Sources.MockClass.cs` to use `__i` instead of `i` as the lambda variable in generated verification code, preventing naming collisions with user-defined parameter names.