### PR TITLE
coverage: add tests for interaction edge cases

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
@@ -48,12 +48,101 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
+	public async Task FastEventBuffer_Subscribe_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Pins the `r.Boxed ??= new EventSubscription(...)` cache in AppendBoxed. With the
+		// `??=` mutated to `=`, every AppendBoxed call would allocate a fresh record.
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventSubscribe(0);
+		buffer.Append("E", this, SampleMethod);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastEventBuffer_Subscribe_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Pins the `r.Boxed ??= new EventSubscription(...)` cache in AppendBoxedUnverified.
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventSubscribe(0);
+		buffer.Append("E", this, SampleMethod);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastEventBuffer_SubscribeAppend_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
 			FastEventBuffer buffer = store.InstallEventSubscribe(0);
 			return () => buffer.Append("E", this, SampleMethod);
 		});
+
+	[Fact]
+	public async Task FastEventBuffer_Unsubscribe_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
+		buffer.Append("E", this, SampleMethod);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastEventBuffer_Unsubscribe_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
+		buffer.Append("E", this, SampleMethod);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastEventBuffer_Unsubscribe_AppendBoxedUnverified_ShouldBoxAsEventUnsubscription()
+	{
+		// Pins the `_kind == FastEventBufferKind.Subscribe ? new EventSubscription(...) :
+		// new EventUnsubscription(...)` ternary in AppendBoxedUnverified. With the conditional
+		// flipped to `(true ? Subscription : Unsubscription)`, an unsubscribe buffer would
+		// surface its records as EventSubscription.
+		FastMockInteractions store = new(1);
+		FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
+		buffer.Append("E", this, SampleMethod);
+
+		List<(long Seq, IInteraction Interaction)> dest = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
+
+		await That(dest).HasCount(1);
+		await That(dest[0].Interaction).IsExactly<EventUnsubscription>();
+	}
 
 	[Fact]
 	public async Task FastEventBuffer_UnsubscribeAppend_ShouldRaiseInteractionAdded()
@@ -108,6 +197,15 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
+	public async Task FastIndexerGetterBuffer1_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+			IndexerGetterAccess<int> access = new(7);
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
+
+	[Fact]
 	public async Task FastIndexerGetterBuffer2_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -150,6 +248,15 @@ public class FastBufferBoxingAndUnverifiedTests
 		await That(second).HasCount(1);
 		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
 	}
+
+	[Fact]
+	public async Task FastIndexerGetterBuffer2_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerGetterBuffer<int, string> buffer = store.InstallIndexerGetter<int, string>(0);
+			IndexerGetterAccess<int, string> access = new(7, "k");
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
 
 	[Fact]
 	public async Task FastIndexerGetterBuffer3_Append_ShouldRaiseInteractionAdded()
@@ -199,6 +306,16 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
+	public async Task FastIndexerGetterBuffer3_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerGetterBuffer<int, string, bool> buffer =
+				store.InstallIndexerGetter<int, string, bool>(0);
+			IndexerGetterAccess<int, string, bool> access = new(7, "k", true);
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
+
+	[Fact]
 	public async Task FastIndexerGetterBuffer4_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -246,6 +363,16 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
+	public async Task FastIndexerGetterBuffer4_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerGetterBuffer<int, string, bool, double> buffer =
+				store.InstallIndexerGetter<int, string, bool, double>(0);
+			IndexerGetterAccess<int, string, bool, double> access = new(7, "k", true, 3.14);
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
+
+	[Fact]
 	public async Task FastIndexerSetterBuffer1_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -288,6 +415,15 @@ public class FastBufferBoxingAndUnverifiedTests
 		await That(second).HasCount(1);
 		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
 	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer1_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+			IndexerSetterAccess<int, string> access = new(7, "k");
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
 
 	[Fact]
 	public async Task FastIndexerSetterBuffer2_Append_ShouldRaiseInteractionAdded()
@@ -337,6 +473,16 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
+	public async Task FastIndexerSetterBuffer2_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerSetterBuffer<int, string, bool> buffer =
+				store.InstallIndexerSetter<int, string, bool>(0);
+			IndexerSetterAccess<int, string, bool> access = new(7, "k", true);
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
+
+	[Fact]
 	public async Task FastIndexerSetterBuffer3_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -382,6 +528,16 @@ public class FastBufferBoxingAndUnverifiedTests
 		await That(second).HasCount(1);
 		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
 	}
