### PR TITLE
perf: optimize generator-emitted setups by skipping dual registration

### DIFF
--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -94,7 +94,7 @@ public partial class MockRegistry
 	///     <paramref name="memberId" />, or <see langword="null" /> when no setup has been registered.
 	/// </summary>
 	/// <remarks>
-	///     Property dispatch reads the snapshot via <see cref="GetPropertyFast{TResult}(int, string, Func{MockBehavior, TResult}, Func{TResult}?)" />
+	///     Property dispatch reads the snapshot via <see cref="GetPropertyFast{TResult}(int, string, System.Func{Mockolate.MockBehavior,TResult}, Func{TResult}?)" />
 	///     and falls back to the cold path when the snapshot is empty, so this accessor is intended for
 	///     diagnostics and tests that need to verify the fast-path table directly.
 	/// </remarks>
@@ -232,6 +232,12 @@ public partial class MockRegistry
 			}
 		}
 
+		T? snapshot = GetMatchingIndexerSetupFromSnapshot(predicate);
+		if (snapshot is not null)
+		{
+			return snapshot;
+		}
+
 		return Setup.Indexers.GetMatching(predicate);
 	}
 
@@ -255,7 +261,73 @@ public partial class MockRegistry
 			}
 		}
 
+		T? snapshot = GetMatchingIndexerSetupFromSnapshot<T>(access);
+		if (snapshot is not null)
+		{
+			return snapshot;
+		}
+
 		return Setup.Indexers.GetMatching<T>(access);
