### PR TITLE
coverage: add fast-path and fallback tests for property, indexer, event, and method verification

### DIFF
--- a/Tests/Mockolate.Tests/Verify/MockRegistryVerifyTests.cs
+++ b/Tests/Mockolate.Tests/Verify/MockRegistryVerifyTests.cs
@@ -479,4 +479,306 @@ public class MockRegistryVerifyTests
 			await That(Act).Throws<MockVerificationException>();
 		}
 	}
+
+	public sealed class VerifyPropertyFastPathTests
+	{
+		[Fact]
+		public async Task Getter_FailureMessageIncludesGotPropertyPrefix()
+		{
+			// Pins the expectation factory `() => $"got property {propertyName...}"` against the
+			// string-removal mutation that would replace it with an empty interpolation.
+			FastMockInteractions store = new(1);
+			store.InstallPropertyGetter(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyProperty(new object(), 0, "X").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*got property X*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task Getter_WithBufferAndRecord_PredicateMatchesEveryRecord()
+		{
+			// Pins `static _ => true` predicate in the public memberId-keyed VerifyProperty getter.
+			// Mutating it to `static _ => false` would skip every record and turn this Once() into a
+			// failed verification.
+			FastMockInteractions store = new(1);
+			FastPropertyGetterBuffer buffer = store.InstallPropertyGetter(0);
+			buffer.Append("X");
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyProperty(new object(), 0, "X").Once();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Setter_FailureMessageIncludesSetPropertyPrefix()
+		{
+			// Pins the expectation factory `() => $"set property {propertyName...} to {value}"`
+			// against the string-removal mutation.
+			FastMockInteractions store = new(1);
+			store.InstallPropertySetter<int>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyProperty(new object(), 0, "X",
+					(IParameterMatch<int>)It.Is(7)).Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*set property X to *7*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task Setter_WithBufferAndMatchingRecord_PredicateMatchesByValue()
+		{
+			// Pins the local Predicate's body in the memberId-keyed property setter overload.
+			// Block-removal would turn the predicate into `return default;` (i.e. always false) and
+			// drop every recorded setter, failing this Once().
+			FastMockInteractions store = new(1);
+			FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+			buffer.Append("X", 7);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyProperty(new object(), 0, "X",
+					(IParameterMatch<int>)It.Is(7)).Once();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task Setter_WithNonMatchingValue_PredicateRejects()
+		{
+			// Same Predicate body — but exercises the negative branch so the `value.Matches(...)`
+			// term cannot be silently dropped.
+			FastMockInteractions store = new(1);
+			FastPropertySetterBuffer<int> buffer = store.InstallPropertySetter<int>(0);
+			buffer.Append("X", 99);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.VerifyProperty(new object(), 0, "X",
+					(IParameterMatch<int>)It.Is(7)).Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>();
+		}
+	}
+
+	public sealed class IndexerFastPathTests
+	{
+		[Fact]
+		public async Task Got_FailureMessageIncludesGotIndexerPrefix()
+		{
+			// Pins `() => $"got indexer {parametersDescription()}"` in the public memberId-keyed
+			// IndexerGot expression body against the string-removal mutation.
+			FastMockInteractions store = new(1);
+			store.InstallIndexerGetter<int>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerGot(new object(), 0,
+					_ => true,
+					() => "[1]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*got indexer [1]*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task Set_FailureMessageIncludesSetIndexerPrefix()
+		{
+			// Pins `() => $"set indexer {parametersDescription()} to {value}"` against the
+			// string-removal mutation.
+			FastMockInteractions store = new(1);
+			store.InstallIndexerSetter<int, string>(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerSet(new object(), 0,
+					(_, _) => true,
+					(IParameterMatch<string>)It.Is<string>("x"),
+					() => "[1]").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*set indexer [1] to *x*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task Set_WithBufferAndMatchingRecord_PredicateMatchesByValue()
+		{
+			// Pins the local Predicate body in the memberId-keyed IndexerSet overload — the
+			// block-removal mutant would turn it into `return default;` and skip every record.
+			FastMockInteractions store = new(1);
+			FastIndexerSetterBuffer<int, string> buffer = store.InstallIndexerSetter<int, string>(0);
+			buffer.Append(1, "x");
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.IndexerSet(new object(), 0,
+					(interaction, v) => interaction is IndexerSetterAccess<int, string> s &&
+					                    s.Parameter1 == 1 && v.Matches(s.TypedValue),
+					(IParameterMatch<string>)It.Is<string>("x"),
+					() => "[1]").Once();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+
+	public sealed class SubscribedToFastPathTests
+	{
+		[Fact]
+		public async Task FailureMessageIncludesSubscribedToEventPrefix()
+		{
+			// Pins the expectation factory `() => $"subscribed to event {eventName...}"`.
+			FastMockInteractions store = new(1);
+			store.InstallEventSubscribe(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.SubscribedTo(new object(), 0, "Tick").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*subscribed to event Tick*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task WithBufferAndRecord_PredicateMatchesEveryRecord()
+		{
+			// Pins `static _ => true` in the memberId-keyed SubscribedTo. Mutating to `false`
+			// would drop every record and fail Once().
+			FastMockInteractions store = new(1);
+			FastEventBuffer buffer = store.InstallEventSubscribe(0);
+			buffer.Append("Tick", null, typeof(object).GetMethod(nameof(ToString))!);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.SubscribedTo(new object(), 0, "Tick").Once();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WithoutBuffer_FallsBackToLegacyAndFiltersByEventName()
+		{
+			// Kills two coupled mutants on `if (buffer is null)`:
+			//   - equality flip `is not null` would fall through to the fast-path constructor with
+			//     a null buffer and `static _ => true`, which CollectMatching's null-buffer branch
+			//     turns into "match every recorded interaction";
+			//   - block removal `{}` does the same thing (drops the early `return SubscribedTo(...)`).
+			// Either way, the unrelated PropertyGetterAccess below would be counted as a Tick
+			// subscription and `.Never()` would throw.
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(new PropertyGetterAccess("Other"));
+
+			void Act()
+			{
+				registry.SubscribedTo(new object(), 0, "Tick").Never();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+
+	public sealed class UnsubscribedFromFastPathTests
+	{
+		[Fact]
+		public async Task FailureMessageIncludesUnsubscribedFromEventPrefix()
+		{
+			FastMockInteractions store = new(1);
+			store.InstallEventUnsubscribe(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.UnsubscribedFrom(new object(), 0, "Tick").Once();
+			}
+
+			await That(Act).Throws<MockVerificationException>()
+				.WithMessage("*unsubscribed from event Tick*").AsWildcard();
+		}
+
+		[Fact]
+		public async Task WithBufferAndRecord_PredicateMatchesEveryRecord()
+		{
+			FastMockInteractions store = new(1);
+			FastEventBuffer buffer = store.InstallEventUnsubscribe(0);
+			buffer.Append("Tick", null, typeof(object).GetMethod(nameof(ToString))!);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			void Act()
+			{
+				registry.UnsubscribedFrom(new object(), 0, "Tick").Once();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WithoutBuffer_FallsBackToLegacyAndFiltersByEventName()
+		{
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(new PropertyGetterAccess("Other"));
+
+			void Act()
+			{
+				registry.UnsubscribedFrom(new object(), 0, "Tick").Never();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+
+	public sealed class VerifyMethodFallbackTests
+	{
+		[Fact]
+		public async Task Parameterless_WithoutFastMethod0Buffer_PredicateMatchesAllMethodInvocations()
+		{
+			// Kills the `_ => true` → `_ => false` mutation in the slow-path fallback at the bottom
+			// of `VerifyMethod<T>(subject, memberId, methodName, expectation)`. We enter the
+			// fallback because no FastMethod0Buffer is installed at memberId 0; the registered
+			// MethodInvocation must still be counted.
+			FastMockInteractions store = new(0);
+			MockRegistry registry = new(MockBehavior.Default, store);
+
+			IMockInteractions interactions = store;
+			interactions.RegisterInteraction(new MethodInvocation("Foo"));
+
+			void Act()
+			{
+				registry.VerifyMethod(new object(), 0, "Foo", () => "Foo()").Once();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+	}
 }

--- a/Tests/Mockolate.Tests/Verify/VerificationResultMutationTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultMutationTests.cs
@@ -1,6 +1,6 @@
+using System.Collections.Generic;
 using aweXpect.Chronology;
 using Mockolate.Exceptions;
-using Mockolate.Interactions;
 using Mockolate.Tests.TestHelpers;
 using Mockolate.Verify;
 
@@ -22,6 +22,26 @@ public sealed class VerificationResultMutationTests
 	}
 
 	[Fact]
+	public async Task AwaitableVerify_RecordsArrayPath_AfterSuccess_MarksMatchingInteractionsAsVerified()
+	{
+		// Pins the `_interactions.Verified(matchingInteractions);` call inside Awaitable's
+		// IVerificationResult.Verify (the records-array path). Statement-removal would skip the
+		// bookkeeping and leave the matching record in the unverified set — but the predicate
+		// still returns true, so the failure surfaces only via GetUnverifiedInteractions().
+		IChocolateDispenser sut = IChocolateDispenser.CreateMock();
+		sut.Dispense("Dark", 1);
+
+		VerificationResult<Mock.IMockVerifyForIChocolateDispenser> result =
+			sut.Mock.Verify.Dispense(Match.AnyParameters()).Within(50.Milliseconds());
+
+		bool verified = ((IVerificationResult)result).Verify(arr => arr.Length > 0);
+
+		await That(verified).IsTrue();
+		IMockInteractions interactions = ((IMock)sut).MockRegistry.Interactions;
+		await That(interactions.GetUnverifiedInteractions()).IsEmpty();
+	}
+
+	[Fact]
 	public async Task AwaitableVerify_WithRecordingDisabled_ShouldThrowMockException()
 	{
 		IMyService sut = IMyService.CreateMock(MockBehavior.Default.SkippingInteractionRecording());
@@ -35,5 +55,111 @@ public sealed class VerificationResultMutationTests
 
 		await That(Act).Throws<MockException>()
 			.WithMessage("*interaction recording is disabled*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task AwaitableVerifyCount_NoFastCountSource_AfterSuccess_MarksMatchingInteractionsAsVerified()
+	{
+		// Pins the `_interactions.Verified(matchingInteractions);` call inside Awaitable's
+		// IFastVerifyCountResult.VerifyCount second branch (when `_fastCountSource is null`).
+		// IndexerGot(memberId, ...) returns a VerificationResult with a buffer but no fast-count
+		// source, so wrapping it with .Within(...) walks exactly that branch.
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+		buffer.Append(1);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		registry.IndexerGot(new object(), 0,
+				interaction => interaction is IndexerGetterAccess<int> g && g.Parameter1 == 1,
+				() => "[1]")
+			.Within(50.Milliseconds()).Once();
+
+		await That(((IMockInteractions)store).GetUnverifiedInteractions()).IsEmpty();
+	}
+
+	[Fact]
+	public async Task CollectMatching_WithMultipleRecordsOutOfSeqOrder_SortsBySeqBeforeReturning()
+	{
+		// Kills the `records.Sort(...)` statement removal and the `records.Count > 1` → `<= 1`
+		// flip in CollectMatching's buffer-walking branch. With a custom buffer that emits
+		// records in non-Seq order, the sort is the only thing that puts them back in seq
+		// order — without it, the user predicate sees the buffer's natural order and the
+		// assertion below fails.
+		FastMockInteractions store = new(1);
+		MethodInvocation<int> rec5 = new("Foo", 5);
+		MethodInvocation<int> rec1 = new("Foo", 1);
+		MethodInvocation<int> rec3 = new("Foo", 3);
+		OutOfOrderBuffer buffer = new(
+		[
+			(5L, rec5),
+			(1L, rec1),
+			(3L, rec3),
+		]);
+		store.InstallBuffer(0, buffer);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		VerificationResult<object>.IgnoreParameters result =
+			registry.VerifyMethod<object, MethodInvocation<int>>(
+				new object(), 0, "Foo", _ => true, () => "Foo");
+
+		List<int> values = [];
+		bool verified = ((IVerificationResult)result).Verify(arr =>
+		{
+			foreach (IInteraction interaction in arr)
+			{
+				values.Add(((MethodInvocation<int>)interaction).Parameter1);
+			}
+
+			return arr.Length == 3;
+		});
+
+		await That(verified).IsTrue();
+		await That(values).IsEqualTo([1, 3, 5,]);
+	}
+
+	[Fact]
+	public async Task SyncVerifyCount_NoFastCountSource_AfterSuccess_MarksMatchingInteractionsAsVerified()
+	{
+		// Pins the `_interactions.Verified(matchingInteractions);` call inside the non-Awaitable
+		// IFastVerifyCountResult.VerifyCount second branch (when `_fastCountSource is null`).
+		FastMockInteractions store = new(1);
+		FastIndexerGetterBuffer<int> buffer = store.InstallIndexerGetter<int>(0);
+		buffer.Append(1);
+		MockRegistry registry = new(MockBehavior.Default, store);
+
+		registry.IndexerGot(new object(), 0,
+			interaction => interaction is IndexerGetterAccess<int> g && g.Parameter1 == 1,
+			() => "[1]").Once();
+
+		await That(((IMockInteractions)store).GetUnverifiedInteractions()).IsEmpty();
+	}
+
+	private sealed class OutOfOrderBuffer : IFastMemberBuffer
+	{
+		private readonly List<(long Seq, IInteraction Interaction)> _records;
+
+		public OutOfOrderBuffer(IEnumerable<(long, IInteraction)> records)
+		{
+			_records = new List<(long, IInteraction)>();
+			foreach ((long seq, IInteraction interaction) in records)
+			{
+				_records.Add((seq, interaction));
+			}
+		}
+
+		public int Count => _records.Count;
+
+		public void Clear() => _records.Clear();
+
+		public void AppendBoxed(List<(long Seq, IInteraction Interaction)> dest)
+		{
+			foreach ((long Seq, IInteraction Interaction) record in _records)
+			{
+				dest.Add(record);
+			}
+		}
+
+		public void AppendBoxedUnverified(List<(long Seq, IInteraction Interaction)> dest)
+			=> AppendBoxed(dest);
 	}
 }


### PR DESCRIPTION
This pull request adds comprehensive new tests to the `Mockolate.Tests/Verify` suite, focusing on verifying the correct behavior of interaction verification, fast-path property/indexer/event handling, and record sorting logic. These tests ensure that verification methods mark interactions as verified, that buffer and fallback logic is exercised, and that error messages are properly formatted.

**New test coverage for fast-path and fallback verification:**

* Adds `VerifyPropertyFastPathTests` to test property getter/setter verification, including correct error messages, predicate logic, and buffer handling.
* Adds `IndexerFastPathTests` to test indexer getter/setter verification, including error messages and value matching.
* Adds `SubscribedToFastPathTests` and `UnsubscribedFromFastPathTests` to verify event subscription and unsubscription handling, including buffer and fallback logic.
* Adds `VerifyMethodFallbackTests` to ensure method verification works when fast buffers are not present.

**Enhancements to verification result mutation tests:**

* Adds tests in `VerificationResultMutationTests` to ensure that both awaitable and synchronous verification methods mark matching interactions as verified, including when fast-count sources are absent.
* Adds a test to verify that matching records are sorted by sequence before being returned, ensuring correct order even with out-of-sequence buffers.
* Introduces a custom `OutOfOrderBuffer` test helper to simulate out-of-sequence interaction records for sorting tests.