### PR TITLE
coverage: add missing tests for Sources.MockClass.cs

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -224,7 +224,7 @@ internal static partial class Sources
 			sb.Append("\t\t\t=> CreateMock(null, setup, constructorParameters);").AppendLine();
 			sb.AppendLine();
 
-			AppendTypedCreateMockOverloads(sb, @class, constructors, setupType, escapedClassName, createMockReturns);
+			AppendTypedCreateMockOverloads(sb, @class, constructors!.Value, setupType, escapedClassName, createMockReturns);
 		}
 
 		sb.AppendXmlSummary(
@@ -738,16 +738,6 @@ internal static partial class Sources
 				AppendMockSubject_BehaviorBaseClassConstructor(sb, name, constructor,
 					@class.HasRequiredMembers);
 			}
-		}
-		else
-		{
-			sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
-			sb.Append("\t\tpublic ").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry)").AppendLine();
-			sb.Append("\t\t{").AppendLine();
-			sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(" = mockRegistry;").AppendLine();
-			sb.Append("\t\t}").AppendLine();
-			sb.AppendLine();
-			AppendMockSubject_BehaviorConstructor(sb, name);
 		}
 
 		AppendMockSubject_ImplementClass(sb, @class, mockRegistryName, null, memberIds, memberIdPrefix);
@@ -1773,13 +1763,8 @@ internal static partial class Sources
 #pragma warning restore S107 // Methods should not have too many parameters
 
 	private static void AppendTypedCreateMockOverloads(StringBuilder sb, Class @class,
-		EquatableArray<Method>? constructors, string setupType, string escapedClassName, string createMockReturns)
+		EquatableArray<Method> constructors, string setupType, string escapedClassName, string createMockReturns)
 	{
-		if (constructors is null)
-		{
-			return;
-		}
-
 		// Seeded signatures track the hand-written CreateMock overloads so typed overloads that
 		// would collide with them are skipped. The key order mirrors the emitted C# signature:
 		// "mockBehavior? | setup? | ctor-param-types...".
@@ -1795,7 +1780,7 @@ internal static partial class Sources
 			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>|object?[]",
 		};
 
-		foreach (Method constructor in constructors.Value)
+		foreach (Method constructor in constructors)
 		{
 			if (constructor.Parameters.Count == 0)
 			{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -33,7 +33,9 @@ public sealed partial class MockTests
 				await That(result.Sources["Mock.MyService.g.cs"])
 					.DoesNotContain("global::MyCode.MyService wraps)")
 					.IgnoringNewlineStyle()
-					.Because("the pattern-match cast must not bind a local named `wraps` while the user's parameter already occupies that name").And
+					.Because(
+						"the pattern-match cast must not bind a local named `wraps` while the user's parameter already occupies that name")
+					.And
 					.Contains("global::MyCode.MyService wraps1)")
 					.IgnoringNewlineStyle().And
 					.Contains("wraps1.Run(wraps);")
@@ -205,7 +207,8 @@ public sealed partial class MockTests
 				await That(result.Diagnostics).IsEmpty();
 				await That(result.Sources).ContainsKey("Mock.IMyService.g.cs");
 				await That(result.Sources["Mock.IMyService.g.cs"])
-					.Contains("throw new global::System.NotSupportedException(\"Mockolate: methods with a generic type parameter declaring 'allows ref struct' are not supported. Method 'global::MyCode.IMyService.G8<T>'.\");");
+					.Contains(
+						"throw new global::System.NotSupportedException(\"Mockolate: methods with a generic type parameter declaring 'allows ref struct' are not supported. Method 'global::MyCode.IMyService.G8<T>'.\");");
 			}
 
 			[Fact]
@@ -271,7 +274,9 @@ public sealed partial class MockTests
 				await That(result.Sources["Mock.IMyService.g.cs"])
 					.Contains("IOutParameter<int> outParam_11")
 					.IgnoringNewlineStyle()
-					.Because("the numbered cast variable must not reuse the parameter name (the base is renamed so `outParam1`/`outParam2` parameters and `outParam_1` cast don't collide)").And
+					.Because(
+						"the numbered cast variable must not reuse the parameter name (the base is renamed so `outParam1`/`outParam2` parameters and `outParam_1` cast don't collide)")
+					.And
 					.Contains("IOutParameter<int> outParam_12")
 					.IgnoringNewlineStyle();
 			}
