### PR TITLE
feat: bind `Method(default, …)` to the by-values overload

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/CallbackBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CallbackBenchmarks.cs
@@ -31,6 +31,39 @@ public class CallbackBenchmarks : BenchmarksBase
 	}
 
 	/// <summary>
+	///     <see href="https://github.com/themidnightgospel/Imposter" />
+	/// </summary>
+	[Benchmark]
+	public int Callback_Imposter()
+	{
+		int count = 0;
+		IMyCallbackInterfaceImposter imposter = IMyCallbackInterface.Imposter();
+		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Callback(_ => count++);
+
+		IMyCallbackInterface instance = imposter.Instance();
+		instance.MyFunc(1);
+		instance.MyFunc(2);
+		return count;
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/thomhurst/TUnit/" />
+	/// </summary>
+	[Benchmark]
+	public int Callback_TUnitMocks()
+	{
+		int count = 0;
+		Mock<IMyCallbackInterface> mock = TUnit.Mocks.Mock.Of<IMyCallbackInterface>();
+		mock.MyFunc(Any<int>())
+			.Callback(() => count++);
+
+		IMyCallbackInterface svc = mock.Object;
+		svc.MyFunc(1);
+		svc.MyFunc(2);
+		return count;
+	}
+
+	/// <summary>
 	///     <see href="https://github.com/devlooped/moq" />
 	/// </summary>
 	[Benchmark]
@@ -73,39 +106,6 @@ public class CallbackBenchmarks : BenchmarksBase
 
 		mock.MyFunc(1);
 		mock.MyFunc(2);
-		return count;
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/themidnightgospel/Imposter" />
-	/// </summary>
-	[Benchmark]
-	public int Callback_Imposter()
-	{
-		int count = 0;
-		IMyCallbackInterfaceImposter imposter = IMyCallbackInterface.Imposter();
-		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Callback(_ => count++);
-
-		IMyCallbackInterface instance = imposter.Instance();
-		instance.MyFunc(1);
-		instance.MyFunc(2);
-		return count;
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/thomhurst/TUnit/" />
-	/// </summary>
-	[Benchmark]
-	public int Callback_TUnitMocks()
-	{
-		int count = 0;
-		Mock<IMyCallbackInterface> mock = TUnit.Mocks.Mock.Of<IMyCallbackInterface>();
-		mock.MyFunc(Any<int>())
-			.Callback(() => count++);
-
-		IMyCallbackInterface svc = mock.Object;
-		svc.MyFunc(1);
-		svc.MyFunc(2);
 		return count;
 	}
 

--- a/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
@@ -34,6 +34,36 @@ public class CompleteEventBenchmarks : BenchmarksBase
 	}
 
 	/// <summary>
+	///     <see href="https://github.com/themidnightgospel/Imposter" />
+	/// </summary>
+	[Benchmark]
+	public void Event_Imposter()
+	{
+		IMyEventInterfaceImposter imposter = IMyEventInterface.Imposter();
+		EventHandler handler = (_, _) => { };
+
+		imposter.Instance().SomeEvent += handler;
+		imposter.SomeEvent.Raise(null!, EventArgs.Empty);
+
+		imposter.SomeEvent.Subscribed(handler, Count.Once());
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/thomhurst/TUnit/" />
+	/// </summary>
+	[Benchmark]
+	public void Event_TUnitMocks()
+	{
+		Mock<IMyEventInterface> mock = TUnit.Mocks.Mock.Of<IMyEventInterface>();
+		EventHandler handler = (_, _) => { };
+
+		mock.Object.SomeEvent += handler;
+		mock.RaiseSomeEvent(EventArgs.Empty);
+
+		_ = mock.Events.SomeEvent.SubscriberCount;
+	}
+
+	/// <summary>
 	///     <see href="https://github.com/devlooped/moq" />
 	/// </summary>
 	[Benchmark]
@@ -80,36 +110,6 @@ public class CompleteEventBenchmarks : BenchmarksBase
 			.Where(call => call.Method.Name == "add_SomeEvent")
 			// Expect 2, because raising an event in FakeItEasy is implemented as a call to the add accessor of the event.
 			.MustHaveHappened(2, FakeItEasy.Times.Exactly);
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/themidnightgospel/Imposter" />
-	/// </summary>
-	[Benchmark]
-	public void Event_Imposter()
-	{
-		IMyEventInterfaceImposter imposter = IMyEventInterface.Imposter();
-		EventHandler handler = (_, _) => { };
-
-		imposter.Instance().SomeEvent += handler;
-		imposter.SomeEvent.Raise(null!, EventArgs.Empty);
-
-		imposter.SomeEvent.Subscribed(handler, Count.Once());
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/thomhurst/TUnit/" />
-	/// </summary>
-	[Benchmark]
-	public void Event_TUnitMocks()
-	{
-		Mock<IMyEventInterface> mock = TUnit.Mocks.Mock.Of<IMyEventInterface>();
-		EventHandler handler = (_, _) => { };
-
-		mock.Object.SomeEvent += handler;
-		mock.RaiseSomeEvent(EventArgs.Empty);
-
-		_ = mock.Events.SomeEvent.SubscriberCount;
 	}
 
 	public interface IMyEventInterface

--- a/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
@@ -5,6 +5,7 @@ using Mockolate.Benchmarks;
 using Mockolate.Verify;
 using NSubstitute;
 using Arg = NSubstitute.Arg;
+using Raise = NSubstitute.Raise;
 using Times = Moq.Times;
 
 [assembly: GenerateImposter(typeof(CompleteEventBenchmarks.IMyEventInterface))]
@@ -58,7 +59,7 @@ public class CompleteEventBenchmarks : BenchmarksBase
 		EventHandler handler = (_, _) => { };
 
 		mock.SomeEvent += handler;
-		mock.SomeEvent += NSubstitute.Raise.EventWith(null, EventArgs.Empty);
+		mock.SomeEvent += Raise.EventWith(null, EventArgs.Empty);
 
 		mock.Received(1).SomeEvent += Arg.Any<EventHandler>();
 	}

--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -17,8 +17,7 @@ namespace Mockolate.Benchmarks;
 /// </summary>
 public class CompleteIndexerBenchmarks : BenchmarksBase
 {
-	[Params(1, 10)]
-	public int N { get; set; }
+	[Params(1, 10)] public int N { get; set; }
 
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />

--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -39,6 +39,46 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 	}
 
 	/// <summary>
+	///     <see href="https://github.com/themidnightgospel/Imposter" />
+	/// </summary>
+	[Benchmark]
+	public void Indexer_Imposter()
+	{
+		IMyIndexerInterfaceImposter imposter = IMyIndexerInterface.Imposter();
+		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Returns("foo");
+		IMyIndexerInterface sut = imposter.Instance();
+
+		for (int i = 0; i < N; i++)
+		{
+			_ = sut[42];
+			sut[42] = "bar";
+		}
+
+		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(N));
+		imposter[Imposter.Abstractions.Arg<int>.Any()].Setter().Called(Count.Exactly(N));
+	}
+
+	/* Indexers not supported on TUnit.Mocks
+	/// <summary>
+	///     <see href="https://github.com/thomhurst/TUnit/" />
+	/// </summary>
+	[Benchmark]
+	public void Indexer_TUnitMocks()
+	{
+		TUnit.Mocks.Mock<IMyIndexerInterface> mock = TUnit.Mocks.Mock.Of<IMyIndexerInterface>();
+		mock[Any<int>()].Returns("foo");
+
+		for (int i = 0; i < N; i++)
+		{
+			_ = mock.Object[42];
+			mock.Object[42] = "bar";
+		}
+
+		mock[Any<int>()].WasCalled(TUnit.Mocks.Times.Exactly(N));
+	}
+	*/
+
+	/// <summary>
 	///     <see href="https://github.com/devlooped/moq" />
 	/// </summary>
 	[Benchmark]
@@ -95,46 +135,6 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 		A.CallTo(() => mock[A<int>.Ignored]).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 		A.CallToSet(() => mock[A<int>.Ignored]).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 	}
-
-	/// <summary>
-	///     <see href="https://github.com/themidnightgospel/Imposter" />
-	/// </summary>
-	[Benchmark]
-	public void Indexer_Imposter()
-	{
-		IMyIndexerInterfaceImposter imposter = IMyIndexerInterface.Imposter();
-		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Returns("foo");
-		IMyIndexerInterface sut = imposter.Instance();
-
-		for (int i = 0; i < N; i++)
-		{
-			_ = sut[42];
-			sut[42] = "bar";
-		}
-
-		imposter[Imposter.Abstractions.Arg<int>.Any()].Getter().Called(Count.Exactly(N));
-		imposter[Imposter.Abstractions.Arg<int>.Any()].Setter().Called(Count.Exactly(N));
-	}
-
-	/* Indexers not supported on TUnit.Mocks
-	/// <summary>
-	///     <see href="https://github.com/thomhurst/TUnit/" />
-	/// </summary>
-	[Benchmark]
-	public void Indexer_TUnitMocks()
-	{
-		TUnit.Mocks.Mock<IMyIndexerInterface> mock = TUnit.Mocks.Mock.Of<IMyIndexerInterface>();
-		mock[Any<int>()].Returns("foo");
-
-		for (int i = 0; i < N; i++)
-		{
-			_ = mock.Object[42];
-			mock.Object[42] = "bar";
-		}
-
-		mock[Any<int>()].WasCalled(TUnit.Mocks.Times.Exactly(N));
-	}
-	*/
 
 	public interface IMyIndexerInterface
 	{

--- a/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
@@ -37,6 +37,42 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 	}
 
 	/// <summary>
+	///     <see href="https://github.com/themidnightgospel/Imposter" />
+	/// </summary>
+	[Benchmark]
+	public void Method_Imposter()
+	{
+		IMyMethodInterfaceImposter imposter = IMyMethodInterface.Imposter();
+		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Returns(true);
+		IMyMethodInterface sut = imposter.Instance();
+
+		for (int i = 0; i < N; i++)
+		{
+			sut.MyFunc(42);
+		}
+
+		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(N));
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/thomhurst/TUnit/" />
+	/// </summary>
+	[Benchmark]
+	public void Method_TUnitMocks()
+	{
+		Mock<IMyMethodInterface> mock = TUnit.Mocks.Mock.Of<IMyMethodInterface>();
+		mock.MyFunc(Any<int>()).Returns(true);
+		IMyMethodInterface sut = mock.Object;
+
+		for (int i = 0; i < N; i++)
+		{
+			sut.MyFunc(42);
+		}
+
+		mock.MyFunc(Any<int>()).WasCalled(TUnit.Mocks.Times.Exactly(N));
+	}
+
+	/// <summary>
 	///     <see href="https://github.com/devlooped/moq" />
 	/// </summary>
 	[Benchmark]
@@ -86,42 +122,6 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 		}
 
 		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(N, FakeItEasy.Times.Exactly);
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/themidnightgospel/Imposter" />
-	/// </summary>
-	[Benchmark]
-	public void Method_Imposter()
-	{
-		IMyMethodInterfaceImposter imposter = IMyMethodInterface.Imposter();
-		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Returns(true);
-		IMyMethodInterface sut = imposter.Instance();
-
-		for (int i = 0; i < N; i++)
-		{
-			sut.MyFunc(42);
-		}
-
-		imposter.MyFunc(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(N));
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/thomhurst/TUnit/" />
-	/// </summary>
-	[Benchmark]
-	public void Method_TUnitMocks()
-	{
-		Mock<IMyMethodInterface> mock = TUnit.Mocks.Mock.Of<IMyMethodInterface>();
-		mock.MyFunc(Any<int>()).Returns(true);
-		IMyMethodInterface sut = mock.Object;
-
-		for (int i = 0; i < N; i++)
-		{
-			sut.MyFunc(42);
-		}
-
-		mock.MyFunc(Any<int>()).WasCalled(TUnit.Mocks.Times.Exactly(N));
 	}
 
 	public interface IMyMethodInterface

--- a/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
@@ -17,8 +17,7 @@ namespace Mockolate.Benchmarks;
 /// </summary>
 public class CompleteMethodBenchmarks : BenchmarksBase
 {
-	[Params(1, 10)]
-	public int N { get; set; }
+	[Params(1, 10)] public int N { get; set; }
 
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -4,6 +4,7 @@ using Imposter.Abstractions;
 using Mockolate.Benchmarks;
 using Mockolate.Verify;
 using NSubstitute;
+using Arg = NSubstitute.Arg;
 using Times = Moq.Times;
 
 [assembly: GenerateImposter(typeof(CompletePropertyBenchmarks.IMyPropertyInterface))]
@@ -16,8 +17,7 @@ namespace Mockolate.Benchmarks;
 /// </summary>
 public class CompletePropertyBenchmarks : BenchmarksBase
 {
-	[Params(1, 10)]
-	public int N { get; set; }
+	[Params(1, 10)] public int N { get; set; }
 
 	/// <summary>
 	///     <see href="https://awexpect.com/Mockolate" />
@@ -74,7 +74,7 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 		}
 
 		_ = mock.Received(N).Counter;
-		mock.Received(N).Counter = NSubstitute.Arg.Any<int>();
+		mock.Received(N).Counter = Arg.Any<int>();
 	}
 
 	/// <summary>

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -39,6 +39,46 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 	}
 
 	/// <summary>
+	///     <see href="https://github.com/themidnightgospel/Imposter" />
+	/// </summary>
+	[Benchmark]
+	public void Property_Imposter()
+	{
+		IMyPropertyInterfaceImposter imposter = IMyPropertyInterface.Imposter();
+		imposter.Counter.Getter().Returns(42);
+		IMyPropertyInterface sut = imposter.Instance();
+
+		for (int i = 0; i < N; i++)
+		{
+			_ = sut.Counter;
+			sut.Counter = i;
+		}
+
+		imposter.Counter.Getter().Called(Count.Exactly(N));
+		imposter.Counter.Setter(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(N));
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/thomhurst/TUnit/" />
+	/// </summary>
+	[Benchmark]
+	public void Property_TUnitMocks()
+	{
+		Mock<IMyPropertyInterface> mock = TUnit.Mocks.Mock.Of<IMyPropertyInterface>();
+		mock.Counter.Returns(42);
+		IMyPropertyInterface sut = mock.Object;
+
+		for (int i = 0; i < N; i++)
+		{
+			_ = sut.Counter;
+			sut.Counter = i;
+		}
+
+		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(N));
+		mock.Counter.Setter.WasCalled(TUnit.Mocks.Times.Exactly(N));
+	}
+
+	/// <summary>
 	///     <see href="https://github.com/devlooped/moq" />
 	/// </summary>
 	[Benchmark]
