### PR TITLE
feat: add baseline benchmark comparison to reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,15 @@ jobs:
                         10.0.x
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks --benchmark-filter "*${{ matrix.benchmark }}*"
-    
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v7
+                with:
+                    name: Benchmarks-${{ matrix.benchmark }}
+                    path: |
+                        ./Artifacts/*
+                    if-no-files-found: ignore
+
     mutation-tests:
         name: "Mutation tests"
         runs-on: ubuntu-latest

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
@@ -85,8 +87,11 @@ partial class Build
 				return;
 			}
 
+			AbsolutePath baselineDirectory = ArtifactsDirectory / "Baseline";
+			string baselineResultsDirectory = await DownloadBaselineBenchmarks(baselineDirectory);
+
 			string prNumber = File.ReadAllText(ArtifactsDirectory / "PR.txt");
-			string body = CreateBenchmarkCommentBody(files);
+			string body = CreateBenchmarkCommentBody(files, baselineResultsDirectory);
 			Log.Debug("Pull request number: {PullRequestId}", prNumber);
 			if (int.TryParse(prNumber, out int prId))
 			{
@@ -123,19 +128,51 @@ partial class Build
 		.DependsOn(BenchmarkDotNet)
 		.DependsOn(BenchmarkResult);
 
-	string CreateBenchmarkCommentBody(string[] files)
+	async Task<string> DownloadBaselineBenchmarks(AbsolutePath baselineDirectory)
+	{
+		long? runId = await BuildExtensions.FindLatestSuccessfulRun("build.yml", "main", GithubToken);
+		if (runId == null)
+		{
+			Log.Information("No successful main 'Build' run found - skipping baseline column.");
+			return null;
+		}
+
+		baselineDirectory.CreateOrCleanDirectory();
+		await BuildExtensions.DownloadArtifactsFromRunStartingWith(runId.Value, "Benchmarks-",
+			baselineDirectory, GithubToken);
+
+		string resultsDirectory = baselineDirectory / "Benchmarks" / "results";
+		if (!Directory.Exists(resultsDirectory))
+		{
+			Log.Information("Baseline run #{RunId} did not contain benchmark results - skipping baseline column.",
+				runId.Value);
+			return null;
+		}
+
+		Log.Information("Loaded baseline benchmark results from main run #{RunId}.", runId.Value);
+		return resultsDirectory;
+	}
+
+	string CreateBenchmarkCommentBody(string[] files, string baselineResultsDirectory)
 	{
 		StringBuilder sb = new();
 		sb.AppendLine("## :rocket: Benchmark Results");
 		string[] columnsToRemove = ["RatioSD", "Gen0", "Gen1", "Gen2",];
+		bool anyBaselineInjected = false;
 		foreach (string file in files)
 		{
+			Dictionary<string, string[]> baselineRows = LoadBaselineRows(
+				baselineResultsDirectory == null ? null : Path.Combine(baselineResultsDirectory, Path.GetFileName(file)),
+				columnsToRemove);
+			bool injectBaseline = baselineRows.Count > 0;
 			int count = 0;
 			string[] lines = File.ReadAllLines(file);
 			sb.AppendLine();
 			sb.AppendLine("<details>");
 			sb.AppendLine("<summary>Details</summary>");
 			int[] droppedColumnIndices = null;
+			int meanIndex = -1;
+			int tableRowIndex = 0;
 			foreach (string line in lines)
 			{
 				if (line.StartsWith("```"))
@@ -153,6 +190,8 @@ partial class Build
 					}
 
 					droppedColumnIndices = null;
+					meanIndex = -1;
+					tableRowIndex = 0;
 					continue;
 				}
 
@@ -160,7 +199,37 @@ partial class Build
 				{
 					droppedColumnIndices ??= DetermineDroppedColumnIndices(line, columnsToRemove);
 					string filteredLine = RemoveColumns(line, droppedColumnIndices);
-					if (filteredLine.Contains("_Mockolate", StringComparison.OrdinalIgnoreCase))
+					string[] filteredTokens = filteredLine.Split('|',
+						StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+					if (tableRowIndex == 0)
+					{
+						meanIndex = Array.FindIndex(filteredTokens,
+							t => string.Equals(t, "Mean", StringComparison.OrdinalIgnoreCase));
+					}
+
+					tableRowIndex++;
+
+					bool isMockolateRow = filteredLine.Contains("_Mockolate", StringComparison.OrdinalIgnoreCase);
+
+					if (isMockolateRow && injectBaseline && meanIndex > 0)
+					{
+						string key = string.Join("|", filteredTokens.Take(meanIndex));
+						if (baselineRows.TryGetValue(key, out string[] baselineTokens) && baselineTokens.Length > 0)
+						{
+							string[] modifiedBaseline = new string[baselineTokens.Length];
+							for (int i = 0; i < baselineTokens.Length; i++)
+							{
+								string content = i == 0 ? "baseline*" : baselineTokens[i];
+								modifiedBaseline[i] = string.IsNullOrWhiteSpace(content) ? content : $"_{content}_";
+							}
+
+							sb.AppendLine(JoinTokens(modifiedBaseline));
+							anyBaselineInjected = true;
+						}
+					}
+
+					if (isMockolateRow)
 					{
 						MakeLineBold(sb, filteredLine);
 						continue;
@@ -174,8 +243,74 @@ partial class Build
 			}
 		}
 
+		if (anyBaselineInjected)
+		{
+			sb.AppendLine();
+			sb.AppendLine(
+				"> `baseline*` rows show the corresponding Mockolate benchmark from the latest successful main branch build, for regression comparison.");
+		}
+
 		string body = sb.ToString();
 		return body;
+	}
+
+	static Dictionary<string, string[]> LoadBaselineRows(string baselineFile, string[] columnsToRemove)
+	{
+		Dictionary<string, string[]> result = new();
+		if (baselineFile == null || !File.Exists(baselineFile))
+		{
+			return result;
+		}
+
+		int[] droppedColumnIndices = null;
+		int meanIndex = -1;
+		int tableRowIndex = 0;
+		foreach (string line in File.ReadAllLines(baselineFile))
+		{
+			if (!line.StartsWith('|') || !line.EndsWith('|'))
+			{
+				if (tableRowIndex > 0)
+				{
+					droppedColumnIndices = null;
+					meanIndex = -1;
+					tableRowIndex = 0;
+				}
+
+				continue;
+			}
+
+			droppedColumnIndices ??= DetermineDroppedColumnIndices(line, columnsToRemove);
+			string filtered = RemoveColumns(line, droppedColumnIndices);
+			string[] tokens = filtered.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+			if (tableRowIndex == 0)
+			{
+				meanIndex = Array.FindIndex(tokens,
+					t => string.Equals(t, "Mean", StringComparison.OrdinalIgnoreCase));
+			}
+			else if (tableRowIndex >= 2 && meanIndex > 0 && meanIndex <= tokens.Length)
+			{
+				string key = string.Join("|", tokens.Take(meanIndex));
+				result[key] = tokens;
+			}
+
+			tableRowIndex++;
+		}
+
+		return result;
+	}
+
+	static string JoinTokens(string[] tokens)
+	{
+		StringBuilder sb = new();
+		sb.Append('|');
+		foreach (string token in tokens)
+		{
+			sb.Append(' ');
+			sb.Append(token);
+			sb.Append(" |");
+		}
+
+		return sb.ToString();
 	}
 
 	static int[] DetermineDroppedColumnIndices(string headerLine, string[] columnsToRemove)

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -130,27 +130,41 @@ partial class Build
 
 	async Task<string> DownloadBaselineBenchmarks(AbsolutePath baselineDirectory)
 	{
-		long? runId = await BuildExtensions.FindLatestSuccessfulRun("build.yml", "main", GithubToken);
-		if (runId == null)
+		long[] candidateRunIds = await BuildExtensions.FindRecentSuccessfulRunIds("build.yml", "main", 10, GithubToken);
+		if (candidateRunIds.Length == 0)
 		{
 			Log.Information("No successful main 'Build' run found - skipping baseline column.");
 			return null;
 		}
 
-		baselineDirectory.CreateOrCleanDirectory();
-		await BuildExtensions.DownloadArtifactsFromRunStartingWith(runId.Value, "Benchmarks-",
-			baselineDirectory, GithubToken);
-
-		string resultsDirectory = baselineDirectory / "Benchmarks" / "results";
-		if (!Directory.Exists(resultsDirectory))
+		AbsolutePath resultsDirectory = baselineDirectory / "Benchmarks" / "results";
+		foreach (long runId in candidateRunIds)
 		{
-			Log.Information("Baseline run #{RunId} did not contain benchmark results - skipping baseline column.",
-				runId.Value);
-			return null;
+			baselineDirectory.CreateOrCleanDirectory();
+			try
+			{
+				await BuildExtensions.DownloadArtifactsFromRunStartingWith(runId, "Benchmarks-",
+					baselineDirectory, GithubToken);
+			}
+			catch (Exception ex)
+			{
+				Log.Warning(ex, "Failed to download artifacts from main run #{RunId}, trying older run.", runId);
+				continue;
+			}
+
+			if (Directory.Exists(resultsDirectory))
+			{
+				Log.Information("Loaded baseline benchmark results from main run #{RunId}.", runId);
+				return resultsDirectory;
+			}
+
+			Log.Information("Main run #{RunId} did not contain benchmark results, trying older run.", runId);
 		}
 
-		Log.Information("Loaded baseline benchmark results from main run #{RunId}.", runId.Value);
-		return resultsDirectory;
+		Log.Information(
+			"No baseline benchmark results found in the last {Count} successful main runs - skipping baseline column.",
+			candidateRunIds.Length);
+		return null;
 	}
 
 	string CreateBenchmarkCommentBody(string[] files, string baselineResultsDirectory)
@@ -170,9 +184,7 @@ partial class Build
 			sb.AppendLine();
 			sb.AppendLine("<details>");
 			sb.AppendLine("<summary>Details</summary>");
-			int[] droppedColumnIndices = null;
-			int meanIndex = -1;
-			int tableRowIndex = 0;
+			BenchmarkTableParser parser = new(columnsToRemove);
 			foreach (string line in lines)
 			{
 				if (line.StartsWith("```"))
@@ -189,57 +201,42 @@ partial class Build
 						sb.AppendLine();
 					}
 
-					droppedColumnIndices = null;
-					meanIndex = -1;
-					tableRowIndex = 0;
+					parser.Reset();
 					continue;
 				}
 
-				if (line.StartsWith('|') && line.EndsWith('|'))
+				if (!parser.TryConsume(line, out _, out string filteredLine, out string[] filteredTokens))
 				{
-					droppedColumnIndices ??= DetermineDroppedColumnIndices(line, columnsToRemove);
-					string filteredLine = RemoveColumns(line, droppedColumnIndices);
-					string[] filteredTokens = filteredLine.Split('|',
-						StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-
-					if (tableRowIndex == 0)
-					{
-						meanIndex = Array.FindIndex(filteredTokens,
-							t => string.Equals(t, "Mean", StringComparison.OrdinalIgnoreCase));
-					}
-
-					tableRowIndex++;
-
-					bool isMockolateRow = filteredLine.Contains("_Mockolate", StringComparison.OrdinalIgnoreCase);
-
-					if (isMockolateRow && injectBaseline && meanIndex > 0)
-					{
-						string key = string.Join("|", filteredTokens.Take(meanIndex));
-						if (baselineRows.TryGetValue(key, out string[] baselineTokens) && baselineTokens.Length > 0)
-						{
-							string[] modifiedBaseline = new string[baselineTokens.Length];
-							for (int i = 0; i < baselineTokens.Length; i++)
-							{
-								string content = i == 0 ? "baseline*" : baselineTokens[i];
-								modifiedBaseline[i] = string.IsNullOrWhiteSpace(content) ? content : $"_{content}_";
-							}
-
-							sb.AppendLine(JoinTokens(modifiedBaseline));
-							anyBaselineInjected = true;
-						}
-					}
-
-					if (isMockolateRow)
-					{
-						MakeLineBold(sb, filteredLine);
-						continue;
-					}
-
-					sb.AppendLine(filteredLine);
+					sb.AppendLine(line);
 					continue;
 				}
 
-				sb.AppendLine(line);
+				bool isMockolateRow = filteredLine.Contains("_Mockolate", StringComparison.OrdinalIgnoreCase);
+
+				if (isMockolateRow && injectBaseline && parser.MeanIndex > 0)
+				{
+					string key = string.Join("|", filteredTokens.Take(parser.MeanIndex));
+					if (baselineRows.TryGetValue(key, out string[] baselineTokens) && baselineTokens.Length > 0)
+					{
+						string[] modifiedBaseline = new string[baselineTokens.Length];
+						for (int i = 0; i < baselineTokens.Length; i++)
+						{
+							string content = i == 0 ? "baseline*" : baselineTokens[i];
+							modifiedBaseline[i] = string.IsNullOrWhiteSpace(content) ? content : $"_{content}_";
+						}
+
+						sb.AppendLine(JoinTokens(modifiedBaseline));
+						anyBaselineInjected = true;
+					}
+				}
+
+				if (isMockolateRow)
+				{
+					MakeLineBold(sb, filteredLine);
+					continue;
+				}
+
+				sb.AppendLine(filteredLine);
 			}
 		}
 
@@ -247,7 +244,7 @@ partial class Build
 		{
 			sb.AppendLine();
 			sb.AppendLine(
-				"> `baseline*` rows show the corresponding Mockolate benchmark from the latest successful main branch build, for regression comparison.");
+				"> `baseline*` rows show the corresponding Mockolate benchmark from the most recent successful main branch build with results, for regression comparison.");
 		}
 
 		string body = sb.ToString();
@@ -262,38 +259,21 @@ partial class Build
 			return result;
 		}
 
-		int[] droppedColumnIndices = null;
-		int meanIndex = -1;
-		int tableRowIndex = 0;
+		BenchmarkTableParser parser = new(columnsToRemove);
 		foreach (string line in File.ReadAllLines(baselineFile))
 		{
-			if (!line.StartsWith('|') || !line.EndsWith('|'))
+			if (!parser.TryConsume(line, out int rowIndex, out _, out string[] tokens))
 			{
-				if (tableRowIndex > 0)
-				{
-					droppedColumnIndices = null;
-					meanIndex = -1;
-					tableRowIndex = 0;
-				}
-
 				continue;
 			}
 
-			droppedColumnIndices ??= DetermineDroppedColumnIndices(line, columnsToRemove);
-			string filtered = RemoveColumns(line, droppedColumnIndices);
-			string[] tokens = filtered.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-			if (tableRowIndex == 0)
+			if (rowIndex >= BenchmarkTableParser.DataRowStartIndex
+			    && parser.MeanIndex > 0
+			    && tokens.Length > parser.MeanIndex)
 			{
-				meanIndex = Array.FindIndex(tokens,
-					t => string.Equals(t, "Mean", StringComparison.OrdinalIgnoreCase));
-			}
-			else if (tableRowIndex >= 2 && meanIndex > 0 && meanIndex <= tokens.Length)
-			{
-				string key = string.Join("|", tokens.Take(meanIndex));
+				string key = string.Join("|", tokens.Take(parser.MeanIndex));
 				result[key] = tokens;
 			}
-
-			tableRowIndex++;
 		}
 
 		return result;
@@ -382,5 +362,63 @@ partial class Build
 		}
 
 		sb.AppendLine();
+	}
+
+	/// <summary>
+	///     Parses the markdown tables produced by BenchmarkDotNet's GitHub exporter.
+	///     Tables are framed by a header row (index 0), a separator row like <c>|---|---|</c> (index 1), and one or more
+	///     data rows (index >= <see cref="DataRowStartIndex" />). The parser auto-resets on the first non-table line that
+	///     follows a table, so a single instance can walk a document that contains multiple tables.
+	/// </summary>
+	sealed class BenchmarkTableParser
+	{
+		public const int DataRowStartIndex = 2;
+
+		readonly string[] _columnsToRemove;
+		int[] _droppedColumnIndices;
+		int _nextRowIndex;
+
+		public BenchmarkTableParser(string[] columnsToRemove)
+		{
+			_columnsToRemove = columnsToRemove;
+		}
+
+		public int MeanIndex { get; private set; } = -1;
+
+		public bool TryConsume(string line, out int rowIndex, out string filteredLine, out string[] tokens)
+		{
+			rowIndex = -1;
+			filteredLine = null;
+			tokens = null;
+			if (!line.StartsWith('|') || !line.EndsWith('|'))
+			{
+				if (_nextRowIndex > 0)
+				{
+					Reset();
+				}
+
+				return false;
+			}
+
+			_droppedColumnIndices ??= DetermineDroppedColumnIndices(line, _columnsToRemove);
+			filteredLine = RemoveColumns(line, _droppedColumnIndices);
+			tokens = filteredLine.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+			if (_nextRowIndex == 0)
+			{
+				MeanIndex = Array.FindIndex(tokens,
+					t => string.Equals(t, "Mean", StringComparison.OrdinalIgnoreCase));
+			}
+
+			rowIndex = _nextRowIndex;
+			_nextRowIndex++;
+			return true;
+		}
+
+		public void Reset()
+		{
+			_droppedColumnIndices = null;
+			MeanIndex = -1;
+			_nextRowIndex = 0;
+		}
 	}
 }

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
@@ -14,6 +15,8 @@ namespace Build;
 
 public static class BuildExtensions
 {
+	private const string RepositoryApiBaseUrl = "https://api.github.com/repos/aweXpect/Mockolate";
+
 	public static SonarScannerBeginSettings SetPullRequestOrBranchName(
 		this SonarScannerBeginSettings settings,
 		GitHubActions gitHubActions,
@@ -49,39 +52,45 @@ public static class BuildExtensions
 		=> DownloadArtifactsWhere(name => name.StartsWith(artifactNamePrefix, StringComparison.OrdinalIgnoreCase),
 			artifactsDirectory, githubToken);
 
-	public static async Task<long?> FindLatestSuccessfulRun(string workflowFileName, string branch, string githubToken)
+	public static async Task<long[]> FindRecentSuccessfulRunIds(string workflowFileName, string branch, int count,
+		string githubToken)
 	{
-		using HttpClient client = new();
-		client.DefaultRequestHeaders.UserAgent.ParseAdd("Mockolate");
-		if (!string.IsNullOrEmpty(githubToken))
+		if (string.IsNullOrEmpty(githubToken))
 		{
-			client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
+			throw new ArgumentException("A GitHub token is required.", nameof(githubToken));
 		}
 
-		HttpResponseMessage response = await client.GetAsync(
-			$"https://api.github.com/repos/aweXpect/Mockolate/actions/workflows/{workflowFileName}/runs?status=success&branch={branch}&per_page=1");
+		using HttpClient client = new();
+		client.DefaultRequestHeaders.UserAgent.ParseAdd("Mockolate");
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
+
+		string url = $"{RepositoryApiBaseUrl}/actions/workflows/{Uri.EscapeDataString(workflowFileName)}/runs" +
+		             $"?status=success&branch={Uri.EscapeDataString(branch)}&per_page={count}";
+		HttpResponseMessage response = await client.GetAsync(url);
 		string responseContent = await response.Content.ReadAsStringAsync();
 		if (!response.IsSuccessStatusCode)
 		{
-			Log.Warning($"Could not find latest run for workflow '{workflowFileName}' on branch '{branch}': {responseContent}");
-			return null;
+			Log.Warning(
+				$"Could not find recent runs for workflow '{workflowFileName}' on branch '{branch}': {responseContent}");
+			return [];
 		}
 
 		try
 		{
-			JsonDocument jsonDocument = JsonDocument.Parse(responseContent);
+			using JsonDocument jsonDocument = JsonDocument.Parse(responseContent);
 			JsonElement runs = jsonDocument.RootElement.GetProperty("workflow_runs");
-			if (runs.GetArrayLength() == 0)
+			long[] ids = new long[runs.GetArrayLength()];
+			for (int i = 0; i < ids.Length; i++)
 			{
-				return null;
+				ids[i] = runs[i].GetProperty("id").GetInt64();
 			}
 
-			return runs[0].GetProperty("id").GetInt64();
+			return ids;
 		}
-		catch (JsonException e)
+		catch (Exception e) when (e is JsonException or KeyNotFoundException or InvalidOperationException)
 		{
-			Log.Error($"Could not parse JSON: {e.Message}\n{responseContent}");
-			return null;
+			Log.Error($"Could not parse workflow runs response: {e.Message}\n{responseContent}");
+			return [];
 		}
 	}
 
@@ -111,7 +120,7 @@ public static class BuildExtensions
 		client.DefaultRequestHeaders.UserAgent.ParseAdd("Mockolate");
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
 		HttpResponseMessage response = await client.GetAsync(
-			$"https://api.github.com/repos/aweXpect/Mockolate/actions/runs/{runId}/artifacts");
+			$"{RepositoryApiBaseUrl}/actions/runs/{runId}/artifacts");
 
 		string responseContent = await response.Content.ReadAsStringAsync();
 		if (!response.IsSuccessStatusCode)
@@ -122,7 +131,7 @@ public static class BuildExtensions
 
 		try
 		{
-			JsonDocument jsonDocument = JsonDocument.Parse(responseContent);
+			using JsonDocument jsonDocument = JsonDocument.Parse(responseContent);
 			foreach (JsonElement artifact in jsonDocument.RootElement.GetProperty("artifacts").EnumerateArray())
 			{
 				string name = artifact.GetProperty("name").GetString()!;
@@ -130,7 +139,7 @@ public static class BuildExtensions
 				{
 					long artifactId = artifact.GetProperty("id").GetInt64();
 					HttpResponseMessage fileResponse = await client.GetAsync(
-						$"https://api.github.com/repos/aweXpect/Mockolate/actions/artifacts/{artifactId}/zip");
+						$"{RepositoryApiBaseUrl}/actions/artifacts/{artifactId}/zip");
 					if (fileResponse.IsSuccessStatusCode)
 					{
 						using ZipArchive archive = new(await fileResponse.Content.ReadAsStreamAsync());

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -49,16 +49,64 @@ public static class BuildExtensions
 		=> DownloadArtifactsWhere(name => name.StartsWith(artifactNamePrefix, StringComparison.OrdinalIgnoreCase),
 			artifactsDirectory, githubToken);
 
-	private static async Task DownloadArtifactsWhere(Func<string, bool> namePredicate, string artifactsDirectory,
+	public static async Task<long?> FindLatestSuccessfulRun(string workflowFileName, string branch, string githubToken)
+	{
+		using HttpClient client = new();
+		client.DefaultRequestHeaders.UserAgent.ParseAdd("Mockolate");
+		if (!string.IsNullOrEmpty(githubToken))
+		{
+			client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
+		}
+
+		HttpResponseMessage response = await client.GetAsync(
+			$"https://api.github.com/repos/aweXpect/Mockolate/actions/workflows/{workflowFileName}/runs?status=success&branch={branch}&per_page=1");
+		string responseContent = await response.Content.ReadAsStringAsync();
+		if (!response.IsSuccessStatusCode)
+		{
+			Log.Warning($"Could not find latest run for workflow '{workflowFileName}' on branch '{branch}': {responseContent}");
+			return null;
+		}
+
+		try
+		{
+			JsonDocument jsonDocument = JsonDocument.Parse(responseContent);
+			JsonElement runs = jsonDocument.RootElement.GetProperty("workflow_runs");
+			if (runs.GetArrayLength() == 0)
+			{
+				return null;
+			}
+
+			return runs[0].GetProperty("id").GetInt64();
+		}
+		catch (JsonException e)
+		{
+			Log.Error($"Could not parse JSON: {e.Message}\n{responseContent}");
+			return null;
+		}
+	}
+
+	public static Task DownloadArtifactsFromRunStartingWith(long runId, string artifactNamePrefix,
+		string artifactsDirectory, string githubToken)
+		=> DownloadArtifactsFromRun(runId.ToString(),
+			name => name.StartsWith(artifactNamePrefix, StringComparison.OrdinalIgnoreCase),
+			artifactsDirectory, githubToken);
+
+	private static Task DownloadArtifactsWhere(Func<string, bool> namePredicate, string artifactsDirectory,
 		string githubToken)
 	{
 		string runId = Environment.GetEnvironmentVariable("WorkflowRunId");
 		if (string.IsNullOrEmpty(runId))
 		{
 			Log.Information("Skip downloading artifacts, because no 'WorkflowRunId' environment variable is set.");
-			return;
+			return Task.CompletedTask;
 		}
 
+		return DownloadArtifactsFromRun(runId, namePredicate, artifactsDirectory, githubToken);
+	}
+
+	private static async Task DownloadArtifactsFromRun(string runId, Func<string, bool> namePredicate,
+		string artifactsDirectory, string githubToken)
+	{
 		using HttpClient client = new();
 		client.DefaultRequestHeaders.UserAgent.ParseAdd("Mockolate");
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
@@ -86,7 +134,7 @@ public static class BuildExtensions
 					if (fileResponse.IsSuccessStatusCode)
 					{
 						using ZipArchive archive = new(await fileResponse.Content.ReadAsStreamAsync());
-						archive.ExtractToDirectory(artifactsDirectory, overwriteFiles: true);
+						archive.ExtractToDirectory(artifactsDirectory, true);
 						Log.Information(
 							$"Extracted artifact '{name}' (#{artifactId}) with {archive.Entries.Count} entries to {artifactsDirectory}:\n - {string.Join("\n - ", archive.Entries.Select(entry => $"{entry.Name} ({entry.Length})"))}");
 					}


### PR DESCRIPTION
This pull request enhances the benchmark reporting workflow by enabling comparison with previous main-branch benchmark results and refactoring artifact download utilities. The main focus is to automatically fetch and inject baseline benchmark results into pull request comments, making regression detection easier. Several utility methods for downloading and parsing artifacts from GitHub Actions have been added or improved.

**Benchmark baseline comparison and reporting:**

* The benchmark reporting logic in `Build.Benchmarks.cs` was updated to download benchmark artifacts from recent successful main branch runs and inject corresponding baseline results into the PR comment, allowing for regression comparisons. Baseline rows are clearly marked and explained in the comment.
* Introduced the `BenchmarkTableParser` helper class to robustly parse and process markdown benchmark tables, supporting the new baseline injection logic.

**Artifact download and GitHub Actions integration:**

* Added new utility methods in `BuildExtensions.cs` to find recent successful workflow run IDs, and to download artifacts from specific runs or based on name prefixes. These methods use the GitHub API and improve error handling and logging.
* Refactored artifact download logic to use a constant for the repository API base URL and to support both environment-based and explicit run ID selection.

**CI workflow improvements:**

* Updated `.github/workflows/build.yml` to always upload benchmark artifacts after running benchmarks, ensuring that results are available for baseline comparison in future PRs.

**General code improvements:**

* Added missing `using` statements for required namespaces in both `Build.Benchmarks.cs` and `BuildExtensions.cs`.