@@ -306,7 +311,8 @@ public sealed partial class MockTests
 					.IgnoringNewlineStyle().And
 					.Contains("methodSetup?.TriggerCallbacks(result);")
 					.IgnoringNewlineStyle().And
-					.Contains("return methodSetup?.TryGetReturnValue(result, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, result);")
+					.Contains(
+						"return methodSetup?.TryGetReturnValue(result, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, result);")
 					.IgnoringNewlineStyle();
 			}
 
@@ -444,6 +450,41 @@ public sealed partial class MockTests
 					.Contains("int global::MyCode.IMyServiceBase1.Value()").Once().And
 					.Contains("public int Value(int p1)").Once().And
 					.Contains("long global::MyCode.IMyServiceBase2.Value()").Once();
+			}
+
+			[Fact]
+			public async Task
+				MultipleStaticAbstractMethods_WithCollidingSignature_ShouldEmitStaticKeywordOnExplicitImplementation()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IDerived.CreateMock();
+					         }
+					     }
+
+					     public interface IBase
+					     {
+					         static abstract int Compute();
+					     }
+
+					     public interface IDerived : IBase
+					     {
+					         new static abstract int Compute();
+					     }
+					     """);
+
+				await That(result.Sources).ContainsKey("Mock.IDerived.g.cs");
+				await That(result.Sources["Mock.IDerived.g.cs"])
+					.Contains("static int global::MyCode.IBase.Compute(")
+					.Because(
+						"a colliding static abstract method on a base interface must be emitted as an explicit static implementation, with the static keyword preserved");
 			}
 
 			[Fact]
@@ -1358,6 +1399,40 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task StaticAbstractMethodWithParameter_ShouldAppendArgumentToFastBuffer()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IStaticOps.CreateMock();
+					         }
+					     }
+
+					     public interface IStaticOps
+					     {
+					         static abstract int DoIt(int value);
+					     }
+					     """);
+
+				await That(result.Sources).ContainsKey("Mock.IStaticOps.g.cs");
+				await That(result.Sources["Mock.IStaticOps.g.cs"])
+					.Contains("global::Mockolate.Interactions.FastMethod1Buffer<int>").And
+					.Contains("MockRegistryProvider.Value.Interactions).Buffers[")
+					.Because(
+						"static methods record interactions via the typed FastMethodBuffer accessed through the AsyncLocal-backed registry")
+					.And
+					.Contains("Append(\"global::MyCode.IStaticOps.DoIt\", value)")
+					.Because("the static-method fast-buffer branch must include the call argument when arity > 0");
+			}
+
+			[Fact]
 			public async Task VirtualMethodOverride_WithConstrainedGeneric_ShouldNotRepeatConstraints()
 			{
 				GeneratorResult result = Generator
@@ -1395,7 +1470,8 @@ public sealed partial class MockTests
 					          		public override bool MyMethod<T>(T entity)
 					          		{
 					          """).IgnoringNewlineStyle().And
-					.DoesNotContain("public override bool MyMethod<T>(T entity)\n\t\t\twhere T :").IgnoringNewlineStyle()
+					.DoesNotContain("public override bool MyMethod<T>(T entity)\n\t\t\twhere T :")
+					.IgnoringNewlineStyle()
 					.Because("CS0460: constraints on override methods are inherited from the base method");
 			}
 		}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -86,6 +86,41 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task
+				MultipleStaticAbstractProperties_WithCollidingName_ShouldEmitStaticKeywordOnExplicitImplementation()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IDerived.CreateMock();
+					         }
+					     }
+
+					     public interface IBase
+					     {
+					         static abstract int Counter { get; }
+					     }
+
+					     public interface IDerived : IBase
+					     {
+					         new static abstract int Counter { get; }
+					     }
+					     """);
+
+				await That(result.Sources).ContainsKey("Mock.IDerived.g.cs");
+				await That(result.Sources["Mock.IDerived.g.cs"])
+					.Contains("static int global::MyCode.IBase.Counter")
+					.Because(
+						"a colliding static abstract property on a base interface must be emitted as an explicit static implementation, with the static keyword preserved");
+			}
+
+			[Fact]
 			public async Task RefReturn_ShouldCompile()
 			{
 				GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CombinationTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CombinationTests.cs
@@ -40,12 +40,19 @@ public sealed partial class MockTests
 
 			await That(result.Sources).ContainsKey("Mock.MyService__IMyInterface.g.cs");
 			await That(result.Sources["Mock.MyService__IMyInterface.g.cs"])
-				.Contains("static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)").And
-				.Contains("static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)").And
-				.Contains("if (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)")
+				.Contains(
+					"static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)")
+				.And
+				.Contains(
+					"static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)")
+				.And
+				.Contains(
+					"if (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)")
 				.Because("the parameterless dispatch branch must be emitted").And
-				.Contains("else if (mock.MockRegistry.ConstructorParameters.Length >= 1 && mock.MockRegistry.ConstructorParameters.Length <= 2")
-				.Because("the 'else if' arity dispatch chain must include the optional-range branch for a mixed-required + defaulted ctor");
+				.Contains(
+					"else if (mock.MockRegistry.ConstructorParameters.Length >= 1 && mock.MockRegistry.ConstructorParameters.Length <= 2")
+				.Because(
+					"the 'else if' arity dispatch chain must include the optional-range branch for a mixed-required + defaulted ctor");
 		}
 
 		[Fact]
