### PR TITLE
fix: rename methodSetup local in setup impl to avoid parameter name collision

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -4257,9 +4257,10 @@ internal static partial class Sources
 
 		sb.AppendLine();
 		sb.AppendLine("\t\t{");
+		string methodSetupVar = Helpers.GetUniqueLocalVariableName("methodSetup", method.Parameters);
 		if (method.ReturnType != Type.Void)
 		{
-			sb.Append("\t\t\tvar methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<")
+			sb.Append("\t\t\tvar ").Append(methodSetupVar).Append(" = new global::Mockolate.Setup.ReturnMethodSetup<")
 				.AppendTypeOrWrapper(method.ReturnType);
 
 			foreach (MethodParameter parameter in method.Parameters)
@@ -4271,7 +4272,7 @@ internal static partial class Sources
 		}
 		else
 		{
-			sb.Append("\t\t\tvar methodSetup = new global::Mockolate.Setup.VoidMethodSetup");
+			sb.Append("\t\t\tvar ").Append(methodSetupVar).Append(" = new global::Mockolate.Setup.VoidMethodSetup");
 
 			if (method.Parameters.Count > 0)
 			{
@@ -4305,8 +4306,8 @@ internal static partial class Sources
 
 			sb.Append(");").AppendLine();
 			sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(".SetupMethod(")
-				.Append(memberIdRef).Append(", ").Append(scopePrefix).Append("methodSetup);").AppendLine();
-			sb.Append("\t\t\treturn methodSetup;").AppendLine();
+				.Append(memberIdRef).Append(", ").Append(scopePrefix).Append(methodSetupVar).Append(");").AppendLine();
+			sb.Append("\t\t\treturn ").Append(methodSetupVar).Append(';').AppendLine();
 		}
 		else
 		{
@@ -4330,8 +4331,8 @@ internal static partial class Sources
 
 			sb.Append(");").AppendLine();
 			sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(".SetupMethod(")
-				.Append(memberIdRef).Append(", ").Append(scopePrefix).Append("methodSetup);").AppendLine();
-			sb.Append("\t\t\treturn methodSetup;").AppendLine();
+				.Append(memberIdRef).Append(", ").Append(scopePrefix).Append(methodSetupVar).Append(");").AppendLine();
+			sb.Append("\t\t\treturn ").Append(methodSetupVar).Append(';').AppendLine();
 		}
 
 		sb.AppendLine("\t\t}");

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -444,6 +444,32 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task ParameterNamedSetup_ShouldCompile()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public interface IMyService
+					     {
+					         void Run(int setup, int methodSetup, int s_methodSetup);
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+			}
+
+			[Fact]
 			public async Task ShouldImplementAllMethodsFromInterfaces()
 			{
 				GeneratorResult result = Generator


### PR DESCRIPTION
This pull request addresses a variable naming collision issue in the generated mock setup code, ensuring that local variables do not conflict with method parameter names. It also adds a test to verify that methods with parameters named `setup` or `methodSetup` compile correctly.

**Fixes for variable naming collisions in generated code:**

* Updated `AppendMethodSetupImplementation` in `Sources.MockClass.cs` to generate unique local variable names for method setup variables, preventing conflicts with parameter names.
* Replaced hardcoded `"methodSetup"` variable names with a unique name throughout the method setup code, including in return statements and registry setup calls.