+
+	[Fact]
+	public async Task FastIndexerSetterBuffer3_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerSetterBuffer<int, string, bool, double> buffer =
+				store.InstallIndexerSetter<int, string, bool, double>(0);
+			IndexerSetterAccess<int, string, bool, double> access = new(7, "k", true, 3.14);
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
 
 	[Fact]
 	public async Task FastIndexerSetterBuffer4_Append_ShouldRaiseInteractionAdded()
@@ -431,6 +587,35 @@ public class FastBufferBoxingAndUnverifiedTests
 	}
 
 	[Fact]
+	public async Task FastIndexerSetterBuffer4_AppendWithAccess_ShouldPublishAndRaiseInteractionAdded()
+		=> await VerifyAppendWithAccessPublishesAndRaises(store =>
+		{
+			FastIndexerSetterBuffer<int, string, bool, double, char> buffer =
+				store.InstallIndexerSetter<int, string, bool, double, char>(0);
+			IndexerSetterAccess<int, string, bool, double, char> access = new(7, "k", true, 3.14, 'z');
+			return (() => buffer.Append(access), () => buffer.Count);
+		});
+
+	[Fact]
+	public async Task FastMethod0Buffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Pins the `r.Boxed ??= new MethodInvocation(r.Name)` cache in Method0 AppendBoxed.
+		FastMockInteractions store = new(1);
+		FastMethod0Buffer buffer = store.InstallMethod(0);
+
+		buffer.Append("M");
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastMethod1Buffer_Append_ShouldRaiseInteractionAdded()
 		=> await VerifyRaisesInteractionAdded(store =>
 		{
@@ -473,6 +658,44 @@ public class FastBufferBoxingAndUnverifiedTests
 		});
 
 	[Fact]
+	public async Task FastMethod3Buffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Pins the `r.Boxed ??= new MethodInvocation<T1,T2,T3>(...)` cache in Method3 AppendBoxed.
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+
+		buffer.Append("M", 1, "a", true);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastMethod3Buffer_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Pins the `r.Boxed ??= new MethodInvocation<T1,T2,T3>(...)` cache in Method3 AppendBoxedUnverified.
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+
+		buffer.Append("M", 1, "a", true);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
 	public async Task FastMethod3Buffer_AppendBoxedUnverified_ShouldSkipMatchedSlots()
 	{
 		FastMockInteractions store = new(1);
@@ -502,6 +725,46 @@ public class FastBufferBoxingAndUnverifiedTests
 				store.InstallMethod<int, string, bool, double>(0);
 			return () => buffer.Append("M", 1, "a", true, 1.0);
 		});
