### PR TITLE
fix: skip IMockSetup<T> parent for interfaces with only static abstract events

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1153,7 +1153,7 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary($"Set up the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 		sb.Append("\tinternal interface IMockSetupFor").Append(name);
-		if (!hasStaticMembers)
+		if (!hasStaticMembers && !hasStaticEvents)
 		{
 			sb.Append(" : global::Mockolate.Setup.IMockSetup<").Append(@class.ClassFullName).Append(">").AppendLine();
 		}
@@ -1235,7 +1235,7 @@ internal static partial class Sources
 
 		sb.AppendXmlSummary($"Verify interactions with the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 		sb.Append("\tinternal interface IMockVerifyFor").Append(name);
-		if (!hasStaticMembers)
+		if (!hasStaticMembers && !hasStaticEvents)
 		{
 			sb.Append(" : global::Mockolate.Verify.IMockVerify<").Append(@class.ClassFullName).Append(">").AppendLine();
 		}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -418,6 +418,32 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task ParameterNamedI_ShouldNotCollideWithVerifyLambdaVariable()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyService
+					     {
+					         void Do(int i, string s);
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+			}
+
+			[Fact]
 			public async Task ShouldImplementAllMethodsFromInterfaces()
 			{
 				GeneratorResult result = Generator
@@ -1250,6 +1276,33 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task StaticAbstractEventOnly_ShouldCompile()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using System;
+					     using Mockolate;
+
+					     namespace MyCode;
+
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyService
+					     {
+					         static abstract event Action<int> AbstractStaticEvent;
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+			}
+
+			[Fact]
 			public async Task VirtualMethodOverride_WithConstrainedGeneric_ShouldNotRepeatConstraints()
 			{
 				GeneratorResult result = Generator
@@ -1289,32 +1342,6 @@ public sealed partial class MockTests
 					          """).IgnoringNewlineStyle().And
 					.DoesNotContain("public override bool MyMethod<T>(T entity)\n\t\t\twhere T :").IgnoringNewlineStyle()
 					.Because("CS0460: constraints on override methods are inherited from the base method");
-			}
-
-			[Fact]
-			public async Task ParameterNamedI_ShouldNotCollideWithVerifyLambdaVariable()
-			{
-				GeneratorResult result = Generator
-					.Run("""
-					     using Mockolate;
-
-					     namespace MyCode;
-
-					     public class Program
-					     {
-					         public static void Main(string[] args)
-					         {
-					     		_ = IMyService.CreateMock();
-					         }
-					     }
-
-					     public interface IMyService
-					     {
-					         void Do(int i, string s);
-					     }
-					     """);
-
-				await That(result.Diagnostics).IsEmpty();
 			}
 		}
 	}


### PR DESCRIPTION
This pull request improves the handling of static abstract events in mock generation and adds targeted tests to prevent variable name collisions and ensure correct code generation. The main changes focus on updating interface inheritance logic in the source generator and expanding test coverage.

### Source generator improvements

* Updated the logic in `Sources.MockClass.cs` so that generated `IMockSetupFor` and `IMockVerifyFor` interfaces only inherit from base mock interfaces if the target interface does not have static members or static events, preventing incorrect inheritance for interfaces with static abstract events.