### PR TITLE
coverage: add tests and accessor for property setup snapshot in `MockRegistry`

### DIFF
--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -90,6 +90,28 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Returns the current default-scope property setup registered under the generator-emitted
+	///     <paramref name="memberId" />, or <see langword="null" /> when no setup has been registered.
+	/// </summary>
+	/// <remarks>
+	///     Property dispatch reads the snapshot via <see cref="GetPropertyFast{TResult}(int, string, Func{MockBehavior, TResult}, Func{TResult}?)" />
+	///     and falls back to the cold path when the snapshot is empty, so this accessor is intended for
+	///     diagnostics and tests that need to verify the fast-path table directly.
+	/// </remarks>
+	/// <param name="memberId">The generator-emitted member id for the property accessor.</param>
+	/// <returns>The setup for the property, or <see langword="null" /> when none is registered.</returns>
+	internal PropertySetup? GetPropertySetupSnapshot(int memberId)
+	{
+		PropertySetup?[]? table = Volatile.Read(ref _propertySetupsByMemberId);
+		if (table is null || (uint)memberId >= (uint)table.Length)
+		{
+			return null;
+		}
+
+		return table[memberId];
+	}
+
+	/// <summary>
 	///     Enumerates method setups of type <typeparamref name="T" /> matching <paramref name="methodName" />
 	///     in latest-registered-first order, scenario-scoped setups before default-scope setups.
 	/// </summary>

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -77,8 +77,10 @@ public partial class MockRegistry
 		{
 			IndexerSetup[]?[]? oldTable = _indexerSetupsByMemberId;
 			int requiredLen = memberId + 1;
+			// Stryker disable once Conditional : when oldTable is not null and requiredLen <= oldTable.Length, the resize-condition below is false either way and the else-branch reuses oldTable; newLen is unread, so collapsing the ternary to requiredLen is observationally identical.
 			int newLen = oldTable is null ? requiredLen : Math.Max(oldTable.Length, requiredLen);
 			IndexerSetup[]?[] newTable;
+			// Stryker disable once Equality : flipping > to >= only fires the realloc-and-copy path when newLen == oldTable.Length, producing a fresh table with identical contents — externally indistinguishable from reusing oldTable.
 			if (oldTable is null || newLen > oldTable.Length)
 			{
 				newTable = new IndexerSetup[newLen][];
@@ -168,8 +170,10 @@ public partial class MockRegistry
 		{
 			MethodSetup[]?[]? oldTable = _setupsByMemberId;
 			int requiredLen = memberId + 1;
+			// Stryker disable once Conditional : when oldTable is not null and requiredLen <= oldTable.Length, the resize-condition below is false either way and the else-branch reuses oldTable; newLen is unread, so collapsing the ternary to requiredLen is observationally identical.
 			int newLen = oldTable is null ? requiredLen : Math.Max(oldTable.Length, requiredLen);
 			MethodSetup[]?[] newTable;
+			// Stryker disable once Equality : flipping > to >= only fires the realloc-and-copy path when newLen == oldTable.Length, producing a fresh table with identical contents — externally indistinguishable from reusing oldTable.
 			if (oldTable is null || newLen > oldTable.Length)
 			{
 				newTable = new MethodSetup[newLen][];
@@ -261,8 +265,10 @@ public partial class MockRegistry
 		{
 			PropertySetup?[]? oldTable = _propertySetupsByMemberId;
 			int requiredLen = memberId + 1;
+			// Stryker disable once Conditional : when oldTable is not null and requiredLen <= oldTable.Length, the resize-condition below is false either way and the else-branch reuses oldTable; newLen is unread, so collapsing the ternary to requiredLen is observationally identical.
 			int newLen = oldTable is null ? requiredLen : Math.Max(oldTable.Length, requiredLen);
 			PropertySetup?[] newTable;
+			// Stryker disable once Equality : flipping > to >= only fires the realloc-and-copy path when newLen == oldTable.Length, producing a fresh table with identical contents — externally indistinguishable from reusing oldTable.
 			if (oldTable is null || newLen > oldTable.Length)
 			{
 				newTable = new PropertySetup?[newLen];
@@ -344,8 +350,10 @@ public partial class MockRegistry
 		{
 			EventSetup[]?[]? oldTable = _eventSetupsByMemberId;
 			int requiredLen = memberId + 1;
+			// Stryker disable once Conditional : when oldTable is not null and requiredLen <= oldTable.Length, the resize-condition below is false either way and the else-branch reuses oldTable; newLen is unread, so collapsing the ternary to requiredLen is observationally identical.
 			int newLen = oldTable is null ? requiredLen : Math.Max(oldTable.Length, requiredLen);
 			EventSetup[]?[] newTable;
+			// Stryker disable once Equality : flipping > to >= only fires the realloc-and-copy path when newLen == oldTable.Length, producing a fresh table with identical contents — externally indistinguishable from reusing oldTable.
 			if (oldTable is null || newLen > oldTable.Length)
 			{
 				newTable = new EventSetup[newLen][];

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
@@ -104,6 +104,36 @@ public sealed class MockRegistrySetupSnapshotTests
 	public sealed class PropertyTests
 	{
 		[Fact]
+		public async Task PublishPropertyToMemberIdBucket_WhenResized_PreservesEarlierEntries()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setupLow = new(registry, "P5");
+			setupLow.InitializeWith(50);
+			PropertySetup<int> setupHigh = new(registry, "P10");
+			setupHigh.InitializeWith(100);
+
+			registry.SetupProperty(5, setupLow);
+			registry.SetupProperty(10, setupHigh);
+
+			await That(registry.GetPropertySetupSnapshot(5)).IsSameAs(setupLow);
+			await That(registry.GetPropertySetupSnapshot(10)).IsSameAs(setupHigh);
+		}
+
+		[Fact]
+		public async Task PublishPropertyToMemberIdBucket_WithDefaultThenDefault_OverwritesInSnapshotTable()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup.Default<int> defaultA = new("P1", 0);
+			PropertySetup.Default<int> defaultB = new("P1", 0);
+
+			registry.SetupProperty(1, defaultA);
+			registry.SetupProperty(1, defaultB);
+
+			PropertySetup? snapshot = registry.GetPropertySetupSnapshot(1);
+			await That(snapshot).IsSameAs(defaultB);
+		}
+
+		[Fact]
 		public async Task PublishPropertyToMemberIdBucket_WithDefaultThenUserSetup_RetainsUserSetup()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
@@ -117,6 +147,20 @@ public sealed class MockRegistrySetupSnapshotTests
 
 			int observed = registry.GetPropertyFast(1, "P1", _ => -1);
 			await That(observed).IsEqualTo(99);
+		}
+
+		[Fact]
+		public async Task PublishPropertyToMemberIdBucket_WithUserThenDefault_RetainsUserSetupInSnapshotTable()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> userSetup = new(registry, "P1");
+			userSetup.InitializeWith(99);
+
+			registry.SetupProperty(1, userSetup);
+			registry.SetupProperty(1, new PropertySetup.Default<int>("P1", 0));
+
+			PropertySetup? snapshot = registry.GetPropertySetupSnapshot(1);
+			await That(snapshot).IsSameAs(userSetup);
 		}
 
 		[Fact]
@@ -167,6 +211,19 @@ public sealed class MockRegistrySetupSnapshotTests
 		}
 
 		[Fact]
+		public async Task SetupProperty_WithMemberId_PublishesUserSetupToSnapshotTable()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P5");
+			setup.InitializeWith(50);
+
+			registry.SetupProperty(5, setup);
+
+			PropertySetup? snapshot = registry.GetPropertySetupSnapshot(5);
+			await That(snapshot).IsSameAs(setup);
+		}
+
+		[Fact]
 		public async Task SetupProperty_WithMemberIdAndDefaultScenario_PublishesToSnapshot()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
@@ -177,6 +234,19 @@ public sealed class MockRegistrySetupSnapshotTests
 
 			int observed = registry.GetPropertyFast(5, "P5", _ => -1);
 			await That(observed).IsEqualTo(50);
+		}
+
+		[Fact]
+		public async Task SetupProperty_WithMemberIdAndDefaultScenario_PublishesUserSetupToSnapshotTable()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P5");
+			setup.InitializeWith(50);
+
+			registry.SetupProperty(5, "", setup);
+
+			PropertySetup? snapshot = registry.GetPropertySetupSnapshot(5);
+			await That(snapshot).IsSameAs(setup);
 		}
 
 		[Fact]


### PR DESCRIPTION
This pull request introduces improvements to the handling and testing of property setup snapshots in the `MockRegistry` class. The main changes include adding a new internal accessor for property setup snapshots, enhancing test coverage for property setup behaviors, and adding comments to clarify code paths for mutation testing tools.

### Property setup snapshot improvements

* Added a new internal method `GetPropertySetupSnapshot(int memberId)` to `MockRegistry.Interactions.cs` for retrieving the current property setup snapshot by member ID. This method is intended for diagnostics and direct verification in tests.

### Test coverage enhancements

* Added multiple new unit tests in `MockRegistrySetupSnapshotTests.cs` to verify correct behavior of property setup snapshotting, including:
  - Ensuring earlier entries are preserved when resizing the property setup table.
  - Verifying that default setups overwrite previous defaults, but user setups are retained over defaults.
  - Confirming that setups are correctly published to the snapshot table for both direct and scenario-based registrations. 