@@ -94,46 +134,6 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 
 		A.CallTo(() => mock.Counter).MustHaveHappened(N, FakeItEasy.Times.Exactly);
 		A.CallToSet(() => mock.Counter).MustHaveHappened(N, FakeItEasy.Times.Exactly);
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/themidnightgospel/Imposter" />
-	/// </summary>
-	[Benchmark]
-	public void Property_Imposter()
-	{
-		IMyPropertyInterfaceImposter imposter = IMyPropertyInterface.Imposter();
-		imposter.Counter.Getter().Returns(42);
-		IMyPropertyInterface sut = imposter.Instance();
-
-		for (int i = 0; i < N; i++)
-		{
-			_ = sut.Counter;
-			sut.Counter = i;
-		}
-
-		imposter.Counter.Getter().Called(Count.Exactly(N));
-		imposter.Counter.Setter(Imposter.Abstractions.Arg<int>.Any()).Called(Count.Exactly(N));
-	}
-
-	/// <summary>
-	///     <see href="https://github.com/thomhurst/TUnit/" />
-	/// </summary>
-	[Benchmark]
-	public void Property_TUnitMocks()
-	{
-		Mock<IMyPropertyInterface> mock = TUnit.Mocks.Mock.Of<IMyPropertyInterface>();
-		mock.Counter.Returns(42);
-		IMyPropertyInterface sut = mock.Object;
-
-		for (int i = 0; i < N; i++)
-		{
-			_ = sut.Counter;
-			sut.Counter = i;
-		}
-
-		mock.Counter.WasCalled(TUnit.Mocks.Times.Exactly(N));
-		mock.Counter.Setter.WasCalled(TUnit.Mocks.Times.Exactly(N));
 	}
 
 	public interface IMyPropertyInterface

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -15,12 +15,12 @@ It enables fast, compile-time validated mocking with .NET Standard 2.0, .NET 8, 
 
 ## Why Mockolate
 
-|  | Reflection-based mocks (Moq, NSubstitute, …) | Mockolate |
-|---|---|---|
-| AOT / trimming | not supported | supported |
-| Validation | runtime exceptions | analyzers + compile errors |
-| Setup API | `Expression<Func<…>>` trees | regular method calls |
-| Hot path | dynamic-proxy dispatch | direct dispatch |
+|                | Reflection-based mocks (Moq, NSubstitute, …) | Mockolate                  |
+|----------------|----------------------------------------------|----------------------------|
+| AOT / trimming | not supported                                | supported                  |
+| Validation     | runtime exceptions                           | analyzers + compile errors |
+| Setup API      | `Expression<Func<…>>` trees                  | regular method calls       |
+| Hot path       | dynamic-proxy dispatch                       | direct dispatch            |
 
 For side-by-side setup, usage, and verification syntax against Moq, NSubstitute, and FakeItEasy, see the [full code comparison](08-comparison.md).
 