@@ -83,6 +90,42 @@ public sealed partial class MockTests
 				.Contains("No parameterless constructor found for 'MyCode.MyService'").And
 				.Contains("static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)").And
 				.DoesNotContain("static bool TryCastWithDefaultValue<TValue>");
+		}
+
+		[Fact]
+		public async Task
+			CombinationOnConcreteClassWithStaticAbstractInterface_ShouldPrimeMockRegistryProviderInBaseClassConstructor()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				     		_ = MyService.CreateMock().Implementing<IStaticAware>();
+				         }
+				     }
+
+				     public class MyService
+				     {
+				         public MyService() { }
+				     }
+
+				     public interface IStaticAware
+				     {
+				         static abstract int Counter { get; }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.MyService__IStaticAware.g.cs");
+			await That(result.Sources["Mock.MyService__IStaticAware.g.cs"])
+				.Contains("MockRegistryProvider.Value = mockRegistry;")
+				.Because(
+					"when a concrete base class is combined with an interface declaring static abstract members, the (MockRegistry) constructor must prime the AsyncLocal so virtual calls during base-class construction can resolve the registry");
 		}
 
 		[Fact]
@@ -152,7 +195,8 @@ public sealed partial class MockTests
 			await That(result.Sources).ContainsKey("Mock.MyService__IExtra.g.cs");
 			await That(result.Sources["Mock.MyService__IExtra.g.cs"])
 				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]")
-				.Because("AppendMockSubject_BaseClassConstructor must stamp SetsRequiredMembers on the generated constructor when the base class declares any `required` member");
+				.Because(
+					"AppendMockSubject_BaseClassConstructor must stamp SetsRequiredMembers on the generated constructor when the base class declares any `required` member");
 		}
 
 		[Fact]
@@ -188,7 +232,8 @@ public sealed partial class MockTests
 			await That(result.Sources["Mock.IBase__IStaticEvents.g.cs"])
 				.Contains("IMockStaticRaiseOnIStaticEvents").And
 				.Contains("#region IMockStaticRaiseOnIStaticEvents").And
-				.Contains("internal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider");
+				.Contains(
+					"internal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider");
 		}
 
 		[Fact]
@@ -226,7 +271,8 @@ public sealed partial class MockTests
 				.Contains("IMockStaticVerifyForIStaticAware").And
 				.Contains("#region IMockStaticSetupForIStaticAware").And
 				.Contains("#region IMockStaticVerifyForIStaticAware").And
-				.Contains("internal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider")
+				.Contains(
+					"internal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider")
 				.Because("the AsyncLocal field is required so static accessors can find the registry");
 		}
 	}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.RefStructTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.RefStructTests.cs
