### PR TITLE
refactor: fix sonar issues

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -1,9 +1,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 
@@ -17,6 +15,7 @@ internal class Class : IEquatable<Class>
 	private List<Property>? _allProperties;
 	private string? _classNameWithoutDots;
 
+#pragma warning disable S107 // Methods should not have too many parameters
 	public Class(ITypeSymbol type,
 		IAssemblySymbol sourceAssembly,
 		List<Method>? alreadyDefinedMethods = null,
@@ -25,6 +24,7 @@ internal class Class : IEquatable<Class>
 		List<Method>? exceptMethods = null,
 		List<Property>? exceptProperties = null,
 		List<Event>? exceptEvents = null)
+#pragma warning restore S107
 	{
 		_sourceAssembly = sourceAssembly;
 		ClassFullName = type.ToDisplayString(Helpers.TypeDisplayFormat);
@@ -34,11 +34,21 @@ internal class Class : IEquatable<Class>
 		INamedTypeSymbol? containingType = type.ContainingType;
 		if (containingType is not null)
 		{
+			List<string> ancestors = new();
 			while (containingType is not null)
 			{
-				ClassName = containingType.Name + "." + ClassName;
+				ancestors.Add(containingType.Name);
 				containingType = containingType.ContainingType;
 			}
+
+			StringBuilder nameBuilder = new();
+			for (int i = ancestors.Count - 1; i >= 0; i--)
+			{
+				nameBuilder.Append(ancestors[i]).Append('.');
+			}
+
+			nameBuilder.Append(ClassName);
+			ClassName = nameBuilder.ToString();
 		}
 
 		IsInterface = type.TypeKind == TypeKind.Interface;
@@ -151,6 +161,18 @@ internal class Class : IEquatable<Class>
 		}
 	}
 
+	public EquatableArray<Method> Methods { get; }
+	public EquatableArray<Class> InheritedTypes { get; }
+	public EquatableArray<Property> Properties { get; }
+	public EquatableArray<Event> Events { get; }
+	public EquatableArray<string> ReservedNames { get; }
+
+	public bool IsInterface { get; }
+	public bool HasRequiredMembers { get; }
+	public string ClassFullName { get; }
+	public string ClassName { get; }
+	public string DisplayString { get; }
+
 	/// <summary>
 	///     Folds the member surface (methods, properties, events, recursive base/interface chain,
 	///     reserved names, kind, required-member flag) into a single content-derived integer.
@@ -172,18 +194,6 @@ internal class Class : IEquatable<Class>
 		hash = unchecked((hash * 17) + (HasRequiredMembers ? 1 : 0));
 		return hash;
 	}
-
-	public EquatableArray<Method> Methods { get; }
-	public EquatableArray<Class> InheritedTypes { get; }
-	public EquatableArray<Property> Properties { get; }
-	public EquatableArray<Event> Events { get; }
-	public EquatableArray<string> ReservedNames { get; }
-
-	public bool IsInterface { get; }
-	public bool HasRequiredMembers { get; }
-	public string ClassFullName { get; }
-	public string ClassName { get; }
-	public string DisplayString { get; }
 
 	/// <summary>
 	///     Identifiers that the mock class shares its scope with but that aren't surfaced through

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
@@ -284,11 +284,17 @@ public class FastMockInteractionsTests
 			}, TaskCreationOptions.LongRunning);
 		}
 
+#if NET48
+		CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+#else
+		CancellationToken cancellationToken = CancellationToken.None;
+#endif
+
 		for (int round = 0; round < rounds; round++)
 		{
 			fallbackField.SetValue(sut, null);
-			barrier.SignalAndWait();
-			barrier.SignalAndWait();
+			barrier.SignalAndWait(cancellationToken);
+			barrier.SignalAndWait(cancellationToken);
 
 			object? installed = fallbackField.GetValue(sut);
 			await That(installed).IsNotNull();

--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/TypeIsFormattableTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/TypeIsFormattableTests.cs
@@ -19,11 +19,11 @@ public class TypeIsFormattableTests
 			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location),],
 			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 		SemanticModel model = compilation.GetSemanticModel(tree);
-		FieldDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+		FieldDeclarationSyntax declaration = tree.GetRoot(TestContext.Current.CancellationToken).DescendantNodes()
 			.OfType<FieldDeclarationSyntax>()
 			.First();
 		VariableDeclaratorSyntax variable = declaration.Declaration.Variables.Single();
-		IFieldSymbol fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(variable)!;
+		IFieldSymbol fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(variable, TestContext.Current.CancellationToken)!;
 
 		Type type = Type.From(fieldSymbol.Type);
 