+
+	[Fact]
+	public async Task FastMethod4Buffer_AppendBoxed_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Pins the `r.Boxed ??= new MethodInvocation<T1,T2,T3,T4>(...)` cache in Method4 AppendBoxed.
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+
+		buffer.Append("M", 1, "a", true, 1.0);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxed(first);
+		((IFastMemberBuffer)buffer).AppendBoxed(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
+
+	[Fact]
+	public async Task FastMethod4Buffer_AppendBoxedUnverified_CachesAndReusesAlreadyBoxedRecord()
+	{
+		// Pins the `r.Boxed ??= new MethodInvocation<T1,T2,T3,T4>(...)` cache in Method4 AppendBoxedUnverified.
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+
+		buffer.Append("M", 1, "a", true, 1.0);
+
+		List<(long Seq, IInteraction Interaction)> first = [];
+		List<(long Seq, IInteraction Interaction)> second = [];
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(first);
+		((IFastMemberBuffer)buffer).AppendBoxedUnverified(second);
+
+		await That(first).HasCount(1);
+		await That(second).HasCount(1);
+		await That(second[0].Interaction).IsSameAs(first[0].Interaction);
+	}
 
 	[Fact]
 	public async Task FastMethod4Buffer_AppendBoxedUnverified_ShouldSkipMatchedSlots()
@@ -959,6 +1222,29 @@ public class FastBufferBoxingAndUnverifiedTests
 		await That(dest).HasCount(2);
 		await That(((IndexerSetterAccess<int, string, bool, double, char>)dest[0].Interaction).Parameter1).IsEqualTo(0);
 		await That(((IndexerSetterAccess<int, string, bool, double, char>)dest[1].Interaction).Parameter1).IsEqualTo(2);
+	}
+
+	private static async Task VerifyAppendWithAccessPublishesAndRaises(
+		Func<FastMockInteractions, (Action Append, Func<int> CountReader)> setupFactory)
+	{
+		// The singleton-aware Append(access) overloads each end with three statements that the
+		// existing tests never exercise: `_storage.Publish();`, `if (_owner.HasInteractionAddedSubscribers)`,
+		// and `_owner.RaiseAdded();`. Asserting both buffer.Count and the InteractionAdded handler
+		// runs pins the publish, the guard, and the raise call together — covers the L61/L63/L65
+		// mutant cluster across all 8 indexer arity overloads.
+		FastMockInteractions store = new(1);
+		(Action append, Func<int> countReader) = setupFactory(store);
+		int invocations = 0;
+		EventHandler handler = (_, _) => invocations++;
+		store.InteractionAdded += handler;
+
+		append();
+		append();
+
+		store.InteractionAdded -= handler;
+
+		await That(countReader()).IsEqualTo(2);
+		await That(invocations).IsEqualTo(2);
 	}
 
 	private static readonly MethodInfo SampleMethod =

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferConsumeMatchingTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferConsumeMatchingTests.cs
@@ -228,6 +228,20 @@ public class FastBufferConsumeMatchingTests
 	}
 
 	[Fact]
+	public async Task FastMethod1Buffer_ConsumeAll_OnEmptyBuffer_ShouldReturnZeroWithoutThrowing()
+	{
+		// Pins the `slot < n` loop bound in Method1 ConsumeAll. Mutated to `slot <= n`, an empty
+		// buffer (n == 0) would still enter the loop at slot=0 and call VerifiedUnderLock(0),
+		// which dereferences the not-yet-allocated VerifiedChunks[0] → NRE.
+		FastMockInteractions store = new(1);
+		FastMethod1Buffer<int> buffer = store.InstallMethod<int>(0);
+
+		int consumed = buffer.ConsumeAll();
+
+		await That(consumed).IsEqualTo(0);
+	}
+
+	[Fact]
 	public async Task FastMethod1Buffer_ConsumeMatching_ShouldHonorMatcher()
 	{
 		FastMockInteractions store = new(1);
@@ -240,6 +254,17 @@ public class FastBufferConsumeMatchingTests
 		await That(buffer.ConsumeMatching((IParameterMatch<int>)It.IsAny<int>())).IsEqualTo(3);
 		await That(buffer.ConsumeMatching((IParameterMatch<int>)It.Is(2))).IsEqualTo(1);
 		await That(buffer.ConsumeMatching((IParameterMatch<int>)It.Is(99))).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task FastMethod2Buffer_ConsumeAll_OnEmptyBuffer_ShouldReturnZeroWithoutThrowing()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod2Buffer<int, string> buffer = store.InstallMethod<int, string>(0);
+
+		int consumed = buffer.ConsumeAll();
+
+		await That(consumed).IsEqualTo(0);
 	}
 
 	[Fact]
@@ -264,6 +289,17 @@ public class FastBufferConsumeMatchingTests
 		await That(buffer.ConsumeMatching(
 			(IParameterMatch<int>)It.Is(99),
 			(IParameterMatch<string>)It.IsAny<string>())).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task FastMethod3Buffer_ConsumeAll_OnEmptyBuffer_ShouldReturnZeroWithoutThrowing()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod3Buffer<int, string, bool> buffer = store.InstallMethod<int, string, bool>(0);
+
+		int consumed = buffer.ConsumeAll();
+
+		await That(consumed).IsEqualTo(0);
 	}
 
 	[Fact]
@@ -292,6 +328,18 @@ public class FastBufferConsumeMatchingTests
 			(IParameterMatch<int>)It.IsAny<int>(),
 			(IParameterMatch<string>)It.Is<string>("b"),
 			(IParameterMatch<bool>)It.Is(false))).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task FastMethod4Buffer_ConsumeAll_OnEmptyBuffer_ShouldReturnZeroWithoutThrowing()