+	}
+
+	private T? GetMatchingIndexerSetupFromSnapshot<T>(Func<T, bool> predicate) where T : IndexerSetup
+	{
+		IndexerSetup[]?[]? table = Volatile.Read(ref _indexerSetupsByMemberId);
+		if (table is null)
+		{
+			return null;
+		}
+
+		// Walk every memberId bucket: the snapshot is keyed by member id, but predicate-based callers
+		// don't know which id to consult, so we filter by type then by predicate. Within each bucket
+		// the latest registration wins (reverse iteration); buckets are walked in registration order.
+		for (int b = 0; b < table.Length; b++)
+		{
+			IndexerSetup[]? bucket = table[b];
+			if (bucket is null)
+			{
+				continue;
+			}
+
+			for (int i = bucket.Length - 1; i >= 0; i--)
+			{
+				if (bucket[i] is T typed && predicate(typed))
+				{
+					return typed;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private T? GetMatchingIndexerSetupFromSnapshot<T>(IndexerAccess access) where T : IndexerSetup
+	{
+		IndexerSetup[]?[]? table = Volatile.Read(ref _indexerSetupsByMemberId);
+		if (table is null)
+		{
+			return null;
+		}
+
+		for (int b = 0; b < table.Length; b++)
+		{
+			IndexerSetup[]? bucket = table[b];
+			if (bucket is null)
+			{
+				continue;
+			}
+
+			for (int i = bucket.Length - 1; i >= 0; i--)
+			{
+				if (bucket[i] is T typed &&
+				    ((IInteractiveIndexerSetup)typed).Matches(access))
+				{
+					return typed;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/// <summary>
@@ -428,6 +500,31 @@ public partial class MockRegistry
 			if (hasScoped)
 			{
 				yield break;
+			}
+		}
+
+		// Default-scope: walk the memberId-keyed snapshot table for generator-emitted setups (the
+		// SetupEvent(int, ...) overloads bypass the dict). The unsubscribe-side dispatch always falls
+		// here because the snapshot is keyed by subscribe id only — the bucket walk reunites it with
+		// its setup. Then walk the dict for legacy SetupEvent(EventSetup) entries.
+		EventSetup[]?[]? table = Volatile.Read(ref _eventSetupsByMemberId);
+		if (table is not null)
+		{
+			for (int b = 0; b < table.Length; b++)
+			{
+				EventSetup[]? bucket = table[b];
+				if (bucket is null)
+				{
+					continue;
+				}
+
+				for (int i = 0; i < bucket.Length; i++)
+				{
+					if (bucket[i].Name.Equals(name))
+					{
+						yield return bucket[i];
+					}
+				}
 			}
 		}
 

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -118,8 +118,13 @@ public partial class MockRegistry
 	/// <remarks>
 	///     The caller iterates and evaluates each setup's matcher on the stack (passing ref-struct
 	///     values where applicable), so no predicate closure is captured.
-	///     Scenario-scoped results come first; the caller is expected to stop on the first match so
-	///     scenarios override the default scope.
+	///     Order: scenario-scoped dict (newest first), then default-scope memberId-keyed snapshot
+	///     entries (newest first per bucket, but bucket order is registration order), then default-scope
+	///     hand-written dict entries. The caller is expected to stop on the first match so scenarios
+	///     override the default scope.
+	///     When the call stays entirely on the default scope and neither the snapshot table nor the
+	///     dict has any entries, the empty-storage fast path returns <see cref="Array.Empty{T}" />
+	///     directly so the dispatch hot path skips an iterator state-machine allocation per call.
 	/// </remarks>
 	/// <typeparam name="T">The concrete <see cref="MethodSetup" /> subtype to return.</typeparam>
 	/// <param name="methodName">The simple method name.</param>
@@ -129,7 +134,30 @@ public partial class MockRegistry
 		if (!string.IsNullOrEmpty(Scenario) &&
 		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
 		{
-			foreach (T setup in scopedBucket.Methods.EnumerateByName<T>(methodName))
+			return EnumerateScopedAndGlobalMethodSetups<T>(methodName, scopedBucket);
+		}
+
+		MethodSetup[]?[]? snapshot = Volatile.Read(ref _setupsByMemberId);
+		if (snapshot is null)
+		{
+			return Setup.Methods.EnumerateByName<T>(methodName);
+		}
+
+		return EnumerateGlobalMethodSetups<T>(methodName, snapshot);
+	}
+
+	private IEnumerable<T> EnumerateScopedAndGlobalMethodSetups<T>(string methodName,
+		MockScenarioSetup scopedBucket) where T : MethodSetup
+	{
+		foreach (T setup in scopedBucket.Methods.EnumerateByName<T>(methodName))
+		{
+			yield return setup;
+		}
+
+		MethodSetup[]?[]? snapshot = Volatile.Read(ref _setupsByMemberId);
+		if (snapshot is not null)
+		{
+			foreach (T setup in EnumerateSnapshotByName<T>(methodName, snapshot))
 			{
 				yield return setup;
 			}
@@ -138,6 +166,48 @@ public partial class MockRegistry
 		foreach (T setup in Setup.Methods.EnumerateByName<T>(methodName))
 		{
 			yield return setup;
+		}
+	}
+
+	private IEnumerable<T> EnumerateGlobalMethodSetups<T>(string methodName,
+		MethodSetup[]?[] snapshot) where T : MethodSetup
+	{
+		foreach (T setup in EnumerateSnapshotByName<T>(methodName, snapshot))
+		{
+			yield return setup;
+		}
+
+		// Hand-written SetupMethod(MethodSetup) entries (e.g. the HttpClientExtensions pipeline) live
+		// only in the root dict; the empty-storage fast path returns Array.Empty<T> so the loop
+		// allocates nothing further when no such entry exists.
+		foreach (T setup in Setup.Methods.EnumerateByName<T>(methodName))
+		{
+			yield return setup;
+		}
+	}
+
+	private static IEnumerable<T> EnumerateSnapshotByName<T>(string methodName,
+		MethodSetup[]?[] snapshot) where T : MethodSetup
+	{
+		// Walk every memberId bucket: the snapshot is keyed by member id, but a name-based caller
+		// (scenario-active dispatch, ref-struct dispatch) doesn't know the id, so we filter by Name
+		// after the type-test. Bucket count grows linearly with registered setups, so the scan is
+		// proportional to setup count, not interaction count.
+		for (int b = 0; b < snapshot.Length; b++)
+		{
+			MethodSetup[]? bucket = snapshot[b];
+			if (bucket is null)
+			{
+				continue;
+			}
+
+			for (int i = bucket.Length - 1; i >= 0; i--)
+			{
+				if (bucket[i] is T typed && typed.Name.Equals(methodName))
+				{
+					yield return typed;
+				}
+			}
 		}
 	}
 

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -487,50 +487,64 @@ public partial class MockRegistry
 
 	private IEnumerable<EventSetup> GetEventSetupsByName(string name)
 	{
+		// Scenario-scoped setups override default scope when at least one matches the name. The
+		// underlying GetByName already returns a materialized List, so a Count check is cheaper than
+		// the lazy "did we yield anything?" flag pattern this used to track.
 		if (!string.IsNullOrEmpty(Scenario) &&
 		    Setup.TryGetScenario(Scenario, out MockScenarioSetup? scopedBucket))
 		{
-			bool hasScoped = false;
-			foreach (EventSetup setup in scopedBucket.Events.GetByName(name))
+			List<EventSetup> scoped = scopedBucket.Events.GetByName(name);
+			if (scoped.Count > 0)
 			{
-				hasScoped = true;
-				yield return setup;
-			}
-
-			if (hasScoped)
-			{
-				yield break;
+				return scoped;
 			}
 		}
 
-		// Default-scope: walk the memberId-keyed snapshot table for generator-emitted setups (the
-		// SetupEvent(int, ...) overloads bypass the dict). The unsubscribe-side dispatch always falls
-		// here because the snapshot is keyed by subscribe id only — the bucket walk reunites it with
-		// its setup. Then walk the dict for legacy SetupEvent(EventSetup) entries.
-		EventSetup[]?[]? table = Volatile.Read(ref _eventSetupsByMemberId);
-		if (table is not null)
-		{
-			for (int b = 0; b < table.Length; b++)
-			{
-				EventSetup[]? bucket = table[b];
-				if (bucket is null)
-				{
-					continue;
-				}
+		return EnumerateDefaultScopeEventSetupsByName(name);
+	}
 
-				for (int i = 0; i < bucket.Length; i++)
-				{
-					if (bucket[i].Name.Equals(name))
-					{
-						yield return bucket[i];
-					}
-				}
-			}
+	/// <summary>
+	///     Walks the memberId-keyed snapshot table for generator-emitted setups (the
+	///     <c>SetupEvent(int, ...)</c> overloads bypass the dict), then the root dict for legacy
+	///     <c>SetupEvent(EventSetup)</c> entries. The unsubscribe-side dispatch always lands here
+	///     because the snapshot is keyed by subscribe id only — the bucket walk reunites it with its
+	///     setup.
+	/// </summary>
+	private IEnumerable<EventSetup> EnumerateDefaultScopeEventSetupsByName(string name)
+	{
+		foreach (EventSetup setup in EnumerateEventSnapshotByName(name))
+		{
+			yield return setup;
 		}
 
 		foreach (EventSetup setup in Setup.Events.GetByName(name))
 		{
 			yield return setup;
+		}
+	}
+
+	private IEnumerable<EventSetup> EnumerateEventSnapshotByName(string name)
+	{
+		EventSetup[]?[]? table = Volatile.Read(ref _eventSetupsByMemberId);
+		if (table is null)
+		{
+			yield break;
+		}
+
+		foreach (EventSetup[]? bucket in table)
+		{
+			if (bucket is null)
+			{
+				continue;
+			}
+
+			foreach (EventSetup setup in bucket)
+			{
+				if (setup.Name.Equals(name))
+				{
+					yield return setup;
+				}
+			}
 		}
 	}
 

--- a/Source/Mockolate/MockRegistry.Interactions.cs
+++ b/Source/Mockolate/MockRegistry.Interactions.cs
@@ -119,9 +119,9 @@ public partial class MockRegistry
 	///     The caller iterates and evaluates each setup's matcher on the stack (passing ref-struct
 	///     values where applicable), so no predicate closure is captured.
 	///     Order: scenario-scoped dict (newest first), then default-scope memberId-keyed snapshot
-	///     entries (newest first per bucket, but bucket order is registration order), then default-scope
-	///     hand-written dict entries. The caller is expected to stop on the first match so scenarios
-	///     override the default scope.
+	///     entries (newest first within each bucket, with buckets visited in memberId/index order),
+	///     then default-scope hand-written dict entries. The caller is expected to stop on the first
+	///     match so scenarios override the default scope.
 	///     When the call stays entirely on the default scope and neither the snapshot table nor the
 	///     dict has any entries, the empty-storage fast path returns <see cref="Array.Empty{T}" />
 	///     directly so the dispatch hot path skips an iterator state-machine allocation per call.
@@ -191,8 +191,8 @@ public partial class MockRegistry
 	{
 		// Walk every memberId bucket: the snapshot is keyed by member id, but a name-based caller
 		// (scenario-active dispatch, ref-struct dispatch) doesn't know the id, so we filter by Name
-		// after the type-test. Bucket count grows linearly with registered setups, so the scan is
-		// proportional to setup count, not interaction count.
+		// after the type-test. The outer scan is proportional to snapshot.Length (the memberId table
+		// size / mocked member count), not interaction count; the table may be sparse for a method.
 		for (int b = 0; b < snapshot.Length; b++)
 		{
 			MethodSetup[]? bucket = snapshot[b];
@@ -279,8 +279,9 @@ public partial class MockRegistry
 		}
 
 		// Walk every memberId bucket: the snapshot is keyed by member id, but predicate-based callers
-		// don't know which id to consult, so we filter by type then by predicate. Within each bucket
-		// the latest registration wins (reverse iteration); buckets are walked in registration order.
+		// don't know which id to consult, so we filter by type then by predicate. Buckets are walked
+		// by ascending memberId/index order; within each bucket, reverse iteration means the latest
+		// registration wins.
 		for (int b = 0; b < table.Length; b++)
 		{
 			IndexerSetup[]? bucket = table[b];

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -131,36 +131,39 @@ public partial class MockRegistry
 		=> Setup.GetOrCreateScenario(scenario).Methods.Add(methodSetup);
 
 	/// <summary>
-	///     Registers <paramref name="methodSetup" /> for the default scenario and additionally indexes it by the
+	///     Registers <paramref name="methodSetup" /> for the default scenario by indexing it under the
 	///     generator-emitted <paramref name="memberId" /> for fast dispatch from the proxy method body.
 	/// </summary>
 	/// <remarks>
 	///     The <paramref name="memberId" /> is a compile-time constant emitted by the source generator, one per
 	///     mocked member. Reads via <see cref="GetMethodSetupSnapshot(int)" /> are lock-free; writes take an
 	///     internal lock and publish a new snapshot via <see cref="Volatile.Write{T}(ref T, T)" />.
+	///     The default-scope string-keyed list (<see cref="GetMethodSetups{T}(string)" />) is intentionally
+	///     bypassed — the snapshot is authoritative for default-scope dispatch from generator-emitted code.
 	/// </remarks>
 	/// <param name="memberId">The generator-emitted member id for the setup's target member.</param>
 	/// <param name="methodSetup">The method setup produced by the fluent <c>Setup.MethodName(...)</c> API.</param>
 	public void SetupMethod(int memberId, MethodSetup methodSetup)
-	{
-		SetupMethod(methodSetup);
-		AppendToMemberIdBucket(memberId, methodSetup);
-	}
+		=> AppendToMemberIdBucket(memberId, methodSetup);
 
 	/// <summary>
 	///     Registers <paramref name="methodSetup" /> for the given <paramref name="scenario" />. When
-	///     <paramref name="scenario" /> is the default scope, the setup is additionally indexed by
-	///     <paramref name="memberId" /> for fast dispatch.
+	///     <paramref name="scenario" /> is the default scope, the setup is indexed by <paramref name="memberId" />
+	///     for fast dispatch instead of the string-keyed list; scenario-scoped setups continue to land in the
+	///     scenario bucket only.
 	/// </summary>
 	/// <param name="memberId">The generator-emitted member id for the setup's target member.</param>
 	/// <param name="scenario">The scenario name the setup applies to.</param>
 	/// <param name="methodSetup">The method setup produced by the fluent <c>Setup.MethodName(...)</c> API.</param>
 	public void SetupMethod(int memberId, string scenario, MethodSetup methodSetup)
 	{
-		SetupMethod(scenario, methodSetup);
 		if (string.IsNullOrEmpty(scenario))
 		{
 			AppendToMemberIdBucket(memberId, methodSetup);
+		}
+		else
+		{
+			SetupMethod(scenario, methodSetup);
 		}
 	}
 

--- a/Source/Mockolate/MockRegistry.Setup.cs
+++ b/Source/Mockolate/MockRegistry.Setup.cs
@@ -43,31 +43,37 @@ public partial class MockRegistry
 		=> Setup.GetOrCreateScenario(scenario).Indexers.Add(indexerSetup);
 
 	/// <summary>
-	///     Registers <paramref name="indexerSetup" /> for the default scenario and additionally indexes it by the
+	///     Registers <paramref name="indexerSetup" /> for the default scenario by indexing it under the
 	///     generator-emitted <paramref name="memberId" /> for fast dispatch from the proxy indexer body.
 	/// </summary>
+	/// <remarks>
+	///     The default-scope string-keyed list is intentionally bypassed — the snapshot is authoritative
+	///     for default-scope dispatch from generator-emitted code, and <see cref="GetIndexerSetup{T}(Mockolate.Interactions.IndexerAccess)" />
+	///     consults the snapshot table directly for scenario-active fallback callers.
+	/// </remarks>
 	/// <param name="memberId">The generator-emitted member id for the setup's target indexer accessor.</param>
 	/// <param name="indexerSetup">The indexer setup produced by the fluent <c>Setup[...]</c> API.</param>
 	public void SetupIndexer(int memberId, IndexerSetup indexerSetup)
-	{
-		SetupIndexer(indexerSetup);
-		AppendToIndexerMemberIdBucket(memberId, indexerSetup);
-	}
+		=> AppendToIndexerMemberIdBucket(memberId, indexerSetup);
 
 	/// <summary>
 	///     Registers <paramref name="indexerSetup" /> for the given <paramref name="scenario" />. When
-	///     <paramref name="scenario" /> is the default scope, the setup is additionally indexed by
-	///     <paramref name="memberId" /> for fast dispatch.
+	///     <paramref name="scenario" /> is the default scope, the setup is indexed by <paramref name="memberId" />
+	///     for fast dispatch instead of the string-keyed list; scenario-scoped setups continue to land in the
+	///     scenario bucket only.
 	/// </summary>
 	/// <param name="memberId">The generator-emitted member id for the setup's target indexer accessor.</param>
 	/// <param name="scenario">The scenario name the setup applies to.</param>
 	/// <param name="indexerSetup">The indexer setup produced by the fluent <c>Setup[...]</c> API.</param>
 	public void SetupIndexer(int memberId, string scenario, IndexerSetup indexerSetup)
 	{
-		SetupIndexer(scenario, indexerSetup);
 		if (string.IsNullOrEmpty(scenario))
 		{
 			AppendToIndexerMemberIdBucket(memberId, indexerSetup);
+		}
+		else
+		{
+			SetupIndexer(scenario, indexerSetup);
 		}
 	}
 
@@ -313,37 +319,42 @@ public partial class MockRegistry
 		=> Setup.GetOrCreateScenario(scenario).Events.Add(eventSetup);
 
 	/// <summary>
-	///     Registers <paramref name="eventSetup" /> for the default scenario and additionally indexes it by the
-	///     generator-emitted <paramref name="memberId" /> for fast dispatch from the proxy event subscribe/unsubscribe body.
+	///     Registers <paramref name="eventSetup" /> for the default scenario by indexing it under the
+	///     generator-emitted subscribe-side <paramref name="memberId" /> for fast dispatch from the proxy event
+	///     subscribe/unsubscribe body.
 	/// </summary>
 	/// <remarks>
 	///     The <paramref name="memberId" /> is the subscribe-side member id emitted by the source generator. A
 	///     single <see cref="EventSetup" /> typically wires both subscribe and unsubscribe behavior, so the bucket
 	///     is keyed off the subscribe id. Reads via <see cref="GetEventSetupSnapshot(int)" /> are lock-free; writes
 	///     take an internal lock and publish a new snapshot via <see cref="Volatile.Write{T}(ref T, T)" />.
+	///     The default-scope string-keyed list is intentionally bypassed — the snapshot is authoritative for
+	///     default-scope subscribe dispatch. The unsubscribe path falls through to a name-filtered scan of the
+	///     snapshot table inside <c>GetEventSetupsByName</c> (see <see cref="RemoveEvent(int, string, object?, System.Reflection.MethodInfo?)" />).
 	/// </remarks>
 	/// <param name="memberId">The generator-emitted subscribe-side member id for the setup's target event.</param>
 	/// <param name="eventSetup">The event setup produced by the fluent <c>Setup.EventName</c> API.</param>
 	public void SetupEvent(int memberId, EventSetup eventSetup)
-	{
-		SetupEvent(eventSetup);
-		AppendToEventMemberIdBucket(memberId, eventSetup);
-	}
+		=> AppendToEventMemberIdBucket(memberId, eventSetup);
 
 	/// <summary>
 	///     Registers <paramref name="eventSetup" /> for the given <paramref name="scenario" />. When
-	///     <paramref name="scenario" /> is the default scope, the setup is additionally indexed by
-	///     <paramref name="memberId" /> for fast dispatch.
+	///     <paramref name="scenario" /> is the default scope, the setup is indexed by <paramref name="memberId" />
+	///     for fast dispatch instead of the string-keyed list; scenario-scoped setups continue to land in the
+	///     scenario bucket only.
 	/// </summary>
 	/// <param name="memberId">The generator-emitted subscribe-side member id for the setup's target event.</param>
 	/// <param name="scenario">The scenario name the setup applies to.</param>
 	/// <param name="eventSetup">The event setup produced by the fluent <c>Setup.EventName</c> API.</param>
 	public void SetupEvent(int memberId, string scenario, EventSetup eventSetup)
 	{
-		SetupEvent(scenario, eventSetup);
 		if (string.IsNullOrEmpty(scenario))
 		{
 			AppendToEventMemberIdBucket(memberId, eventSetup);
+		}
+		else
+		{
+			SetupEvent(scenario, eventSetup);
 		}
 	}
 

--- a/Source/Mockolate/MockRegistry.Verify.cs
+++ b/Source/Mockolate/MockRegistry.Verify.cs
@@ -757,8 +757,9 @@ public partial class MockRegistry
 	///     <paramref name="interactions" />.
 	/// </summary>
 	/// <remarks>
-	///     The default-scope method snapshot table populated by the <see cref="SetupMethod(int, MethodSetup)" />
-	///     overloads is walked alongside the string-keyed list, so generator-emitted setups are visible to the
+	///     The default-scope method and indexer snapshot tables populated by the
+	///     <see cref="SetupMethod(int, MethodSetup)" /> / <see cref="SetupIndexer(int, IndexerSetup)" /> overloads
+	///     are walked alongside the string-keyed lists, so generator-emitted setups are visible to the
 	///     diagnostic enumeration even though they bypass the dictionary.
 	/// </remarks>
 	/// <param name="interactions">The interactions to check against.</param>
@@ -771,6 +772,7 @@ public partial class MockRegistry
 			..Setup.Properties.EnumerateUnusedSetupsBy(interactions),
 			..Setup.Methods.EnumerateUnusedSetupsBy(interactions),
 			..EnumerateUnusedMethodSnapshotSetups(interactions),
+			..EnumerateUnusedIndexerSnapshotSetups(interactions),
 		];
 		return unusedSetups;
 	}
@@ -796,6 +798,41 @@ public partial class MockRegistry
 				foreach (IMethodInteraction interaction in interactions.OfType<IMethodInteraction>())
 				{
 					if (((IVerifiableMethodSetup)setup).Matches(interaction))
+					{
+						matched = true;
+						break;
+					}
+				}
+
+				if (!matched)
+				{
+					yield return setup;
+				}
+			}
+		}
+	}
+
+	private IEnumerable<IndexerSetup> EnumerateUnusedIndexerSnapshotSetups(IMockInteractions interactions)
+	{
+		IndexerSetup[]?[]? table = Volatile.Read(ref _indexerSetupsByMemberId);
+		if (table is null)
+		{
+			yield break;
+		}
+
+		foreach (IndexerSetup[]? bucket in table)
+		{
+			if (bucket is null)
+			{
+				continue;
+			}
+
+			foreach (IndexerSetup setup in bucket)
+			{
+				bool matched = false;
+				foreach (IndexerAccess access in interactions.OfType<IndexerAccess>())
+				{
+					if (((IInteractiveIndexerSetup)setup).Matches(access))
 					{
 						matched = true;
 						break;

--- a/Source/Mockolate/MockRegistry.Verify.cs
+++ b/Source/Mockolate/MockRegistry.Verify.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
@@ -785,6 +784,15 @@ public partial class MockRegistry
 			yield break;
 		}
 
+		List<IMethodInteraction> methodInteractions = [];
+		foreach (IInteraction interaction in interactions)
+		{
+			if (interaction is IMethodInteraction method)
+			{
+				methodInteractions.Add(method);
+			}
+		}
+
 		foreach (MethodSetup[]? bucket in table)
 		{
 			if (bucket is null)
@@ -795,7 +803,7 @@ public partial class MockRegistry
 			foreach (MethodSetup setup in bucket)
 			{
 				bool matched = false;
-				foreach (IMethodInteraction interaction in interactions.OfType<IMethodInteraction>())
+				foreach (IMethodInteraction interaction in methodInteractions)
 				{
 					if (((IVerifiableMethodSetup)setup).Matches(interaction))
 					{
@@ -820,6 +828,15 @@ public partial class MockRegistry
 			yield break;
 		}
 
+		List<IndexerAccess> indexerAccesses = [];
+		foreach (IInteraction interaction in interactions)
+		{
+			if (interaction is IndexerAccess access)
+			{
+				indexerAccesses.Add(access);
+			}
+		}
+
 		foreach (IndexerSetup[]? bucket in table)
 		{
 			if (bucket is null)
@@ -830,7 +847,7 @@ public partial class MockRegistry
 			foreach (IndexerSetup setup in bucket)
 			{
 				bool matched = false;
-				foreach (IndexerAccess access in interactions.OfType<IndexerAccess>())
+				foreach (IndexerAccess access in indexerAccesses)
 				{
 					if (((IInteractiveIndexerSetup)setup).Matches(access))
 					{

--- a/Source/Mockolate/MockRegistry.Verify.cs
+++ b/Source/Mockolate/MockRegistry.Verify.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading;
 using Mockolate.Exceptions;
 using Mockolate.Interactions;
 using Mockolate.Internals;
@@ -754,6 +756,11 @@ public partial class MockRegistry
 	///     Returns every registered setup (indexer, property, method) that was not hit by any of the given
 	///     <paramref name="interactions" />.
 	/// </summary>
+	/// <remarks>
+	///     The default-scope method snapshot table populated by the <see cref="SetupMethod(int, MethodSetup)" />
+	///     overloads is walked alongside the string-keyed list, so generator-emitted setups are visible to the
+	///     diagnostic enumeration even though they bypass the dictionary.
+	/// </remarks>
 	/// <param name="interactions">The interactions to check against.</param>
 	/// <returns>The unused setups; empty when every setup was exercised.</returns>
 	public IReadOnlyCollection<ISetup> GetUnusedSetups(IMockInteractions interactions)
@@ -763,7 +770,43 @@ public partial class MockRegistry
 			..Setup.Indexers.EnumerateUnusedSetupsBy(interactions),
 			..Setup.Properties.EnumerateUnusedSetupsBy(interactions),
 			..Setup.Methods.EnumerateUnusedSetupsBy(interactions),
+			..EnumerateUnusedMethodSnapshotSetups(interactions),
 		];
 		return unusedSetups;
+	}
+
+	private IEnumerable<MethodSetup> EnumerateUnusedMethodSnapshotSetups(IMockInteractions interactions)
+	{
+		MethodSetup[]?[]? table = Volatile.Read(ref _setupsByMemberId);
+		if (table is null)
+		{
+			yield break;
+		}
+
+		foreach (MethodSetup[]? bucket in table)
+		{
+			if (bucket is null)
+			{
+				continue;
+			}
+
+			foreach (MethodSetup setup in bucket)
+			{
+				bool matched = false;
+				foreach (IMethodInteraction interaction in interactions.OfType<IMethodInteraction>())
+				{
+					if (((IVerifiableMethodSetup)setup).Matches(interaction))
+					{
+						matched = true;
+						break;
+					}
+				}
+
+				if (!matched)
+				{
+					yield return setup;
+				}
+			}
+		}
 	}
 }

--- a/Source/Mockolate/Setup/MockSetups.Methods.cs
+++ b/Source/Mockolate/Setup/MockSetups.Methods.cs
@@ -85,16 +85,25 @@ internal partial class MockSetups
 		///     Used by the generated code for methods with ref-struct parameters, where the usual
 		///     <c>GetMatching</c> predicate cannot capture the ref-struct value. Callers iterate this
 		///     sequence and evaluate <c>Matches</c> synchronously on the stack, then invoke the first
-		///     matching setup.
+		///     matching setup. The empty-storage path returns <see cref="Array.Empty{T}" /> instead of a
+		///     yielding state machine, so the dispatch hot path skips an iterator allocation per call when
+		///     no string-keyed setups have been registered (the common case after generator-emitted
+		///     <c>SetupMethod(int, ...)</c> bypasses this list).
 		/// </remarks>
 		public IEnumerable<T> EnumerateByName<T>(string methodName) where T : MethodSetup
 		{
 			List<MethodSetup>? storage = _storage;
 			if (storage is null)
 			{
-				yield break;
+				return Array.Empty<T>();
 			}
 
+			return EnumerateByNameCore<T>(methodName, storage);
+		}
+
+		private static IEnumerable<T> EnumerateByNameCore<T>(string methodName, List<MethodSetup> storage)
+			where T : MethodSetup
+		{
 			// Snapshot the matching entries under lock; yield them without holding the lock so the
 			// caller's Matches/Invoke can run user code (including throws) without risk of re-entering
 			// the storage lock on the same thread.

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySnapshotRetrievalTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistrySnapshotRetrievalTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Mockolate.Interactions;
+using Mockolate.Internal.Tests.TestHelpers;
+using Mockolate.Setup;
+
+namespace Mockolate.Internal.Tests.Registry;
+
+public sealed class MockRegistrySnapshotRetrievalTests
+{
+	private static MethodInfo GetMethodInfo()
+		=> typeof(MockRegistrySnapshotRetrievalTests).GetMethod(nameof(GetMethodInfo),
+			BindingFlags.Static | BindingFlags.NonPublic)!;
+
+	public sealed class GetMethodSetupsTests
+	{
+		[Fact]
+		public async Task WithActiveScenarioAndScopedSetup_YieldsScopedThenSnapshot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeMethodSetup snapshotSetup = new();
+			FakeMethodSetup scopedSetup = new();
+			registry.SetupMethod(2, snapshotSetup);
+			registry.Setup.GetOrCreateScenario("a").Methods.Add(scopedSetup);
+
+			registry.TransitionTo("a");
+
+			List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+			await That(setups).HasCount(2);
+			await That(setups[0]).IsSameAs(scopedSetup);
+			await That(setups[1]).IsSameAs(snapshotSetup);
+		}
+
+		[Fact]
+		public async Task WithActiveScenarioButNoScopedBucket_FallsBackToSnapshot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeMethodSetup snapshotSetup = new();
+
+			registry.SetupMethod(2, snapshotSetup);
+			registry.TransitionTo("never-registered");
+
+			List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+			await That(setups).HasCount(1);
+			await That(setups[0]).IsSameAs(snapshotSetup);
+		}
+
+		[Fact]
+		public async Task WithSnapshotAndGlobalDictSetups_YieldsSnapshotBeforeGlobalDict()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeMethodSetup snapshotSetup = new();
+			FakeMethodSetup globalDictSetup = new();
+
+			registry.SetupMethod(2, snapshotSetup);
+			registry.Setup.Methods.Add(globalDictSetup);
+
+			List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+			await That(setups).HasCount(2);
+			await That(setups[0]).IsSameAs(snapshotSetup);
+			await That(setups[1]).IsSameAs(globalDictSetup);
+		}
+
+		[Fact]
+		public async Task WithSnapshotSetupOnly_YieldsSnapshotSetup()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeMethodSetup setup = new();
+
+			registry.SetupMethod(2, setup);
+
+			List<MethodSetup> setups = registry.GetMethodSetups<MethodSetup>("foo").ToList();
+
+			await That(setups).HasCount(1);
+			await That(setups[0]).IsSameAs(setup);
+		}
+	}
+
+	public sealed class GetIndexerSetupTests
+	{
+		[Fact]
+		public async Task ByAccess_WithActiveScenarioAndScopedDoesNotMatch_FallsBackToSnapshot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeIndexerSetup snapshotSetup = new(true);
+			FakeIndexerSetup scopedNonMatching = new(false);
+			registry.SetupIndexer(0, snapshotSetup);
+			registry.Setup.GetOrCreateScenario("a").Indexers.Add(scopedNonMatching);
+
+			registry.TransitionTo("a");
+
+			IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(new IndexerGetterAccess<int>(1));
+
+			await That(result).IsSameAs(snapshotSetup);
+		}
+
+		[Fact]
+		public async Task ByAccess_WithSnapshotSetupOnly_ReturnsSnapshotSetup()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeIndexerSetup setup = new(true);
+
+			registry.SetupIndexer(0, setup);
+
+			IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(new IndexerGetterAccess<int>(1));
+
+			await That(result).IsSameAs(setup);
+		}
+
+		[Fact]
+		public async Task ByPredicate_WithActiveScenarioAndPredicateRejectsScoped_FallsBackToSnapshot()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeIndexerSetup snapshotSetup = new(true);
+			FakeIndexerSetup scopedSetup = new(true);
+			registry.SetupIndexer(0, snapshotSetup);
+			registry.Setup.GetOrCreateScenario("a").Indexers.Add(scopedSetup);
+
+			registry.TransitionTo("a");
+
+			IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(s => ReferenceEquals(s, snapshotSetup));
+
+			await That(result).IsSameAs(snapshotSetup);
+		}
+
+		[Fact]
+		public async Task ByPredicate_WithSnapshotSetupOnly_ReturnsSnapshotSetup()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeIndexerSetup setup = new(true);
+
+			registry.SetupIndexer(0, setup);
+
+			IndexerSetup? result = registry.GetIndexerSetup<IndexerSetup>(_ => true);
+
+			await That(result).IsSameAs(setup);
+		}
+	}
+
+	public sealed class RemoveEventSnapshotByNameTests
+	{
+		[Fact]
+		public async Task RemoveEvent_WhenUnsubscribeMemberIdDiffersFromSubscribe_FiresUnsubscribedCallbackViaNameScan()
+		{
+			// The source generator mints separate subscribe and unsubscribe member ids and registers the
+			// event setup under the subscribe id only. The unsubscribe path therefore always misses the
+			// snapshot lookup-by-id and must fall through to the name-based snapshot scan inside
+			// EnumerateDefaultScopeEventSetupsByName for unsubscribed callbacks to fire.
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			int unsubscribedCount = 0;
+			EventSetup setup = new(registry, "OnFoo");
+			setup.OnUnsubscribed.Do(() => unsubscribedCount++);
+
+			const int subscribeMemberId = 5;
+			const int unsubscribeMemberId = 6;
+			registry.SetupEvent(subscribeMemberId, setup);
+
+			registry.RemoveEvent(unsubscribeMemberId, "OnFoo", this, GetMethodInfo());
+
+			await That(unsubscribedCount).IsEqualTo(1);
+		}
+	}
+
+	public sealed class GetUnusedSetupsTests
+	{
+		[Fact]
+		public async Task IncludesIndexerSnapshotSetup_WhenNoInteractionsMatch()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeIndexerSetup setup = new(false);
+
+			registry.SetupIndexer(2, setup);
+
+			IReadOnlyCollection<ISetup> unused = registry.GetUnusedSetups(registry.Interactions);
+
+			await That(unused).Contains(setup);
+		}
+
+		[Fact]
+		public async Task IncludesMethodSnapshotSetup_WhenNoInteractionsMatch()
+		{
+			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
+			FakeMethodSetup setup = new();
+
+			registry.SetupMethod(2, setup);
+
+			IReadOnlyCollection<ISetup> unused = registry.GetUnusedSetups(registry.Interactions);
+
+			await That(unused).Contains(setup);
+		}
+	}
+}


### PR DESCRIPTION
This pull request makes significant improvements to how mock setups (methods, indexers, and events) are registered, stored, and enumerated in the Mockolate mocking framework. The changes focus on optimizing storage for generator-emitted setups, ensuring fast-path dispatch, and improving diagnostics and verification, especially for unused setups. The most important changes are grouped below:

### Storage and Registration Optimizations

* **Generator-emitted setups now bypass string-keyed lists for default-scope registrations:** Instead, they are stored only in memberId-keyed snapshot tables, making snapshot storage authoritative for fast dispatch and reducing unnecessary allocations. This affects `SetupMethod`, `SetupIndexer`, and `SetupEvent` registration logic.
* **Scenario-scoped setups remain in scenario buckets; default-scope setups use snapshots:** Registration methods now clearly separate scenario and default-scope behaviors, ensuring correct storage and lookup.

### Fast-path Dispatch and Enumeration

* **New enumeration logic for method, indexer, and event setups:** Methods like `GetMethodSetups<T>`, `GetMatchingIndexerSetupFromSnapshot`, and `GetEventSetupsByName` now walk snapshot tables for default-scope setups, ensuring generator-emitted setups are found efficiently and without unnecessary allocations.
* **Empty-storage fast paths return `Array.Empty<T>`:** This prevents iterator state machine allocations on hot paths when no setups are registered, improving performance.

### Diagnostics and Verification Improvements

* **Unused setup enumeration now includes snapshot tables:** The verification logic for unused setups now checks both string-keyed lists and snapshot tables, ensuring that generator-emitted setups are included in diagnostic reports.
* **Improved documentation and remarks:** XML comments have been updated to clarify the new storage and dispatch behaviors, making the codebase easier to understand and maintain.