### PR TITLE
refactor: improve table row parsing by introducing SplitTableRow method

### DIFF
--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -180,7 +180,7 @@ partial class Build
 
 	static int[] DetermineDroppedColumnIndices(string headerLine, string[] columnsToRemove)
 	{
-		string[] tokens = headerLine.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+		string[] tokens = SplitTableRow(headerLine);
 		List<int> indices = new();
 		for (int i = 0; i < tokens.Length; i++)
 		{
@@ -204,7 +204,7 @@ partial class Build
 			return line;
 		}
 
-		string[] tokens = line.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+		string[] tokens = SplitTableRow(line);
 		StringBuilder result = new();
 		result.Append('|');
 		for (int i = 0; i < tokens.Length; i++)
@@ -220,6 +220,19 @@ partial class Build
 		}
 
 		return result.ToString();
+	}
+
+	static string[] SplitTableRow(string line)
+	{
+		string[] parts = line.Split('|', StringSplitOptions.TrimEntries);
+		if (parts.Length < 2)
+		{
+			return [];
+		}
+
+		string[] tokens = new string[parts.Length - 2];
+		Array.Copy(parts, 1, tokens, 0, tokens.Length);
+		return tokens;
 	}
 
 	static void MakeLineBold(StringBuilder sb, string line)


### PR DESCRIPTION
This pull request refactors how table rows are split and parsed in the benchmark comment generation logic. The main change is the introduction of a new helper method to consistently handle table row splitting, improving code clarity and reducing duplication.

**Refactoring and code quality improvements:**

* Introduced a new helper method `SplitTableRow` to standardize how table rows are split and parsed, ensuring consistent handling of table formatting. (`Pipeline/Build.Benchmarks.cs`)
* Updated `DetermineDroppedColumnIndices` and `RemoveColumns` to use the new `SplitTableRow` method instead of directly splitting on the `|` character, which simplifies the logic and makes it more robust.