### PR TITLE
fix: also remove "Gen2" from benchmark tables

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/MockCreationBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/MockCreationBenchmarks.cs
@@ -8,43 +8,42 @@ using NSubstitute;
 
 namespace Mockolate.Benchmarks;
 #pragma warning disable CA1822 // Mark members as static
-
 /// <summary>
 ///     Measures the cost of creating an empty mock — no setup, no invocations, no verification.
 /// </summary>
 public class MockCreationBenchmarks : BenchmarksBase
 {
-	[Benchmark(Baseline = true, Description = "Mockolate")]
-	public object Mockolate_CreateMock()
+	[Benchmark(Baseline = true)]
+	public object CreateMock_Mockolate()
 		=> ICalculatorService.CreateMock();
 
-	[Benchmark(Description = "Imposter")]
-	public object Imposter_CreateMock()
+	[Benchmark]
+	public object CreateMock_Imposter()
 	{
 		ICalculatorServiceImposter imposter = ICalculatorService.Imposter();
 		return imposter.Instance();
 	}
 
-	[Benchmark(Description = "TUnit.Mocks")]
-	public object TUnitMocks_CreateMock()
+	[Benchmark]
+	public object CreateMock_TUnitMocks()
 	{
-		TUnit.Mocks.Mock<ICalculatorService> mock = TUnit.Mocks.Mock.Of<ICalculatorService>();
+		Mock<ICalculatorService> mock = TUnit.Mocks.Mock.Of<ICalculatorService>();
 		return mock.Object;
 	}
 
-	[Benchmark(Description = "Moq")]
-	public object Moq_CreateMock()
+	[Benchmark]
+	public object CreateMock_Moq()
 	{
 		Moq.Mock<ICalculatorService> mock = new();
 		return mock.Object;
 	}
 
-	[Benchmark(Description = "NSubstitute")]
-	public object NSubstitute_CreateMock()
+	[Benchmark]
+	public object CreateMock_NSubstitute()
 		=> Substitute.For<ICalculatorService>();
 
-	[Benchmark(Description = "FakeItEasy")]
-	public object FakeItEasy_CreateMock()
+	[Benchmark]
+	public object CreateMock_FakeItEasy()
 		=> A.Fake<ICalculatorService>();
 
 	public interface ICalculatorService

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -127,7 +127,7 @@ partial class Build
 	{
 		StringBuilder sb = new();
 		sb.AppendLine("## :rocket: Benchmark Results");
-		string[] columnsToRemove = ["RatioSD", "Gen0", "Gen1",];
+		string[] columnsToRemove = ["RatioSD", "Gen0", "Gen1", "Gen2",];
 		foreach (string file in files)
 		{
 			int count = 0;


### PR DESCRIPTION
This pull request makes improvements to the benchmark suite and its reporting. The main changes include standardizing benchmark method names for clarity and updating the benchmark report to exclude an additional column.

**Benchmark code cleanup and consistency:**

* Renamed benchmark methods in `MockCreationBenchmarks.cs` to follow a consistent `CreateMock_*` naming convention, and removed the `Description` parameter from `[Benchmark]` attributes for cleaner output.

**Benchmark report formatting:**

* Updated the `CreateBenchmarkCommentBody` method in `Build.Benchmarks.cs` to also remove the `Gen2` column from benchmark reports, in addition to the previously removed columns.