### PR TITLE
coverage: add missing tests for `It.*`

### DIFF
--- a/Tests/Mockolate.Tests/ItTests.IsNotNullTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNotNullTests.cs
@@ -31,6 +31,15 @@ public sealed partial class ItTests
 		}
 
 		[Fact]
+		public async Task ShouldReturnSharedInstance_WhenToStringIsOmitted()
+		{
+			IParameter<string> first = It.IsNotNull<string>();
+			IParameter<string> second = It.IsNotNull<string>();
+
+			await That(first).IsSameAs(second);
+		}
+
+		[Fact]
 		public async Task ToString_ShouldReturnExpectedValue()
 		{
 			IParameter<string> sut = It.IsNotNull<string>();

--- a/Tests/Mockolate.Tests/ItTests.IsNullTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNullTests.cs
@@ -31,6 +31,15 @@ public sealed partial class ItTests
 		}
 
 		[Fact]
+		public async Task ShouldReturnSharedInstance_WhenToStringIsOmitted()
+		{
+			IParameter<string> first = It.IsNull<string>();
+			IParameter<string> second = It.IsNull<string>();
+
+			await That(first).IsSameAs(second);
+		}
+
+		[Fact]
 		public async Task ToString_ShouldReturnExpectedValue()
 		{
 			IParameter<string> sut = It.IsNull<string>();

--- a/Tests/Mockolate.Tests/ItTests.SequenceEqualsTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.SequenceEqualsTests.cs
@@ -162,6 +162,17 @@ public sealed partial class ItTests
 		}
 
 		[Fact]
+		public async Task ToString_WithNullElement_ShouldRenderNullToken()
+		{
+			IParameter<object?[]> sut = It.SequenceEquals<object?>("foo", null, 3);
+			string expectedValue = "It.SequenceEquals(\"foo\", null, 3)";
+
+			string? result = sut.ToString();
+
+			await That(result).IsEqualTo(expectedValue);
+		}
+
+		[Fact]
 		public async Task ToString_WithStringValues_ShouldReturnExpectedValue()
 		{
 			IParameter<string[]> sut = It.SequenceEquals("foo", "bar");
@@ -184,6 +195,22 @@ public sealed partial class ItTests
 
 		public sealed class DoTests
 		{
+			[Fact]
+			public async Task Do_MultipleRegistrations_ShouldAllInvoke()
+			{
+				It.ISequenceEqualsParameter<int> sut = It.SequenceEquals(1, 2, 3);
+				int firstCount = 0;
+				int secondCount = 0;
+				((IParameterWithCallback<int[]>)sut).Do(_ => firstCount++);
+				((IParameterWithCallback<int[]>)sut).Do(_ => secondCount++);
+
+				int[] source = [1, 2, 3,];
+				((IParameterMatch<int[]>)sut).InvokeCallbacks(source);
+
+				await That(firstCount).IsEqualTo(1);
+				await That(secondCount).IsEqualTo(1);
+			}
+
 			[Fact]
 			public async Task Do_RegistersCallbackForArray()
 			{


### PR DESCRIPTION
This pull request adds new unit tests to improve coverage and ensure correct behavior of the `It.IsNull`, `It.IsNotNull`, and `It.SequenceEquals` parameter matchers in the Mockolate testing framework. The most important changes include verifying the use of shared instances, correct string representations, handling of nulls in sequences, and support for multiple callbacks.

**Parameter matcher instance behavior:**

* Added tests to verify that `It.IsNull<string>()` and `It.IsNotNull<string>()` return shared instances when `ToString()` is not called, ensuring consistent identity semantics.

**String representation and null handling:**

* Added a test to `It.SequenceEquals<object?>` to ensure that the string representation correctly renders `null` elements as `null` tokens in the output.

**Callback registration and invocation:**

* Added a test to verify that multiple callbacks registered with `ISequenceEqualsParameter<int>` are all invoked when the matcher is triggered, improving confidence in the callback mechanism.