### PR TITLE
fix: support ref and ref readonly return types

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -13,6 +13,8 @@ internal record Method
 		IsAbstract = methodSymbol.IsAbstract;
 		IsStatic = methodSymbol.IsStatic;
 		IsInitOnly = methodSymbol.IsInitOnly;
+		IsRefReturn = methodSymbol.RefKind == RefKind.Ref;
+		IsRefReadonlyReturn = methodSymbol.RefKind == RefKind.RefReadOnly;
 		ReturnType = methodSymbol.ReturnsVoid ? Type.Void : Type.From(methodSymbol.ReturnType);
 		Name = Helpers.EscapeIfKeyword(methodSymbol.ExplicitInterfaceImplementations.Length > 0 ? methodSymbol.ExplicitInterfaceImplementations[0].Name : methodSymbol.Name);
 		ContainingType = methodSymbol.ContainingType.ToDisplayString(Helpers.TypeDisplayFormat);
@@ -53,6 +55,8 @@ internal record Method
 	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
 	public bool IsInitOnly { get; }
+	public bool IsRefReturn { get; }
+	public bool IsRefReadonlyReturn { get; }
 	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal;
 
 	public MemberType MemberType => (IsStatic, IsProtected) switch

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Mockolate.SourceGenerators.Entities;
-using Mockolate.SourceGenerators.Internals;
 using GenericParameter = Mockolate.SourceGenerators.Entities.GenericParameter;
 using Type = Mockolate.SourceGenerators.Entities.Type;
 
@@ -2670,7 +2669,7 @@ internal static partial class Sources
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
 						useFastForIndexer ? indexerSetIdRef : null,
 						useFastForIndexer ? indexerGetIdRef : null,
-						cachedBufferRef: indexerSetCachedBufferRef);
+						indexerSetCachedBufferRef);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append(");")
@@ -2727,7 +2726,7 @@ internal static partial class Sources
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
 						useFastForIndexer ? indexerSetIdRef : null,
 						useFastForIndexer ? indexerGetIdRef : null,
-						cachedBufferRef: indexerSetCachedBufferRef);
+						indexerSetCachedBufferRef);
 					sb.Append("\t\t\t\tif (!").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append("))").AppendLine();
@@ -2763,7 +2762,7 @@ internal static partial class Sources
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
 						useFastForIndexer ? indexerSetIdRef : null,
 						useFastForIndexer ? indexerGetIdRef : null,
-						cachedBufferRef: indexerSetCachedBufferRef);
+						indexerSetCachedBufferRef);
 					sb.Append("\t\t\t\t").Append(mockRegistry).Append(".ApplyIndexerSetter(")
 						.Append(accessVarName).Append(", ").Append(setupVarName).Append(", value, ")
 						.Append(signatureIndex).Append(");").AppendLine();
@@ -2843,6 +2842,22 @@ internal static partial class Sources
 #pragma warning restore S107
 	{
 		string mockRegistry = method.IsStatic ? "MockRegistryProvider.Value" : $"this.{mockRegistryName}";
+		string returnRefPrefix = (method.IsRefReturn, method.IsRefReadonlyReturn) switch
+		{
+			(true, _) => "ref ",
+			(false, true) => "ref readonly ",
+			(_, _) => "",
+		};
+		string refReturnStorageField = method.IsRefReturn || method.IsRefReadonlyReturn
+			? "_refReturnStorage_" + new string((method.ContainingType + "_" + method.Name)
+				.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray())
+			: "";
+		if (method.IsRefReturn || method.IsRefReadonlyReturn)
+		{
+			sb.Append("\t\tprivate ").Append(method.ReturnType.Fullname).Append(' ')
+				.Append(refReturnStorageField).Append(';').AppendLine();
+		}
+
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(method.ContainingType.EscapeForXmlDoc()).Append('.')
 			.Append(method.Name.EscapeForXmlDoc()).Append('(')
 			.Append(string.Join(", ", method.Parameters.Select(p => p.RefKind.GetString() + p.Type.Fullname))
@@ -2856,7 +2871,7 @@ internal static partial class Sources
 				sb.Append("static ");
 			}
 
-			sb.Append(method.ReturnType.Fullname).Append(' ').Append(className).Append('.').Append(method.Name)
+			sb.Append(returnRefPrefix).Append(method.ReturnType.Fullname).Append(' ').Append(className).Append('.').Append(method.Name)
 				.Append('(');
 		}
 		else
