### PR TITLE
coverage: add tests for property, indexer, and method setup edge cases and matching logic

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySetupSnapshotTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Mockolate.Interactions;
 using Mockolate.Internal.Tests.TestHelpers;
 using Mockolate.Setup;
@@ -6,6 +7,13 @@ namespace Mockolate.Internal.Tests.Registry;
 
 public sealed class MockRegistrySetupSnapshotTests
 {
+	private static PropertySetup?[]? GetPropertySnapshotTable(MockRegistry registry)
+	{
+		FieldInfo field = typeof(MockRegistry).GetField(
+			"_propertySetupsByMemberId", BindingFlags.Instance | BindingFlags.NonPublic)!;
+		return (PropertySetup?[]?)field.GetValue(registry);
+	}
+
 	public sealed class MethodTests
 	{
 		[Fact]
@@ -178,6 +186,56 @@ public sealed class MockRegistrySetupSnapshotTests
 		}
 
 		[Fact]
+		public async Task SetupProperty_DefaultDoesNotOverwriteUserSetupAtSameMemberIdInSnapshot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> userSetup = new(registry, "Pg");
+			userSetup.InitializeWith(7);
+
+			registry.SetupProperty(1, userSetup);
+			registry.SetupProperty(1, new PropertySetup.Default<int>("Pg", 0));
+
+			PropertySetup?[]? table = GetPropertySnapshotTable(registry);
+			await That(table).IsNotNull();
+			await That(table![1]).IsSameAs(userSetup);
+		}
+
+		[Fact]
+		public async Task SetupProperty_UserSetupDoesOverwriteDefaultAtSameMemberIdInSnapshot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> userSetup = new(registry, "Pg");
+			userSetup.InitializeWith(7);
+			PropertySetup.Default<int> defaultSetup = new("Pg", 0);
+
+			registry.SetupProperty(1, defaultSetup);
+			registry.SetupProperty(1, userSetup);
+
+			PropertySetup?[]? table = GetPropertySnapshotTable(registry);
+			await That(table).IsNotNull();
+			await That(table![1]).IsSameAs(userSetup);
+		}
+
+		[Fact]
+		public async Task SetupProperty_WithGrowingMemberIds_PreservesEarlierEntriesViaArrayCopy()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setupA = new(registry, "Pa");
+			setupA.InitializeWith(1);
+			PropertySetup<int> setupB = new(registry, "Pb");
+			setupB.InitializeWith(2);
+
+			registry.SetupProperty(0, setupA);
+			registry.SetupProperty(5, setupB);
+
+			PropertySetup?[]? table = GetPropertySnapshotTable(registry);
+			await That(table).IsNotNull();
+			await That(table!.Length).IsGreaterThanOrEqualTo(6);
+			await That(table[0]).IsSameAs(setupA);
+			await That(table[5]).IsSameAs(setupB);
+		}
+
+		[Fact]
 		public async Task SetupProperty_WithIncreasingMemberIds_GrowsTableLazily()
 		{
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
@@ -195,6 +253,21 @@ public sealed class MockRegistrySetupSnapshotTests
 			await That(registry.GetPropertyFast(0, "P0", _ => -1)).IsEqualTo(10);
 			await That(registry.GetPropertyFast(7, "P7", _ => -1)).IsEqualTo(70);
 			await That(registry.GetPropertyFast(3, "P3", _ => -1)).IsEqualTo(30);
+		}
+
+		[Fact]
+		public async Task SetupProperty_WithMemberId_PopulatesSnapshotSlot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P3");
+			setup.InitializeWith(33);
+
+			registry.SetupProperty(3, setup);
+
+			PropertySetup?[]? table = GetPropertySnapshotTable(registry);
+			await That(table).IsNotNull();
+			await That(table!.Length).IsGreaterThanOrEqualTo(4);
+			await That(table[3]).IsSameAs(setup);
 		}
 
 		[Fact]
@@ -221,6 +294,20 @@ public sealed class MockRegistrySetupSnapshotTests
 
 			PropertySetup? snapshot = registry.GetPropertySetupSnapshot(5);
 			await That(snapshot).IsSameAs(setup);
+		}
+
+		[Fact]
+		public async Task SetupProperty_WithMemberIdAndDefaultScenario_PopulatesSnapshotSlot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P3");
+			setup.InitializeWith(33);
+
+			registry.SetupProperty(3, "", setup);
+
+			PropertySetup?[]? table = GetPropertySnapshotTable(registry);
+			await That(table).IsNotNull();
+			await That(table![3]).IsSameAs(setup);
 		}
 
 		[Fact]
