### PR TITLE
fix: preserve ref/out/in modifiers when raising events with by-ref delegates

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -5251,6 +5251,16 @@ internal static partial class Sources
 				.Append(FormatParametersWithTypeAndName(@event.Delegate.Parameters))
 				.Append(")").AppendLine();
 			sb.AppendLine("\t\t{");
+			// Pre-assign declared `out` parameters: when no subscriber exists the conditional
+			// Invoke is skipped, so the compiler-required definite assignment must come from us.
+			foreach (MethodParameter p in @event.Delegate.Parameters)
+			{
+				if (p.RefKind == RefKind.Out)
+				{
+					sb.Append("\t\t\t").Append(p.Name).Append(" = default!;").AppendLine();
+				}
+			}
+
 			sb.Append("\t\t\t").Append(backingFieldAccess).Append("?.Invoke(");
 			if (@event.Delegate.Parameters.Count > 0)
 			{
@@ -5279,13 +5289,36 @@ internal static partial class Sources
 			sb.AppendLine("\t\t{");
 			sb.Append("\t\t\tglobal::Mockolate.MockBehavior mockBehavior = ").Append(mockRegistry).Append(".Behavior;")
 				.AppendLine();
+			// ref/out delegate parameters can't accept arbitrary expressions — bind each generated
+			// default to a local so it has an addressable storage location for the Invoke call.
+			bool hasByRef = @event.Delegate.Parameters.Any(p
+				=> p.RefKind == RefKind.Ref || p.RefKind == RefKind.Out ||
+				   p.RefKind == RefKind.In || p.RefKind == RefKind.RefReadOnlyParameter);
+
+			List<string> argNames = new();
+			int idx = 0;
+			foreach (MethodParameter p in @event.Delegate.Parameters)
+			{
+				idx++;
+				string defaultExpr = $"mockBehavior.DefaultValue.Generate(default({p.Type.Fullname.TrimEnd('?')}))";
+				if (hasByRef)
+				{
+					string local = $"__arg{idx}";
+					sb.Append("\t\t\t").Append(p.Type.Fullname).Append(' ').Append(local).Append(" = ")
+						.Append(defaultExpr).Append(";").AppendLine();
+					argNames.Add($"{RefKindKeyword(p.RefKind)}{local}");
+				}
+				else
+				{
+					argNames.Add(defaultExpr);
+				}
+			}
+
 			sb.Append("\t\t\t").Append(backingFieldAccess).Append("?.Invoke(");
 
 			if (@event.Delegate.Parameters.Count > 0)
 			{
-				sb.Append(string.Join(", ",
-					@event.Delegate.Parameters.Select(p
-						=> $"mockBehavior.DefaultValue.Generate(default({p.Type.Fullname.TrimEnd('?')}))")));
+				sb.Append(string.Join(", ", argNames));
 			}
 
 			sb.Append(");").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.cs
@@ -395,16 +395,27 @@ internal static partial class Sources
 		=> string.Join(", ", parameters.Select(p => p.Name));
 
 	/// <summary>
-	///     Formats parameters with type and name (e.g., "int value, string name").
+	///     Formats parameters with type and name (e.g., "int value, ref string name"), preserving any
+	///     ref/out/in modifier so the generated declaration matches the original delegate signature.
 	/// </summary>
 	private static string FormatParametersWithTypeAndName(IEnumerable<MethodParameter> parameters)
-		=> string.Join(", ", parameters.Select(p => $"{p.Type.Fullname} {p.Name}"));
+		=> string.Join(", ", parameters.Select(p => $"{RefKindKeyword(p.RefKind)}{p.Type.Fullname} {p.Name}"));
 
 	/// <summary>
-	///     Formats parameters as names only (e.g., "value1, value2").
+	///     Formats parameters as names only (e.g., "ref value1, out value2"), preserving any
+	///     ref/out/in modifier so the generated invocation argument list matches the delegate signature.
 	/// </summary>
 	private static string FormatParametersAsNames(IEnumerable<MethodParameter> parameters)
-		=> string.Join(", ", parameters.Select(p => p.Name));
+		=> string.Join(", ", parameters.Select(p => $"{RefKindKeyword(p.RefKind)}{p.Name}"));
+
+	private static string RefKindKeyword(RefKind kind) => kind switch
+	{
+		RefKind.Ref => "ref ",
+		RefKind.Out => "out ",
+		RefKind.In => "in ",
+		RefKind.RefReadOnlyParameter => "ref readonly ",
+		_ => "",
+	};
 
 	/// <summary>
 	///     Appends a NamedParameter with nullable handling.

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
@@ -450,6 +450,33 @@ public sealed partial class MockTests
 					          		}
 					          """).IgnoringNewlineStyle();
 			}
+
+			[Fact]
+			public async Task EventWithRefOutDelegate_ShouldPreserveModifiersOnRaise()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public delegate void MyEventDelegate(ref int value, out string message);
+
+					     public interface IMyService
+					     {
+					         event MyEventDelegate SomeEvent;
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request improves the code generation logic for event delegates with by-ref parameters (`ref`, `out`, `in`, and `ref readonly`) in the mock class source generator. The changes ensure that parameter modifiers are preserved in both method declarations and invocations, and that definite assignment requirements for `out` parameters are satisfied, preventing potential compiler errors. Additionally, a new test verifies correct behavior for events with `ref` and `out` delegate parameters.

**Code generation improvements for by-ref parameters:**

* Updated `FormatParametersWithTypeAndName` and `FormatParametersAsNames` to preserve `ref`, `out`, and `in` modifiers, ensuring generated method signatures and invocations match the original delegate signatures. Introduced the helper method `RefKindKeyword` for cleaner modifier handling.
* In the mock event raise implementation, added logic to pre-assign default values to `out` parameters when there are no subscribers, ensuring definite assignment as required by the compiler.
* Modified argument generation for delegate invocations to bind by-ref arguments to local variables with default values, ensuring addressable storage and correct modifier usage.