@@ -2876,7 +2891,7 @@ internal static partial class Sources
 					sb.Append("override ");
 				}
 
-				sb.Append(method.ReturnType.Fullname).Append(' ')
+				sb.Append(returnRefPrefix).Append(method.ReturnType.Fullname).Append(' ')
 					.Append(method.Name).Append('(');
 			}
 			else
@@ -2886,7 +2901,7 @@ internal static partial class Sources
 					sb.Append("static ");
 				}
 
-				sb.Append(method.ReturnType.Fullname).Append(' ')
+				sb.Append(returnRefPrefix).Append(method.ReturnType.Fullname).Append(' ')
 					.Append(method.ExplicitImplementation).Append('.').Append(method.Name).Append('(');
 			}
 		}
@@ -3217,13 +3232,33 @@ internal static partial class Sources
 
 		if (method.ReturnType != Type.Void)
 		{
+			bool isRefReturn = method.IsRefReturn || method.IsRefReadonlyReturn;
 			string returnValue = Helpers.GetUniqueLocalVariableName("returnValue", method.Parameters);
 			sb.Append("\t\t\tif (").Append(methodSetup).Append("?.HasReturnCallbacks != true && ")
 				.Append(hasWrappedResult).Append(")").AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\treturn ").Append(wrappedResult).Append(";").AppendLine();
+			if (isRefReturn)
+			{
+				sb.Append("\t\t\t\tthis.").Append(refReturnStorageField).Append(" = ")
+					.Append(wrappedResult).Append(";").AppendLine();
+				sb.Append("\t\t\t\treturn ref this.").Append(refReturnStorageField).Append(";").AppendLine();
+			}
+			else
+			{
+				sb.Append("\t\t\t\treturn ").Append(wrappedResult).Append(";").AppendLine();
+			}
+
 			sb.Append("\t\t\t}").AppendLine();
-			sb.Append("\t\t\treturn ").Append(methodSetup).Append("?.TryGetReturnValue(");
+			if (isRefReturn)
+			{
+				sb.Append("\t\t\tthis.").Append(refReturnStorageField).Append(" = ")
+					.Append(methodSetup).Append("?.TryGetReturnValue(");
+			}
+			else
+			{
+				sb.Append("\t\t\treturn ").Append(methodSetup).Append("?.TryGetReturnValue(");
+			}
+
 			string defaultValueGeneratorSuffix = "";
 			if (method.Parameters.Count > 0)
 			{
@@ -3235,6 +3270,10 @@ internal static partial class Sources
 				.AppendDefaultValueGeneratorFor(method.ReturnType, $"{mockRegistry}.Behavior.DefaultValue",
 					defaultValueGeneratorSuffix)
 				.Append(';').AppendLine();
+			if (isRefReturn)
+			{
+				sb.Append("\t\t\treturn ref this.").Append(refReturnStorageField).Append(";").AppendLine();
+			}
 		}
 
 		sb.AppendLine("\t\t}");

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -86,6 +86,32 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task RefReturn_ShouldCompile()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyService
+					     {
+					         ref int GetByRef();
+					         ref readonly int GetByRefReadonly();
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+			}
+
+			[Fact]
 			public async Task ShouldImplementAllPropertiesFromInterfaces()
 			{
 				GeneratorResult result = Generator


### PR DESCRIPTION
This pull request adds support for generating mock methods that return by reference (`ref` and `ref readonly`). The changes ensure that the code generator properly handles these method signatures and produces compilable code for interfaces with `ref` and `ref readonly` return types. Additionally, a new test verifies that this functionality works as expected.

**Support for ref and ref readonly return types:**

* The `Method` entity now tracks whether a method returns by `ref` or `ref readonly` by adding `IsRefReturn` and `IsRefReadonlyReturn` properties, and sets them based on the method symbol.
* The code generator (`Sources.MockClass.cs`) now:
  - Declares a backing field for storing the value returned by reference when generating such methods.
  - Prepends the correct `ref` or `ref readonly` modifier to the method signature in all supported cases.
  - Assigns the return value to the backing field and returns it by reference, both for the normal and fallback/mock return paths.