### PR TITLE
docs: update migration package description to include NSubstitute support

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -24,7 +24,9 @@ It enables fast, compile-time validated mocking with .NET Standard 2.0, .NET 8, 
 
 For side-by-side setup, usage, and verification syntax against Moq, NSubstitute, and FakeItEasy, see the [full code comparison](08-comparison.md).
 
-Already on Moq? The companion package [`Mockolate.Migration`](https://github.com/aweXpect/Mockolate.Migration) ships analyzers and code fixers that translate common Moq patterns to Mockolate syntax in-place - point it at an existing test project and apply the suggested fixes.
+Already on Moq or NSubstitute? The companion package [`Mockolate.Migration`](https://github.com/aweXpect/Mockolate.Migration)
+ships analyzers and code fixers that translate common Moq and NSubstitute patterns to Mockolate syntax in-place: point it
+at an existing test project and apply the suggested fixes.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ It enables fast, compile-time validated mocking with .NET Standard 2.0, .NET 8, 
 For side-by-side setup, usage, and verification syntax against Moq, NSubstitute, and FakeItEasy, see the
 [full code comparison](https://awexpect.com/docs/mockolate/comparison).
 
-Already on Moq? The companion package [`Mockolate.Migration`](https://github.com/aweXpect/Mockolate.Migration) ships
-analyzers and code fixers that translate common Moq patterns to Mockolate syntax in-place: point it at an existing test
-project and apply the suggested fixes.
+Already on Moq or NSubstitute? The companion package [`Mockolate.Migration`](https://github.com/aweXpect/Mockolate.Migration)
+ships analyzers and code fixers that translate common Moq and NSubstitute patterns to Mockolate syntax in-place: point it
+at an existing test project and apply the suggested fixes.
 
 ## Getting Started
 


### PR DESCRIPTION
Updates the project’s public-facing docs to reflect that the companion `Mockolate.Migration` package supports migrating from NSubstitute in addition to Moq.