@@ -260,6 +347,19 @@ public sealed class MockRegistrySetupSnapshotTests
 
 			int observed = registry.GetPropertyFast(5, "P5", _ => -1);
 			await That(observed).IsEqualTo(-1);
+		}
+
+		[Fact]
+		public async Task SetupProperty_WithMemberIdAndNamedScenario_LeavesSnapshotUnpublished()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			PropertySetup<int> setup = new(registry, "P3");
+			setup.InitializeWith(33);
+
+			registry.SetupProperty(3, "scope", setup);
+
+			PropertySetup?[]? table = GetPropertySnapshotTable(registry);
+			await That(table).IsNull();
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/IndexerSetupTests.cs
@@ -165,6 +165,32 @@ public sealed class IndexerSetupTests
 	}
 
 	[Fact]
+	public async Task MatchesAccess_WithUnknownAccessType_ShouldReturnFalse()
+	{
+		IndexerSetup<int, string> setup = new(
+			new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
+			(IParameterMatch<string>)It.IsAny<string>());
+		FakeIndexerAccess access = new();
+
+		bool matches = ((IInteractiveIndexerSetup)setup).Matches(access);
+
+		await That(matches).IsFalse();
+	}
+
+	[Fact]
+	public async Task SetResult_WhenValueDoesNotCastToTValue_ShouldNotInvokeSetterCallbacks()
+	{
+		MyIndexerSetup<int> setup = new();
+		int callCount = 0;
+		setup.OnSet.Do(() => callCount++);
+		IndexerSetterAccess<int, string> access = new(1, "stored");
+
+		setup.DoSetResult(access, 2L);
+
+		await That(callCount).IsEqualTo(0);
+	}
+
+	[Fact]
 	public async Task TryCast_WhenValueIsNotOfTargetTypeAndNotNull_ShouldReturnFalse()
 	{
 		bool success = FakeIndexerSetup.InvokeTryCast(42, out string _, MockBehavior.Default);
@@ -354,6 +380,20 @@ public sealed class IndexerSetupTests
 			await That(result).IsEqualTo("7-9");
 			await That(found).IsTrue();
 			await That(stored).IsEqualTo("7-9");
+		}
+
+		[Fact]
+		public async Task MatchesAccess_WithUnknownAccessType_ShouldReturnFalse()
+		{
+			IndexerSetup<string, int, int> setup = new(
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>());
+			FakeIndexerAccess access = new();
+
+			bool matches = ((IInteractiveIndexerSetup)setup).Matches(access);
+
+			await That(matches).IsFalse();
 		}
 
 		private sealed class MyIndexerSetup<T1, T2>()
@@ -557,6 +597,21 @@ public sealed class IndexerSetupTests
 			await That(result).IsEqualTo("7-8-9");
 			await That(found).IsTrue();
 			await That(stored).IsEqualTo("7-8-9");
+		}
+
+		[Fact]
+		public async Task MatchesAccess_WithUnknownAccessType_ShouldReturnFalse()
+		{
+			IndexerSetup<string, int, int, int> setup = new(
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>());
+			FakeIndexerAccess access = new();
+
+			bool matches = ((IInteractiveIndexerSetup)setup).Matches(access);
+
+			await That(matches).IsFalse();
 		}
 
 		private sealed class MyIndexerSetup<T1, T2, T3>()
@@ -771,6 +826,22 @@ public sealed class IndexerSetupTests
 			await That(result).IsEqualTo("6-7-8-9");
 			await That(found).IsTrue();
 			await That(stored).IsEqualTo("6-7-8-9");
+		}
+
+		[Fact]
+		public async Task MatchesAccess_WithUnknownAccessType_ShouldReturnFalse()
+		{
+			IndexerSetup<string, int, int, int, int> setup = new(
+				new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>(),
+				(IParameterMatch<int>)It.IsAny<int>());
+			FakeIndexerAccess access = new();
+
+			bool matches = ((IInteractiveIndexerSetup)setup).Matches(access);
+
+			await That(matches).IsFalse();
 		}
 
 		private sealed class MyIndexerSetup<T1, T2, T3, T4>()