@@ -43,7 +43,7 @@ public class TypeIsFormattableTests
 		                          public IFormattable Value;
 		                      }
 		                      """;
-		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+		SyntaxTree tree = CSharpSyntaxTree.ParseText(source, cancellationToken: TestContext.Current.CancellationToken);
 		CSharpCompilation compilation = CSharpCompilation.Create(
 			"TestAssembly",
 			[tree,],
@@ -53,11 +53,11 @@ public class TypeIsFormattableTests
 			],
 			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 		SemanticModel model = compilation.GetSemanticModel(tree);
-		FieldDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+		FieldDeclarationSyntax declaration = tree.GetRoot(TestContext.Current.CancellationToken).DescendantNodes()
 			.OfType<FieldDeclarationSyntax>()
 			.First();
 		VariableDeclaratorSyntax variable = declaration.Declaration.Variables.Single();
-		IFieldSymbol fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(variable)!;
+		IFieldSymbol fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(variable, TestContext.Current.CancellationToken)!;
 		ITypeSymbol typeSymbol = fieldSymbol.Type;
 
 		Type type = Type.From(typeSymbol);

--- a/Tests/Mockolate.Tests/MockBehaviorTests.InitializeTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.InitializeTests.cs
@@ -9,8 +9,9 @@ public sealed partial class MockBehaviorTests
 		[Fact]
 		public async Task Initialize_DirectSetupsTakePrecedence()
 		{
-			MockBehavior behavior = MockBehavior.Default.Initialize<IChocolateDispenser>(setup
-				=> setup[It.Satisfies<string>(s => s.StartsWith("da"))].InitializeWith(5));
+			MockBehavior behavior = MockBehavior.Default.Initialize<IChocolateDispenser>(
+				(Mock.IMockSetupForIChocolateDispenser setup)
+					=> setup[It.Satisfies<string>((string s) => s.StartsWith("da"))].InitializeWith(5));
 
 			IChocolateDispenser sut = IChocolateDispenser.CreateMock(behavior,
 				setup => setup[It.Satisfies<string>(s => s.EndsWith("rk"))].InitializeWith(16));
@@ -30,8 +31,9 @@ public sealed partial class MockBehaviorTests
 		public async Task Initialize_OtherType_ShouldIgnoreInitializations()
 		{
 			MockBehavior behavior =
-				MockBehavior.Default.Initialize<IChocolateDispenser>(setup
-					=> setup[It.Is("Dark")].InitializeWith(15));
+				MockBehavior.Default.Initialize<IChocolateDispenser>(
+					(Mock.IMockSetupForIChocolateDispenser setup)
+						=> setup[It.Is("Dark")].InitializeWith(15));
 
 			void Act()
 			{
@@ -45,8 +47,9 @@ public sealed partial class MockBehaviorTests
 		public async Task Initialize_ShouldApplySetupToCreatedMock()
 		{
 			MockBehavior behavior =
-				MockBehavior.Default.Initialize<IChocolateDispenser>(setup
-					=> setup[It.Is("Dark")].InitializeWith(15));
+				MockBehavior.Default.Initialize<IChocolateDispenser>(
+					(Mock.IMockSetupForIChocolateDispenser setup)
+						=> setup[It.Is("Dark")].InitializeWith(15));
 
 			IChocolateDispenser sut = IChocolateDispenser.CreateMock(behavior);
 


### PR DESCRIPTION
This pull request includes several improvements and fixes across both the source generator code and the test suite. The most significant changes enhance the robustness of equality checks for the `Class` entity, improve handling of nested type names, and update test code to support cancellation tokens for better compatibility and reliability.

**Entities and Equality Improvements:**

* Refactored the `Class` entity's equality logic to ensure equality is based on both the class's full name and a content-derived hash of its member surface, making incremental builds more reliable and preventing stale cache issues. The `Equals(Class? other)` method is now more robust and includes detailed documentation.
* Moved the declaration of key `Class` properties (like `Methods`, `Properties`, etc.) to a more logical location in the file for clarity and maintainability.

**Nested Type Name Handling:**

* Improved the logic for constructing `ClassName` for nested types by building the name using a list and a `StringBuilder`, ensuring correct ordering and formatting for deeply nested types.

**Code Quality and Style:**

* Added and restored a pragma directive to suppress the "too many parameters" warning for the `Class` constructor, clarifying intentional design and suppressing unnecessary linter noise.

**Test Suite Enhancements:**

* Updated test code to consistently use `TestContext.Current.CancellationToken` when working with Roslyn APIs and multithreading primitives, improving test reliability and compatibility across frameworks (notably for .NET 4.8).
* Clarified the type signature in test setup lambdas for `MockBehavior.Initialize`, improving readability and type safety.