@@ -479,6 +479,78 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task MethodReturningNonSpanRefStruct_WithRefStructParameter_ShouldEmitNotSupportedExceptionAndSkipSetupSurface()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Packet(int id) { public int Id { get; } = id; }
+
+				     public interface IPacketTransformer
+				     {
+				         Packet Wrap(Packet input);
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IPacketTransformer.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.IPacketTransformer.g.cs");
+			await That(result.Sources["Mock.IPacketTransformer.g.cs"])
+				.Contains("Mockolate: methods returning a non-span ref struct are not supported. Method 'global::MyCode.IPacketTransformer.Wrap'.")
+				.Because("the method body must throw NotSupportedException because non-Span ref-struct return types cannot flow through the setup pipeline").And
+				.DoesNotContain("IRefStructReturnMethodSetup<global::MyCode.Packet, global::MyCode.Packet>")
+				.Because("the setup-interface declaration must be skipped for unsupported ref-struct return types").And
+				.DoesNotContain("new global::Mockolate.Setup.RefStructReturnMethodSetup<global::MyCode.Packet, global::MyCode.Packet>")
+				.Because("the setup-interface implementation must be skipped for unsupported ref-struct return types");
+		}
+
+		[Fact]
+		public async Task MethodWithOutRefStructParameter_ShouldEmitNotSupportedExceptionAndSkipSetupSurface()
+		{
+			GeneratorResult result = Generator
+				.Run("""
+				     using System;
+				     using Mockolate;
+
+				     namespace MyCode;
+
+				     public readonly ref struct Packet(int id) { public int Id { get; } = id; }
+
+				     public interface IPacketBag
+				     {
+				         void Take(out Packet packet);
+				     }
+
+				     public class Program
+				     {
+				         public static void Main(string[] args)
+				         {
+				             _ = IPacketBag.CreateMock();
+				         }
+				     }
+				     """);
+
+			await That(result.Sources).ContainsKey("Mock.IPacketBag.g.cs");
+			await That(result.Sources["Mock.IPacketBag.g.cs"])
+				.Contains("Mockolate: out/ref ref-struct parameters are not supported. Method 'global::MyCode.IPacketBag.Take'.")
+				.Because("the method body must throw NotSupportedException because the ref-struct out parameter cannot flow through the setup pipeline").And
+				.DoesNotContain("IRefStructVoidMethodSetup<global::MyCode.Packet>")
+				.Because("the setup-interface declaration must be skipped for unsupported ref-struct signatures").And
+				.DoesNotContain("new global::Mockolate.Setup.RefStructVoidMethodSetup<global::MyCode.Packet>")
+				.Because("the setup-interface implementation must be skipped for unsupported ref-struct signatures");
+		}
+
+		[Fact]
 		public async Task MixedParameters_RefStructPlusValueType_ShouldRouteThroughRefStructPipeline()
 		{
 			GeneratorResult result = Generator


### PR DESCRIPTION
This pull request adds tests for new language features and improved error handling for unsupported method signatures.

**Support for static abstract members and explicit implementations:**

- Added tests to ensure that when interfaces declare static abstract methods or properties with colliding names in base and derived interfaces, the generated code emits explicit static implementations with the `static` keyword preserved. 
- Added a test to verify that static abstract methods with parameters correctly append arguments to the fast buffer, ensuring proper interaction recording.
- Added a test to confirm that when a concrete base class is combined with an interface declaring static abstract members, the generated constructor primes the `MockRegistryProvider` so that virtual calls during base-class construction can resolve the registry.

**Improved handling and validation for ref struct methods:**

- Added tests to ensure that methods returning a non-span ref struct or using out/ref ref struct parameters throw `NotSupportedException` and skip setup surface generation, preventing unsupported ref struct signatures from being used in the setup pipeline.

**Source generator code and overloads:**

- Refactored the generator code to require non-null constructor lists for overload generation, simplifying the logic in `AppendTypedCreateMockOverloads`.
- Removed an unnecessary constructor overload and related code for cases where no constructors are present, streamlining the generated code.