--- a/Tests/Mockolate.Internal.Tests/Setup/MethodSetupMatchesTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/MethodSetupMatchesTests.cs
@@ -1,0 +1,512 @@
+using System.Collections.Generic;
+using Mockolate.Interactions;
+using Mockolate.Parameters;
+using Mockolate.Setup;
+
+namespace Mockolate.Internal.Tests.Setup;
+
+public sealed class MethodSetupMatchesTests
+{
+	private static MockRegistry CreateRegistry()
+		=> new(MockBehavior.Default, new FastMockInteractions(0));
+
+	private sealed class RecordingParametersMatch(bool result) : IParameters, IParametersMatch
+	{
+		public List<object?[]> Received { get; } = new();
+
+		public bool Matches(ReadOnlySpan<object?> values)
+		{
+			Received.Add(values.ToArray());
+			return result;
+		}
+	}
+
+	private sealed class RecordingNamedParametersMatch(bool result) : IParameters, INamedParametersMatch
+	{
+		public List<(string, object?)[]> Received { get; } = new();
+
+		public bool Matches(ReadOnlySpan<(string, object?)> values)
+		{
+			Received.Add(values.ToArray());
+			return result;
+		}
+	}
+
+	public sealed class ReturnMethodSetupTests
+	{
+		public sealed class OneParameter
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardNamedParameterValue()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1");
+
+				bool result = setup.Matches("hello");
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", (object?)"hello"),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardSingleParameterValue()
+			{
+				RecordingParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1");
+
+				bool result = setup.Matches("hello");
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"hello",
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				ReturnMethodSetup<int, string>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1");
+
+				bool result = setup.Matches("anything");
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1_ShouldReturnFalse()
+			{
+				ReturnMethodSetup<int, string>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+
+		public sealed class TwoParameters
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardBothNamedParameterValues()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2");
+
+				bool result = setup.Matches("a", 1);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", "a"), ("p2", (object?)1),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardBothParameterValues()
+			{
+				RecordingParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2");
+
+				bool result = setup.Matches("a", 1);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"a", 1,
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				ReturnMethodSetup<int, string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2");
+
+				bool result = setup.Matches("a", 1);
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1AndT2_ShouldReturnFalse()
+			{
+				ReturnMethodSetup<int, string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+
+		public sealed class ThreeParameters
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardAllNamedParameterValues()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3");
+
+				bool result = setup.Matches("a", 1, 2.5);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", "a"), ("p2", 1), ("p3", (object?)2.5),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardAllParameterValues()
+			{
+				RecordingParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3");
+
+				bool result = setup.Matches("a", 1, 2.5);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"a", 1, 2.5,
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				ReturnMethodSetup<int, string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3");
+
+				bool result = setup.Matches("a", 1, 2.5);
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1T2T3_ShouldReturnFalse()
+			{
+				ReturnMethodSetup<int, string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+
+		public sealed class FourParameters
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardAllNamedParameterValues()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3", "p4");
+
+				bool result = setup.Matches("a", 1, 2.5, true);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", "a"), ("p2", 1), ("p3", 2.5), ("p4", (object?)true),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardAllParameterValues()
+			{
+				RecordingParametersMatch matcher = new(true);
+				ReturnMethodSetup<int, string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3", "p4");
+
+				bool result = setup.Matches("a", 1, 2.5, true);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"a", 1, 2.5, true,
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				ReturnMethodSetup<int, string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3", "p4");
+
+				bool result = setup.Matches("a", 1, 2.5, true);
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1T2T3T4_ShouldReturnFalse()
+			{
+				ReturnMethodSetup<int, string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3", "p4");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+	}
+
+	public sealed class VoidMethodSetupTests
+	{
+		public sealed class OneParameter
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardNamedParameterValue()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				VoidMethodSetup<string>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1");
+
+				bool result = setup.Matches("hello");
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", (object?)"hello"),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardSingleParameterValue()
+			{
+				RecordingParametersMatch matcher = new(true);
+				VoidMethodSetup<string>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1");
+
+				bool result = setup.Matches("hello");
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"hello",
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				VoidMethodSetup<string>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1");
+
+				bool result = setup.Matches("anything");
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1_ShouldReturnFalse()
+			{
+				VoidMethodSetup<string>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+
+		public sealed class TwoParameters
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardBothNamedParameterValues()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				VoidMethodSetup<string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2");
+
+				bool result = setup.Matches("a", 1);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", "a"), ("p2", (object?)1),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardBothParameterValues()
+			{
+				RecordingParametersMatch matcher = new(true);
+				VoidMethodSetup<string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2");
+
+				bool result = setup.Matches("a", 1);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"a", 1,
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				VoidMethodSetup<string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2");
+
+				bool result = setup.Matches("a", 1);
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1AndT2_ShouldReturnFalse()
+			{
+				VoidMethodSetup<string, int>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+
+		public sealed class ThreeParameters
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardAllNamedParameterValues()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				VoidMethodSetup<string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3");
+
+				bool result = setup.Matches("a", 1, 2.5);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", "a"), ("p2", 1), ("p3", (object?)2.5),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardAllParameterValues()
+			{
+				RecordingParametersMatch matcher = new(true);
+				VoidMethodSetup<string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3");
+
+				bool result = setup.Matches("a", 1, 2.5);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"a", 1, 2.5,
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				VoidMethodSetup<string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3");
+
+				bool result = setup.Matches("a", 1, 2.5);
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1T2T3_ShouldReturnFalse()
+			{
+				VoidMethodSetup<string, int, double>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+
+		public sealed class FourParameters
+		{
+			[Fact]
+			public async Task Matches_WithINamedParametersMatch_ShouldForwardAllNamedParameterValues()
+			{
+				RecordingNamedParametersMatch matcher = new(true);
+				VoidMethodSetup<string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3", "p4");
+
+				bool result = setup.Matches("a", 1, 2.5, true);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new[]
+				{
+					("p1", "a"), ("p2", 1), ("p3", 2.5), ("p4", (object?)true),
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithIParametersMatch_ShouldForwardAllParameterValues()
+			{
+				RecordingParametersMatch matcher = new(true);
+				VoidMethodSetup<string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", matcher, "p1", "p2", "p3", "p4");
+
+				bool result = setup.Matches("a", 1, 2.5, true);
+
+				await That(result).IsTrue();
+				await That(matcher.Received).HasCount(1);
+				await That(matcher.Received[0]).IsEqualTo(new object?[]
+				{
+					"a", 1, 2.5, true,
+				});
+			}
+
+			[Fact]
+			public async Task Matches_WithUnknownIParameters_ShouldReturnTrue()
+			{
+				VoidMethodSetup<string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3", "p4");
+
+				bool result = setup.Matches("a", 1, 2.5, true);
+
+				await That(result).IsTrue();
+			}
+
+			[Fact]
+			public async Task MatchesInteraction_WithNonMethodInvocationOfT1T2T3T4_ShouldReturnFalse()
+			{
+				VoidMethodSetup<string, int, double, bool>.WithParameters setup =
+					new(CreateRegistry(), "M", Match.AnyParameters(), "p1", "p2", "p3", "p4");
+
+				bool result = ((IVerifiableMethodSetup)setup).Matches(new MethodInvocation("M"));
+
+				await That(result).IsFalse();
+			}
+		}
+	}
+}

--- a/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.IndexersTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.IndexersTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Mockolate.Internal.Tests.TestHelpers;
 using Mockolate.Setup;
 
@@ -21,6 +22,43 @@ public partial class MockSetupsTests
 				setups.GetMatching<FakeIndexerSetup>(s => ((IInteractiveIndexerSetup)s).Matches(access));
 
 			await That(result).IsEqualTo(setup1);
+		}
+
+		[Fact]
+		public async Task GetMatching_OnEmptyStorage_ShouldReturnNullWithoutThrowing()
+		{
+			MockSetups.IndexerSetups setups = new();
+
+			IndexerSetup? result = setups.GetMatching<IndexerSetup>(_ => true);
+
+			await That(result).IsNull();
+		}
+
+		[Fact]
+		public async Task InitializeStorageCount_OnFreshInstance_ShouldAllocateValueStoragesArrayWithRequestedLength()
+		{
+			MockSetups.IndexerSetups setups = new();
+
+			setups.InitializeStorageCount(5);
+
+			Array? storages = GetValueStoragesField(setups);
+			await That(storages).IsNotNull();
+			await That(storages!.Length).IsEqualTo(5);
+		}
+
+		[Fact]
+		public async Task InitializeStorageCount_WhenAlreadyAllocated_ShouldKeepFirstAllocation()
+		{
+			MockSetups.IndexerSetups setups = new();
+			setups.InitializeStorageCount(3);
+			Array? firstAllocation = GetValueStoragesField(setups);
+
+			setups.InitializeStorageCount(7);
+
+			Array? secondAllocation = GetValueStoragesField(setups);
+			await That(secondAllocation).IsNotNull();
+			await That(secondAllocation!.Length).IsEqualTo(3);
+			await That(secondAllocation).IsSameAs(firstAllocation);
 		}
 
 		[Fact]
@@ -68,6 +106,13 @@ public partial class MockSetupsTests
 			Parallel.For(0, 200, _ => setups.Add(new FakeIndexerSetup(false)));
 
 			await That(setups.Count).IsEqualTo(200);
+		}
+
+		private static Array? GetValueStoragesField(MockSetups.IndexerSetups setups)
+		{
+			FieldInfo field = typeof(MockSetups.IndexerSetups).GetField(
+				"_valueStorages", BindingFlags.Instance | BindingFlags.NonPublic)!;
+			return (Array?)field.GetValue(setups);
 		}
 	}
 }

--- a/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.MethodsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.MethodsTests.cs
@@ -21,6 +21,16 @@ public partial class MockSetupsTests
 		}
 
 		[Fact]
+		public async Task GetLatestOrDefault_OnEmptyStorage_ShouldReturnNullWithoutThrowing()
+		{
+			MockSetups.MethodSetups setups = new();
+
+			MethodSetup? result = setups.GetLatestOrDefault(_ => true);
+
+			await That(result).IsNull();
+		}
+
+		[Fact]
 		public async Task GetLatestOrDefault_ShouldReturnLatestMatching()
 		{
 			MockSetups.MethodSetups setups = new();

--- a/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.PropertiesTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.PropertiesTests.cs
@@ -8,6 +8,36 @@ public partial class MockSetupsTests
 	public class PropertiesTests
 	{
 		[Fact]
+		public async Task Add_DefaultPlaceholderAfterUserSetup_ShouldNotOverwriteUserSetup()
+		{
+			MockSetups.PropertySetups setups = new();
+			FakePropertySetup userSetup = new("p");
+			PropertySetup defaultSetup = new PropertySetup.Default<int>("p", 0);
+
+			setups.Add(userSetup);
+			setups.Add(defaultSetup);
+
+			setups.TryGetValue("p", out PropertySetup? found);
+			await That(found).IsSameAs(userSetup);
+			await That(setups.Count).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task Add_DefaultPlaceholderOverDefault_ShouldKeepDefaultEntry()
+		{
+			MockSetups.PropertySetups setups = new();
+			PropertySetup firstDefault = new PropertySetup.Default<int>("p", 0);
+			PropertySetup secondDefault = new PropertySetup.Default<int>("p", 0);
+
+			setups.Add(firstDefault);
+			setups.Add(secondDefault);
+
+			setups.TryGetValue("p", out PropertySetup? found);
+			await That(found).IsSameAs(secondDefault);
+			await That(setups.Count).IsEqualTo(0);
+		}
+
+		[Fact]
 		public async Task Add_ReplacingDefaultWithUserSetup_ShouldIncrementCountByOne()
 		{
 			MockSetups.PropertySetups setups = new();

--- a/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/MockSetupsTests.cs
@@ -62,6 +62,28 @@ public partial class MockSetupsTests
 		await That(result).IsEqualTo(expected);
 	}
 
+	[Fact]
+	public async Task TryGetScenario_WithEmptyName_ShouldReturnTrueAndYieldRootBucket()
+	{
+		MockSetups setups = new();
+
+		bool result = setups.TryGetScenario("", out MockScenarioSetup? scenario);
+
+		await That(result).IsTrue();
+		await That(scenario).IsSameAs(setups);
+	}
+
+	[Fact]
+	public async Task TryGetScenario_WithNullName_ShouldReturnTrueAndYieldRootBucket()
+	{
+		MockSetups setups = new();
+
+		bool result = setups.TryGetScenario(null!, out MockScenarioSetup? scenario);
+
+		await That(result).IsTrue();
+		await That(scenario).IsSameAs(setups);
+	}
+
 	internal interface IMyService
 	{
 	}

--- a/Tests/Mockolate.Internal.Tests/Setup/PropertySetupTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/PropertySetupTests.cs
@@ -1,4 +1,5 @@
 using Mockolate.Exceptions;
+using Mockolate.Interactions;
 using Mockolate.Internal.Tests.TestHelpers;
 using Mockolate.Setup;
 
@@ -30,6 +31,37 @@ public sealed class PropertySetupTests
 		float value = interactive.InvokeGetter(null, MockBehavior.Default, () => 99f);
 
 		await That(value).IsEqualTo(99f);
+	}
+
+	[Fact]
+	public async Task DefaultInvokeGetter_WhenRequestedTypeIsBoxedSuperType_ShouldReturnStoredValueViaPatternMatch()
+	{
+		PropertySetup.Default<int> setup = new("p", 42);
+		IInteractivePropertySetup interactive = setup;
+
+		object value = interactive.InvokeGetter<object>(null, MockBehavior.Default, () => 99);
+
+		await That(value).IsEqualTo(42);
+	}
+
+	[Fact]
+	public async Task DefaultInvokeGetterFast_WhenRequestedTypeIsBoxedSuperType_ShouldReturnStoredValueViaPatternMatch()
+	{
+		PropertySetup.Default<int> setup = new("p", 42);
+
+		object value = setup.InvokeGetterFast<object>(MockBehavior.Default, _ => 99);
+
+		await That(value).IsEqualTo(42);
+	}
+
+	[Fact]
+	public async Task DefaultInvokeGetterFast_WhenStoredValueIsNullReference_ShouldReturnNullViaTypeofFastPath()
+	{
+		PropertySetup.Default<string> setup = new("p", null!);
+
+		string value = setup.InvokeGetterFast<string>(MockBehavior.Default, _ => "fallback");
+
+		await That(value).IsNull();
 	}
 
 	[Fact]
@@ -72,6 +104,43 @@ public sealed class PropertySetupTests
 
 		await That(Act).Throws<MockException>()
 			.WithMessage("*'int'*'string'*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task PropertySetupInvokeGetter_WhenRequestedTypeIsBoxedSuperType_ShouldReturnStoredValueViaPatternMatch()
+	{
+		PropertySetup<int> setup = new(
+			new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "p");
+		setup.InitializeWith(42);
+		IInteractivePropertySetup interactive = setup;
+
+		object value = interactive.InvokeGetter<object>(null, MockBehavior.Default, () => 99);
+
+		await That(value).IsEqualTo(42);
+	}
+
+	[Fact]
+	public async Task PropertySetupInvokeGetter_WhenStoredValueIsNullReference_ShouldReturnNullViaTypeofFastPath()
+	{
+		PropertySetup<string> setup = new(
+			new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "p");
+		IInteractivePropertySetup interactive = setup;
+
+		string value = interactive.InvokeGetter<string>(null, MockBehavior.Default, () => "fallback");
+
+		await That(value).IsNull();
+	}
+
+	[Fact]
+	public async Task PropertySetupInvokeGetterFast_WhenRequestedTypeIsBoxedSuperType_ShouldReturnStoredValueViaPatternMatch()
+	{
+		PropertySetup<int> setup = new(
+			new MockRegistry(MockBehavior.Default, new FastMockInteractions(0)), "p");
+		setup.InitializeWith(42);
+
+		object value = setup.InvokeGetterFast<object>(MockBehavior.Default, _ => 99);
+
+		await That(value).IsEqualTo(42);
 	}
 
 	[Fact]


### PR DESCRIPTION
This pull request adds comprehensive new unit tests to the Mockolate internal test suite, focusing on improved coverage and correctness for property, indexer, and method setup behaviors. The new tests verify correct handling of edge cases, such as type conversions, storage allocation, and scenario management, as well as ensuring that default and user setups interact as intended.

**Property and Setup Management:**

* Added tests to ensure that default property setups do not overwrite user-defined setups and that user setups correctly overwrite defaults in `MockRegistry` and `MockSetups.PropertySetups`
* Introduced tests verifying that the internal property snapshot table in `MockRegistry` is updated and preserved correctly during property setup operations, including array growth and scenario handling

**Indexer and Method Setup Handling:**

* Added tests to ensure that indexer setups correctly handle unknown access types and improper type casting, and that storage allocation for indexer setups is managed correctly and efficiently
* Added tests for method setups to ensure that querying for the latest or matching setup on empty storage returns null without exceptions (`MockSetupsTests.MethodsTests.cs`).

**Type Conversion and Getter Logic:**

* Introduced tests to verify that property getter logic correctly handles type conversions, including returning stored values when requested as boxed supertypes and handling null references properly

**Scenario Management:**

* Added tests ensuring that requesting a scenario with an empty or null name returns the root scenario bucket as expected (`MockSetupsTests.cs`).