+	{
+		FastMockInteractions store = new(1);
+		FastMethod4Buffer<int, string, bool, double> buffer =
+			store.InstallMethod<int, string, bool, double>(0);
+
+		int consumed = buffer.ConsumeAll();
+
+		await That(consumed).IsEqualTo(0);
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
@@ -46,6 +46,39 @@ public class FastMockInteractionsTests
 	}
 
 	[Fact]
+	public async Task Clear_FallbackPath_ShouldClearStrongReferencesInRecordsArray()
+	{
+		// Pins the `Array.Clear(_records, 0, _count);` call inside FallbackBuffer.Clear. With
+		// the statement removed, _count is still reset to 0 but the underlying _records array
+		// keeps strong references to the cleared interactions. The behavioral surface (Count,
+		// enumeration) is unchanged — but the array contents leak. Inspect via reflection.
+		IMockInteractions sut = new FastMockInteractions(0);
+		MethodInvocation first = new("first");
+		MethodInvocation second = new("second");
+		sut.RegisterInteraction(first);
+		sut.RegisterInteraction(second);
+
+		sut.Clear();
+
+		FieldInfo fallbackField = typeof(FastMockInteractions).GetField(
+			"_fallback", BindingFlags.NonPublic | BindingFlags.Instance)!;
+		object fallback = fallbackField.GetValue(sut)!;
+
+		FieldInfo recordsField = fallback.GetType().GetField(
+			"_records", BindingFlags.NonPublic | BindingFlags.Instance)!;
+		Array records = (Array)recordsField.GetValue(fallback)!;
+
+		Type slotType = records.GetType().GetElementType()!;
+		FieldInfo interactionField = slotType.GetField("Item2")!;
+		for (int i = 0; i < records.Length; i++)
+		{
+			object? slot = records.GetValue(i);
+			object? interaction = interactionField.GetValue(slot);
+			await That(interaction).IsNull();
+		}
+	}
+
+	[Fact]
 	public async Task Clear_FallbackPath_ShouldNotResurfaceOldRecordsAfterRefill()
 	{
 		IMockInteractions sut = new FastMockInteractions(0);
@@ -148,6 +181,28 @@ public class FastMockInteractionsTests
 	}
 
 	[Fact]