--- a/Docs/pages/01-create-mocks.md
+++ b/Docs/pages/01-create-mocks.md
@@ -28,14 +28,14 @@ MyChocolateDispenser classMock = MyChocolateDispenser.CreateMock(behavior, "Dark
 
 **`MockBehavior` options**
 
-| Option | Default | Purpose |
-|---|---|---|
-| `SkipBaseClass` | `false` | When `true`, the mock does not call any base class implementations. Otherwise, the base class implementation is used as the default value when no explicit setup matches. |
-| `ThrowWhenNotSetup` | `false` | When `true`, the mock throws when no matching setup is found. Otherwise, it returns a default value (see `DefaultValue` below). |
-| `SkipInteractionRecording` | `false` | When `true`, interactions are not recorded - setups, returns, callbacks, and base-class delegation still work, but `.Verify.X()` throws a `MockException`. Useful in performance-sensitive scenarios. |
-| `DefaultValue` | sensible defaults | Customizes how default values are generated for unset methods and properties (see below). |
-| `Initialize<T>(...)` | - | Automatically applies the given setups to all mocks of type `T` when they are created. |
-| `UseConstructorParametersFor<T>(...)` | - | Configures default constructor parameters for mocks of type `T`, unless explicit parameters are supplied to `CreateMock([…])`. The `Func<object?[]>` overload defers parameter resolution until each mock is created. |
+| Option                                | Default           | Purpose                                                                                                                                                                                                               |
+|---------------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SkipBaseClass`                       | `false`           | When `true`, the mock does not call any base class implementations. Otherwise, the base class implementation is used as the default value when no explicit setup matches.                                             |
+| `ThrowWhenNotSetup`                   | `false`           | When `true`, the mock throws when no matching setup is found. Otherwise, it returns a default value (see `DefaultValue` below).                                                                                       |
+| `SkipInteractionRecording`            | `false`           | When `true`, interactions are not recorded - setups, returns, callbacks, and base-class delegation still work, but `.Verify.X()` throws a `MockException`. Useful in performance-sensitive scenarios.                 |
+| `DefaultValue`                        | sensible defaults | Customizes how default values are generated for unset methods and properties (see below).                                                                                                                             |
+| `Initialize<T>(...)`                  | -                 | Automatically applies the given setups to all mocks of type `T` when they are created.                                                                                                                                |
+| `UseConstructorParametersFor<T>(...)` | -                 | Configures default constructor parameters for mocks of type `T`, unless explicit parameters are supplied to `CreateMock([…])`. The `Func<object?[]>` overload defers parameter resolution until each mock is created. |
 
 **Default value generation**
 

--- a/Docs/pages/setup/04-parameter-matching.md
+++ b/Docs/pages/setup/04-parameter-matching.md
@@ -214,7 +214,6 @@ The following cases are rejected at compile time with diagnostic `Mockolate0003`
 - `out` / `ref` / `ref readonly` parameters of a ref-struct type.
 - Methods that return a custom ref struct. (`Span<T>` / `ReadOnlySpan<T>` returns are supported.)
 
-
 ## Parameter Predicates
 
 When the method name is unique (no overloads), you can use argument matchers from the `Match` class for more flexible parameters matching:

--- a/Mockolate.slnx
+++ b/Mockolate.slnx
@@ -1,82 +1,82 @@
 <Solution>
-  <Folder Name="/Benchmarks/">
-    <Project Path="Benchmarks/Mockolate.Benchmarks/Mockolate.Benchmarks.csproj" />
-  </Folder>
-  <Folder Name="/Pipeline/">
-    <Project Path="Pipeline/Build.csproj">
-      <Build Project="false" />
-    </Project>
-    <Project Path="Tests/Build.Tests/Build.Tests.csproj" />
-  </Folder>
-  <Folder Name="/Tests/">
-    <File Path="Tests/Directory.Build.props" />
-    <Project Path="Tests/Mockolate.Analyzers.Tests/Mockolate.Analyzers.Tests.csproj" />
-    <Project Path="Tests/Mockolate.Api.Tests/Mockolate.Api.Tests.csproj" />
-    <Project Path="Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj" />
-    <Project Path="Tests/Mockolate.Internal.Tests/Mockolate.Internal.Tests.csproj" />
-    <Project Path="Tests/Mockolate.SourceGenerators.Tests/Mockolate.SourceGenerators.Tests.csproj" />
-    <Project Path="Tests/Mockolate.Tests/Mockolate.Tests.csproj" />
-  </Folder>
-  <Folder Name="/Tests/Aot/">
-    <File Path="Tests/Aot/Directory.Build.props" />
-    <Project Path="Tests/Aot/Mockolate.AotCompatibility.TestApp/Mockolate.AotCompatibility.TestApp.csproj" />
-  </Folder>
-  <Folder Name="/_/">
-    <File Path=".editorconfig" />
-    <File Path=".gitattributes" />
-    <File Path=".gitignore" />
-    <File Path="CODE_OF_CONDUCT.md" />
-    <File Path="CONTRIBUTING.md" />
-    <File Path="Directory.Build.props" />
-    <File Path="Directory.Packages.props" />
-    <File Path="global.json" />
-    <File Path="LICENSE" />
-    <File Path="Mockolate.sln.DotSettings" />
-    <File Path="nuget.config" />
-    <File Path="README.md" />
-  </Folder>
-  <Folder Name="/_/.github/" />
-  <Folder Name="/_/.github/workflows/">
-    <File Path=".github/workflows/build.yml" />
-    <File Path=".github/workflows/ci-analysis.yml" />
-    <File Path=".github/workflows/ci.yml" />
-  </Folder>
-  <Folder Name="/_/Docs/">
-    <File Path="Docs/pages/00-index.md" />
-    <File Path="Docs/pages/01-create-mocks.md" />
-    <File Path="Docs/pages/03-mock-events.md" />
-    <File Path="Docs/pages/04-verify-interactions.md" />
-    <File Path="Docs/pages/07-analyzers.md" />
-    <File Path="Docs/pages/08-comparison.md" />
-  </Folder>
-  <Folder Name="/_/Docs/advanced-features/">
-    <File Path="Docs/pages/advanced-features/01-protected-members.md" />
-    <File Path="Docs/pages/advanced-features/02-static-interface-members.md" />
-    <File Path="Docs/pages/advanced-features/03-advanced-callback-features.md" />
-    <File Path="Docs/pages/advanced-features/04-monitor-interactions.md" />
-    <File Path="Docs/pages/advanced-features/05-check-for-unexpected-interactions.md" />
-    <File Path="Docs/pages/advanced-features/_category_.json" />
-  </Folder>
-  <Folder Name="/_/Docs/setup/">
-    <File Path="Docs/pages/setup/01-properties.md" />
-    <File Path="Docs/pages/setup/02-methods.md" />
-    <File Path="Docs/pages/setup/03-indexers.md" />
-    <File Path="Docs/pages/setup/04-parameter-matching.md" />
-    <File Path="Docs/pages/setup/_category_.json" />
-  </Folder>
-  <Folder Name="/_/Docs/special-types/">
-    <File Path="Docs/pages/special-types/01-httpclient.md" />
-    <File Path="Docs/pages/special-types/02-delegates.md" />
-    <File Path="Docs/pages/special-types/_category_.json" />
-  </Folder>
-  <Folder Name="/_/Source/">
-    <File Path="Source/Directory.Build.props" />
-  </Folder>
-  <Folder Name="/_/Tests/">
-    <File Path="Tests/Directory.Build.props" />
-  </Folder>
-  <Project Path="Source/Mockolate.Analyzers.CodeFixers/Mockolate.Analyzers.CodeFixers.csproj" />
-  <Project Path="Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj" />
-  <Project Path="Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj" />
-  <Project Path="Source/Mockolate/Mockolate.csproj" />
+	<Folder Name="/Benchmarks/">
+		<Project Path="Benchmarks/Mockolate.Benchmarks/Mockolate.Benchmarks.csproj"/>
+	</Folder>
+	<Folder Name="/Pipeline/">
+		<Project Path="Pipeline/Build.csproj">
+			<Build Project="false"/>
+		</Project>
+		<Project Path="Tests/Build.Tests/Build.Tests.csproj"/>
+	</Folder>
+	<Folder Name="/Tests/">
+		<File Path="Tests/Directory.Build.props"/>
+		<Project Path="Tests/Mockolate.Analyzers.Tests/Mockolate.Analyzers.Tests.csproj"/>
+		<Project Path="Tests/Mockolate.Api.Tests/Mockolate.Api.Tests.csproj"/>
+		<Project Path="Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj"/>
+		<Project Path="Tests/Mockolate.Internal.Tests/Mockolate.Internal.Tests.csproj"/>
+		<Project Path="Tests/Mockolate.SourceGenerators.Tests/Mockolate.SourceGenerators.Tests.csproj"/>
+		<Project Path="Tests/Mockolate.Tests/Mockolate.Tests.csproj"/>
+	</Folder>
+	<Folder Name="/Tests/Aot/">
+		<File Path="Tests/Aot/Directory.Build.props"/>
+		<Project Path="Tests/Aot/Mockolate.AotCompatibility.TestApp/Mockolate.AotCompatibility.TestApp.csproj"/>
+	</Folder>
+	<Folder Name="/_/">
+		<File Path=".editorconfig"/>
+		<File Path=".gitattributes"/>
+		<File Path=".gitignore"/>
+		<File Path="CODE_OF_CONDUCT.md"/>
+		<File Path="CONTRIBUTING.md"/>
+		<File Path="Directory.Build.props"/>
+		<File Path="Directory.Packages.props"/>
+		<File Path="global.json"/>
+		<File Path="LICENSE"/>
+		<File Path="Mockolate.sln.DotSettings"/>
+		<File Path="nuget.config"/>
+		<File Path="README.md"/>
+	</Folder>
+	<Folder Name="/_/.github/"/>
+	<Folder Name="/_/.github/workflows/">
+		<File Path=".github/workflows/build.yml"/>
+		<File Path=".github/workflows/ci-analysis.yml"/>
+		<File Path=".github/workflows/ci.yml"/>
+	</Folder>
+	<Folder Name="/_/Docs/">
+		<File Path="Docs/pages/00-index.md"/>
+		<File Path="Docs/pages/01-create-mocks.md"/>
+		<File Path="Docs/pages/03-mock-events.md"/>
+		<File Path="Docs/pages/04-verify-interactions.md"/>
+		<File Path="Docs/pages/07-analyzers.md"/>
+		<File Path="Docs/pages/08-comparison.md"/>
+	</Folder>
+	<Folder Name="/_/Docs/advanced-features/">
+		<File Path="Docs/pages/advanced-features/01-protected-members.md"/>
+		<File Path="Docs/pages/advanced-features/02-static-interface-members.md"/>
+		<File Path="Docs/pages/advanced-features/03-advanced-callback-features.md"/>
+		<File Path="Docs/pages/advanced-features/04-monitor-interactions.md"/>
+		<File Path="Docs/pages/advanced-features/05-check-for-unexpected-interactions.md"/>
+		<File Path="Docs/pages/advanced-features/_category_.json"/>
+	</Folder>
+	<Folder Name="/_/Docs/setup/">
+		<File Path="Docs/pages/setup/01-properties.md"/>
+		<File Path="Docs/pages/setup/02-methods.md"/>
+		<File Path="Docs/pages/setup/03-indexers.md"/>
+		<File Path="Docs/pages/setup/04-parameter-matching.md"/>
+		<File Path="Docs/pages/setup/_category_.json"/>
+	</Folder>
+	<Folder Name="/_/Docs/special-types/">
+		<File Path="Docs/pages/special-types/01-httpclient.md"/>
+		<File Path="Docs/pages/special-types/02-delegates.md"/>
+		<File Path="Docs/pages/special-types/_category_.json"/>
+	</Folder>
+	<Folder Name="/_/Source/">
+		<File Path="Source/Directory.Build.props"/>
+	</Folder>
+	<Folder Name="/_/Tests/">
+		<File Path="Tests/Directory.Build.props"/>
+	</Folder>
+	<Project Path="Source/Mockolate.Analyzers.CodeFixers/Mockolate.Analyzers.CodeFixers.csproj"/>
+	<Project Path="Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj"/>
+	<Project Path="Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj"/>
+	<Project Path="Source/Mockolate/Mockolate.csproj"/>
 </Solution>

--- a/Pipeline/BenchmarkReport.cs
+++ b/Pipeline/BenchmarkReport.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -299,9 +297,9 @@ internal static class BenchmarkReport
 		string unitPart = spaceIdx > 0 ? trimmed.Substring(spaceIdx + 1).Trim() : string.Empty;
 
 		if (!double.TryParse(numberPart,
-			NumberStyles.Float | NumberStyles.AllowThousands,
-			CultureInfo.InvariantCulture,
-			out double number))
+			    NumberStyles.Float | NumberStyles.AllowThousands,
+			    CultureInfo.InvariantCulture,
+			    out double number))
 		{
 			return false;
 		}

--- a/Pipeline/BenchmarkReport.cs
+++ b/Pipeline/BenchmarkReport.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -14,8 +14,7 @@ namespace Build;
 )]
 partial class Build : NukeBuild
 {
-	[Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
-	readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
+	[Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")] readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Pipeline/Directory.Build.props
+++ b/Pipeline/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
 </Project>

--- a/Source/Mockolate.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Mockolate.Analyzers/AnalyzerReleases.Shipped.md
@@ -2,8 +2,8 @@
 
 ### New Rules
 
- Rule ID       | Category | Severity | Notes                           
----------------|----------|----------|---------------------------------
- Mockolate0001 | Usage    | Error    | Verifications must be used      
- Mockolate0002 | Usage    | Error    | Mock arguments must be mockable 
- Mockolate0003 | Usage    | Warning  | Ref-struct parameter mocking not supported on this build
+ Rule ID       | Category | Severity | Notes                                                    
+---------------|----------|----------|----------------------------------------------------------
+ Mockolate0001 | Usage    | Error    | Verifications must be used                               
+ Mockolate0002 | Usage    | Error    | Mock arguments must be mockable                          
+ Mockolate0003 | Usage    | Warning  | Ref-struct parameter mocking not supported on this build 

--- a/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
+++ b/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/Mockolate.SourceGenerators/Entities/Attribute.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Attribute.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -174,6 +174,25 @@ internal class Class : IEquatable<Class>
 	public string DisplayString { get; }
 
 	/// <summary>
+	///     Equality is keyed on <see cref="ClassFullName" /> plus a content-derived hash of the
+	///     member surface (<see cref="ComputeSurfaceHash" />). The full name alone is necessary
+	///     but not sufficient as a Roslyn incremental cache key: across edits, a target type can
+	///     keep its name while its members change, and a name-only comparison would let Roslyn
+	///     skip downstream stages and persist stale generated source. Folding the surface into a
+	///     precomputed hash keeps the comparison O(1) on the cache hot path while still
+	///     invalidating on any change to the emitted member set. Hash collisions are theoretically
+	///     possible but the leaf entities (<see cref="Method" />, <see cref="Property" />, and
+	///     <see cref="Event" />) are records with content-based hashes that propagate through
+	///     <see cref="EquatableArray{T}" />, so different surfaces almost always hash apart.
+	/// </summary>
+	public virtual bool Equals(Class? other)
+		=> ReferenceEquals(this, other) ||
+		   (other is not null &&
+		    GetType() == other.GetType() &&
+		    _surfaceHash == other._surfaceHash &&
+		    ClassFullName == other.ClassFullName);
+
+	/// <summary>
 	///     Folds the member surface (methods, properties, events, recursive base/interface chain,
 	///     reserved names, kind, required-member flag) into a single content-derived integer.
 	///     Roslyn's incremental cache uses <see cref="Equals(Class?)" /> to decide whether a
@@ -501,25 +520,6 @@ internal class Class : IEquatable<Class>
 
 		return _classNameWithoutDots = sb.ToString();
 	}
-
-	/// <summary>
-	///     Equality is keyed on <see cref="ClassFullName" /> plus a content-derived hash of the
-	///     member surface (<see cref="ComputeSurfaceHash" />). The full name alone is necessary
-	///     but not sufficient as a Roslyn incremental cache key: across edits, a target type can
-	///     keep its name while its members change, and a name-only comparison would let Roslyn
-	///     skip downstream stages and persist stale generated source. Folding the surface into a
-	///     precomputed hash keeps the comparison O(1) on the cache hot path while still
-	///     invalidating on any change to the emitted member set. Hash collisions are theoretically
-	///     possible but the leaf entities (<see cref="Method" />, <see cref="Property" />, and
-	///     <see cref="Event" />) are records with content-based hashes that propagate through
-	///     <see cref="EquatableArray{T}" />, so different surfaces almost always hash apart.
-	/// </summary>
-	public virtual bool Equals(Class? other)
-		=> ReferenceEquals(this, other) ||
-		   (other is not null &&
-		    GetType() == other.GetType() &&
-		    _surfaceHash == other._surfaceHash &&
-		    ClassFullName == other.ClassFullName);
 
 	public override bool Equals(object? obj) => Equals(obj as Class);
 

--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 

--- a/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/GenericParameter.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -74,19 +74,6 @@ internal record Method
 	public string? ExplicitImplementation { get; }
 	public EquatableArray<Attribute>? Attributes { get; }
 
-	internal string GetUniqueNameString()
-	{
-		if (GenericParameters != null)
-		{
-			string name = Name.Substring(0, Name.IndexOf('<'));
-			string parameters = string.Join(", ",
-				GenericParameters.Value.Select(genericParameter => $"{{typeof({genericParameter.Name})}}"));
-			return $"$\"{ContainingType}.{name}<{parameters}>\"";
-		}
-
-		return $"\"{ContainingType}.{Name}\"";
-	}
-
 	/// <summary>
 	///     A method has an unsupported <c>allows ref struct</c> type parameter when one of its
 	///     own generic parameters declares the anti-constraint <i>and</i> is referenced in the
@@ -127,6 +114,19 @@ internal record Method
 
 			return false;
 		}
+	}
+
+	internal string GetUniqueNameString()
+	{
+		if (GenericParameters != null)
+		{
+			string name = Name.Substring(0, Name.IndexOf('<'));
+			string parameters = string.Join(", ",
+				GenericParameters.Value.Select(genericParameter => $"{{typeof({genericParameter.Name})}}"));
+			return $"$\"{ContainingType}.{name}<{parameters}>\"";
+		}
+
+		return $"\"{ContainingType}.{Name}\"";
 	}
 
 	private static bool ContainsAnyTypeParameter(string text, GenericParameter[] genericParameters)

--- a/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/MockClass.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 
@@ -35,15 +34,6 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 
 	public EquatableArray<Class> AdditionalImplementations { get; }
 
-	public IEnumerable<Class> AllImplementations()
-	{
-		yield return this;
-		foreach (Class additionalImplementation in AdditionalImplementations)
-		{
-			yield return additionalImplementation;
-		}
-	}
-
 	/// <summary>
 	///     MockClass equality is keyed on <see cref="Class.ClassFullName" /> plus a content-derived
 	///     hash that folds the base surface together with the mock-only fields
@@ -57,6 +47,15 @@ internal sealed class MockClass : Class, IEquatable<MockClass>
 		   (other is not null &&
 		    _mockSurfaceHash == other._mockSurfaceHash &&
 		    ClassFullName == other.ClassFullName);
+
+	public IEnumerable<Class> AllImplementations()
+	{
+		yield return this;
+		foreach (Class additionalImplementation in AdditionalImplementations)
+		{
+			yield return additionalImplementation;
+		}
+	}
 
 	public override bool Equals(Class? other) => other is MockClass mc && Equals(mc);
 

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Entities;
 

--- a/Source/Mockolate.SourceGenerators/Helpers.cs
+++ b/Source/Mockolate.SourceGenerators/Helpers.cs
@@ -3,7 +3,6 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Entities;
-using Mockolate.SourceGenerators.Internals;
 using Attribute = Mockolate.SourceGenerators.Entities.Attribute;
 using Type = Mockolate.SourceGenerators.Entities.Type;
 

--- a/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
+++ b/Source/Mockolate.SourceGenerators/Internals/EntityCache.cs
@@ -51,7 +51,7 @@ internal sealed class EntityCache
 	public readonly struct Scope : IDisposable
 	{
 		private static void ExitScope(EntityCache? previous) => Current = previous;
-		
+
 		private readonly EntityCache? _previous;
 
 		internal Scope(EntityCache? previous)

--- a/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
+++ b/Source/Mockolate.SourceGenerators/MockGeneratorHelpers.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Mockolate.SourceGenerators.Entities;

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MemberIds.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text;
 using Mockolate.SourceGenerators.Entities;
 using Event = Mockolate.SourceGenerators.Entities.Event;
@@ -132,8 +131,8 @@ internal static partial class Sources
 	internal sealed class MemberIdTable
 	{
 		private readonly List<string> _declarations = new();
-		private readonly Dictionary<string, int> _usedIdentifiers = new();
 		private readonly List<(Property Property, string FieldName)> _propertyGetterAccessFields = new();
+		private readonly Dictionary<string, int> _usedIdentifiers = new();
 
 		internal Dictionary<Method, int> MethodIds { get; } = new();
 		internal Dictionary<Property, int> PropertyGetIds { get; } = new();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3645,6 +3645,51 @@ internal static partial class Sources
 		return result;
 	}
 
+	// Priority hierarchy among same-arity overloads emitted for one method:
+	//   all-values            : int.MaxValue       (so `Method(default, …)` binds here and exposes `.AnyParameters()`)
+	//   IParameters           : int.MaxValue - 1
+	//   pure IParameter<T>?   : parameterCount     (just below all-values, above any mixed combo)
+	//   mixed                 : count of non-value (matcher) params, in [1, parameterCount - 1]
+	// parameterCount == 0 returns int.MaxValue so the lone zero-arg overload keeps its historical priority.
+	private static string ComputeMethodOverloadPriority(bool useParameters, bool[]? valueFlags, int parameterCount)
+	{
+		if (parameterCount == 0)
+		{
+			return "int.MaxValue";
+		}
+
+		if (useParameters)
+		{
+			return "int.MaxValue - 1";
+		}
+
+		if (valueFlags is null)
+		{
+			return parameterCount.ToString();
+		}
+
+		return valueFlags.Count(x => !x).ToString();
+	}
+
+	// Object-typed parameters defeat the all-values bump: every reference type — including the
+	// IParameter<T>? matcher itself — implicitly converts to object, so promoting `Method(object?)` over
+	// `Method(IParameter<object?>?)` would silently capture matcher instances as raw values. Detect that case
+	// here and skip the priority bump so callers keep using Match.AnyParameters() / It.IsAny<object?>().
+	private static bool ParametersBlockAllValuesPromotion(EquatableArray<MethodParameter> parameters,
+		bool[] valueFlags)
+	{
+		ReadOnlySpan<MethodParameter> span = parameters.AsSpan();
+		for (int i = 0; i < span.Length; i++)
+		{
+			if (valueFlags[i] && span[i].Type.SpecialType == SpecialType.System_Object)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static void DefineSetupInterface(StringBuilder sb, Class @class, MemberType memberType,
 		bool hasOverloadResolutionPriority)
 	{
@@ -3881,6 +3926,14 @@ internal static partial class Sources
 		{
 			if (valueFlags?.All(x => x) == true)
 			{
+				if (hasOverloadResolutionPriority &&
+				    !ParametersBlockAllValuesPromotion(method.Parameters, valueFlags))
+				{
+					sb.Append(
+							"\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]")
+						.AppendLine();
+				}
+
 				sb.Append("\t\tglobal::Mockolate.Setup.IReturnMethodSetupParameterIgnorer");
 			}
 			else
@@ -3888,7 +3941,8 @@ internal static partial class Sources
 				if (hasOverloadResolutionPriority)
 				{
 					sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(")
-						.Append(valueFlags?.Count(x => !x).ToString() ?? "int.MaxValue").Append(")]").AppendLine();
+						.Append(ComputeMethodOverloadPriority(useParameters, valueFlags, method.Parameters.Count))
+						.Append(")]").AppendLine();
 				}
 
 				sb.Append(method.Parameters.Count > 0
@@ -3910,6 +3964,14 @@ internal static partial class Sources
 		{
 			if (valueFlags?.All(x => x) == true)
 			{
+				if (hasOverloadResolutionPriority &&
+				    !ParametersBlockAllValuesPromotion(method.Parameters, valueFlags))
+				{
+					sb.Append(
+							"\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]")
+						.AppendLine();
+				}
+
 				sb.Append("\t\tglobal::Mockolate.Setup.IVoidMethodSetupParameterIgnorer");
 			}
 			else
@@ -3917,7 +3979,8 @@ internal static partial class Sources
 				if (hasOverloadResolutionPriority)
 				{
 					sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(")
-						.Append(valueFlags?.Count(x => !x).ToString() ?? "int.MaxValue").Append(")]").AppendLine();
+						.Append(ComputeMethodOverloadPriority(useParameters, valueFlags, method.Parameters.Count))
+						.Append(")]").AppendLine();
 				}
 
 				sb.Append(method.Parameters.Count > 0
@@ -5532,6 +5595,13 @@ internal static partial class Sources
 			valueFlags, true);
 		if (valueFlags?.All(x => x) == true || (method.Parameters.Count == 0 && !useParameters))
 		{
+			if (hasOverloadResolutionPriority && method.Parameters.Count > 0 && valueFlags is not null &&
+			    !ParametersBlockAllValuesPromotion(method.Parameters, valueFlags))
+			{
+				sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]")
+					.AppendLine();
+			}
+
 			sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<").Append(verifyName)
 				.Append(">.IgnoreParameters ").Append(methodName).Append("(");
 		}
@@ -5540,7 +5610,8 @@ internal static partial class Sources
 			if (hasOverloadResolutionPriority)
 			{
 				sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(")
-					.Append(valueFlags?.Count(x => !x).ToString() ?? "int.MaxValue").Append(")]").AppendLine();
+					.Append(ComputeMethodOverloadPriority(useParameters, valueFlags, method.Parameters.Count))
+					.Append(")]").AppendLine();
 			}
 
 			sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<").Append(verifyName).Append("> ")

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Mockolate.SourceGenerators.Entities;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Sources;
 

--- a/Source/Mockolate/Interactions/FastEventBuffer.cs
+++ b/Source/Mockolate/Interactions/FastEventBuffer.cs
@@ -136,4 +136,3 @@ public sealed class FastEventBuffer : IFastMemberBuffer
 		public IInteraction? Boxed;
 	}
 }
-

--- a/Source/Mockolate/Interactions/FastIndexerBuffer.cs
+++ b/Source/Mockolate/Interactions/FastIndexerBuffer.cs
@@ -1099,4 +1099,3 @@ public sealed class FastIndexerSetterBuffer<T1, T2, T3, T4, TValue> : IFastMembe
 		public IInteraction? Boxed;
 	}
 }
-

--- a/Source/Mockolate/Interactions/FastMethodBuffer.cs
+++ b/Source/Mockolate/Interactions/FastMethodBuffer.cs
@@ -637,4 +637,3 @@ public sealed class FastMethod4Buffer<T1, T2, T3, T4> : IFastMemberBuffer
 		public IInteraction? Boxed;
 	}
 }
-

--- a/Source/Mockolate/Interactions/FastMockInteractions.cs
+++ b/Source/Mockolate/Interactions/FastMockInteractions.cs
@@ -30,7 +30,7 @@ public class FastMockInteractions : IMockInteractions
 	/// <summary>
 	///     Creates a new <see cref="FastMockInteractions" /> sized to <paramref name="memberCount" />.
 	///     Each mockable member's buffer slot starts empty and is materialized lazily on first access via
-	///     <see cref="GetOrCreateBuffer{TBuffer}(int, Func{FastMockInteractions, TBuffer})" />.
+	///     <see cref="GetOrCreateBuffer{TBuffer}(int, System.Func{Mockolate.Interactions.FastMockInteractions,TBuffer})" />.
 	/// </summary>
 	/// <param name="memberCount">The number of distinct mockable members the buffer array should hold.</param>
 	/// <param name="skipInteractionRecording">Mirrors <see cref="MockBehavior.SkipInteractionRecording" />.</param>

--- a/Source/Mockolate/Interactions/FastPropertyBuffer.cs
+++ b/Source/Mockolate/Interactions/FastPropertyBuffer.cs
@@ -245,4 +245,3 @@ public sealed class FastPropertySetterBuffer<T> : IFastMemberBuffer
 		public IInteraction? Boxed;
 	}
 }
-

--- a/Source/Mockolate/It.Is.cs
+++ b/Source/Mockolate/It.Is.cs
@@ -47,7 +47,7 @@ public partial class It
 	/// <returns>A parameter matcher whose diagnostic string is computed lazily.</returns>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static IIsParameter<T> IsValue<T>(T value)
-		=> new ParameterEqualsMatch<T>(value, valueExpression: null);
+		=> new ParameterEqualsMatch<T>(value, null);
 
 	/// <summary>
 	///     An <see cref="IParameter{T}" /> used for equality comparison, with an opt-in custom comparer.
@@ -73,9 +73,9 @@ public partial class It
 	private sealed class ParameterEqualsMatch<T> : TypedMatch<T>, IIsParameter<T>
 	{
 		private readonly T _value;
-		private string? _valueExpression;
 		private IEqualityComparer<T>? _comparer;
 		private string? _comparerExpression;
+		private string? _valueExpression;
 
 		/// <summary>
 		///     Constructs an equality matcher for <paramref name="value" />. When

--- a/Source/Mockolate/Verify/VerificationPropertyResult.cs
+++ b/Source/Mockolate/Verify/VerificationPropertyResult.cs
@@ -7,7 +7,7 @@ namespace Mockolate.Verify;
 ///     Verifications on a property of type <typeparamref name="TParameter" />.
 /// </summary>
 #if !DEBUG
-[DebuggerNonUserCode]
+[System.Diagnostics.DebuggerNonUserCode]
 #endif
 public class VerificationPropertyResult<TSubject, TParameter>
 {

--- a/Source/Mockolate/Verify/VerificationPropertyResult.cs
+++ b/Source/Mockolate/Verify/VerificationPropertyResult.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Mockolate.Parameters;
 
@@ -61,7 +60,8 @@ public class VerificationPropertyResult<TSubject, TParameter>
 	/// </summary>
 	[OverloadResolutionPriority(1)]
 	public VerificationResult<TSubject> Set(TParameter value,
-		[CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
 		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName,
 			It.Is(value, doNotPopulateThisValue).AsParameterMatch());
 }

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Mockolate.Exceptions;

--- a/Source/Mockolate/Verify/VerificationResultExtensions.cs
+++ b/Source/Mockolate/Verify/VerificationResultExtensions.cs
@@ -18,7 +18,7 @@ namespace Mockolate.Verify;
 ///     interactions produced on a background thread.
 /// </remarks>
 #if !DEBUG
-[DebuggerNonUserCode]
+[System.Diagnostics.DebuggerNonUserCode]
 #endif
 public static class VerificationResultExtensions
 {

--- a/Tests/Build.Tests/BuildBodyTests.cs
+++ b/Tests/Build.Tests/BuildBodyTests.cs
@@ -129,26 +129,6 @@ public sealed class BuildBodyTests
 	}
 
 	[Fact]
-	public async Task BuildBody_WhenTableHasEmptyRowSeparatingParameterGroups_ShouldNotEmitBareSeparator()
-	{
-		string[] report =
-		[
-			"| Method | N | Mean | Allocated |",
-			"|--------|---|-----:|----------:|",
-			"| Indexer_Mockolate | 1 | 100 ns | 1 KB |",
-			"| Indexer_Moq | 1 | 200 ns | 2 KB |",
-			"|         |   |      |          |",
-			"| Indexer_Mockolate | 10 | 1000 ns | 10 KB |",
-			"| Indexer_Moq | 10 | 2000 ns | 20 KB |",
-		];
-		BenchmarkReportFile file = new(report, null);
-
-		string body = BenchmarkReport.BuildBody([file,], _columnsToRemove);
-
-		await That(body).DoesNotContain($"{Environment.NewLine}|{Environment.NewLine}");
-	}
-
-	[Fact]
 	public async Task BuildBody_WhenTableHasEmptyRowSeparatingParameterGroups_ShouldEmitEmptyRowMatchingHeaderColumnCount()
 	{
 		string[] report =
@@ -171,6 +151,26 @@ public sealed class BuildBodyTests
 		await That(firstGroupLast).IsGreaterThan(-1);
 		await That(secondGroupFirst).IsGreaterThan(firstGroupLast);
 		await That(lines[firstGroupLast + 1]).IsEqualTo("|  |  |  |  |");
+	}
+
+	[Fact]
+	public async Task BuildBody_WhenTableHasEmptyRowSeparatingParameterGroups_ShouldNotEmitBareSeparator()
+	{
+		string[] report =
+		[
+			"| Method | N | Mean | Allocated |",
+			"|--------|---|-----:|----------:|",
+			"| Indexer_Mockolate | 1 | 100 ns | 1 KB |",
+			"| Indexer_Moq | 1 | 200 ns | 2 KB |",
+			"|         |   |      |          |",
+			"| Indexer_Mockolate | 10 | 1000 ns | 10 KB |",
+			"| Indexer_Moq | 10 | 2000 ns | 20 KB |",
+		];
+		BenchmarkReportFile file = new(report, null);
+
+		string body = BenchmarkReport.BuildBody([file,], _columnsToRemove);
+
+		await That(body).DoesNotContain($"{Environment.NewLine}|{Environment.NewLine}");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Analyzers.Tests/AnalyzerHelpersTests.cs
+++ b/Tests/Mockolate.Analyzers.Tests/AnalyzerHelpersTests.cs
@@ -12,76 +12,19 @@ namespace Mockolate.Analyzers.Tests;
 public class AnalyzerHelpersTests
 {
 	[Fact]
-	public async Task WhenInvokedMethodIsNotGeneric_ShouldNotReturnAnyTypeArgument()
-	{
-		const string source = """
-			public class C
-			{
-				public void Foo() { }
-				public void Bar() { Foo(); }
-			}
-			""";
-		IMethodSymbol method = GetInvokedMethod(source, "Foo");
-
-		ITypeSymbol? result = AnalyzerHelpers.GetSingleInvocationTypeArgumentOrNull(method);
-
-		await That(result).IsNull();
-	}
-
-	[Fact]
-	public async Task WhenInvokedMethodIsGeneric_ShouldReturnFirstTypeArgument()
-	{
-		const string source = """
-			public class C
-			{
-				public T Foo<T>() => default!;
-				public void Bar() { Foo<int>(); }
-			}
-			""";
-		IMethodSymbol method = GetInvokedMethod(source, "Foo");
-
-		ITypeSymbol? result = AnalyzerHelpers.GetSingleInvocationTypeArgumentOrNull(method);
-
-		await That(result).IsNotNull();
-		await That(result!.SpecialType).IsEqualTo(SpecialType.System_Int32);
-	}
-
-	[Fact]
-	public async Task WhenSyntaxIsNotInvocationExpression_ShouldNotReturnAnyLocation()
-	{
-		const string source = """
-			public class C
-			{
-				public int Foo() => 0;
-			}
-			""";
-		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
-		CSharpCompilation compilation = CreateCompilation(tree);
-		SemanticModel model = compilation.GetSemanticModel(tree);
-		MethodDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
-			.OfType<MethodDeclarationSyntax>()
-			.Single();
-		IMethodSymbol symbol = (IMethodSymbol)model.GetDeclaredSymbol(declaration)!;
-
-		Location? result = AnalyzerHelpers.GetTypeArgumentLocation(declaration, symbol.ReturnType);
-
-		await That(result).IsNull();
-	}
-
-	[Fact]
 	public async Task WhenInvocationHasGenericNameSyntax_ShouldReturnTypeArgumentLocation()
 	{
 		const string source = """
-			public static class S
-			{
-				public static T Make<T>() => default!;
-			}
+		                      public static class S
+		                      {
+		                      	public static T Make<T>() => default!;
+		                      }
 
-			public class C
-			{
-				public void Foo() { S.Make<int>(); }
-			}
-			""";
+		                      public class C
+		                      {
+		                      	public void Foo() { S.Make<int>(); }
+		                      }
+		                      """;
 		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
 		CSharpCompilation compilation = CreateCompilation(tree);
 		SemanticModel model = compilation.GetSemanticModel(tree);
@@ -94,6 +37,63 @@ public class AnalyzerHelpersTests
 		Location? result = AnalyzerHelpers.GetTypeArgumentLocation(invocation, typeArgument);
 
 		await That(result).IsNotNull();
+	}
+
+	[Fact]
+	public async Task WhenInvokedMethodIsGeneric_ShouldReturnFirstTypeArgument()
+	{
+		const string source = """
+		                      public class C
+		                      {
+		                      	public T Foo<T>() => default!;
+		                      	public void Bar() { Foo<int>(); }
+		                      }
+		                      """;
+		IMethodSymbol method = GetInvokedMethod(source, "Foo");
+
+		ITypeSymbol? result = AnalyzerHelpers.GetSingleInvocationTypeArgumentOrNull(method);
+
+		await That(result).IsNotNull();
+		await That(result!.SpecialType).IsEqualTo(SpecialType.System_Int32);
+	}
+
+	[Fact]
+	public async Task WhenInvokedMethodIsNotGeneric_ShouldNotReturnAnyTypeArgument()
+	{
+		const string source = """
+		                      public class C
+		                      {
+		                      	public void Foo() { }
+		                      	public void Bar() { Foo(); }
+		                      }
+		                      """;
+		IMethodSymbol method = GetInvokedMethod(source, "Foo");
+
+		ITypeSymbol? result = AnalyzerHelpers.GetSingleInvocationTypeArgumentOrNull(method);
+
+		await That(result).IsNull();
+	}
+
+	[Fact]
+	public async Task WhenSyntaxIsNotInvocationExpression_ShouldNotReturnAnyLocation()
+	{
+		const string source = """
+		                      public class C
+		                      {
+		                      	public int Foo() => 0;
+		                      }
+		                      """;
+		SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+		CSharpCompilation compilation = CreateCompilation(tree);
+		SemanticModel model = compilation.GetSemanticModel(tree);
+		MethodDeclarationSyntax declaration = tree.GetRoot().DescendantNodes()
+			.OfType<MethodDeclarationSyntax>()
+			.Single();
+		IMethodSymbol symbol = (IMethodSymbol)model.GetDeclaredSymbol(declaration)!;
+
+		Location? result = AnalyzerHelpers.GetTypeArgumentLocation(declaration, symbol.ReturnType);
+
+		await That(result).IsNull();
 	}
 
 	private static IMethodSymbol GetInvokedMethod(string source, string methodName)

--- a/Tests/Mockolate.SourceGenerators.Tests/Entities/PropertyEqualityComparerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Entities/PropertyEqualityComparerTests.cs
@@ -79,10 +79,10 @@ public class PropertyEqualityComparerTests
 	}
 
 	private static Property CreateProperty(string source, string propertyName)
-		=> new Property(ParsePropertySymbol(source, propertyName, false), null);
+		=> new(ParsePropertySymbol(source, propertyName, false), null);
 
 	private static Property CreateIndexer(string source)
-		=> new Property(ParsePropertySymbol(source, null, true), null);
+		=> new(ParsePropertySymbol(source, null, true), null);
 
 	private static IPropertySymbol ParsePropertySymbol(string source, string? propertyName, bool isIndexer)
 	{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Mockolate.SourceGenerators.Entities;
-using Mockolate.SourceGenerators.Internals;
 
 namespace Mockolate.SourceGenerators.Tests;
 

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
@@ -7,6 +7,33 @@ public sealed partial class MockTests
 		public sealed class EventsTests
 		{
 			[Fact]
+			public async Task EventWithRefOutDelegate_ShouldPreserveModifiersOnRaise()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = IMyService.CreateMock();
+					         }
+					     }
+
+					     public delegate void MyEventDelegate(ref int value, out string message);
+
+					     public interface IMyService
+					     {
+					         event MyEventDelegate SomeEvent;
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+			}
+
+			[Fact]
 			public async Task MultipleImplementations_ShouldOnlyHaveOneExplicitImplementation()
 			{
 				GeneratorResult result = Generator
@@ -449,33 +476,6 @@ public sealed partial class MockTests
 					          			}
 					          		}
 					          """).IgnoringNewlineStyle();
-			}
-
-			[Fact]
-			public async Task EventWithRefOutDelegate_ShouldPreserveModifiersOnRaise()
-			{
-				GeneratorResult result = Generator
-					.Run("""
-					     using Mockolate;
-
-					     namespace MyCode;
-					     public class Program
-					     {
-					         public static void Main(string[] args)
-					         {
-					     		_ = IMyService.CreateMock();
-					         }
-					     }
-
-					     public delegate void MyEventDelegate(ref int value, out string message);
-
-					     public interface IMyService
-					     {
-					         event MyEventDelegate SomeEvent;
-					     }
-					     """);
-
-				await That(result.Diagnostics).IsEmpty();
 			}
 		}
 	}

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -232,28 +232,31 @@ internal static partial class Mock
 		internal const int MemberId_WithDefaults = 24;
 		internal const int MemberId_WithCollidingNames = 25;
 		internal const int MemberId_GetMaybeNull = 26;
-		internal const int MemberId_DoTask = 27;
-		internal const int MemberId_DoTaskOf = 28;
-		internal const int MemberId_DoVT = 29;
-		internal const int MemberId_DoVTOf = 30;
-		internal const int MemberId_GetTuple = 31;
-		internal const int MemberId_GetNullable = 32;
-		internal const int MemberId_GetSpan = 33;
-		internal const int MemberId_GetROSpan = 34;
-		internal const int MemberId_GetByRef = 35;
-		internal const int MemberId_GetByRefReadonly = 36;
-		internal const int MemberId_G1_T_ = 37;
-		internal const int MemberId_G2_T_ = 38;
-		internal const int MemberId_G3_T_ = 39;
-		internal const int MemberId_G4_T_ = 40;
-		internal const int MemberId_G5_T_ = 41;
-		internal const int MemberId_G6_T_ = 42;
-		internal const int MemberId_G7_T_ = 43;
-		internal const int MemberId_G8_T_ = 44;
-		internal const int MemberId_Five = 45;
-		internal const int MemberId_Seventeen = 46;
-		internal const int MemberId_SeventeenVoid = 47;
-		internal const int MemberCount = 48;
+		internal const int MemberId_TakeObject = 27;
+		internal const int MemberId_TakeTwoObjects = 28;
+		internal const int MemberId_TakeIntAndObject = 29;
+		internal const int MemberId_DoTask = 30;
+		internal const int MemberId_DoTaskOf = 31;
+		internal const int MemberId_DoVT = 32;
+		internal const int MemberId_DoVTOf = 33;
+		internal const int MemberId_GetTuple = 34;
+		internal const int MemberId_GetNullable = 35;
+		internal const int MemberId_GetSpan = 36;
+		internal const int MemberId_GetROSpan = 37;
+		internal const int MemberId_GetByRef = 38;
+		internal const int MemberId_GetByRefReadonly = 39;
+		internal const int MemberId_G1_T_ = 40;
+		internal const int MemberId_G2_T_ = 41;
+		internal const int MemberId_G3_T_ = 42;
+		internal const int MemberId_G4_T_ = 43;
+		internal const int MemberId_G5_T_ = 44;
+		internal const int MemberId_G6_T_ = 45;
+		internal const int MemberId_G7_T_ = 46;
+		internal const int MemberId_G8_T_ = 47;
+		internal const int MemberId_Five = 48;
+		internal const int MemberId_Seventeen = 49;
+		internal const int MemberId_SeventeenVoid = 50;
+		internal const int MemberCount = 51;
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_GetSet_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSet");
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_GetOnly_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly");
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_SetOnly_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly");
@@ -303,6 +306,15 @@ internal static partial class Mock
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		private global::Mockolate.Interactions.FastMethod1Buffer<string?> MockolateBuffer_GetMaybeNull
 			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastMethod1Buffer<string?>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, static fast => new global::Mockolate.Interactions.FastMethod1Buffer<string?>(fast)));
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		private global::Mockolate.Interactions.FastMethod1Buffer<object?> MockolateBuffer_TakeObject
+			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastMethod1Buffer<object?>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, static fast => new global::Mockolate.Interactions.FastMethod1Buffer<object?>(fast)));
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		private global::Mockolate.Interactions.FastMethod2Buffer<object?, object?> MockolateBuffer_TakeTwoObjects
+			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastMethod2Buffer<object?, object?>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, static fast => new global::Mockolate.Interactions.FastMethod2Buffer<object?, object?>(fast)));
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		private global::Mockolate.Interactions.FastMethod2Buffer<int, object?> MockolateBuffer_TakeIntAndObject
+			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastMethod2Buffer<int, object?>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, static fast => new global::Mockolate.Interactions.FastMethod2Buffer<int, object?>(fast)));
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		private global::Mockolate.Interactions.FastMethod0Buffer MockolateBuffer_DoTask
 			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastMethod0Buffer>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_DoTask, static fast => new global::Mockolate.Interactions.FastMethod0Buffer(fast)));
@@ -978,6 +990,183 @@ internal static partial class Mock
 				return wrappedResult;
 			}
 			return methodSetup?.TryGetReturnValue(s, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(string?)!, s);
+		}
+
+		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)" />
+		public bool TakeObject(object? obj)
+		{
+			global::Mockolate.Setup.ReturnMethodSetup<bool, object?>? methodSetup = null;
+			if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
+			{
+				global::Mockolate.Setup.MethodSetup[]? snapshot_methodSetup = this.MockRegistry.GetMethodSetupSnapshot(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject);
+				if (snapshot_methodSetup is not null)
+				{
+					for (int i_methodSetup = snapshot_methodSetup.Length - 1; i_methodSetup >= 0; i_methodSetup--)
+					{
+						if (snapshot_methodSetup[i_methodSetup] is global::Mockolate.Setup.ReturnMethodSetup<bool, object?> s_methodSetup && s_methodSetup.Matches(obj))
+						{
+							methodSetup = s_methodSetup;
+							break;
+						}
+					}
+				}
+			}
+			if (methodSetup is null)
+			{
+				foreach (global::Mockolate.Setup.ReturnMethodSetup<bool, object?> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<bool, object?>>("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject"))
+				{
+					if (s_methodSetup.Matches(obj))
+					{
+						methodSetup = s_methodSetup;
+						break;
+					}
+				}
+			}
+			bool hasWrappedResult = false;
+			bool wrappedResult = default!;
+			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+			{
+				this.MockolateBuffer_TakeObject.Append("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj);
+			}
+			try
+			{
+				if (this.MockRegistry.Wraps is global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
+				{
+					wrappedResult = wraps.TakeObject(obj);
+					hasWrappedResult = true;
+				}
+			}
+			finally
+			{
+				methodSetup?.TriggerCallbacks(obj);
+			}
+			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
+			{
+				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)' was invoked without prior setup.");
+			}
+			if (methodSetup?.HasReturnCallbacks != true && hasWrappedResult)
+			{
+				return wrappedResult;
+			}
+			return methodSetup?.TryGetReturnValue(obj, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(bool)!, obj);
+		}
+
+		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)" />
+		public int TakeTwoObjects(object? first, object? second)
+		{
+			global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>? methodSetup = null;
+			if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
+			{
+				global::Mockolate.Setup.MethodSetup[]? snapshot_methodSetup = this.MockRegistry.GetMethodSetupSnapshot(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects);
+				if (snapshot_methodSetup is not null)
+				{
+					for (int i_methodSetup = snapshot_methodSetup.Length - 1; i_methodSetup >= 0; i_methodSetup--)
+					{
+						if (snapshot_methodSetup[i_methodSetup] is global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?> s_methodSetup && s_methodSetup.Matches(first, second))
+						{
+							methodSetup = s_methodSetup;
+							break;
+						}
+					}
+				}
+			}
+			if (methodSetup is null)
+			{
+				foreach (global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>>("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects"))
+				{
+					if (s_methodSetup.Matches(first, second))
+					{
+						methodSetup = s_methodSetup;
+						break;
+					}
+				}
+			}
+			bool hasWrappedResult = false;
+			int wrappedResult = default!;
+			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+			{
+				this.MockolateBuffer_TakeTwoObjects.Append("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", first, second);
+			}
+			try
+			{
+				if (this.MockRegistry.Wraps is global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
+				{
+					wrappedResult = wraps.TakeTwoObjects(first, second);
+					hasWrappedResult = true;
+				}
+			}
+			finally
+			{
+				methodSetup?.TriggerCallbacks(first, second);
+			}
+			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
+			{
+				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)' was invoked without prior setup.");
+			}
+			if (methodSetup?.HasReturnCallbacks != true && hasWrappedResult)
+			{
+				return wrappedResult;
+			}
+			return methodSetup?.TryGetReturnValue(first, second, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, first, second);
+		}
+
+		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)" />
+		public int TakeIntAndObject(int n, object? obj)
+		{
+			global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>? methodSetup = null;
+			if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
+			{
+				global::Mockolate.Setup.MethodSetup[]? snapshot_methodSetup = this.MockRegistry.GetMethodSetupSnapshot(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject);
+				if (snapshot_methodSetup is not null)
+				{
+					for (int i_methodSetup = snapshot_methodSetup.Length - 1; i_methodSetup >= 0; i_methodSetup--)
+					{
+						if (snapshot_methodSetup[i_methodSetup] is global::Mockolate.Setup.ReturnMethodSetup<int, int, object?> s_methodSetup && s_methodSetup.Matches(n, obj))
+						{
+							methodSetup = s_methodSetup;
+							break;
+						}
+					}
+				}
+			}
+			if (methodSetup is null)
+			{
+				foreach (global::Mockolate.Setup.ReturnMethodSetup<int, int, object?> s_methodSetup in this.MockRegistry.GetMethodSetups<global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>>("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject"))
+				{
+					if (s_methodSetup.Matches(n, obj))
+					{
+						methodSetup = s_methodSetup;
+						break;
+					}
+				}
+			}
+			bool hasWrappedResult = false;
+			int wrappedResult = default!;
+			if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+			{
+				this.MockolateBuffer_TakeIntAndObject.Append("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", n, obj);
+			}
+			try
+			{
+				if (this.MockRegistry.Wraps is global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
+				{
+					wrappedResult = wraps.TakeIntAndObject(n, obj);
+					hasWrappedResult = true;
+				}
+			}
+			finally
+			{
+				methodSetup?.TriggerCallbacks(n, obj);
+			}
+			if (methodSetup is null && !hasWrappedResult && this.MockRegistry.Behavior.ThrowWhenNotSetup)
+			{
+				throw new global::Mockolate.Exceptions.MockNotSetupException("The method 'global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)' was invoked without prior setup.");
+			}
+			if (methodSetup?.HasReturnCallbacks != true && hasWrappedResult)
+			{
+				return wrappedResult;
+			}
+			return methodSetup?.TryGetReturnValue(n, obj, out var returnValue) == true ? returnValue : this.MockRegistry.Behavior.DefaultValue.Generate(default(int)!, n, obj);
 		}
 
 		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask()" />
@@ -2442,6 +2631,110 @@ internal static partial class Mock
 		}
 
 		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameters(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", parameters, "obj");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameter<object?>? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", CovariantParameterAdapter<object?>.Wrap(obj ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(object? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameters(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", parameters, "first", "second");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, global::Mockolate.Parameters.IParameter<object?>? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", CovariantParameterAdapter<object?>.Wrap(first ?? global::Mockolate.It.IsNull<object?>("null")), CovariantParameterAdapter<object?>.Wrap(second ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(object? first, global::Mockolate.Parameters.IParameter<object?>? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(first), CovariantParameterAdapter<object?>.Wrap(second ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, object? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", CovariantParameterAdapter<object?>.Wrap(first ?? global::Mockolate.It.IsNull<object?>("null")), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(second));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(first), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(second));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameters(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", parameters, "n", "obj");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, global::Mockolate.Parameters.IParameter<object?>? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", CovariantParameterAdapter<int>.Wrap(n ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<object?>.Wrap(obj ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(int n, global::Mockolate.Parameters.IParameter<object?>? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n), CovariantParameterAdapter<object?>.Wrap(obj ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, object? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", CovariantParameterAdapter<int>.Wrap(n ?? global::Mockolate.It.IsNull<int>("null")), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetup<global::System.Threading.Tasks.Task> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.DoTask()
 		{
 			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask");
@@ -2961,6 +3254,73 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<string?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", __i => 
 				(global::System.Collections.Generic.EqualityComparer<string?>.Default.Equals(s, __i.Parameter1)), () => $"GetMaybeNull({s})");
 		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameters parameters)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => parameters switch
+				{
+					global::Mockolate.Parameters.IParametersMatch m => m.Matches([__i.Parameter1]),
+					global::Mockolate.Parameters.INamedParametersMatch m => m.Matches([("obj", __i.Parameter1)]),
+					_ => true
+				}, () => $"TakeObject({parameters})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameter<object?>? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(obj), () => $"TakeObject({obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeObject(object? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter1)), () => $"TakeObject({obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => parameters switch
+				{
+					global::Mockolate.Parameters.IParametersMatch m => m.Matches([__i.Parameter1, __i.Parameter2]),
+					global::Mockolate.Parameters.INamedParametersMatch m => m.Matches([("first", __i.Parameter1), ("second", __i.Parameter2)]),
+					_ => true
+				}, () => $"TakeTwoObjects({parameters})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, global::Mockolate.Parameters.IParameter<object?>? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", first is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(first), second is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(second), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(object? first, global::Mockolate.Parameters.IParameter<object?>? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(first, __i.Parameter1)) && 
+				(second is not null ? CovariantParameterAdapter<object?>.Wrap(second).Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(__i.Parameter2, default(object?))), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, object? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
+				(first is not null ? CovariantParameterAdapter<object?>.Wrap(first).Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(__i.Parameter1, default(object?))) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(first, __i.Parameter1)) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => parameters switch
+				{
+					global::Mockolate.Parameters.IParametersMatch m => m.Matches([__i.Parameter1, __i.Parameter2]),
+					global::Mockolate.Parameters.INamedParametersMatch m => m.Matches([("n", __i.Parameter1), ("obj", __i.Parameter2)]),
+					_ => true
+				}, () => $"TakeIntAndObject({parameters})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, global::Mockolate.Parameters.IParameter<object?>? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", n is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(n), obj is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(obj), () => $"TakeIntAndObject({n}, {obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(int n, global::Mockolate.Parameters.IParameter<object?>? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
+				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)) && 
+				(obj is not null ? CovariantParameterAdapter<object?>.Wrap(obj).Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(__i.Parameter2, default(object?))), () => $"TakeIntAndObject({n}, {obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, object? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
+				(n is not null ? CovariantParameterAdapter<int>.Wrap(n).Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
+				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
+		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.DoTask()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_DoTask, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask", () => $"DoTask()");
 		/// <inheritdoc />
@@ -3424,6 +3784,73 @@ internal static partial class Mock
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetMaybeNull(string? s)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<string?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", __i => 
 				(global::System.Collections.Generic.EqualityComparer<string?>.Default.Equals(s, __i.Parameter1)), () => $"GetMaybeNull({s})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameters parameters)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => parameters switch
+				{
+					global::Mockolate.Parameters.IParametersMatch m => m.Matches([__i.Parameter1]),
+					global::Mockolate.Parameters.INamedParametersMatch m => m.Matches([("obj", __i.Parameter1)]),
+					_ => true
+				}, () => $"TakeObject({parameters})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameter<object?>? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(obj), () => $"TakeObject({obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeObject(object? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter1)), () => $"TakeObject({obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => parameters switch
+				{
+					global::Mockolate.Parameters.IParametersMatch m => m.Matches([__i.Parameter1, __i.Parameter2]),
+					global::Mockolate.Parameters.INamedParametersMatch m => m.Matches([("first", __i.Parameter1), ("second", __i.Parameter2)]),
+					_ => true
+				}, () => $"TakeTwoObjects({parameters})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, global::Mockolate.Parameters.IParameter<object?>? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", first is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(first), second is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(second), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(object? first, global::Mockolate.Parameters.IParameter<object?>? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(first, __i.Parameter1)) && 
+				(second is not null ? CovariantParameterAdapter<object?>.Wrap(second).Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(__i.Parameter2, default(object?))), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, object? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
+				(first is not null ? CovariantParameterAdapter<object?>.Wrap(first).Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(__i.Parameter1, default(object?))) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(first, __i.Parameter1)) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => parameters switch
+				{
+					global::Mockolate.Parameters.IParametersMatch m => m.Matches([__i.Parameter1, __i.Parameter2]),
+					global::Mockolate.Parameters.INamedParametersMatch m => m.Matches([("n", __i.Parameter1), ("obj", __i.Parameter2)]),
+					_ => true
+				}, () => $"TakeIntAndObject({parameters})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, global::Mockolate.Parameters.IParameter<object?>? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", n is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(n), obj is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(obj), () => $"TakeIntAndObject({n}, {obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(int n, global::Mockolate.Parameters.IParameter<object?>? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
+				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)) && 
+				(obj is not null ? CovariantParameterAdapter<object?>.Wrap(obj).Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(__i.Parameter2, default(object?))), () => $"TakeIntAndObject({n}, {obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, object? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
+				(n is not null ? CovariantParameterAdapter<int>.Wrap(n).Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
+		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
+				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)) && 
+				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.DoTask()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_DoTask, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask", () => $"DoTask()");
@@ -3932,6 +4359,110 @@ internal static partial class Mock
 		{
 			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<string?, string?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", (global::Mockolate.Parameters.IParameterMatch<string?>)global::Mockolate.It.IsValue<string?>(s));
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameters(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", parameters, "obj");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameter<object?>? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", CovariantParameterAdapter<object?>.Wrap(obj ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(object? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameters(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", parameters, "first", "second");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, global::Mockolate.Parameters.IParameter<object?>? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", CovariantParameterAdapter<object?>.Wrap(first ?? global::Mockolate.It.IsNull<object?>("null")), CovariantParameterAdapter<object?>.Wrap(second ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(object? first, global::Mockolate.Parameters.IParameter<object?>? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(first), CovariantParameterAdapter<object?>.Wrap(second ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, object? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", CovariantParameterAdapter<object?>.Wrap(first ?? global::Mockolate.It.IsNull<object?>("null")), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(second));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(first), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(second));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameters(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", parameters, "n", "obj");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, global::Mockolate.Parameters.IParameter<object?>? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", CovariantParameterAdapter<int>.Wrap(n ?? global::Mockolate.It.IsNull<int>("null")), CovariantParameterAdapter<object?>.Wrap(obj ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(int n, global::Mockolate.Parameters.IParameter<object?>? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n), CovariantParameterAdapter<object?>.Wrap(obj ?? global::Mockolate.It.IsNull<object?>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, object? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", CovariantParameterAdapter<int>.Wrap(n ?? global::Mockolate.It.IsNull<int>("null")), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, _scenarioName, methodSetup);
 			return methodSetup;
 		}
 
@@ -4525,6 +5056,120 @@ internal static partial class Mock
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<string?, string?> GetMaybeNull(string? s);
 
 		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)">TakeObject(object?)</see> with the given <paramref name="parameters" />.
+		/// </summary>
+		/// <remarks>
+		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<bool, object?> TakeObject(global::Mockolate.Parameters.IParameters parameters);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)">TakeObject(object?)</see> with the given <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<bool, object?> TakeObject(global::Mockolate.Parameters.IParameter<object?>? obj);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)">TakeObject(object?)</see> with the given <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
+		/// </remarks>
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<bool, object?> TakeObject(object? obj);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="parameters" />.
+		/// </summary>
+		/// <remarks>
+		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, global::Mockolate.Parameters.IParameter<object?>? second);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="first" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="second" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> TakeTwoObjects(object? first, global::Mockolate.Parameters.IParameter<object?>? second);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="second" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="first" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, object?, object?> TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, object? second);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
+		/// </remarks>
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, object?, object?> TakeTwoObjects(object? first, object? second);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="parameters" />.
+		/// </summary>
+		/// <remarks>
+		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, global::Mockolate.Parameters.IParameter<object?>? obj);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="n" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="obj" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> TakeIntAndObject(int n, global::Mockolate.Parameters.IParameter<object?>? obj);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="obj" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="n" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, object?> TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, object? obj);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
+		/// </remarks>
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int, object?> TakeIntAndObject(int n, object? obj);
+
+		/// <summary>
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask()">DoTask()</see>.
 		/// </summary>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
@@ -5004,6 +5649,120 @@ internal static partial class Mock
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters GetMaybeNull(string? s);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)">TakeObject(object?)</see> with the given <paramref name="parameters"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeObject(global::Mockolate.Parameters.IParameters parameters);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)">TakeObject(object?)</see> with the given <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeObject(global::Mockolate.Parameters.IParameter<object?>? obj);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject(object?)">TakeObject(object?)</see> with the given <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
+		/// </remarks>
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters TakeObject(object? obj);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="parameters"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, global::Mockolate.Parameters.IParameter<object?>? second);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="first" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="second" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeTwoObjects(object? first, global::Mockolate.Parameters.IParameter<object?>? second);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="second" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="first" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeTwoObjects(global::Mockolate.Parameters.IParameter<object?>? first, object? second);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects(object?, object?)">TakeTwoObjects(object?, object?)</see> with the given <paramref name="first"/>, <paramref name="second"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
+		/// </remarks>
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters TakeTwoObjects(object? first, object? second);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="parameters"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, global::Mockolate.Parameters.IParameter<object?>? obj);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="n" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="obj" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeIntAndObject(int n, global::Mockolate.Parameters.IParameter<object?>? obj);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts a direct value for <paramref name="obj" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="n" />.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> TakeIntAndObject(global::Mockolate.Parameters.IParameter<int>? n, object? obj);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject(int, object?)">TakeIntAndObject(int, object?)</see> with the given <paramref name="n"/>, <paramref name="obj"/>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
+		/// </remarks>
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters TakeIntAndObject(int n, object? obj);
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask()">DoTask()</see>.

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -4404,7 +4404,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> WithModifiers(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4413,7 +4413,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(4)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, global::Mockolate.Parameters.IParameter<int[]>? tail);
 
 		/// <summary>
@@ -4449,7 +4449,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, global::Mockolate.Tests.GeneratorCoverage.MyEnum, decimal, float, char, string?, global::Mockolate.Tests.GeneratorCoverage.MyStruct> WithDefaults(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4458,7 +4458,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(7)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, global::Mockolate.Tests.GeneratorCoverage.MyEnum, decimal, float, char, string?, global::Mockolate.Tests.GeneratorCoverage.MyStruct> WithDefaults(global::Mockolate.Parameters.IParameter<int>? i = null, global::Mockolate.Parameters.IParameter<global::Mockolate.Tests.GeneratorCoverage.MyEnum>? e = null, global::Mockolate.Parameters.IParameter<decimal>? d = null, global::Mockolate.Parameters.IParameter<float>? f = null, global::Mockolate.Parameters.IParameter<char>? c = null, global::Mockolate.Parameters.IParameter<string?>? s = null, global::Mockolate.Parameters.IParameter<global::Mockolate.Tests.GeneratorCoverage.MyStruct>? st = null);
 
 		/// <summary>
@@ -4467,6 +4467,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<int, global::Mockolate.Tests.GeneratorCoverage.MyEnum, decimal, float, char, string?, global::Mockolate.Tests.GeneratorCoverage.MyStruct> WithDefaults(int i, global::Mockolate.Tests.GeneratorCoverage.MyEnum e, decimal d, float f, char c, string? s, global::Mockolate.Tests.GeneratorCoverage.MyStruct st);
 
 		/// <summary>
@@ -4475,7 +4476,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int, int, int, int> WithCollidingNames(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4484,7 +4485,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(5)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int, int, int, int> WithCollidingNames(global::Mockolate.Parameters.IParameter<int>? wraps, global::Mockolate.Parameters.IParameter<int>? result, global::Mockolate.Parameters.IParameter<int>? outParam1, global::Mockolate.Parameters.IParameter<int>? methodExecution, global::Mockolate.Parameters.IParameter<int>? returnValue);
 
 		/// <summary>
@@ -4493,6 +4494,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<int, int, int, int, int> WithCollidingNames(int wraps, int result, int outParam1, int methodExecution, int returnValue);
 
 		/// <summary>
@@ -4501,7 +4503,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<string?, string?> GetMaybeNull(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4510,7 +4512,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<string?, string?> GetMaybeNull(global::Mockolate.Parameters.IParameter<string?>? s);
 
 		/// <summary>
@@ -4519,6 +4521,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<string?, string?> GetMaybeNull(string? s);
 
 		/// <summary>
@@ -4563,7 +4566,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::Mockolate.Setup.SpanWrapper<char>, int> GetSpan(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4572,7 +4575,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::Mockolate.Setup.SpanWrapper<char>, int> GetSpan(global::Mockolate.Parameters.IParameter<int>? n);
 
 		/// <summary>
@@ -4581,6 +4584,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::Mockolate.Setup.SpanWrapper<char>, int> GetSpan(int n);
 
 		/// <summary>
@@ -4589,7 +4593,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int> GetROSpan(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4598,7 +4602,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int> GetROSpan(global::Mockolate.Parameters.IParameter<int>? n);
 
 		/// <summary>
@@ -4607,6 +4611,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int> GetROSpan(int n);
 
 		/// <summary>
@@ -4676,7 +4681,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, int, int, int, int> Five(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4685,7 +4690,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(5)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, int, int, int, int> Five(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<int>? c, global::Mockolate.Parameters.IParameter<int>? d, global::Mockolate.Parameters.IParameter<int>? e);
 
 		/// <summary>
@@ -4694,6 +4699,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int, int, int, int, int> Five(int a, int b, int c, int d, int e);
 
 		/// <summary>
@@ -4702,7 +4708,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> Seventeen(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4711,7 +4717,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(17)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> Seventeen(global::Mockolate.Parameters.IParameter<int>? a1, global::Mockolate.Parameters.IParameter<int>? a2, global::Mockolate.Parameters.IParameter<int>? a3, global::Mockolate.Parameters.IParameter<int>? a4, global::Mockolate.Parameters.IParameter<int>? a5, global::Mockolate.Parameters.IParameter<int>? a6, global::Mockolate.Parameters.IParameter<int>? a7, global::Mockolate.Parameters.IParameter<int>? a8, global::Mockolate.Parameters.IParameter<int>? a9, global::Mockolate.Parameters.IParameter<int>? a10, global::Mockolate.Parameters.IParameter<int>? a11, global::Mockolate.Parameters.IParameter<int>? a12, global::Mockolate.Parameters.IParameter<int>? a13, global::Mockolate.Parameters.IParameter<int>? a14, global::Mockolate.Parameters.IParameter<int>? a15, global::Mockolate.Parameters.IParameter<int>? a16, global::Mockolate.Parameters.IParameter<int>? a17);
 
 		/// <summary>
@@ -4720,6 +4726,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> Seventeen(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17);
 
 		/// <summary>
@@ -4728,7 +4735,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> SeventeenVoid(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4737,7 +4744,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(17)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> SeventeenVoid(global::Mockolate.Parameters.IParameter<int>? a1, global::Mockolate.Parameters.IParameter<int>? a2, global::Mockolate.Parameters.IParameter<int>? a3, global::Mockolate.Parameters.IParameter<int>? a4, global::Mockolate.Parameters.IParameter<int>? a5, global::Mockolate.Parameters.IParameter<int>? a6, global::Mockolate.Parameters.IParameter<int>? a7, global::Mockolate.Parameters.IParameter<int>? a8, global::Mockolate.Parameters.IParameter<int>? a9, global::Mockolate.Parameters.IParameter<int>? a10, global::Mockolate.Parameters.IParameter<int>? a11, global::Mockolate.Parameters.IParameter<int>? a12, global::Mockolate.Parameters.IParameter<int>? a13, global::Mockolate.Parameters.IParameter<int>? a14, global::Mockolate.Parameters.IParameter<int>? a15, global::Mockolate.Parameters.IParameter<int>? a16, global::Mockolate.Parameters.IParameter<int>? a17);
 
 		/// <summary>
@@ -4746,6 +4753,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> SeventeenVoid(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17);
 
 	}
@@ -4877,7 +4885,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithModifiers(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4886,7 +4894,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(4)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, global::Mockolate.Parameters.IParameter<int[]>? tail);
 
 		/// <summary>
@@ -4922,7 +4930,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithDefaults(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4931,7 +4939,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(7)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithDefaults(global::Mockolate.Parameters.IParameter<int>? i = null, global::Mockolate.Parameters.IParameter<global::Mockolate.Tests.GeneratorCoverage.MyEnum>? e = null, global::Mockolate.Parameters.IParameter<decimal>? d = null, global::Mockolate.Parameters.IParameter<float>? f = null, global::Mockolate.Parameters.IParameter<char>? c = null, global::Mockolate.Parameters.IParameter<string?>? s = null, global::Mockolate.Parameters.IParameter<global::Mockolate.Tests.GeneratorCoverage.MyStruct>? st = null);
 
 		/// <summary>
@@ -4940,6 +4948,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters WithDefaults(int i, global::Mockolate.Tests.GeneratorCoverage.MyEnum e, decimal d, float f, char c, string? s, global::Mockolate.Tests.GeneratorCoverage.MyStruct st);
 
 		/// <summary>
@@ -4948,7 +4957,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithCollidingNames(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4957,7 +4966,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(5)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithCollidingNames(global::Mockolate.Parameters.IParameter<int>? wraps, global::Mockolate.Parameters.IParameter<int>? result, global::Mockolate.Parameters.IParameter<int>? outParam1, global::Mockolate.Parameters.IParameter<int>? methodExecution, global::Mockolate.Parameters.IParameter<int>? returnValue);
 
 		/// <summary>
@@ -4966,6 +4975,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters WithCollidingNames(int wraps, int result, int outParam1, int methodExecution, int returnValue);
 
 		/// <summary>
@@ -4974,7 +4984,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> GetMaybeNull(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -4983,7 +4993,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> GetMaybeNull(global::Mockolate.Parameters.IParameter<string?>? s);
 
 		/// <summary>
@@ -4992,6 +5002,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters GetMaybeNull(string? s);
 
 		/// <summary>
@@ -5030,7 +5041,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> GetSpan(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -5039,7 +5050,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> GetSpan(global::Mockolate.Parameters.IParameter<int>? n);
 
 		/// <summary>
@@ -5048,6 +5059,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters GetSpan(int n);
 
 		/// <summary>
@@ -5056,7 +5068,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> GetROSpan(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -5065,7 +5077,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> GetROSpan(global::Mockolate.Parameters.IParameter<int>? n);
 
 		/// <summary>
@@ -5074,6 +5086,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters GetROSpan(int n);
 
 		/// <summary>
@@ -5140,7 +5153,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> Five(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -5149,7 +5162,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(5)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> Five(global::Mockolate.Parameters.IParameter<int>? a, global::Mockolate.Parameters.IParameter<int>? b, global::Mockolate.Parameters.IParameter<int>? c, global::Mockolate.Parameters.IParameter<int>? d, global::Mockolate.Parameters.IParameter<int>? e);
 
 		/// <summary>
@@ -5158,6 +5171,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters Five(int a, int b, int c, int d, int e);
 
 		/// <summary>
@@ -5166,7 +5180,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> Seventeen(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -5175,7 +5189,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(17)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> Seventeen(global::Mockolate.Parameters.IParameter<int>? a1, global::Mockolate.Parameters.IParameter<int>? a2, global::Mockolate.Parameters.IParameter<int>? a3, global::Mockolate.Parameters.IParameter<int>? a4, global::Mockolate.Parameters.IParameter<int>? a5, global::Mockolate.Parameters.IParameter<int>? a6, global::Mockolate.Parameters.IParameter<int>? a7, global::Mockolate.Parameters.IParameter<int>? a8, global::Mockolate.Parameters.IParameter<int>? a9, global::Mockolate.Parameters.IParameter<int>? a10, global::Mockolate.Parameters.IParameter<int>? a11, global::Mockolate.Parameters.IParameter<int>? a12, global::Mockolate.Parameters.IParameter<int>? a13, global::Mockolate.Parameters.IParameter<int>? a14, global::Mockolate.Parameters.IParameter<int>? a15, global::Mockolate.Parameters.IParameter<int>? a16, global::Mockolate.Parameters.IParameter<int>? a17);
 
 		/// <summary>
@@ -5184,6 +5198,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters Seventeen(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17);
 
 		/// <summary>
@@ -5192,7 +5207,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> SeventeenVoid(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -5201,7 +5216,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(17)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> SeventeenVoid(global::Mockolate.Parameters.IParameter<int>? a1, global::Mockolate.Parameters.IParameter<int>? a2, global::Mockolate.Parameters.IParameter<int>? a3, global::Mockolate.Parameters.IParameter<int>? a4, global::Mockolate.Parameters.IParameter<int>? a5, global::Mockolate.Parameters.IParameter<int>? a6, global::Mockolate.Parameters.IParameter<int>? a7, global::Mockolate.Parameters.IParameter<int>? a8, global::Mockolate.Parameters.IParameter<int>? a9, global::Mockolate.Parameters.IParameter<int>? a10, global::Mockolate.Parameters.IParameter<int>? a11, global::Mockolate.Parameters.IParameter<int>? a12, global::Mockolate.Parameters.IParameter<int>? a13, global::Mockolate.Parameters.IParameter<int>? a14, global::Mockolate.Parameters.IParameter<int>? a15, global::Mockolate.Parameters.IParameter<int>? a16, global::Mockolate.Parameters.IParameter<int>? a17);
 
 		/// <summary>
@@ -5210,6 +5225,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters SeventeenVoid(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17);
 
 		/// <summary>

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpClient.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpClient.g.cs
@@ -1401,7 +1401,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> Send(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1410,7 +1410,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1437,6 +1437,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 		/// <summary>
@@ -1445,7 +1446,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> SendAsync(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1454,7 +1455,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1481,6 +1482,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 	}
@@ -1496,7 +1498,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> Dispose(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1505,7 +1507,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing);
 
 		/// <summary>
@@ -1514,6 +1516,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> Dispose(bool disposing);
 
 	}
@@ -1529,7 +1532,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient> Send(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1538,7 +1541,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient> Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1565,6 +1568,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient>.IgnoreParameters Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 		/// <summary>
@@ -1573,7 +1577,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient> SendAsync(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1582,7 +1586,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient> SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1609,6 +1613,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient>.IgnoreParameters SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 	}
@@ -1624,7 +1629,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpClient> Dispose(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1633,7 +1638,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpClient> Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing);
 
 		/// <summary>
@@ -1642,6 +1647,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpClient>.IgnoreParameters Dispose(bool disposing);
 
 	}

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpMessageHandler.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpMessageHandler.g.cs
@@ -1122,7 +1122,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> Send(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1131,7 +1131,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1158,6 +1158,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 		/// <summary>
@@ -1166,7 +1167,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> SendAsync(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1175,7 +1176,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1202,6 +1203,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 		/// <summary>
@@ -1210,7 +1212,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> Dispose(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1219,7 +1221,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing);
 
 		/// <summary>
@@ -1228,6 +1230,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> Dispose(bool disposing);
 
 	}
@@ -1250,7 +1253,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> Send(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1259,7 +1262,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1286,6 +1289,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler>.IgnoreParameters Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 		/// <summary>
@@ -1294,7 +1298,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> SendAsync(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1303,7 +1307,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken);
 
 		/// <summary>
@@ -1330,6 +1334,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler>.IgnoreParameters SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken);
 
 		/// <summary>
@@ -1338,7 +1343,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> Dispose(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1347,7 +1352,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing);
 
 		/// <summary>
@@ -1356,6 +1361,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler>.IgnoreParameters Dispose(bool disposing);
 
 	}

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
@@ -1321,7 +1321,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int> @if(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1330,7 +1330,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int> @if(global::Mockolate.Parameters.IParameter<int>? @params);
 
 		/// <summary>
@@ -1339,6 +1339,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<int> @if(int @params);
 
 		/// <summary>
@@ -1347,7 +1348,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload configures the setup via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int> @void<@class>(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1356,7 +1357,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Setup.IReturnMethodSetupWithCallback<int, int> @void<@class>(global::Mockolate.Parameters.IParameter<int>? @ref);
 
 		/// <summary>
@@ -1365,6 +1366,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int> @void<@class>(int @ref);
 
 	}
@@ -1443,7 +1445,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases> @if(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1452,7 +1454,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases> @if(global::Mockolate.Parameters.IParameter<int>? @params);
 
 		/// <summary>
@@ -1461,6 +1463,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases>.IgnoreParameters @if(int @params);
 
 		/// <summary>
@@ -1469,7 +1472,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload matches invocations via a custom <see cref="global::Mockolate.Match">Match</see> predicate (for example <see cref="global::Mockolate.Match.AnyParameters()">AnyParameters()</see> or <see cref="global::Mockolate.Match.Parameters(global::System.Func{object?[], bool}, string)">Parameters(Func&lt;object?[], bool&gt;, string)</see>) rather than per-parameter matchers.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue - 1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases> @void<@class>(global::Mockolate.Parameters.IParameters parameters);
 
 		/// <summary>
@@ -1478,7 +1481,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
 		/// </remarks>
-		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases> @void<@class>(global::Mockolate.Parameters.IParameter<int>? @ref);
 
 		/// <summary>
@@ -1487,6 +1490,7 @@ internal static partial class Mock
 		/// <remarks>
 		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
 		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases>.IgnoreParameters @void<@class>(int @ref);
 
 		/// <summary>

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/MockGenerationSnapshotTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/MockGenerationSnapshotTests.cs
@@ -19,6 +19,27 @@ namespace Mockolate.SourceGenerators.Tests.Snapshot;
 /// </summary>
 public sealed partial class MockGenerationSnapshotTests
 {
+	[Theory]
+	[MemberData(nameof(ScenarioNames))]
+	public async Task GeneratorOutput_MatchesExpectedSnapshot(string scenarioName)
+	{
+		SnapshotScenario scenario = Scenarios.Single(s => s.Name == scenarioName);
+		GeneratorResult result = RunGenerator(scenario);
+		await That(result.Diagnostics).IsEmpty();
+
+		IReadOnlyDictionary<string, string> generated = NormalizeSources(result);
+		IReadOnlyDictionary<string, string> expected = SnapshotStorage.GetExpected(scenarioName);
+
+		await That(generated.Keys).IsEqualTo(expected.Keys).InAnyOrder();
+
+		foreach (string fileName in expected.Keys)
+		{
+			await That(StripConfigSpecificLines(generated[fileName]))
+				.IsEqualTo(StripConfigSpecificLines(expected[fileName]))
+				.IgnoringNewlineStyle();
+		}
+	}
+
 	internal static readonly IReadOnlyList<SnapshotScenario> Scenarios =
 	[
 		new(
@@ -92,27 +113,6 @@ public sealed partial class MockGenerationSnapshotTests
 			}
 
 			return data;
-		}
-	}
-
-	[Theory]
-	[MemberData(nameof(ScenarioNames))]
-	public async Task GeneratorOutput_MatchesExpectedSnapshot(string scenarioName)
-	{
-		SnapshotScenario scenario = Scenarios.Single(s => s.Name == scenarioName);
-		GeneratorResult result = RunGenerator(scenario);
-		await That(result.Diagnostics).IsEmpty();
-
-		IReadOnlyDictionary<string, string> generated = NormalizeSources(result);
-		IReadOnlyDictionary<string, string> expected = SnapshotStorage.GetExpected(scenarioName);
-
-		await That(generated.Keys).IsEqualTo(expected.Keys).InAnyOrder();
-
-		foreach (string fileName in expected.Keys)
-		{
-			await That(StripConfigSpecificLines(generated[fileName]))
-				.IsEqualTo(StripConfigSpecificLines(expected[fileName]))
-				.IgnoringNewlineStyle();
 		}
 	}
 

--- a/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
+++ b/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
@@ -57,6 +57,10 @@ public interface IComprehensiveInterface
 
 	string? GetMaybeNull(string? s);
 
+	bool TakeObject(object? obj);
+	int TakeTwoObjects(object? first, object? second);
+	int TakeIntAndObject(int n, object? obj);
+
 	Task DoTask();
 	Task<int> DoTaskOf();
 	ValueTask DoVT();

--- a/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
+++ b/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
@@ -1,4 +1,7 @@
 #if NET10_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
 namespace Mockolate.Tests.GeneratorCoverage;
 
 public class MyBase

--- a/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
+++ b/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
@@ -1,7 +1,4 @@
 #if NET10_0_OR_GREATER
-using System;
-using System.Threading.Tasks;
-
 namespace Mockolate.Tests.GeneratorCoverage;
 
 public class MyBase

--- a/Tests/Mockolate.Tests/MockBehaviorTests.InitializeTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.InitializeTests.cs
@@ -9,9 +9,8 @@ public sealed partial class MockBehaviorTests
 		[Fact]
 		public async Task Initialize_DirectSetupsTakePrecedence()
 		{
-			MockBehavior behavior = MockBehavior.Default.Initialize<IChocolateDispenser>(
-				(Mock.IMockSetupForIChocolateDispenser setup)
-					=> setup[It.Satisfies<string>((string s) => s.StartsWith("da"))].InitializeWith(5));
+			MockBehavior behavior = MockBehavior.Default.Initialize<IChocolateDispenser>(setup
+				=> setup[It.Satisfies((string s) => s.StartsWith("da"))].InitializeWith(5));
 
 			IChocolateDispenser sut = IChocolateDispenser.CreateMock(behavior,
 				setup => setup[It.Satisfies<string>(s => s.EndsWith("rk"))].InitializeWith(16));
@@ -31,9 +30,8 @@ public sealed partial class MockBehaviorTests
 		public async Task Initialize_OtherType_ShouldIgnoreInitializations()
 		{
 			MockBehavior behavior =
-				MockBehavior.Default.Initialize<IChocolateDispenser>(
-					(Mock.IMockSetupForIChocolateDispenser setup)
-						=> setup[It.Is("Dark")].InitializeWith(15));
+				MockBehavior.Default.Initialize<IChocolateDispenser>(setup
+					=> setup[It.Is("Dark")].InitializeWith(15));
 
 			void Act()
 			{
@@ -47,9 +45,8 @@ public sealed partial class MockBehaviorTests
 		public async Task Initialize_ShouldApplySetupToCreatedMock()
 		{
 			MockBehavior behavior =
-				MockBehavior.Default.Initialize<IChocolateDispenser>(
-					(Mock.IMockSetupForIChocolateDispenser setup)
-						=> setup[It.Is("Dark")].InitializeWith(15));
+				MockBehavior.Default.Initialize<IChocolateDispenser>(setup
+					=> setup[It.Is("Dark")].InitializeWith(15));
 
 			IChocolateDispenser sut = IChocolateDispenser.CreateMock(behavior);
 

--- a/Tests/Mockolate.Tests/MockBehaviorTests.SkipInteractionRecordingTests.cs
+++ b/Tests/Mockolate.Tests/MockBehaviorTests.SkipInteractionRecordingTests.cs
@@ -1,5 +1,4 @@
 using Mockolate.Exceptions;
-using Mockolate.Interactions;
 using Mockolate.Tests.TestHelpers;
 
 namespace Mockolate.Tests;

--- a/Tests/Mockolate.Tests/MockEvents/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/InteractionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Mockolate.Interactions;
-using Mockolate.Tests.TestHelpers;
+﻿using Mockolate.Tests.TestHelpers;
 
 namespace Mockolate.Tests.MockEvents;
 

--- a/Tests/Mockolate.Tests/MockIndexers/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/InteractionsTests.cs
@@ -1,5 +1,4 @@
 using aweXpect.Chronology;
-using Mockolate.Interactions;
 
 namespace Mockolate.Tests.MockIndexers;
 

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Mockolate.Exceptions;
-using Mockolate.Interactions;
 using Mockolate.Setup;
 
 namespace Mockolate.Tests.MockIndexers;
@@ -518,7 +517,6 @@ public sealed partial class SetupIndexerTests
 			await That(Act).Throws<ArgumentOutOfRangeException>()
 				.WithParamName("signatureIndex");
 		}
-
 	}
 
 

--- a/Tests/Mockolate.Tests/MockMethods/InteractionsTests.CancellationTokenTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/InteractionsTests.CancellationTokenTests.cs
@@ -76,6 +76,18 @@ public sealed partial class InteractionsTests
 			await That(result.IsCanceled).IsTrue();
 		}
 
+		[Fact]
+		public async Task WithTupleContainingTask_ShouldCancelTaskElement()
+		{
+			IMockWithCancellationToken sut = IMockWithCancellationToken.CreateMock();
+			CancellationToken canceledToken = new(true);
+
+			(Task task, string text) result = sut.TupleWithTaskMethod(canceledToken);
+
+			await That(result.task.IsCanceled).IsTrue();
+			await That(result.text).IsEqualTo(string.Empty);
+		}
+
 #if NET8_0_OR_GREATER
 		[Fact]
 		public async Task WithValueTask_ShouldReturnCanceledTask()
@@ -101,18 +113,6 @@ public sealed partial class InteractionsTests
 			await That(result.IsCanceled).IsTrue();
 		}
 #endif
-
-		[Fact]
-		public async Task WithTupleContainingTask_ShouldCancelTaskElement()
-		{
-			IMockWithCancellationToken sut = IMockWithCancellationToken.CreateMock();
-			CancellationToken canceledToken = new(true);
-
-			(Task task, string text) result = sut.TupleWithTaskMethod(canceledToken);
-
-			await That(result.task.IsCanceled).IsTrue();
-			await That(result.text).IsEqualTo(string.Empty);
-		}
 	}
 
 	public interface IMockWithCancellationToken

--- a/Tests/Mockolate.Tests/MockMethods/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/InteractionsTests.cs
@@ -1,5 +1,4 @@
 using aweXpect.Chronology;
-using Mockolate.Interactions;
 
 namespace Mockolate.Tests.MockMethods;
 

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -149,12 +149,12 @@ public sealed partial class SetupMethodTests
 	{
 		IMethodService sut = IMethodService.CreateMock();
 		MyMethodServiceType value = new(5);
-		sut.Mock.Setup.Combine(value, null).Returns(4);
+		sut.Mock.Setup.Combine(value, null!).Returns(4);
 
 		int result = sut.Combine(value, null!);
 
 		await That(result).IsEqualTo(4);
-		await That(sut.Mock.Verify.Combine(value, null)).Once();
+		await That(sut.Mock.Verify.Combine(value, null!)).Once();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -585,6 +585,18 @@ public sealed partial class SetupMethodTests
 			await That(result2).IsEqualTo("foo");
 		}
 
+		[Fact]
+		public async Task AnyParameters_OnUntypedDefaultArgument_ShouldBindToValuesOverload()
+		{
+			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
+
+			sut.Mock.Setup.Method1(default).AnyParameters()
+				.Returns("foo");
+
+			await That(sut.Method1(0)).IsEqualTo("foo");
+			await That(sut.Method1(42)).IsEqualTo("foo");
+		}
+
 		[Theory]
 		[InlineData(-1, 0)]
 		[InlineData(1, 1)]
@@ -678,6 +690,18 @@ public sealed partial class SetupMethodTests
 
 			await That(result1).IsEqualTo("foo");
 			await That(result2).IsEqualTo("foo");
+		}
+
+		[Fact]
+		public async Task AnyParameters_OnUntypedDefaultArguments_ShouldBindToValuesOverload()
+		{
+			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
+
+			sut.Mock.Setup.Method2(default, default).AnyParameters()
+				.Returns("foo");
+
+			await That(sut.Method2(0, 0)).IsEqualTo("foo");
+			await That(sut.Method2(7, 9)).IsEqualTo("foo");
 		}
 
 		[Theory]

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using Mockolate.Exceptions;
-using Mockolate.Interactions;
 using Mockolate.Parameters;
 using Mockolate.Setup;
 using Mockolate.Tests.TestHelpers;
@@ -571,6 +570,18 @@ public sealed partial class SetupMethodTests
 	public class ReturnMethodWith1Parameters
 	{
 		[Fact]
+		public async Task AnyParameters_OnUntypedDefaultArgument_ShouldBindToValuesOverload()
+		{
+			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
+
+			sut.Mock.Setup.Method1(default).AnyParameters()
+				.Returns("foo");
+
+			await That(sut.Method1(0)).IsEqualTo("foo");
+			await That(sut.Method1(42)).IsEqualTo("foo");
+		}
+
+		[Fact]
 		public async Task AnyParameters_ShouldIgnoreExplicitParameters()
 		{
 			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
@@ -583,18 +594,6 @@ public sealed partial class SetupMethodTests
 
 			await That(result1).IsEqualTo("foo");
 			await That(result2).IsEqualTo("foo");
-		}
-
-		[Fact]
-		public async Task AnyParameters_OnUntypedDefaultArgument_ShouldBindToValuesOverload()
-		{
-			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
-
-			sut.Mock.Setup.Method1(default).AnyParameters()
-				.Returns("foo");
-
-			await That(sut.Method1(0)).IsEqualTo("foo");
-			await That(sut.Method1(42)).IsEqualTo("foo");
 		}
 
 		[Theory]
@@ -678,6 +677,18 @@ public sealed partial class SetupMethodTests
 	public class ReturnMethodWith2Parameters
 	{
 		[Fact]
+		public async Task AnyParameters_OnUntypedDefaultArguments_ShouldBindToValuesOverload()
+		{
+			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
+
+			sut.Mock.Setup.Method2(default, default).AnyParameters()
+				.Returns("foo");
+
+			await That(sut.Method2(0, 0)).IsEqualTo("foo");
+			await That(sut.Method2(7, 9)).IsEqualTo("foo");
+		}
+
+		[Fact]
 		public async Task AnyParameters_ShouldIgnoreExplicitParameters()
 		{
 			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
@@ -690,18 +701,6 @@ public sealed partial class SetupMethodTests
 
 			await That(result1).IsEqualTo("foo");
 			await That(result2).IsEqualTo("foo");
-		}
-
-		[Fact]
-		public async Task AnyParameters_OnUntypedDefaultArguments_ShouldBindToValuesOverload()
-		{
-			IReturnMethodSetupTest sut = IReturnMethodSetupTest.CreateMock();
-
-			sut.Mock.Setup.Method2(default, default).AnyParameters()
-				.Returns("foo");
-
-			await That(sut.Method2(0, 0)).IsEqualTo("foo");
-			await That(sut.Method2(7, 9)).IsEqualTo("foo");
 		}
 
 		[Theory]

--- a/Tests/Mockolate.Tests/MockProperties/InteractionsTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/InteractionsTests.cs
@@ -1,5 +1,3 @@
-using Mockolate.Interactions;
-
 namespace Mockolate.Tests.MockProperties;
 
 public sealed partial class InteractionsTests

--- a/Tests/Mockolate.Tests/MockSetupsTests.cs
+++ b/Tests/Mockolate.Tests/MockSetupsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Mockolate.Interactions;
 using Mockolate.Tests.TestHelpers;
 
 namespace Mockolate.Tests;

--- a/Tests/Mockolate.Tests/MockTests.CreateTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.CreateTests.cs
@@ -176,9 +176,8 @@ public sealed partial class MockTests
 				.DoSomething(It.IsAny<int>())).Exactly(3);
 		}
 	}
-	
-	#if NET10_0_OR_GREATER
 
+#if NET10_0_OR_GREATER
 	/// <summary>
 	///     Compile-and-create coverage for every special case in
 	///     <c>Source/Mockolate.SourceGenerators</c>. The example types in this folder

--- a/Tests/Mockolate.Tests/Mockolate.Tests.csproj
+++ b/Tests/Mockolate.Tests/Mockolate.Tests.csproj
@@ -6,7 +6,7 @@
 		<ProjectReference Include="..\..\Source\Mockolate.Analyzers\Mockolate.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>
 		<ProjectReference Include="..\..\Source\Mockolate.Analyzers.CodeFixers\Mockolate.Analyzers.CodeFixers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<PackageReference Include="Nullable">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultExtensionsTests.cs
@@ -413,6 +413,18 @@ public class VerificationResultExtensionsTests
 	}
 
 	[Fact]
+	public void Then_RepeatedPropertyGetter_ShouldNotCollapseIntoOnePosition()
+	{
+		IChocolateDispenser sut = IChocolateDispenser.CreateMock();
+		_ = sut.TotalDispensed;
+		sut.Dispense("Dark", 1);
+		_ = sut.TotalDispensed;
+
+		sut.Mock.Verify.TotalDispensed.Got()
+			.Then(m => m.TotalDispensed.Got());
+	}
+
+	[Fact]
 	public async Task Then_ShouldVerifyInOrder()
 	{
 		IChocolateDispenser sut = IChocolateDispenser.CreateMock();
@@ -435,18 +447,6 @@ public class VerificationResultExtensionsTests
 				"Expected that mock invoked method Dispense(It.IsAny<string>(), 2), then invoked method Dispense(It.IsAny<string>(), 1) in order, but it invoked method Dispense(It.IsAny<string>(), 1) too early.");
 		sut.Mock.Verify.Dispense(It.IsAny<string>(), It.Is(1))
 			.Then(m => m.Dispense(It.IsAny<string>(), It.Is(2)));
-	}
-
-	[Fact]
-	public void Then_RepeatedPropertyGetter_ShouldNotCollapseIntoOnePosition()
-	{
-		IChocolateDispenser sut = IChocolateDispenser.CreateMock();
-		_ = sut.TotalDispensed;
-		sut.Dispense("Dark", 1);
-		_ = sut.TotalDispensed;
-
-		sut.Mock.Verify.TotalDispensed.Got()
-			.Then(m => m.TotalDispensed.Got());
 	}
 
 	[Theory]

--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
@@ -33,6 +33,20 @@ public sealed partial class VerificationResultTests
 	}
 
 	[Fact]
+	public async Task AnyParameters_OnUntypedDefaultArguments_ShouldBindToValuesOverload()
+	{
+		IOverloadedMethodService sut = IOverloadedMethodService.CreateMock();
+
+		sut.DoSomething(1);
+		sut.DoSomething(2);
+		sut.DoSomething(3, true);
+
+		await That(sut.Mock.Verify.DoSomething(default).AnyParameters()).Exactly(2);
+		await That(sut.Mock.Verify.DoSomething(default, default).AnyParameters()).Once();
+		await That(sut.Mock.Verify.DoSomething(default!, default!).AnyParameters()).Once();
+	}
+
+	[Fact]
 	public async Task CustomVerificationResult_ShouldKeepExpectation()
 	{
 		IMockInteractions interactions = new FastMockInteractions(0);

--- a/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
+++ b/Tests/Mockolate.Tests/Verify/VerificationResultTests.cs
@@ -1,4 +1,3 @@
-using Mockolate.Interactions;
 using Mockolate.Tests.TestHelpers;
 using Mockolate.Verify;
 


### PR DESCRIPTION
Promote the all-values setup/verify overload to `OverloadResolutionPriority(int.MaxValue)` so untyped `default` arguments resolve to it instead of the matcher (`IParameter<T>?`) overload. Callers can now chain `.AnyParameters()` on those calls — matching NSubstitute's `ReturnsForAnyArgs` ergonomics for migration.

Adjust the rest of the priority hierarchy to keep ordering unambiguous:
  - all-values         : int.MaxValue
  - IParameters        : int.MaxValue - 1
  - pure IParameter<T>?: parameterCount
  - mixed              : count of non-value (matcher) params

Skip the all-values bump when any value-flag-true parameter is `object` — `IParameter<object?>?` is itself an object reference, so the bump would silently capture matcher instances passed to `Equals(object?)` and similar. Those signatures keep the historical behavior; callers continue to use `Match.AnyParameters()`.

Snapshot fixtures updated; the public API surface is unchanged because the by-values return types (`IReturnMethodSetupParameterIgnorer`, `VerificationResult<>.IgnoreParameters`) are subtypes of the previously bound types.