+	public async Task Clear_WithSharedSingletonInVerifiedSet_ShouldResurfaceItAsUnverifiedAfterReAppend()
+	{
+		// Pins the `_verified = null;` reset inside Clear. FastPropertyGetterBuffer reuses a
+		// single PropertyGetterAccess singleton across records (it is cached in the buffer's
+		// `_access` field, which Clear does NOT reset). With the `_verified = null` write
+		// removed, the verified set keeps the singleton across Clear, and a fresh post-Clear
+		// Append would surface as already-verified — masking the new interaction.
+		FastMockInteractions sut = new(1);
+		FastPropertyGetterBuffer buffer = sut.InstallPropertyGetter(0);
+		buffer.Append("P");
+
+		List<IInteraction> all = [..sut,];
+		((IMockInteractions)sut).Verified(all);
+
+		sut.Clear();
+		buffer.Append("P");
+
+		IReadOnlyCollection<IInteraction> unverified = sut.GetUnverifiedInteractions();
+		await That(unverified).HasCount(1);
+	}
+
+	[Fact]
 	public async Task Count_ShouldReflectAppendsAcrossBuffers()
 	{
 		FastMockInteractions sut = new(2);
@@ -186,6 +241,64 @@ public class FastMockInteractionsTests
 		await That(((MethodInvocation<int>)ordered[2]).Parameter1).IsEqualTo(2);
 		await That(((PropertySetterAccess<string>)ordered[1]).Value).IsEqualTo("x");
 		await That(((PropertySetterAccess<string>)ordered[3]).Value).IsEqualTo("y");
+	}
+
+	[Fact]
+	public async Task GetOrCreateFallbackBuffer_BarrierSynchronizedRace_AllCallersResolveToTheSameInstalledBuffer()
+	{
+		// Pins the `existing ?? created` null-coalesce in GetOrCreateFallbackBuffer. With the
+		// left side removed (`existing ?? created` → `created`), CompareExchange losers return
+		// their freshly-allocated buffer instead of the winner's installed one — even though
+		// only the winner's buffer ends up referenced by `_fallback`. Calls private method
+		// directly via reflection from many threads released in lockstep by a Barrier; resets
+		// `_fallback` to null between rounds so every round races from a clean slate. After
+		// each round, every returned buffer must be identical to the one referenced by
+		// `_fallback` — otherwise a loser was handed an orphan instance.
+		const int threads = 32;
+		const int rounds = 5;
+
+		FastMockInteractions sut = new(0);
+		FieldInfo fallbackField = typeof(FastMockInteractions).GetField(
+			"_fallback", BindingFlags.NonPublic | BindingFlags.Instance)!;
+		MethodInfo getOrCreate = typeof(FastMockInteractions).GetMethod(
+			"GetOrCreateFallbackBuffer", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+		object?[] returnedBuffers = new object?[threads];
+
+		using Barrier barrier = new(threads + 1);
+
+		Task[] tasks = new Task[threads];
+		for (int t = 0; t < threads; t++)
+		{
+			int threadId = t;
+#pragma warning disable xUnit1051
+			tasks[t] = Task.Factory.StartNew(() =>
+#pragma warning restore xUnit1051
+			{
+				for (int round = 0; round < rounds; round++)
+				{
+					barrier.SignalAndWait();
+					returnedBuffers[threadId] = getOrCreate.Invoke(sut, null);
+					barrier.SignalAndWait();
+				}
+			}, TaskCreationOptions.LongRunning);
+		}
+
+		for (int round = 0; round < rounds; round++)
+		{
+			fallbackField.SetValue(sut, null);
+			barrier.SignalAndWait();
+			barrier.SignalAndWait();
+
+			object? installed = fallbackField.GetValue(sut);
+			await That(installed).IsNotNull();
+			for (int t = 0; t < threads; t++)
+			{
+				await That(returnedBuffers[t]).IsSameAs(installed);
+			}
+		}
+
+		await Task.WhenAll(tasks);
 	}
 
 	[Fact]
@@ -334,6 +447,20 @@ public class FastMockInteractionsTests
 		await That(unverified).HasCount(1);
 		await That(unverified.Contains(all[0])).IsFalse();
 		await That(unverified.Contains(all[1])).IsTrue();
+	}
+
+	[Fact]
+	public async Task GetUnverifiedInteractions_WhenNothingRecorded_ShouldReturnArrayEmptySingleton()
+	{
+		// Pins the `return Array.Empty<IInteraction>();` early-return on the empty path. With
+		// the block removed, the method falls through to `new IInteraction[unverified.Count]`
+		// and returns a freshly-allocated zero-length array instead of the shared singleton.
+		FastMockInteractions sut = new(1);
+		sut.InstallMethod(0);
+
+		IReadOnlyCollection<IInteraction> result = sut.GetUnverifiedInteractions();
+
+		await That(result).IsSameAs(Array.Empty<IInteraction>());
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/IndexerAccessTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/IndexerAccessTests.cs
@@ -123,12 +123,31 @@ public sealed class IndexerAccessTests
 	}
 
 	[Fact]
+	public async Task ToString_OnIndexerGetterAccess3_FormatsEachNullParameterAsNullLiteral()
+	{
+		// Pins the `?? "null"` literals in IndexerGetterAccess<T1, T2, T3>.ToString. With any of
+		// the three "null" → "" mutations applied, a null parameter would render as an empty
+		// slot like "[, ...]" instead of "[null, ...]".
+		IndexerGetterAccess<string?, string?, string?> access = new(null, null, null);
+
+		await That(access.ToString()).IsEqualTo("get indexer [null, null, null]");
+	}
+
+	[Fact]
 	public async Task ToString_OnIndexerGetterAccess4_FormatsEachNullParameterAsNullLiteral()
 	{
 		IndexerGetterAccess<string?, string?, string?, string?> access =
 			new(null, null, null, null);
 
 		await That(access.ToString()).IsEqualTo("get indexer [null, null, null, null]");
+	}
+
+	[Fact]
+	public async Task ToString_OnIndexerSetterAccess3_FormatsEachNullParameterAsNullLiteral()
+	{
+		IndexerSetterAccess<string?, string?, string?, string?> access = new(null, null, null, null);
+
+		await That(access.ToString()).IsEqualTo("set indexer [null, null, null] to null");
 	}
 
 	[Fact]
@@ -155,6 +174,19 @@ public sealed class IndexerAccessTests
 	}
 
 	[Fact]
+	public async Task TryFindStoredValue_OnIndexerGetterAccess1_WithoutStorage_ShouldReturnFalse()
+	{
+		// Pins the `if (s is null) { return null; }` first guard in
+		// IndexerGetterAccess<T1>.TraverseStorage. With the body removed, the next line would
+		// dereference null `s` to call GetChildDispatch and throw NRE.
+		IndexerGetterAccess<int> access = new(42);
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
 	public async Task TryFindStoredValue_OnIndexerGetterAccess2_UsesGetChildDispatchForEachParameter()
 	{
 		RecordingStorage storage = new();
@@ -169,6 +201,16 @@ public sealed class IndexerAccessTests
 	}
 
 	[Fact]
+	public async Task TryFindStoredValue_OnIndexerGetterAccess2_WithoutStorage_ShouldReturnFalse()
+	{
+		IndexerGetterAccess<int, int> access = new(1, 2);
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
 	public async Task TryFindStoredValue_OnIndexerGetterAccess3_UsesGetChildDispatchForEachParameter()
 	{
 		RecordingStorage storage = new();
@@ -180,6 +222,16 @@ public sealed class IndexerAccessTests
 		access.TryFindStoredValue(out string _);
 
 		await That(storage.Calls).IsEqualTo(["Get(1)", "Get(2)", "Get(3)",]);
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerGetterAccess3_WithoutStorage_ShouldReturnFalse()
+	{
+		IndexerGetterAccess<int, int, int> access = new(1, 2, 3);
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
 	}
 
 	[Fact]
@@ -198,6 +250,16 @@ public sealed class IndexerAccessTests
 	}
 
 	[Fact]
+	public async Task TryFindStoredValue_OnIndexerGetterAccess4_WithoutStorage_ShouldReturnFalse()
+	{
+		IndexerGetterAccess<int, int, int, int> access = new(1, 2, 3, 4);
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
 	public async Task TryFindStoredValue_OnIndexerSetterAccess1_UsesGetChildDispatch()
 	{
 		RecordingStorage storage = new();
@@ -209,6 +271,16 @@ public sealed class IndexerAccessTests
 		access.TryFindStoredValue(out string _);
 
 		await That(storage.Calls).IsEqualTo(["Get(42)",]);
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess1_WithoutStorage_ShouldReturnFalse()
+	{
+		IndexerSetterAccess<int, string> access = new(42, "v");
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
 	}
 
 	[Fact]
@@ -227,6 +299,34 @@ public sealed class IndexerAccessTests
 	}
 
 	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess2_WhenFirstDispatchReturnsNull_ShouldReturnFalse()
+	{
+		// Pins the second `if (s is null) { return null; }` guard inside
+		// IndexerSetterAccess<T1, T2, TValue>.TraverseStorage — the one after Parameter1's
+		// GetChildDispatch returns null. With the body removed, the next line dereferences
+		// null `s` for Parameter2's dispatch and throws NRE.
+		NullAfterStorage storage = new(1);
+		IndexerSetterAccess<int, int, string> access = new(1, 2, "v")
+		{
+			Storage = storage,
+		};
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess2_WithoutStorage_ShouldReturnFalse()
+	{
+		IndexerSetterAccess<int, int, string> access = new(1, 2, "v");
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
 	public async Task TryFindStoredValue_OnIndexerSetterAccess3_UsesGetChildDispatchForEachParameter()
 	{
 		RecordingStorage storage = new();
@@ -239,6 +339,44 @@ public sealed class IndexerAccessTests
 		access.TryFindStoredValue(out string _);
 
 		await That(storage.Calls).IsEqualTo(["Get(1)", "Get(2)", "Get(3)",]);
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess3_WhenFirstDispatchReturnsNull_ShouldReturnFalse()
+	{
+		NullAfterStorage storage = new(1);
+		IndexerSetterAccess<int, int, int, string> access = new(1, 2, 3, "v")
+		{
+			Storage = storage,
+		};
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess3_WhenSecondDispatchReturnsNull_ShouldReturnFalse()
+	{
+		NullAfterStorage storage = new(2);
+		IndexerSetterAccess<int, int, int, string> access = new(1, 2, 3, "v")
+		{
+			Storage = storage,
+		};
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess3_WithoutStorage_ShouldReturnFalse()
+	{
+		IndexerSetterAccess<int, int, int, string> access = new(1, 2, 3, "v");
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
 	}
 
 	[Fact]
@@ -256,6 +394,58 @@ public sealed class IndexerAccessTests
 		await That(storage.Calls).IsEqualTo(["Get(1)", "Get(2)", "Get(3)", "Get(4)",]);
 	}
 
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess4_WhenFirstDispatchReturnsNull_ShouldReturnFalse()
+	{
+		NullAfterStorage storage = new(1);
+		IndexerSetterAccess<int, int, int, int, string> access = new(1, 2, 3, 4, "v")
+		{
+			Storage = storage,
+		};
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess4_WhenSecondDispatchReturnsNull_ShouldReturnFalse()
+	{
+		NullAfterStorage storage = new(2);
+		IndexerSetterAccess<int, int, int, int, string> access = new(1, 2, 3, 4, "v")
+		{
+			Storage = storage,
+		};
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess4_WhenThirdDispatchReturnsNull_ShouldReturnFalse()
+	{
+		NullAfterStorage storage = new(3);
+		IndexerSetterAccess<int, int, int, int, string> access = new(1, 2, 3, 4, "v")
+		{
+			Storage = storage,
+		};
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
+	[Fact]
+	public async Task TryFindStoredValue_OnIndexerSetterAccess4_WithoutStorage_ShouldReturnFalse()
+	{
+		IndexerSetterAccess<int, int, int, int, string> access = new(1, 2, 3, 4, "v");
+
+		bool found = access.TryFindStoredValue(out string _);
+
+		await That(found).IsFalse();
+	}
+
 	private sealed class RecordingStorage : IndexerValueStorage
 	{
 		public List<string> Calls { get; } = [];
@@ -271,5 +461,27 @@ public sealed class IndexerAccessTests
 			Calls.Add($"GetOrAdd({key?.ToString() ?? "<null>"})");
 			return this;
 		}
+	}
+
+	// Returns null on the Nth GetChildDispatch call, otherwise returns this.
+	// _nullAtCall = 1 means return null on the 1st call;
+	// _nullAtCall = 2 means return null on the 2nd call (and the 1st returns this); etc.
+	private sealed class NullAfterStorage : IndexerValueStorage
+	{
+		private readonly int _nullAtCall;
+		private int _calls;
+
+		public NullAfterStorage(int nullAtCall)
+		{
+			_nullAtCall = nullAtCall;
+		}
+
+		public override IndexerValueStorage? GetChildDispatch<TKey>(TKey key)
+		{
+			_calls++;
+			return _calls == _nullAtCall ? null : this;
+		}
+
+		public override IndexerValueStorage GetOrAddChildDispatch<TKey>(TKey key) => this;
 	}
 }

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -833,6 +833,87 @@ public sealed class MockRegistryTests
 		}
 	}
 
+	public sealed class GetPropertyFastSnapshotNullSlotTests
+	{
+		[Fact]
+		public async Task GetPropertyFast_WhenSnapshotTableHasNullEntryAtMemberId_ShouldFallToColdPath()
+		{
+			// Pins the `if (snapshot is not null)` guard inside ResolvePropertyFast. With the
+			// guard inverted to `is null`, the body would dereference a null `snapshot` and
+			// throw NullReferenceException. Forces the snapshot table to be non-null with
+			// length > queried memberId, but with `table[memberId]` itself null.
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> snapshotAtFive = new(registry, "P5");
+			snapshotAtFive.InitializeWith(50);
+			registry.SetupProperty(5, snapshotAtFive);
+
+			int result = registry.GetPropertyFast(2, "P", _ => 7);
+
+			await That(result).IsEqualTo(7);
+		}
+	}
+
+	public sealed class SetPropertyFastScenarioRoutingTests
+	{
+		[Fact]
+		public async Task SetPropertyFast_WithActiveScenario_ShouldUseColdPathAndWriteToScenarioSetup()
+		{
+			// Pins the `string.IsNullOrEmpty(Scenario)` scenario guard around the int-keyed
+			// snapshot lookup in SetPropertyFast. Negation, `Scenario != null`, and
+			// `Scenario != ""` mutations all flip whether the hot path runs when a scenario
+			// is active — and would write to the wrong (default-scope) PropertySetup. Verified
+			// by reading the value back through GetPropertyFast (which routes to the scenario
+			// setup via its cold path) and asserting the new value made it.
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> defaultSetup = new(registry, "P");
+			defaultSetup.InitializeWith(100);
+			registry.SetupProperty(2, defaultSetup);
+
+			PropertySetup<int> scenarioSetup = new(registry, "P");
+			scenarioSetup.InitializeWith(999);
+			registry.SetupProperty(2, "myScenario", scenarioSetup);
+
+			registry.TransitionTo("myScenario");
+			registry.SetPropertyFast(2, 3, "P", 42);
+
+			int result = registry.GetPropertyFast(2, "P", _ => -1);
+
+			await That(result).IsEqualTo(42);
+		}
+	}
+
+	public sealed class SetPropertyFastSnapshotInTableOnlyTests
+	{
+		[Fact]
+		public async Task SetPropertyFast_WithSnapshotOnlyInIntKeyedTable_ShouldHonorHotPath()
+		{
+			// Pins the `matchingSetup = table[memberId];` assignment inside SetPropertyFast's
+			// hot-path block. With the block emptied, matchingSetup stays null and the cold
+			// path runs ResolvePropertySetup, which only consults Setup.Properties. Force the
+			// snapshot into the int-keyed table without registering it in Setup.Properties via
+			// reflection, then prove the hot path was used: ThrowWhenNotSetup behavior makes
+			// the cold path throw, so the test passing means we stayed on the hot path.
+			MockBehavior behavior = MockBehavior.Default.ThrowingWhenNotSetup();
+			MockRegistry registry = new(behavior, new FastMockInteractions(0, behavior.SkipInteractionRecording));
+
+			PropertySetup<int> snapshot = new(registry, "P");
+			snapshot.InitializeWith(0);
+
+			PropertySetup?[] table = new PropertySetup?[6];
+			table[5] = snapshot;
+			typeof(MockRegistry).GetField(
+					"_propertySetupsByMemberId", BindingFlags.NonPublic | BindingFlags.Instance)!
+				.SetValue(registry, table);
+
+			void Act()
+			{
+				registry.SetPropertyFast(5, 6, "P", 42);
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+
 	public sealed class GetPropertyFastInteractionRecordingTests
 	{
 		[Fact]


### PR DESCRIPTION
This pull request significantly expands the unit test coverage for the `FastBuffer` and related classes, focusing on verifying the correct behavior of record boxing, caching, publishing, and event raising logic. The new tests ensure that internal optimizations (such as caching boxed interaction records) and event notification mechanisms are robust and not accidentally broken by future changes. Additionally, the tests pin correct behavior for consuming method buffers when empty, guarding against regressions.

The most important changes are:

### Caching and Boxing Behavior Tests

* Added tests to verify that `AppendBoxed` and `AppendBoxedUnverified` methods on event and method buffers correctly cache and reuse boxed interaction records, preventing unnecessary allocations. These tests cover both event subscription/unsubscription and method invocation buffers of various arities.
* Added a test to ensure that `AppendBoxedUnverified` on an unsubscribe buffer boxes records as `EventUnsubscription`, not `EventSubscription`, pinning the correct conditional logic.

### Event Publishing and Raising Tests

* Introduced a reusable helper and new tests to verify that `AppendWithAccess` on all indexer getter/setter buffer types publishes the interaction and raises the `InteractionAdded` event as expected, ensuring coverage for all indexer arities. 

### Buffer Consumption Edge Cases

* Added tests to verify that calling `ConsumeAll` on empty method buffers (for arities 1 through 4) returns zero and does not throw, pinning correct loop bounds and guarding against null reference exceptions.