### PR TITLE
refactor: move source-generated mock to top of file

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -17,608 +17,39 @@ internal static partial class Sources
 		                                   constructors?.Any(m => m.Parameters.Count > 0) == true;
 		string escapedClassName = @class.ClassFullName.EscapeForXmlDoc();
 		bool hasEvents = @class.AllEvents().Any(x => !x.IsStatic);
-		bool hasStaticEvents = @class.IsInterface &&
-		                       @class.AllEvents().Any(@event => @event.IsStatic);
-		bool hasStaticMembers = @class.IsInterface &&
-		                        (@class.AllMethods().Any(method => method.IsStatic) ||
-		                         @class.AllProperties().Any(property => property.IsStatic));
+		bool hasStaticEvents = @class.IsInterface && @class.AllEvents().Any(@event => @event.IsStatic);
+		bool hasStaticMembers = @class.IsInterface && (@class.AllMethods().Any(method => method.IsStatic) || @class.AllProperties().Any(property => property.IsStatic));
 		bool hasProtectedEvents = !@class.IsInterface && @class.AllEvents().Any(@event => @event.IsProtected);
-		bool hasProtectedMembers = !@class.IsInterface &&
-		                           (@class.AllMethods().Any(method => method.IsProtected)
-		                            || @class.AllProperties().Any(property => property.IsProtected));
-		string setupType = hasProtectedMembers
-			? $"IMockSetupInitializationFor{name}"
-			: $"global::Mockolate.Mock.IMockSetupFor{name}";
+		bool hasProtectedMembers = !@class.IsInterface && (@class.AllMethods().Any(method => method.IsProtected) || @class.AllProperties().Any(property => property.IsProtected));
+		string setupType = hasProtectedMembers ? $"IMockSetupInitializationFor{name}" : $"global::Mockolate.Mock.IMockSetupFor{name}";
 		string mockRegistryName = @class.GetUniqueName("MockRegistry", "MockolateMockRegistry");
 		MemberIdTable memberIds = ComputeMemberIds(@class);
 		string memberIdPrefix = $"global::Mockolate.Mock.{name}.";
+		
 		StringBuilder sb = InitializeBuilder();
-
 		sb.Append("#nullable enable annotations").AppendLine();
 		sb.Append("namespace Mockolate;").AppendLine();
 		sb.AppendLine();
 
-		#region MockForXXXExtensions
-
-		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" />.", "");
-#if !DEBUG
-		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
-#endif
-		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("internal static partial class MockExtensionsFor").Append(name).AppendLine();
-		sb.Append("{").AppendLine();
-
-		#region Type extensions
-
-		sb.Append("\t/// <inheritdoc cref=\"MockExtensionsFor").Append(name).Append("\" />").AppendLine();
-		sb.Append("\textension(").Append(@class.ClassFullName).Append(" mock)").AppendLine();
-		sb.Append("\t{").AppendLine();
-
-		#region Mock Property
-
-		string mockPropertyName = CreateUniquePropertyName(@class, "Mock");
-
-		List<string> mockPropertyRemarks = new()
-		{
-			$"The accessor is the bridge between the strongly-typed instance of <see cref=\"{escapedClassName}\" /> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.",
-			"Through it you can:",
-			"<list type=\"bullet\">",
-			"  <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item>",
-			"  <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item>",
-		};
-		if (hasEvents)
-		{
-			mockPropertyRemarks.Add(
-				"  <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item>");
-		}
-
-		if (hasProtectedMembers || hasProtectedEvents)
-		{
-			mockPropertyRemarks.Add(
-				"  <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword=\"protected\" /> members on class mocks.</description></item>");
-		}
-
-		if (hasStaticMembers || hasStaticEvents)
-		{
-			mockPropertyRemarks.Add(
-				"  <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword=\"static\" /> members on interface mocks.</description></item>");
-		}
-
-		mockPropertyRemarks.Add(
-			"  <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item>");
-		mockPropertyRemarks.Add(
-			"  <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item>");
-		mockPropertyRemarks.Add(
-			"  <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item>");
-		mockPropertyRemarks.Add("</list>");
-
-		sb.AppendXmlSummary(
-			$"Gets the mock accessor for <see cref=\"{escapedClassName}\" /> - the entry point for configuring setups, verifying interactions and raising events.");
-		sb.AppendXmlRemarks(mockPropertyRemarks.ToArray());
-		sb.AppendXmlException("global::Mockolate.Exceptions.MockException",
-			$"The instance is not a Mockolate-generated mock of <see cref=\"{escapedClassName}\" />.");
-		sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(name).Append(' ').Append(mockPropertyName)
-			.AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tget").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(name).Append(" mockInterface)")
-			.AppendLine();
-		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\treturn mockInterface;").AppendLine();
-		sb.Append("\t\t\t\t}").AppendLine();
-		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");")
-			.AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
-
-		#endregion Mock Property
-
-		#region CreateMock
-
-		string createMockReturns =
-			$"A new mock instance of <see cref=\"{escapedClassName}\" />.";
-
-		List<string> createMockRemarks = new()
-		{
-			$"The returned instance is a strongly-typed mock generated at compile time - it implements <see cref=\"{escapedClassName}\" /> and exposes the Mockolate surface through <c>.Mock</c>:",
-			"<list type=\"bullet\">",
-			"  <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item>",
-			"  <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item>",
-		};
-		if (hasEvents)
-		{
-			createMockRemarks.Add(
-				"  <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item>");
-		}
-
-		createMockRemarks.Add("</list>");
-		createMockRemarks.Add(
-			"With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword=\"null\" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref=\"global::Mockolate.MockBehavior\" /> to customize this (for example to make un-configured calls throw or to skip the base class).");
-		createMockRemarks.Add(
-			"Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.");
-
-		sb.AppendXmlSummary(
-			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
-		sb.AppendXmlRemarks(createMockRemarks.ToArray());
-		sb.AppendXmlReturns(createMockReturns);
-		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock()").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(null, null, (object?[]?)null);").AppendLine();
-		sb.AppendLine();
-
-		sb.AppendXmlSummary(
-			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
-		sb.AppendXmlRemarks(
-			"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("setup",
-			"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
-		sb.AppendXmlReturns(createMockReturns);
-		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::System.Action<")
-			.Append(setupType).Append("> setup)").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(null, setup, (object?[]?)null);").AppendLine();
-		sb.AppendLine();
-
-		sb.AppendXmlSummary(
-			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />.");
-		sb.AppendXmlParam("mockBehavior",
-			"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
-		sb.AppendXmlReturns(createMockReturns);
-		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
-			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior)").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(mockBehavior, null, (object?[]?)null);").AppendLine();
-		sb.AppendLine();
-
-		sb.AppendXmlSummary(
-			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
-		sb.AppendXmlRemarks(
-			"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("mockBehavior",
-			"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
-		sb.AppendXmlParam("setup",
-			"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
-		sb.AppendXmlReturns(createMockReturns);
-		sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
-			.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<").Append(setupType)
-			.Append("> setup)").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(mockBehavior, setup, (object?[]?)null);").AppendLine();
-		sb.AppendLine();
-
-		if (hasParameterizedConstructor)
-		{
-			sb.AppendXmlSummary(
-				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> to invoke the base-class constructor.");
-			sb.AppendXmlParam("constructorParameters",
-				"Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
-			sb.AppendXmlReturns(createMockReturns);
-			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
-				.Append(" CreateMock(object?[] constructorParameters)").AppendLine();
-			sb.Append("\t\t\t=> CreateMock(null, null, constructorParameters);").AppendLine();
-			sb.AppendLine();
-
-			sb.AppendXmlSummary(
-				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" /> and <paramref name=\"constructorParameters\" />.");
-			sb.AppendXmlParam("mockBehavior",
-				"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
-			sb.AppendXmlParam("constructorParameters",
-				"Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
-			sb.AppendXmlReturns(createMockReturns);
-			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
-				.Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)")
-				.AppendLine();
-			sb.Append("\t\t\t=> CreateMock(mockBehavior, null, constructorParameters);").AppendLine();
-			sb.AppendLine();
-
-			sb.AppendXmlSummary(
-				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
-			sb.AppendXmlRemarks(
-				"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-			sb.AppendXmlParam("setup",
-				"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
-			sb.AppendXmlParam("constructorParameters",
-				"Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
-			sb.AppendXmlReturns(createMockReturns);
-			sb.Append("\t\tpublic static ").Append(@class.ClassFullName)
-				.Append(" CreateMock(global::System.Action<").Append(setupType)
-				.Append("> setup, object?[] constructorParameters)").AppendLine();
-			sb.Append("\t\t\t=> CreateMock(null, setup, constructorParameters);").AppendLine();
-			sb.AppendLine();
-
-			AppendTypedCreateMockOverloads(sb, @class, constructors!.Value, setupType, escapedClassName, createMockReturns);
-		}
-
-		sb.AppendXmlSummary(
-			$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
-		sb.AppendXmlRemarks(
-			"The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		sb.AppendXmlParam("mockBehavior",
-			"Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <c>MockBehavior.Default</c>.");
-		sb.AppendXmlParam("setup",
-			"Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
-		sb.AppendXmlParam("constructorParameters",
-			"Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
-		sb.AppendXmlReturns(createMockReturns);
-		sb.Append("\t\t").Append(hasParameterizedConstructor ? "public" : "private").Append(" static ")
-			.Append(@class.ClassFullName)
-			.Append(" CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<")
-			.Append(setupType).Append(">? setup, object?[]? constructorParameters)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tif (mockBehavior is not null)").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append(
-				"\t\t\t\tIMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;")
-			.AppendLine();
-		sb.Append("\t\t\t\tif (mockBehaviorAccess.TryGet<global::System.Action<").Append(setupType)
-			.Append(">?>(out var additionalSetup))").AppendLine();
-		sb.Append("\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\tif (setup is null)").AppendLine();
-		sb.Append("\t\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\t\tsetup = additionalSetup;").AppendLine();
-		sb.Append("\t\t\t\t\t}").AppendLine();
-		sb.Append("\t\t\t\t\telse").AppendLine();
-		sb.Append("\t\t\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t\t\tvar originalSetup = setup;").AppendLine();
-		sb.Append("\t\t\t\t\t\tsetup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };").AppendLine();
-		sb.Append("\t\t\t\t\t}").AppendLine();
-		sb.Append("\t\t\t\t}").AppendLine();
-		if (!@class.IsInterface && !hasStaticMembers)
-		{
-			sb.Append("\t\t\t\tif (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<")
-				.Append(@class.ClassFullName).Append(">(out object?[]? parameters))").AppendLine();
-			sb.Append("\t\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t\tconstructorParameters = parameters;").AppendLine();
-			sb.Append("\t\t\t\t}").AppendLine();
-		}
-
-		sb.Append("\t\t\t}").AppendLine();
-		sb.AppendLine();
-
-		if (@class is { ClassFullName: "global::System.Net.Http.HttpClient", })
-		{
-			sb.Append(
-					"\t\t\tglobal::Mockolate.MockBehavior effectiveBehavior = mockBehavior ?? global::Mockolate.MockBehavior.Default;")
-				.AppendLine();
-			sb.Append(
-					"\t\t\tglobal::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(effectiveBehavior, global::Mockolate.Mock.")
-				.Append(name).Append(".CreateFastInteractions(effectiveBehavior), constructorParameters);")
-				.AppendLine();
-			sb.Append("\t\t\tif (constructorParameters is null)").AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\tconstructorParameters = [new global::Mockolate.Mock.HttpMessageHandler(mockRegistry),];")
-				.AppendLine();
-			sb.Append("\t\t\t\tmockRegistry = new global::Mockolate.MockRegistry(mockRegistry, constructorParameters);")
-				.AppendLine();
-			sb.Append("\t\t\t}").AppendLine();
-			sb.Append(
-					"\t\t\telse if (constructorParameters.Length > 0 && constructorParameters[0] is global::Mockolate.Mock.HttpMessageHandler && constructorParameters[0] is global::Mockolate.IMock httpMessageHandlerMock)")
-				.AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			sb.Append(
-					"\t\t\t\tif (mockBehavior is not null && httpMessageHandlerMock.MockRegistry.Behavior != mockBehavior)")
-				.AppendLine();
-			sb.Append("\t\t\t\t{").AppendLine();
-			sb.Append(
-					"\t\t\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"Mock of type 'System.Net.Http.HttpClient' cannot be created with behavior '{mockBehavior}' because it shares its mock registry with a mock of type 'System.Net.Http.HttpMessageHandler' that has behavior '{httpMessageHandlerMock.MockRegistry.Behavior}'.\");")
-				.AppendLine();
-			sb.Append("\t\t\t\t}").AppendLine();
-			sb.Append(
-					"\t\t\t\tmockRegistry = new global::Mockolate.MockRegistry(httpMessageHandlerMock.MockRegistry, constructorParameters);")
-				.AppendLine();
-			sb.Append("\t\t\t}").AppendLine();
-			sb.Append("\t\t\tmockBehavior ??= global::Mockolate.MockBehavior.Default;").AppendLine();
-		}
-		else
-		{
-			sb.Append("\t\t\tmockBehavior ??= global::Mockolate.MockBehavior.Default;").AppendLine();
-			sb.Append(
-					"\t\t\tglobal::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.")
-				.Append(name).Append(".CreateFastInteractions(mockBehavior), constructorParameters);")
-				.AppendLine();
-		}
-
-		sb.Append("\t\t\treturn CreateMockInstance(mockRegistry, constructorParameters, setup);").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-
-		sb.AppendLine();
-		sb.Append("\t\tprivate static ").Append(@class.ClassFullName)
-			.Append(
-				" CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<")
-			.Append(setupType).Append(">? setup)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		if (!@class.IsInterface && constructors?.Count > 0)
-		{
-			sb.Append("\t\t\tif (constructorParameters is null || constructorParameters.Length == 0)").AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			if (constructors.Value.Any(m => m.Parameters.Count == 0))
-			{
-				sb.Append("\t\t\t\tglobal::Mockolate.Mock.").Append(name)
-					.Append(".MockRegistryProvider.Value = mockRegistry;").AppendLine();
-				sb.Append("\t\t\t\tglobal::Mockolate.MockExtensionsFor").Append(name)
-					.Append(".MockSetup? setupTarget = null;").AppendLine();
-				sb.Append("\t\t\t\tif (setup is not null)").AppendLine();
-				sb.Append("\t\t\t\t{").AppendLine();
-				sb.Append("\t\t\t\t\tsetupTarget ??= new(mockRegistry);").AppendLine();
-				sb.Append("\t\t\t\t\tsetup.Invoke(setupTarget);").AppendLine();
-				sb.Append("\t\t\t\t}").AppendLine();
-				sb.Append("\t\t\t\treturn new global::Mockolate.Mock.").Append(name).Append("(mockRegistry);")
-					.AppendLine();
-			}
-			else
-			{
-				sb.Append(
-						"\t\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"No parameterless constructor found for '")
-					.Append(@class.DisplayString).Append("'. Please provide constructor parameters.\");").AppendLine();
-			}
-
-			sb.Append("\t\t\t}").AppendLine();
-			int constructorIndex = 0;
-			bool useTryCast = false;
-			bool useTryCastWithDefaultValue = false;
-			foreach (EquatableArray<MethodParameter> constructorParameters in constructors.Value
-				         .Select(constructor => constructor.Parameters))
-			{
-				constructorIndex++;
-				int requiredParameters = constructorParameters.Count(c => !c.HasExplicitDefaultValue);
-				if (requiredParameters < constructorParameters.Count)
-				{
-					sb.Append("\t\t\telse if (constructorParameters.Length >= ")
-						.Append(requiredParameters).Append(" && constructorParameters.Length <= ")
-						.Append(constructorParameters.Count);
-				}
-				else
-				{
-					sb.Append("\t\t\telse if (constructorParameters.Length == ")
-						.Append(constructorParameters.Count);
-				}
-
-				int constructorParameterIndex = 0;
-				foreach (MethodParameter parameter in constructorParameters)
-				{
-					useTryCast = useTryCast || !parameter.HasExplicitDefaultValue;
-					useTryCastWithDefaultValue = useTryCastWithDefaultValue || parameter.HasExplicitDefaultValue;
-					sb.AppendLine().Append("\t\t\t    && ")
-						.Append(parameter.HasExplicitDefaultValue ? "TryCastWithDefaultValue" : "TryCast")
-						.Append("(constructorParameters, ")
-						.Append(constructorParameterIndex++)
-						.Append(parameter.HasExplicitDefaultValue ? $", {parameter.ExplicitDefaultValue}" : "")
-						.Append(", mockRegistry.Behavior, out ").Append(parameter.Type.Fullname).Append(" c")
-						.Append(constructorIndex)
-						.Append('p')
-						.Append(constructorParameterIndex).Append(")");
-				}
-
-				sb.Append(")").AppendLine();
-				sb.Append("\t\t\t{").AppendLine();
-				sb.Append("\t\t\t\tglobal::Mockolate.Mock.").Append(name)
-					.Append(".MockRegistryProvider.Value = mockRegistry;").AppendLine();
-				sb.Append("\t\t\t\tglobal::Mockolate.MockExtensionsFor").Append(name)
-					.Append(".MockSetup? setupTarget = null;").AppendLine();
-				sb.Append("\t\t\t\tif (setup is not null)").AppendLine();
-				sb.Append("\t\t\t\t{").AppendLine();
-				sb.Append("\t\t\t\t\tsetupTarget ??= new(mockRegistry);").AppendLine();
-				sb.Append("\t\t\t\t\tsetup.Invoke(setupTarget);").AppendLine();
-				sb.Append("\t\t\t\t}").AppendLine();
-				sb.Append("\t\t\t\treturn new global::Mockolate.Mock.").Append(name)
-					.Append("(mockRegistry");
-				for (int i = 1; i <= constructorParameters.Count; i++)
-				{
-					sb.Append(", ").Append('c').Append(constructorIndex).Append('p').Append(i);
-				}
-
-				sb.Append(");").AppendLine();
-				sb.Append("\t\t\t}").AppendLine();
-			}
-
-			sb.Append("\t\t\telse").AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			sb.Append(
-					"\t\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"Could not find any constructor for '")
-				.Append(@class.DisplayString)
-				.Append(
-					"' that matches the {constructorParameters.Length} given parameters ({string.Join(\", \", constructorParameters)}).\");")
-				.AppendLine();
-			sb.Append("\t\t\t}").AppendLine();
-			if (useTryCast)
-			{
-				sb.Append("""
-				          			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
-				          			{
-				          			    var value = values[index];
-				          				if (value is TValue typedValue)
-				          				{
-				          					result = typedValue;
-				          					return true;
-				          				}
-				          				
-				          				result = default!;
-				          				return value is null;
-				          			}
-				          """).AppendLine();
-			}
-
-			if (useTryCastWithDefaultValue)
-			{
-				sb.Append("""
-				          			static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
-				          			{
-				          				if (values.Length > index && values[index] is TValue typedValue)
-				          				{
-				          					result = typedValue;
-				          					return true;
-				          				}
-				          				
-				          				result = defaultValue;
-				          				return true;
-				          			}
-				          """).AppendLine();
-			}
-		}
-		else
-		{
-			sb.Append("\t\t\tvar value = new global::Mockolate.Mock.").Append(name).Append("(mockRegistry);")
-				.AppendLine();
-			sb.Append("\t\t\tif (setup is not null)").AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\tsetup.Invoke(value);").AppendLine();
-			sb.Append("\t\t\t}").AppendLine();
-			sb.Append("\t\t\treturn value;").AppendLine();
-		}
-
-		sb.Append("\t\t}").AppendLine();
-
-		#endregion CreateMock
-
-		sb.AppendXmlSummary("Creates a mock that wraps the given <paramref name=\"instance\" />.");
-		sb.AppendXmlRemarks(
-			"Public members on the mock forward to <paramref name=\"instance\" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.");
-		sb.AppendXmlParam("instance",
-			"The real object whose calls should be forwarded. Must not be <see langword=\"null\" />.");
-		sb.AppendXmlReturns(
-			$"A new mock of <see cref=\"{escapedClassName}\" /> that delegates to <paramref name=\"instance\" />.");
-		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Wrapping(").Append(@class.ClassFullName)
-			.Append(" instance)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tif (mock is global::Mockolate.IMock mockInterface)").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append(
-				"\t\t\t\tglobal::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);")
-			.AppendLine();
-		sb.Append(
-				"\t\t\t\twrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.")
-			.Append(name).Append(".CreateFastInteractions(wrappingRegistry.Behavior));")
-			.AppendLine();
-		sb.Append(
-				"\t\t\t\treturn CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);")
-			.AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");")
-			.AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t}").AppendLine();
-
-		#endregion Type extensions
-
-		sb.AppendLine();
-
-		#region MockBehavior extensions
-
-		sb.Append("\t/// <inheritdoc cref=\"MockExtensionsFor").Append(name).Append("\" />").AppendLine();
-		sb.Append("\textension(global::Mockolate.MockBehavior behavior)").AppendLine();
-		sb.Append("\t{").AppendLine();
-
-		sb.AppendXmlSummary(
-			"Initializes mocks of type <typeparamref name=\"T\" /> with the given <paramref name=\"setup\" />.");
-		sb.AppendXmlRemarks(
-			"The <paramref name=\"setup\" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.");
-		sb.AppendXmlTypeParam("T",
-			$"The mockable type derived from <see cref=\"{escapedClassName}\" /> that this setup should apply to.");
-		sb.AppendXmlParam("setup", "Callback invoked when a new mock of <typeparamref name=\"T\" /> is created.");
-		sb.AppendXmlReturns(
-			"A new <see cref=\"global::Mockolate.MockBehavior\" /> with the registered initializer. The original instance is unchanged.");
-		sb.Append("\t\tpublic global::Mockolate.MockBehavior Initialize<T>(global::System.Action<").Append(setupType)
-			.Append("> setup)").AppendLine();
-		sb.Append("\t\t\twhere T : ").Append(@class.ClassFullName).AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tvar behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;").AppendLine();
-		sb.Append("\t\t\treturn behaviorAccess.Set(setup);").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-
-		sb.Append("\t}").AppendLine();
-
-		#endregion MockBehavior extensions
-
-		#region Setup helpers
-
-		if (!@class.IsInterface && constructors?.Count > 0)
-		{
-			string protectedName = @class.GetUniqueName("Protected", "SetupProtected");
-			if (hasProtectedMembers)
-			{
-				sb.Append("\tinternal interface IMockSetupInitializationFor").Append(name)
-					.Append(" : global::Mockolate.Mock.IMockSetupFor").Append(name).AppendLine();
-				sb.Append("\t{").AppendLine();
-				sb.AppendXmlSummary("Setup protected members");
-				sb.Append("\t\tglobal::Mockolate.Mock.IMockProtectedSetupFor").Append(name).Append(' ')
-					.Append(protectedName).Append(" { get; }").AppendLine();
-				sb.Append("\t}").AppendLine();
-			}
-
-			sb.AppendLine();
-#if !DEBUG
-			sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
-#endif
-			sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-			sb.Append(
-					"\tinternal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupFor")
-				.Append(name);
-			if (hasProtectedMembers)
-			{
-				sb.Append(", global::Mockolate.Mock.IMockProtectedSetupFor").Append(name)
-					.Append(", IMockSetupInitializationFor").Append(name);
-			}
-
-			sb.AppendLine();
-			sb.Append("\t{").AppendLine();
-			if (hasProtectedMembers)
-			{
-				sb.Append("\t\t/// <inheritdoc />").AppendLine();
-				sb.Append("\t\tglobal::Mockolate.Mock.IMockProtectedSetupFor").Append(name)
-					.Append(" IMockSetupInitializationFor").Append(name).Append('.').Append(protectedName)
-					.Append(" => this;").AppendLine();
-			}
-
-			sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName)
-				.Append(" { get; } = mockRegistry;").AppendLine();
-			sb.AppendLine();
-			sb.Append("\t\t#region IMockSetupFor").Append(name).AppendLine();
-			sb.AppendLine();
-			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public,
-				memberIds, memberIdPrefix);
-			sb.Append("\t\t#endregion IMockSetupFor").Append(name).AppendLine();
-			if (hasProtectedMembers)
-			{
-				sb.AppendLine();
-				sb.Append("\t\t#region IMockProtectedSetupFor").Append(name).AppendLine();
-				sb.AppendLine();
-				ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}",
-					MemberType.Protected, memberIds, memberIdPrefix);
-				sb.Append("\t\t#endregion IMockProtectedSetupFor").Append(name).AppendLine();
-			}
-
-			sb.Append("\t}").AppendLine();
-		}
-
-		#endregion Setup helpers
-
-		AppendNestedCovariantParameterAdapter(sb);
-		sb.Append("}").AppendLine();
-
-		#endregion MockForXXXExtensions
-
-		sb.AppendLine();
-
-		#region MockForXXX
+		#region Mock
 
 		sb.Append("internal static partial class Mock").AppendLine();
 		sb.Append("{").AppendLine();
+		
+		#region MockForXXX
+		
 		sb.AppendXmlSummary($"A mock implementation for <see cref=\"{escapedClassName}\" />.", "\t");
-		sb.Append(
-				"\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]")
-			.AppendLine();
+		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
 #if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
 		sb.Append("\tinternal class ").Append(name).Append(" :").AppendLine();
-		sb.Append("\t\t").Append(@class.ClassFullName);
-		sb.Append(", IMockFor").Append(name).Append(", IMockSetupFor").Append(name);
+		sb.Append("\t\t").Append(@class.ClassFullName).Append(", IMockFor").Append(name).Append(", IMockSetupFor").Append(name);
 		if (hasProtectedMembers)
 		{
 			sb.Append(", IMockProtectedSetupFor").Append(name);
-			sb.Append(", global::Mockolate.MockExtensionsFor").Append(name).Append(".IMockSetupInitializationFor")
-				.Append(name);
+			sb.Append(", global::Mockolate.MockExtensionsFor").Append(name).Append(".IMockSetupInitializationFor").Append(name);
 		}
 
 		if (hasStaticMembers)
@@ -669,11 +100,8 @@ internal static partial class Sources
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append(
-				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-			.AppendLine();
-		sb.Append("\t\tglobal::Mockolate.MockRegistry global::Mockolate.IMock.MockRegistry => this.")
-			.Append(mockRegistryName).Append(';').AppendLine();
+		sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.MockRegistry global::Mockolate.IMock.MockRegistry => this.").Append(mockRegistryName).Append(';').AppendLine();
 		if (constructors?.Count > 0)
 		{
 			sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).AppendLine();
@@ -681,33 +109,26 @@ internal static partial class Sources
 			sb.Append("\t\t\tget => field ?? MockRegistryProvider.Value;").AppendLine();
 			sb.Append("\t\t\tset;").AppendLine();
 			sb.Append("\t\t}").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append(
-					"\t\tinternal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider = new global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry>();")
-				.AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tinternal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider = new global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry>();").AppendLine();
 		}
 		else
 		{
-			sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }")
-				.AppendLine();
+			sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }").AppendLine();
 			if (hasStaticMembers)
 			{
-				sb.Append(
-						"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-					.AppendLine();
-				sb.Append(
-						"\t\tinternal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider = new global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry>();")
-					.AppendLine();
+				sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+				sb.Append("\t\tinternal static readonly global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry> MockRegistryProvider = new global::System.Threading.AsyncLocal<global::Mockolate.MockRegistry>();").AppendLine();
 			}
 		}
 
 		sb.AppendLine();
+		
 		AppendCachedFieldDeclarations(sb, "\t\t", @class, memberIds, memberIdPrefix, mockRegistryName);
+		
 		sb.AppendLine();
-		ImplementMockForInterface(sb, mockRegistryName, name, hasEvents, hasProtectedMembers, hasProtectedEvents,
-			hasStaticMembers, hasStaticEvents);
+		
+		ImplementMockForInterface(sb, mockRegistryName, name, hasEvents, hasProtectedMembers, hasProtectedEvents, hasStaticMembers, hasStaticEvents);
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
 		sb.Append("\t\tstring global::Mockolate.IMock.ToString()").AppendLine();
@@ -727,28 +148,27 @@ internal static partial class Sources
 
 			sb.Append("\t\t}").AppendLine();
 			sb.AppendLine();
+			
 			AppendMockSubject_BehaviorConstructor(sb, name);
 		}
 		else if (constructors is not null)
 		{
 			foreach (Method constructor in constructors)
 			{
-				AppendMockSubject_BaseClassConstructor(sb, mockRegistryName, name, constructor,
-					@class.HasRequiredMembers);
-				AppendMockSubject_BehaviorBaseClassConstructor(sb, name, constructor,
-					@class.HasRequiredMembers);
+				AppendMockSubject_BaseClassConstructor(sb, mockRegistryName, name, constructor, @class.HasRequiredMembers);
+				AppendMockSubject_BehaviorBaseClassConstructor(sb, name, constructor, @class.HasRequiredMembers);
 			}
 		}
 
 		AppendMockSubject_ImplementClass(sb, @class, mockRegistryName, null, memberIds, memberIdPrefix);
+		
 		sb.AppendLine();
 
-		#region IMockSetupForXXX
+		#region Mock.Setup
 
 		sb.Append("\t\t#region IMockSetupFor").Append(name).AppendLine();
 		sb.AppendLine();
-		ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public,
-			memberIds, memberIdPrefix);
+		ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public, memberIds, memberIdPrefix);
 		sb.Append("\t\t#endregion IMockSetupFor").Append(name).AppendLine();
 
 		if (hasProtectedMembers)
@@ -756,8 +176,7 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockProtectedSetupFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}",
-				MemberType.Protected, memberIds, memberIdPrefix);
+			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}", MemberType.Protected, memberIds, memberIdPrefix);
 			sb.Append("\t\t#endregion IMockProtectedSetupFor").Append(name).AppendLine();
 		}
 
@@ -766,59 +185,50 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockStaticSetupFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockStaticSetupFor{name}", MemberType.Static,
-				memberIds, memberIdPrefix);
+			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockStaticSetupFor{name}", MemberType.Static, memberIds, memberIdPrefix);
 			sb.Append("\t\t#endregion IMockStaticSetupFor").Append(name).AppendLine();
 		}
 
-		#endregion IMockSetupForXXX
+		#endregion Mock.Setup
 
+		#region Mock.Raise
+		
 		if (hasEvents)
 		{
-			#region IMockRaiseOnXXX
-
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockRaiseOn").Append(name).AppendLine();
 			sb.AppendLine();
 			ImplementRaiseInterface(sb, @class, mockRegistryName, $"IMockRaiseOn{name}", MemberType.Public);
 			sb.Append("\t\t#endregion IMockRaiseOn").Append(name).AppendLine();
 
-			#endregion IMockRaiseOnXXX
 		}
 
 		if (hasProtectedEvents)
 		{
-			#region IMockProtectedRaiseOnXXX
-
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockProtectedRaiseOn").Append(name).AppendLine();
 			sb.AppendLine();
 			ImplementRaiseInterface(sb, @class, mockRegistryName, $"IMockProtectedRaiseOn{name}", MemberType.Protected);
 			sb.Append("\t\t#endregion IMockProtectedRaiseOn").Append(name).AppendLine();
-
-			#endregion IMockProtectedRaiseOnXXX
 		}
 
 		if (hasStaticEvents)
 		{
-			#region IMockStaticRaiseOnXXX
-
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockStaticRaiseOn").Append(name).AppendLine();
 			sb.AppendLine();
 			ImplementRaiseInterface(sb, @class, mockRegistryName, $"IMockStaticRaiseOn{name}", MemberType.Static);
 			sb.Append("\t\t#endregion IMockStaticRaiseOn").Append(name).AppendLine();
-
-			#endregion IMockStaticRaiseOnXXX
 		}
+		
+		#endregion Mock.Raise
 
-		#region IMockVerifyForXXX
+		#region Mock.Verify
 
 		sb.AppendLine();
 		sb.Append("\t\t#region IMockVerifyFor").Append(name).AppendLine();
 		sb.AppendLine();
-		ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockVerifyFor{name}", MemberType.Public,
-			memberIds, memberIdPrefix);
+		ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockVerifyFor{name}", MemberType.Public, memberIds, memberIdPrefix);
 		sb.Append("\t\t#endregion IMockVerifyFor").Append(name).AppendLine();
 
 		if (hasProtectedMembers || hasProtectedEvents)
@@ -826,8 +236,7 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockProtectedVerifyFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockProtectedVerifyFor{name}",
-				MemberType.Protected, memberIds, memberIdPrefix);
+			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockProtectedVerifyFor{name}", MemberType.Protected, memberIds, memberIdPrefix);
 			sb.Append("\t\t#endregion IMockProtectedVerifyFor").Append(name).AppendLine();
 		}
 
@@ -836,42 +245,45 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockStaticVerifyFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockStaticVerifyFor{name}", MemberType.Static,
-				memberIds, memberIdPrefix);
+			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockStaticVerifyFor{name}", MemberType.Static, memberIds, memberIdPrefix);
 			sb.Append("\t\t#endregion IMockStaticVerifyFor").Append(name).AppendLine();
 		}
 
-		#endregion IMockVerifyForXXX
+		#endregion Mock.Verify
 
 		sb.AppendLine("\t}");
-
 		sb.AppendLine();
+
+		#endregion MockForXXX
+
+		#region VerifyMonitor
+		
 #if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("\tprivate sealed class VerifyMonitor").Append(name)
-			.Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor")
-			.Append(name).AppendLine();
+		sb.Append("\tprivate sealed class VerifyMonitor").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName)
-			.Append(" { get; } = mockRegistry;").AppendLine();
+		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; } = mockRegistry;").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t\t#region IMockVerifyFor").Append(name).AppendLine();
 		sb.AppendLine();
-		ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockVerifyFor{name}", MemberType.Public,
-			memberIds, memberIdPrefix);
+		
+		ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockVerifyFor{name}", MemberType.Public, memberIds, memberIdPrefix);
+		
 		sb.Append("\t\t#endregion IMockVerifyFor").Append(name).AppendLine();
 		sb.Append("\t}").AppendLine();
-
 		sb.AppendLine();
+		
+		#endregion VerifyMonitor
+
+		#region MockInScenarioForXXX
+		
 #if !DEBUG
 		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
 #endif
 		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("\tprivate sealed class MockInScenarioFor").Append(name)
-			.Append(" : global::Mockolate.Mock.IMockInScenarioFor").Append(name)
-			.Append(", global::Mockolate.Mock.IMockSetupFor").Append(name);
+		sb.Append("\tprivate sealed class MockInScenarioFor").Append(name).Append(" : global::Mockolate.Mock.IMockInScenarioFor").Append(name).Append(", global::Mockolate.Mock.IMockSetupFor").Append(name);
 		if (hasProtectedMembers)
 		{
 			sb.Append(", global::Mockolate.Mock.IMockProtectedSetupFor").Append(name);
@@ -879,66 +291,60 @@ internal static partial class Sources
 
 		sb.AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }")
-			.AppendLine();
+		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }").AppendLine();
 		sb.Append("\t\tprivate string _scenarioName;").AppendLine();
 		sb.AppendLine();
-		sb.Append("\t\tpublic MockInScenarioFor").Append(name)
-			.Append("(global::Mockolate.MockRegistry mockRegistry, string scenario)").AppendLine();
+		sb.Append("\t\tpublic MockInScenarioFor").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry, string scenario)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(" = mockRegistry;").AppendLine();
 		sb.Append("\t\t\t_scenarioName = scenario;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Mock.IMockSetupFor").Append(name)
-			.Append(" global::Mockolate.Mock.IMockInScenarioFor").Append(name).Append(".Setup").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Mock.IMockSetupFor").Append(name).Append(" global::Mockolate.Mock.IMockInScenarioFor").Append(name).Append(".Setup").AppendLine();
 		sb.Append("\t\t\t=> this;").AppendLine();
 		sb.AppendLine();
 		if (hasProtectedMembers)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append("\t\tglobal::Mockolate.Mock.IMockProtectedSetupFor").Append(name)
-				.Append(" global::Mockolate.Mock.IMockInScenarioFor").Append(name).Append(".SetupProtected")
-				.AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Mock.IMockProtectedSetupFor").Append(name).Append(" global::Mockolate.Mock.IMockInScenarioFor").Append(name).Append(".SetupProtected").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 			sb.AppendLine();
 		}
 
 		sb.Append("\t\t#region IMockSetupFor").Append(name).AppendLine();
 		sb.AppendLine();
-		ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public,
-			memberIds, memberIdPrefix, "_scenarioName");
+		
+		ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public, memberIds, memberIdPrefix, "_scenarioName");
+		
 		sb.Append("\t\t#endregion IMockSetupFor").Append(name).AppendLine();
 		if (hasProtectedMembers)
 		{
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockProtectedSetupFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}", MemberType.Protected,
-				memberIds, memberIdPrefix, "_scenarioName");
+			
+			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}", MemberType.Protected, memberIds, memberIdPrefix, "_scenarioName");
+			
 			sb.Append("\t\t#endregion IMockProtectedSetupFor").Append(name).AppendLine();
 		}
 
 		sb.Append("\t}").AppendLine();
-
-		#endregion MockForXXX
-
 		sb.AppendLine();
+		
+		#endregion MockInScenarioForXXX
 
+		#region Mock Interfaces
+		
 		#region IMockForXXX
 
-		sb.AppendXmlSummary(
-			$"The Mockolate accessor for a mock of <see cref=\"{escapedClassName}\" />, reached through <c>.Mock</c> on the mocked instance.",
-			"\t");
-		sb.AppendXmlRemarks([
-			"Groups every operation that acts on the mock rather than on the mocked subject: setups, verifications, event raising, scenarios and monitoring.",
-		], "\t");
+		sb.AppendXmlSummary($"The Mockolate accessor for a mock of <see cref=\"{escapedClassName}\" />, reached through <c>.Mock</c> on the mocked instance.", "\t");
+		sb.AppendXmlRemarks(["Groups every operation that acts on the mock rather than on the mocked subject: setups, verifications, event raising, scenarios and monitoring.",], "\t");
 		sb.Append("\tinternal interface IMockFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary(
-			$"Configures how members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
-		sb.AppendXmlRemarks([
+		sb.AppendXmlSummary($"Configures how members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
+		sb.AppendXmlRemarks(
+		[
 			"Each mocked member is available as a strongly-typed entry on this surface. Chain <c>Returns</c>, <c>ReturnsAsync</c>, <c>Throws</c>, <c>ThrowsAsync</c> or <c>Do</c> to control the response; chain <c>InitializeWith</c>/<c>Register</c> to initialize properties and indexers; chain multiple returns/throws to define a sequence; use <c>.For(n)</c>, <c>.Only(n)</c>, <c>.Forever()</c>, <c>.When(predicate)</c> to control when a callback runs.",
 			"When two setups overlap, the most recently defined one wins.",
 		]);
@@ -946,57 +352,37 @@ internal static partial class Sources
 		sb.AppendLine();
 		if (hasProtectedMembers)
 		{
-			sb.AppendXmlSummary(
-				$"Configures how <see langword=\"protected\" /> virtual members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
-			sb.AppendXmlRemarks([
-				"Only members declared as <see langword=\"protected\" /> (or <see langword=\"protected\" /> <see langword=\"internal\" />) on the mocked class appear here. All setup chain operators (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, sequences, <c>.For</c>/<c>.Only</c>/<c>.Forever</c>, ...) work identically to <see cref=\"Setup\" />.",
-			]);
+			sb.AppendXmlSummary($"Configures how <see langword=\"protected\" /> virtual members of the mock of <see cref=\"{escapedClassName}\" /> respond when invoked.");
+			sb.AppendXmlRemarks(["Only members declared as <see langword=\"protected\" /> (or <see langword=\"protected\" /> <see langword=\"internal\" />) on the mocked class appear here. All setup chain operators (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, sequences, <c>.For</c>/<c>.Only</c>/<c>.Forever</c>, ...) work identically to <see cref=\"Setup\" />.",]);
 			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" SetupProtected { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasStaticMembers)
 		{
-			sb.AppendXmlSummary(
-				$"Configures how <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> respond when invoked.");
-			sb.AppendXmlRemarks([
-				"Static members are scoped per async/execution flow while the mock is alive; invocations from other flows are not intercepted.",
-			]);
+			sb.AppendXmlSummary($"Configures how <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> respond when invoked.");
+			sb.AppendXmlRemarks(["Static members are scoped per async/execution flow while the mock is alive; invocations from other flows are not intercepted.",]);
 			sb.Append("\t\tIMockStaticSetupFor").Append(name).Append(" SetupStatic { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
-		sb.AppendXmlSummary(
-			$"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> so that additional setups can be registered for that scenario.");
-		sb.AppendXmlRemarks([
-			"Scenarios let you define per-state behavior. Setups registered inside the returned <c>IMockInScenarioFor...</c> scope only apply while the mock's current scenario matches <paramref name=\"scenario\" />; switch scenarios with <see cref=\"TransitionTo\" />.",
-		]);
-		sb.AppendXmlParam("scenario",
-			"Name of the scenario to enter. Any non-null string acts as a key; the mock starts in an unnamed default scenario.");
-		sb.AppendXmlReturns(
-			"A scoped accessor whose <c>Setup</c> (and <c>SetupProtected</c>, where applicable) register scenario-specific setups.");
+		sb.AppendXmlSummary($"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> so that additional setups can be registered for that scenario.");
+		sb.AppendXmlRemarks(["Scenarios let you define per-state behavior. Setups registered inside the returned <c>IMockInScenarioFor...</c> scope only apply while the mock's current scenario matches <paramref name=\"scenario\" />; switch scenarios with <see cref=\"TransitionTo\" />.",]);
+		sb.AppendXmlParam("scenario", "Name of the scenario to enter. Any non-null string acts as a key; the mock starts in an unnamed default scenario.");
+		sb.AppendXmlReturns("A scoped accessor whose <c>Setup</c> (and <c>SetupProtected</c>, where applicable) register scenario-specific setups.");
 		sb.Append("\t\tIMockInScenarioFor").Append(name).Append(" InScenario(string scenario);").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary(
-			$"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> and immediately invokes <paramref name=\"setup\" /> to register scenario-specific setups.");
-		sb.AppendXmlRemarks([
-			"Equivalent to <c>InScenario(scenario)</c> followed by the setup callback, but returns the original <c>IMockFor...</c> accessor so it chains nicely at mock-creation time.",
-		]);
+		sb.AppendXmlSummary($"Opens a named scenario scope on the mock of <see cref=\"{escapedClassName}\" /> and immediately invokes <paramref name=\"setup\" /> to register scenario-specific setups.");
+		sb.AppendXmlRemarks(["Equivalent to <c>InScenario(scenario)</c> followed by the setup callback, but returns the original <c>IMockFor...</c> accessor so it chains nicely at mock-creation time.",]);
 		sb.AppendXmlParam("scenario", "Name of the scenario to enter.");
-		sb.AppendXmlParam("setup",
-			"Callback that receives the scenario-scoped setup surface and registers scenario-specific setups.");
+		sb.AppendXmlParam("setup", "Callback that receives the scenario-scoped setup surface and registers scenario-specific setups.");
 		sb.AppendXmlReturns("This accessor, to allow chaining.");
-		sb.Append("\t\tIMockFor").Append(name)
-			.Append(" InScenario(string scenario, global::System.Action<IMockInScenarioFor")
-			.Append(name).Append("> setup);").AppendLine();
+		sb.Append("\t\tIMockFor").Append(name).Append(" InScenario(string scenario, global::System.Action<IMockInScenarioFor").Append(name).Append("> setup);").AppendLine();
 		sb.AppendLine();
 
-		sb.AppendXmlSummary(
-			$"Switches the active scenario of the mock of <see cref=\"{escapedClassName}\" /> to <paramref name=\"scenario\" />.");
-		sb.AppendXmlRemarks([
-			"After the transition, setups registered via <see cref=\"InScenario(string)\" /> under that scenario take effect. Scenarios that have no matching setup for a given member fall back to the default (un-scoped) setups.",
-		]);
+		sb.AppendXmlSummary($"Switches the active scenario of the mock of <see cref=\"{escapedClassName}\" /> to <paramref name=\"scenario\" />.");
+		sb.AppendXmlRemarks(["After the transition, setups registered via <see cref=\"InScenario(string)\" /> under that scenario take effect. Scenarios that have no matching setup for a given member fall back to the default (un-scoped) setups.",]);
 		sb.AppendXmlParam("scenario", "Name of the scenario to transition to.");
 		sb.AppendXmlReturns("This accessor, to allow chaining.");
 		sb.Append("\t\tIMockFor").Append(name).Append(" TransitionTo(string scenario);").AppendLine();
@@ -1004,40 +390,31 @@ internal static partial class Sources
 
 		if (hasEvents)
 		{
-			sb.AppendXmlSummary(
-				$"Triggers events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
-			sb.AppendXmlRemarks([
-				"One entry per event is generated; the signature matches the event's delegate. Only handlers that are subscribed at the moment of the <c>Raise</c> call are invoked - handlers subscribed later (or already removed) are skipped.",
-			]);
+			sb.AppendXmlSummary($"Triggers events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlRemarks(["One entry per event is generated; the signature matches the event's delegate. Only handlers that are subscribed at the moment of the <c>Raise</c> call are invoked - handlers subscribed later (or already removed) are skipped.",]);
 			sb.Append("\t\tIMockRaiseOn").Append(name).Append(" Raise { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasProtectedEvents)
 		{
-			sb.AppendXmlSummary(
-				$"Triggers <see langword=\"protected\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
-			sb.AppendXmlRemarks([
-				"Same semantics as <see cref=\"Raise\" /> but for events whose accessibility prevents external subscription from outside the class. Useful when testing code that subclasses the mocked type.",
-			]);
+			sb.AppendXmlSummary($"Triggers <see langword=\"protected\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlRemarks(["Same semantics as <see cref=\"Raise\" /> but for events whose accessibility prevents external subscription from outside the class. Useful when testing code that subclasses the mocked type.",]);
 			sb.Append("\t\tIMockProtectedRaiseOn").Append(name).Append(" RaiseProtected { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasStaticEvents)
 		{
-			sb.AppendXmlSummary(
-				$"Triggers <see langword=\"static\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
-			sb.AppendXmlRemarks([
-				"Static events are scoped per async/execution flow while the mock is alive.",
-			]);
+			sb.AppendXmlSummary($"Triggers <see langword=\"static\" /> events declared on <see cref=\"{escapedClassName}\" /> so that currently subscribed handlers are invoked.");
+			sb.AppendXmlRemarks(["Static events are scoped per async/execution flow while the mock is alive.",]);
 			sb.Append("\t\tIMockStaticRaiseOn").Append(name).Append(" RaiseStatic { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
-		sb.AppendXmlSummary(
-			$"Asserts how often, and in which order, members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
-		sb.AppendXmlRemarks([
+		sb.AppendXmlSummary($"Asserts how often, and in which order, members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
+		sb.AppendXmlRemarks(
+		[
 			"Each call to a member here returns a <c>VerificationResult</c> that you terminate with a count assertion: <c>Never()</c>, <c>Once()</c>, <c>Twice()</c>, <c>Exactly(n)</c>, <c>AtLeast(n)</c>/<c>AtLeastOnce()</c>/<c>AtLeastTwice()</c>, <c>AtMost(n)</c>/<c>AtMostOnce()</c>/<c>AtMostTwice()</c>, <c>Between(min, max)</c> or <c>Times(predicate)</c>.",
 			"Use <c>Within(TimeSpan)</c> / <c>WithCancellation(CancellationToken)</c> before the terminator to wait for expected interactions that happen on background threads.",
 			"Chain <c>Then(...)</c> to assert an ordered sequence of calls. A failing assertion throws a <see cref=\"global::Mockolate.Exceptions.MockVerificationException\" />.",
@@ -1046,80 +423,56 @@ internal static partial class Sources
 		sb.AppendLine();
 		if (hasProtectedMembers || hasProtectedEvents)
 		{
-			sb.AppendXmlSummary(
-				$"Asserts how often, and in which order, <see langword=\"protected\" /> members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
-			sb.AppendXmlRemarks([
-				"Same terminators and modifiers as <see cref=\"Verify\" /> (<c>Once()</c>, <c>Exactly(n)</c>, <c>Within(...)</c>, <c>Then(...)</c>, ...); applies to <see langword=\"protected\" /> members and events instead of public ones.",
-			]);
+			sb.AppendXmlSummary($"Asserts how often, and in which order, <see langword=\"protected\" /> members of the mock of <see cref=\"{escapedClassName}\" /> were invoked.");
+			sb.AppendXmlRemarks(["Same terminators and modifiers as <see cref=\"Verify\" /> (<c>Once()</c>, <c>Exactly(n)</c>, <c>Within(...)</c>, <c>Then(...)</c>, ...); applies to <see langword=\"protected\" /> members and events instead of public ones.",]);
 			sb.Append("\t\tIMockProtectedVerifyFor").Append(name).Append(" VerifyProtected { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		if (hasStaticMembers || hasStaticEvents)
 		{
-			sb.AppendXmlSummary(
-				$"Asserts how often, and in which order, <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> were invoked.");
-			sb.AppendXmlRemarks([
-				"Same terminators and modifiers as <see cref=\"Verify\" />; scoped per async/execution flow in the same way as <see cref=\"SetupStatic\" />.",
-			]);
+			sb.AppendXmlSummary($"Asserts how often, and in which order, <see langword=\"static\" /> members declared on <see cref=\"{escapedClassName}\" /> were invoked.");
+			sb.AppendXmlRemarks(["Same terminators and modifiers as <see cref=\"Verify\" />; scoped per async/execution flow in the same way as <see cref=\"SetupStatic\" />.",]);
 			sb.Append("\t\tIMockStaticVerifyFor").Append(name).Append(" VerifyStatic { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
 		sb.AppendXmlSummary("Verifies how often a specific method setup was matched by actual invocations.");
-		sb.AppendXmlRemarks([
-			"Useful when you want to verify &quot;this <em>particular</em> setup was hit N times&quot; without re-stating the matchers. Chain the usual count terminators (<c>Once()</c>, <c>AtLeastOnce()</c>, <c>Exactly(n)</c>, ...) on the returned result.",
-		]);
-		sb.AppendXmlParam("setup",
-			"The setup previously registered through <see cref=\"Setup\" /> (typically returned from a <c>Returns(...)</c>/<c>Throws(...)</c> call).");
+		sb.AppendXmlRemarks(["Useful when you want to verify &quot;this <em>particular</em> setup was hit N times&quot; without re-stating the matchers. Chain the usual count terminators (<c>Once()</c>, <c>AtLeastOnce()</c>, <c>Exactly(n)</c>, ...) on the returned result.",]);
+		sb.AppendXmlParam("setup", "The setup previously registered through <see cref=\"Setup\" /> (typically returned from a <c>Returns(...)</c>/<c>Throws(...)</c> call).");
 		sb.AppendXmlReturns("A <c>VerificationResult</c> that counts invocations matching the given setup.");
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name)
-			.Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary(
-			"Checks whether every recorded interaction on this mock has been observed by at least one <c>Verify</c> call.");
-		sb.AppendXmlRemarks([
-			"Useful in test teardown to catch unexpected interactions (&quot;strict verification&quot;): if any recorded call has never been matched by a verification, the method returns <see langword=\"false\" />.",
-		]);
-		sb.AppendXmlReturns(
-			"<see langword=\"true\" /> if every recorded interaction was verified at least once; otherwise <see langword=\"false\" />.");
+		
+		sb.AppendXmlSummary("Checks whether every recorded interaction on this mock has been observed by at least one <c>Verify</c> call.");
+		sb.AppendXmlRemarks(["Useful in test teardown to catch unexpected interactions (&quot;strict verification&quot;): if any recorded call has never been matched by a verification, the method returns <see langword=\"false\" />.",]);
+		sb.AppendXmlReturns("<see langword=\"true\" /> if every recorded interaction was verified at least once; otherwise <see langword=\"false\" />.");
 		sb.Append("\t\tbool VerifyThatAllInteractionsAreVerified();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary(
-			"Checks whether every registered setup on this mock was matched by at least one actual invocation.");
-		sb.AppendXmlRemarks([
-			"Useful to catch unused setups that silently rot as the test subject evolves.",
-		]);
-		sb.AppendXmlReturns(
-			"<see langword=\"true\" /> if every registered setup was used at least once; otherwise <see langword=\"false\" />.");
+		
+		sb.AppendXmlSummary("Checks whether every registered setup on this mock was matched by at least one actual invocation.");
+		sb.AppendXmlRemarks(["Useful to catch unused setups that silently rot as the test subject evolves.",]);
+		sb.AppendXmlReturns("<see langword=\"true\" /> if every registered setup was used at least once; otherwise <see langword=\"false\" />.");
 		sb.Append("\t\tbool VerifyThatAllSetupsAreUsed();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary(
-			"Removes every recorded interaction from this mock while keeping all registered setups intact.");
-		sb.AppendXmlRemarks([
-			"Handy when a single test exercises multiple logical phases and you only want to verify the interactions of the latest phase.",
-		]);
+		
+		sb.AppendXmlSummary("Removes every recorded interaction from this mock while keeping all registered setups intact.");
+		sb.AppendXmlRemarks(["Handy when a single test exercises multiple logical phases and you only want to verify the interactions of the latest phase.",]);
 		sb.Append("\t\tvoid ClearAllInteractions();").AppendLine();
 		sb.AppendLine();
-		sb.AppendXmlSummary(
-			"Creates a monitor whose <c>Verify</c> surface is scoped to interactions produced between <c>monitor.Run()</c> and the disposal of its <see cref=\"global::System.IDisposable\" /> scope.");
-		sb.AppendXmlRemarks([
-			"The underlying mock keeps recording all interactions as usual - only the monitor's <c>Verify</c> view is scoped. Useful to verify only the interactions produced by a specific block of test code without resetting the mock.",
-		]);
-		sb.AppendXmlReturns(
-			"A <see cref=\"global::Mockolate.Monitor.MockMonitor{T}\" /> that exposes <c>Verify</c> over the monitored interactions and a <c>Run()</c> method that opens the recording scope.");
-		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();")
-			.AppendLine();
+		
+		sb.AppendXmlSummary("Creates a monitor whose <c>Verify</c> surface is scoped to interactions produced between <c>monitor.Run()</c> and the disposal of its <see cref=\"global::System.IDisposable\" /> scope.");
+		sb.AppendXmlRemarks(["The underlying mock keeps recording all interactions as usual - only the monitor's <c>Verify</c> view is scoped. Useful to verify only the interactions produced by a specific block of test code without resetting the mock.",]);
+		sb.AppendXmlReturns("A <see cref=\"global::Mockolate.Monitor.MockMonitor{T}\" /> that exposes <c>Verify</c> over the monitored interactions and a <c>Run()</c> method that opens the recording scope.");
+		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();").AppendLine();
 		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
 
 		#endregion IMockForXXX
 
-		sb.AppendLine();
-
 		#region IMockInScenarioForXXX
 
-		sb.AppendXmlSummary(
-			$"Scoped access to setups for a scenario on the mock of <see cref=\"{escapedClassName}\" />.", "\t");
+		sb.AppendXmlSummary($"Scoped access to setups for a scenario on the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 		sb.Append("\tinternal interface IMockInScenarioFor").Append(name).AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.AppendXmlSummary($"Set up the mock of <see cref=\"{escapedClassName}\" /> within the scenario scope.");
@@ -1127,16 +480,14 @@ internal static partial class Sources
 		if (hasProtectedMembers)
 		{
 			sb.AppendLine();
-			sb.AppendXmlSummary(
-				$"Set up protected members of the mock of <see cref=\"{escapedClassName}\" /> within the scenario scope.");
+			sb.AppendXmlSummary($"Set up protected members of the mock of <see cref=\"{escapedClassName}\" /> within the scenario scope.");
 			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" SetupProtected { get; }").AppendLine();
 		}
 
 		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
 
 		#endregion IMockInScenarioForXXX
-
-		sb.AppendLine();
 
 		#region IMockSetupForXXX
 
@@ -1152,73 +503,93 @@ internal static partial class Sources
 		}
 
 		sb.Append("\t{").AppendLine();
+		
 		DefineSetupInterface(sb, @class, MemberType.Public, hasOverloadResolutionPriority);
+		
 		sb.Append("\t}").AppendLine();
 		sb.AppendLine();
+
+		#endregion IMockSetupForXXX
+
+		#region IMockProtectedSetupForXXX
 
 		if (hasProtectedMembers)
 		{
 			sb.AppendXmlSummary($"Set up protected members for the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 			sb.Append("\tinternal interface IMockProtectedSetupFor").Append(name).AppendLine();
 			sb.Append("\t{").AppendLine();
+			
 			DefineSetupInterface(sb, @class, MemberType.Protected, hasOverloadResolutionPriority);
+			
 			sb.Append("\t}").AppendLine();
 			sb.AppendLine();
 		}
 
+		#endregion IMockProtectedSetupForXXX
+
+		#region IMockStaticSetupForXXX
+		
 		if (hasStaticMembers)
 		{
 			sb.AppendXmlSummary($"Set up static members for the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 			sb.Append("\tinternal interface IMockStaticSetupFor").Append(name).AppendLine();
 			sb.Append("\t{").AppendLine();
+			
 			DefineSetupInterface(sb, @class, MemberType.Static, hasOverloadResolutionPriority);
+			
 			sb.Append("\t}").AppendLine();
 			sb.AppendLine();
 		}
 
-		#endregion IMockSetupForXXX
+		#endregion IMockStaticSetupForXXX
 
+		#region IMockRaiseOnXXX
+		
 		if (hasEvents)
 		{
-			#region IMockRaiseOnXXX
-
 			sb.AppendXmlSummary($"Raise events on the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 			sb.Append("\tinternal interface IMockRaiseOn").Append(name).AppendLine();
 			sb.Append("\t{").AppendLine();
+			
 			DefineRaiseInterface(sb, @class, MemberType.Public);
+			
 			sb.Append("\t}").AppendLine();
 			sb.AppendLine();
-
-			#endregion IMockRaiseOnXXX
 		}
+		
+		#endregion IMockRaiseOnXXX
+
+		#region IMockProtectedRaiseOnXXX
 
 		if (hasProtectedEvents)
 		{
-			#region IMockProtectedRaiseOnXXX
-
 			sb.AppendXmlSummary($"Raise protected events on the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 			sb.Append("\tinternal interface IMockProtectedRaiseOn").Append(name).AppendLine();
 			sb.Append("\t{").AppendLine();
+			
 			DefineRaiseInterface(sb, @class, MemberType.Protected);
+			
 			sb.Append("\t}").AppendLine();
 			sb.AppendLine();
-
-			#endregion IMockProtectedRaiseOnXXX
 		}
+
+		#endregion IMockProtectedRaiseOnXXX
+
+		#region IMockStaticRaiseOnXXX
 
 		if (hasStaticEvents)
 		{
-			#region IMockStaticRaiseOnXXX
-
 			sb.AppendXmlSummary($"Raise static events on the mock of <see cref=\"{escapedClassName}\" />.", "\t");
 			sb.Append("\tinternal interface IMockStaticRaiseOn").Append(name).AppendLine();
 			sb.Append("\t{").AppendLine();
+			
 			DefineRaiseInterface(sb, @class, MemberType.Static);
+			
 			sb.Append("\t}").AppendLine();
 			sb.AppendLine();
-
-			#endregion IMockStaticRaiseOnXXX
 		}
+
+		#endregion IMockStaticRaiseOnXXX
 
 		#region IMockVerifyForXXX
 
@@ -1234,8 +605,14 @@ internal static partial class Sources
 		}
 
 		sb.Append("\t{").AppendLine();
+		
 		DefineVerifyInterface(sb, @class, $"IMockVerifyFor{name}", MemberType.Public, hasOverloadResolutionPriority);
+		
 		sb.Append("\t}").AppendLine();
+
+		#endregion IMockVerifyForXXX
+
+		#region IMockProtectedVerifyForXXX
 
 		if (hasProtectedMembers || hasProtectedEvents)
 		{
@@ -1249,6 +626,10 @@ internal static partial class Sources
 			sb.Append("\t}").AppendLine();
 		}
 
+		#endregion IMockProtectedVerifyForXXX
+
+		#region IMockStaticVerifyForXXX
+
 		if (hasStaticMembers || hasStaticEvents)
 		{
 			sb.AppendLine();
@@ -1261,262 +642,471 @@ internal static partial class Sources
 			sb.Append("\t}").AppendLine();
 		}
 
-		#endregion IMockVerifyForXXX
+		#endregion IMockStaticVerifyForXXX
+
+		#endregion Mock Interfaces
 
 		sb.Append("}").AppendLine();
+		
+		#endregion Mock
+		
+		#region MockForXXXExtensions
+
+		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" />.", "");
+#if !DEBUG
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
+		sb.Append("internal static partial class MockExtensionsFor").Append(name).AppendLine();
+		sb.Append("{").AppendLine();
+
+		#region Mock Type extensions
+
+		sb.Append("\t/// <inheritdoc cref=\"MockExtensionsFor").Append(name).Append("\" />").AppendLine();
+		sb.Append("\textension(").Append(@class.ClassFullName).Append(" mock)").AppendLine();
+		sb.Append("\t{").AppendLine();
+
+		#region Mock Property
+
+		string mockPropertyName = CreateUniquePropertyName(@class, "Mock");
+
+		List<string> mockPropertyRemarks =
+		[
+			$"The accessor is the bridge between the strongly-typed instance of <see cref=\"{escapedClassName}\" /> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.",
+			"Through it you can:",
+			"<list type=\"bullet\">",
+			"  <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item>",
+			"  <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item>",
+		];
+		if (hasEvents)
+		{
+			mockPropertyRemarks.Add("  <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item>");
+		}
+
+		if (hasProtectedMembers || hasProtectedEvents)
+		{
+			mockPropertyRemarks.Add("  <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword=\"protected\" /> members on class mocks.</description></item>");
+		}
+
+		if (hasStaticMembers || hasStaticEvents)
+		{
+			mockPropertyRemarks.Add("  <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword=\"static\" /> members on interface mocks.</description></item>");
+		}
+
+		mockPropertyRemarks.Add("  <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item>");
+		mockPropertyRemarks.Add("  <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item>");
+		mockPropertyRemarks.Add("  <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item>");
+		mockPropertyRemarks.Add("</list>");
+
+		sb.AppendXmlSummary($"Gets the mock accessor for <see cref=\"{escapedClassName}\" /> - the entry point for configuring setups, verifying interactions and raising events.");
+		sb.AppendXmlRemarks(mockPropertyRemarks.ToArray());
+		sb.AppendXmlException("global::Mockolate.Exceptions.MockException", $"The instance is not a Mockolate-generated mock of <see cref=\"{escapedClassName}\" />.");
+		sb.Append("\t\tpublic global::Mockolate.Mock.IMockFor").Append(name).Append(' ').Append(mockPropertyName).AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tget").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tif (mock is global::Mockolate.Mock.IMockFor").Append(name).Append(" mockInterface)").AppendLine();
+		sb.Append("\t\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t\treturn mockInterface;").AppendLine();
+		sb.Append("\t\t\t\t}").AppendLine();
+		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+
+		#endregion Mock Property
+
+		#region CreateMock
+
+		string createMockReturns = $"A new mock instance of <see cref=\"{escapedClassName}\" />.";
+		List<string> createMockRemarks =
+		[
+			$"The returned instance is a strongly-typed mock generated at compile time - it implements <see cref=\"{escapedClassName}\" /> and exposes the Mockolate surface through <c>.Mock</c>:",
+			"<list type=\"bullet\">",
+			"  <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item>",
+			"  <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item>",
+		];
+		if (hasEvents)
+		{
+			createMockRemarks.Add("  <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item>");
+		}
+
+		createMockRemarks.Add("</list>");
+		createMockRemarks.Add("With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword=\"null\" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref=\"global::Mockolate.MockBehavior\" /> to customize this (for example to make un-configured calls throw or to skip the base class).");
+		createMockRemarks.Add("Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.");
+
+		sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlRemarks(createMockRemarks.ToArray());
+		sb.AppendXmlReturns(createMockReturns);
+		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock()").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(null, null, (object?[]?)null);").AppendLine();
+		sb.AppendLine();
+
+		sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the default <see cref=\"global::Mockolate.MockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		sb.AppendXmlReturns(createMockReturns);
+		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::System.Action<").Append(setupType).Append("> setup)").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(null, setup, (object?[]?)null);").AppendLine();
+		sb.AppendLine();
+
+		sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />.");
+		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlReturns(createMockReturns);
+		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior)").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(mockBehavior, null, (object?[]?)null);").AppendLine();
+		sb.AppendLine();
+
+		sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> with the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately.");
+		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		sb.AppendXmlReturns(createMockReturns);
+		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<").Append(setupType).Append("> setup)").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(mockBehavior, setup, (object?[]?)null);").AppendLine();
+		sb.AppendLine();
+
+		if (hasParameterizedConstructor)
+		{
+			sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"constructorParameters\" /> to invoke the base-class constructor.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlReturns(createMockReturns);
+			sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(object?[] constructorParameters)").AppendLine();
+			sb.Append("\t\t\t=> CreateMock(null, null, constructorParameters);").AppendLine();
+			sb.AppendLine();
+
+			sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" /> and <paramref name=\"constructorParameters\" />.");
+			sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlReturns(createMockReturns);
+			sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)").AppendLine();
+			sb.Append("\t\t\t=> CreateMock(mockBehavior, null, constructorParameters);").AppendLine();
+			sb.AppendLine();
+
+			sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
+			sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+			sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+			sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.");
+			sb.AppendXmlReturns(createMockReturns);
+			sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(global::System.Action<").Append(setupType).Append("> setup, object?[] constructorParameters)").AppendLine();
+			sb.Append("\t\t\t=> CreateMock(null, setup, constructorParameters);").AppendLine();
+			sb.AppendLine();
+
+			AppendTypedCreateMockOverloads(sb, @class, constructors!.Value, setupType, escapedClassName, createMockReturns);
+		}
+
+		sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"mockBehavior\" />, applying the given <paramref name=\"setup\" /> immediately, using the given <paramref name=\"constructorParameters\" />.");
+		sb.AppendXmlRemarks("The provided <paramref name=\"setup\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		sb.AppendXmlParam("mockBehavior", "Controls how the mock responds when members are invoked without a matching setup, or <see langword=\"null\" /> for <c>MockBehavior.Default</c>.");
+		sb.AppendXmlParam("setup", "Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword=\"null\" /> to skip.");
+		sb.AppendXmlParam("constructorParameters", "Values forwarded to a matching base-class constructor, or <see langword=\"null\" /> to use the parameterless constructor.");
+		sb.AppendXmlReturns(createMockReturns);
+		sb.Append("\t\t").Append(hasParameterizedConstructor ? "public" : "private").Append(" static ").Append(@class.ClassFullName).Append(" CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<").Append(setupType).Append(">? setup, object?[]? constructorParameters)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tif (mockBehavior is not null)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tIMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;").AppendLine();
+		sb.Append("\t\t\t\tif (mockBehaviorAccess.TryGet<global::System.Action<").Append(setupType).Append(">?>(out var additionalSetup))").AppendLine();
+		sb.Append("\t\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t\tif (setup is null)").AppendLine();
+		sb.Append("\t\t\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t\t\tsetup = additionalSetup;").AppendLine();
+		sb.Append("\t\t\t\t\t}").AppendLine();
+		sb.Append("\t\t\t\t\telse").AppendLine();
+		sb.Append("\t\t\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t\t\tvar originalSetup = setup;").AppendLine();
+		sb.Append("\t\t\t\t\t\tsetup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };").AppendLine();
+		sb.Append("\t\t\t\t\t}").AppendLine();
+		sb.Append("\t\t\t\t}").AppendLine();
+		if (!@class.IsInterface && !hasStaticMembers)
+		{
+			sb.Append("\t\t\t\tif (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<").Append(@class.ClassFullName).Append(">(out object?[]? parameters))").AppendLine();
+			sb.Append("\t\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\t\tconstructorParameters = parameters;").AppendLine();
+			sb.Append("\t\t\t\t}").AppendLine();
+		}
+
+		sb.Append("\t\t\t}").AppendLine();
+		sb.AppendLine();
+
+		if (@class is { ClassFullName: "global::System.Net.Http.HttpClient", })
+		{
+			sb.Append("\t\t\tglobal::Mockolate.MockBehavior effectiveBehavior = mockBehavior ?? global::Mockolate.MockBehavior.Default;").AppendLine();
+			sb.Append("\t\t\tglobal::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(effectiveBehavior, global::Mockolate.Mock.").Append(name).Append(".CreateFastInteractions(effectiveBehavior), constructorParameters);").AppendLine();
+			sb.Append("\t\t\tif (constructorParameters is null)").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\tconstructorParameters = [new global::Mockolate.Mock.HttpMessageHandler(mockRegistry),];").AppendLine();
+			sb.Append("\t\t\t\tmockRegistry = new global::Mockolate.MockRegistry(mockRegistry, constructorParameters);").AppendLine();
+			sb.Append("\t\t\t}").AppendLine();
+			sb.Append("\t\t\telse if (constructorParameters.Length > 0 && constructorParameters[0] is global::Mockolate.Mock.HttpMessageHandler && constructorParameters[0] is global::Mockolate.IMock httpMessageHandlerMock)").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\tif (mockBehavior is not null && httpMessageHandlerMock.MockRegistry.Behavior != mockBehavior)").AppendLine();
+			sb.Append("\t\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"Mock of type 'System.Net.Http.HttpClient' cannot be created with behavior '{mockBehavior}' because it shares its mock registry with a mock of type 'System.Net.Http.HttpMessageHandler' that has behavior '{httpMessageHandlerMock.MockRegistry.Behavior}'.\");").AppendLine();
+			sb.Append("\t\t\t\t}").AppendLine();
+			sb.Append("\t\t\t\tmockRegistry = new global::Mockolate.MockRegistry(httpMessageHandlerMock.MockRegistry, constructorParameters);").AppendLine();
+			sb.Append("\t\t\t}").AppendLine();
+			sb.Append("\t\t\tmockBehavior ??= global::Mockolate.MockBehavior.Default;").AppendLine();
+		}
+		else
+		{
+			sb.Append("\t\t\tmockBehavior ??= global::Mockolate.MockBehavior.Default;").AppendLine();
+			sb.Append("\t\t\tglobal::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.").Append(name).Append(".CreateFastInteractions(mockBehavior), constructorParameters);").AppendLine();
+		}
+
+		sb.Append("\t\t\treturn CreateMockInstance(mockRegistry, constructorParameters, setup);").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+
+		sb.AppendLine();
+		sb.Append("\t\tprivate static ").Append(@class.ClassFullName).Append(" CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<").Append(setupType).Append(">? setup)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		if (!@class.IsInterface && constructors?.Count > 0)
+		{
+			sb.Append("\t\t\tif (constructorParameters is null || constructorParameters.Length == 0)").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			if (constructors.Value.Any(m => m.Parameters.Count == 0))
+			{
+				sb.Append("\t\t\t\tglobal::Mockolate.Mock.").Append(name).Append(".MockRegistryProvider.Value = mockRegistry;").AppendLine();
+				sb.Append("\t\t\t\tglobal::Mockolate.MockExtensionsFor").Append(name).Append(".MockSetup? setupTarget = null;").AppendLine();
+				sb.Append("\t\t\t\tif (setup is not null)").AppendLine();
+				sb.Append("\t\t\t\t{").AppendLine();
+				sb.Append("\t\t\t\t\tsetupTarget ??= new(mockRegistry);").AppendLine();
+				sb.Append("\t\t\t\t\tsetup.Invoke(setupTarget);").AppendLine();
+				sb.Append("\t\t\t\t}").AppendLine();
+				sb.Append("\t\t\t\treturn new global::Mockolate.Mock.").Append(name).Append("(mockRegistry);").AppendLine();
+			}
+			else
+			{
+				sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"No parameterless constructor found for '").Append(@class.DisplayString).Append("'. Please provide constructor parameters.\");").AppendLine();
+			}
+
+			sb.Append("\t\t\t}").AppendLine();
+			int constructorIndex = 0;
+			bool useTryCast = false;
+			bool useTryCastWithDefaultValue = false;
+			foreach (EquatableArray<MethodParameter> constructorParameters in constructors.Value.Select(constructor => constructor.Parameters))
+			{
+				constructorIndex++;
+				int requiredParameters = constructorParameters.Count(c => !c.HasExplicitDefaultValue);
+				if (requiredParameters < constructorParameters.Count)
+				{
+					sb.Append("\t\t\telse if (constructorParameters.Length >= ").Append(requiredParameters).Append(" && constructorParameters.Length <= ").Append(constructorParameters.Count);
+				}
+				else
+				{
+					sb.Append("\t\t\telse if (constructorParameters.Length == ").Append(constructorParameters.Count);
+				}
+
+				int constructorParameterIndex = 0;
+				foreach (MethodParameter parameter in constructorParameters)
+				{
+					useTryCast = useTryCast || !parameter.HasExplicitDefaultValue;
+					useTryCastWithDefaultValue = useTryCastWithDefaultValue || parameter.HasExplicitDefaultValue;
+					sb.AppendLine().Append("\t\t\t    && ")
+						.Append(parameter.HasExplicitDefaultValue ? "TryCastWithDefaultValue" : "TryCast")
+						.Append("(constructorParameters, ")
+						.Append(constructorParameterIndex++)
+						.Append(parameter.HasExplicitDefaultValue ? $", {parameter.ExplicitDefaultValue}" : "")
+						.Append(", mockRegistry.Behavior, out ").Append(parameter.Type.Fullname).Append(" c")
+						.Append(constructorIndex)
+						.Append('p')
+						.Append(constructorParameterIndex).Append(")");
+				}
+
+				sb.Append(")").AppendLine();
+				sb.Append("\t\t\t{").AppendLine();
+				sb.Append("\t\t\t\tglobal::Mockolate.Mock.").Append(name).Append(".MockRegistryProvider.Value = mockRegistry;").AppendLine();
+				sb.Append("\t\t\t\tglobal::Mockolate.MockExtensionsFor").Append(name).Append(".MockSetup? setupTarget = null;").AppendLine();
+				sb.Append("\t\t\t\tif (setup is not null)").AppendLine();
+				sb.Append("\t\t\t\t{").AppendLine();
+				sb.Append("\t\t\t\t\tsetupTarget ??= new(mockRegistry);").AppendLine();
+				sb.Append("\t\t\t\t\tsetup.Invoke(setupTarget);").AppendLine();
+				sb.Append("\t\t\t\t}").AppendLine();
+				sb.Append("\t\t\t\treturn new global::Mockolate.Mock.").Append(name).Append("(mockRegistry");
+				for (int i = 1; i <= constructorParameters.Count; i++)
+				{
+					sb.Append(", ").Append('c').Append(constructorIndex).Append('p').Append(i);
+				}
+
+				sb.Append(");").AppendLine();
+				sb.Append("\t\t\t}").AppendLine();
+			}
+
+			sb.Append("\t\t\telse").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"Could not find any constructor for '").Append(@class.DisplayString).Append("' that matches the {constructorParameters.Length} given parameters ({string.Join(\", \", constructorParameters)}).\");").AppendLine();
+			sb.Append("\t\t\t}").AppendLine();
+			if (useTryCast)
+			{
+				sb.Append("""
+				          			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
+				          			{
+				          			    var value = values[index];
+				          				if (value is TValue typedValue)
+				          				{
+				          					result = typedValue;
+				          					return true;
+				          				}
+				          				
+				          				result = default!;
+				          				return value is null;
+				          			}
+				          """).AppendLine();
+			}
+
+			if (useTryCastWithDefaultValue)
+			{
+				sb.Append("""
+				          			static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
+				          			{
+				          				if (values.Length > index && values[index] is TValue typedValue)
+				          				{
+				          					result = typedValue;
+				          					return true;
+				          				}
+				          				
+				          				result = defaultValue;
+				          				return true;
+				          			}
+				          """).AppendLine();
+			}
+		}
+		else
+		{
+			sb.Append("\t\t\tvar value = new global::Mockolate.Mock.").Append(name).Append("(mockRegistry);").AppendLine();
+			sb.Append("\t\t\tif (setup is not null)").AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			sb.Append("\t\t\t\tsetup.Invoke(value);").AppendLine();
+			sb.Append("\t\t\t}").AppendLine();
+			sb.Append("\t\t\treturn value;").AppendLine();
+		}
+
+		sb.Append("\t\t}").AppendLine();
+
+		#endregion CreateMock
+		
+		#region Wrapping
+
+		sb.AppendXmlSummary("Creates a mock that wraps the given <paramref name=\"instance\" />.");
+		sb.AppendXmlRemarks("Public members on the mock forward to <paramref name=\"instance\" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.");
+		sb.AppendXmlParam("instance", "The real object whose calls should be forwarded. Must not be <see langword=\"null\" />.");
+		sb.AppendXmlReturns($"A new mock of <see cref=\"{escapedClassName}\" /> that delegates to <paramref name=\"instance\" />.");
+		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Wrapping(").Append(@class.ClassFullName).Append(" instance)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tif (mock is global::Mockolate.IMock mockInterface)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tglobal::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);").AppendLine();
+		sb.Append("\t\t\t\twrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.").Append(name).Append(".CreateFastInteractions(wrappingRegistry.Behavior));").AppendLine();
+		sb.Append("\t\t\t\treturn CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+		
+		#endregion Wrapping
+
+		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
+
+		#endregion Mock Type extensions
+
+		#region MockBehavior extensions
+
+		sb.Append("\t/// <inheritdoc cref=\"MockExtensionsFor").Append(name).Append("\" />").AppendLine();
+		sb.Append("\textension(global::Mockolate.MockBehavior behavior)").AppendLine();
+		sb.Append("\t{").AppendLine();
+
+		#region Initialize
+		
+		sb.AppendXmlSummary("Initializes mocks of type <typeparamref name=\"T\" /> with the given <paramref name=\"setup\" />.");
+		sb.AppendXmlRemarks("The <paramref name=\"setup\" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.");
+		sb.AppendXmlTypeParam("T", $"The mockable type derived from <see cref=\"{escapedClassName}\" /> that this setup should apply to.");
+		sb.AppendXmlParam("setup", "Callback invoked when a new mock of <typeparamref name=\"T\" /> is created.");
+		sb.AppendXmlReturns("A new <see cref=\"global::Mockolate.MockBehavior\" /> with the registered initializer. The original instance is unchanged.");
+		sb.Append("\t\tpublic global::Mockolate.MockBehavior Initialize<T>(global::System.Action<").Append(setupType).Append("> setup)").AppendLine();
+		sb.Append("\t\t\twhere T : ").Append(@class.ClassFullName).AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tvar behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;").AppendLine();
+		sb.Append("\t\t\treturn behaviorAccess.Set(setup);").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		
+		#endregion Initialize
+
+		sb.Append("\t}").AppendLine();
+
+		#endregion MockBehavior extensions
+
+		#region Setup helpers
+
+		if (!@class.IsInterface && constructors?.Count > 0)
+		{
+			#region IMockSetupInitializationForXXX
+			string protectedName = @class.GetUniqueName("Protected", "SetupProtected");
+			if (hasProtectedMembers)
+			{
+				sb.Append("\tinternal interface IMockSetupInitializationFor").Append(name).Append(" : global::Mockolate.Mock.IMockSetupFor").Append(name).AppendLine();
+				sb.Append("\t{").AppendLine();
+				sb.AppendXmlSummary("Setup protected members");
+				sb.Append("\t\tglobal::Mockolate.Mock.IMockProtectedSetupFor").Append(name).Append(' ').Append(protectedName).Append(" { get; }").AppendLine();
+				sb.Append("\t}").AppendLine();
+			}
+			#endregion IMockSetupInitializationForXXX
+
+			sb.AppendLine();
+			
+			#region MockSetup
+#if !DEBUG
+			sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+			sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
+			sb.Append("\tinternal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupFor").Append(name);
+			if (hasProtectedMembers)
+			{
+				sb.Append(", global::Mockolate.Mock.IMockProtectedSetupFor").Append(name).Append(", IMockSetupInitializationFor").Append(name);
+			}
+
+			sb.AppendLine();
+			sb.Append("\t{").AppendLine();
+			if (hasProtectedMembers)
+			{
+				sb.Append("\t\t/// <inheritdoc />").AppendLine();
+				sb.Append("\t\tglobal::Mockolate.Mock.IMockProtectedSetupFor").Append(name).Append(" IMockSetupInitializationFor").Append(name).Append('.').Append(protectedName).Append(" => this;").AppendLine();
+			}
+
+			sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; } = mockRegistry;").AppendLine();
+			sb.AppendLine();
+			sb.Append("\t\t#region IMockSetupFor").Append(name).AppendLine();
+			sb.AppendLine();
+			
+			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public, memberIds, memberIdPrefix);
+			
+			sb.Append("\t\t#endregion IMockSetupFor").Append(name).AppendLine();
+			if (hasProtectedMembers)
+			{
+				sb.AppendLine();
+				sb.Append("\t\t#region IMockProtectedSetupFor").Append(name).AppendLine();
+				sb.AppendLine();
+				
+				ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}", MemberType.Protected, memberIds, memberIdPrefix);
+				
+				sb.Append("\t\t#endregion IMockProtectedSetupFor").Append(name).AppendLine();
+			}
+
+			sb.Append("\t}").AppendLine();
+			#endregion MockSetup
+		}
+
+		#endregion Setup helpers
+
+		AppendNestedCovariantParameterAdapter(sb);
+		
+		sb.Append("}").AppendLine();
+
+		#endregion MockForXXXExtensions
+		
 		sb.AppendLine();
 		sb.AppendLine("#nullable disable annotations");
 		return sb.ToString();
-	}
-
-	private static void AppendCreateFastInteractions(StringBuilder sb, string indent)
-	{
-		sb.Append(indent).Append("/// <summary>").AppendLine();
-		sb.Append(indent)
-			.Append("///     Creates a <see cref=\"global::Mockolate.Interactions.FastMockInteractions\" /> sized to ")
-			.Append("<see cref=\"MemberCount\" /> for use as the mock's interaction store.").AppendLine();
-		sb.Append(indent)
-			.Append("///     Per-member buffers are not allocated up-front: the recording hot paths call ")
-			.Append("<see cref=\"global::Mockolate.Interactions.FastMockInteractions.GetOrCreateBuffer{TBuffer}(int, global::System.Func{global::Mockolate.Interactions.FastMockInteractions, TBuffer})\" />")
-			.Append(" so a slot is materialized only when its member is first invoked.").AppendLine();
-		sb.Append(indent).Append("/// </summary>").AppendLine();
-		sb.Append(indent)
-			.Append(
-				"internal static global::Mockolate.Interactions.FastMockInteractions CreateFastInteractions(global::Mockolate.MockBehavior behavior)")
-			.AppendLine();
-		sb.Append(indent)
-			.Append(
-				"\t=> new global::Mockolate.Interactions.FastMockInteractions(MemberCount, behavior.SkipInteractionRecording);")
-			.AppendLine();
-	}
-
-	/// <summary>
-	///     Emits the declarations of the cached <c>MockolateSkipRecording</c> flag and per-member typed
-	///     buffer fields. These mirror values that <c>AppendCreateFastInteractions</c> writes into the
-	///     <c>FastMockInteractions.Buffers</c> array so the body emitters can read them as plain field
-	///     accesses instead of paying the cast / array-index / property-chain on every invocation. Static
-	///     members stay on the legacy path because the cached field would not flow through
-	///     <c>AsyncLocal</c>-resolved registries.
-	/// </summary>
-	/// <summary>
-	///     <see langword="true" /> when the class has at least one fast-eligible non-static indexer or
-	///     method, in which case the generator emits cached typed-buffer fields and a
-	///     <c>MockolateSkipRecording</c> flag that the recording hot paths read instead of paying the
-	///     per-call cast / array-index / property-chain.
-	/// </summary>
-	private static bool HasCachedBufferFields(Class @class)
-	{
-		foreach (Property property in @class.AllProperties())
-		{
-			if (property.IsIndexer && IsFastBufferEligibleIndexer(property))
-			{
-				return true;
-			}
-		}
-
-		foreach (Method method in @class.AllMethods())
-		{
-			if (!method.IsStatic && IsFastBufferEligibleMethod(method))
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	private static void AppendCachedFieldDeclarations(StringBuilder sb, string indent, Class @class,
-		MemberIdTable memberIds, string memberIdPrefix, string mockRegistryName)
-	{
-		if (!HasCachedBufferFields(@class))
-		{
-			return;
-		}
-
-		string mockRegistryRef = "this." + mockRegistryName;
-
-		foreach (Property indexer in @class.AllProperties().Where(p => p.IsIndexer))
-		{
-			if (!IsFastBufferEligibleIndexer(indexer))
-			{
-				continue;
-			}
-
-			string indexerKeyTypeArgs =
-				string.Join(", ", indexer.IndexerParameters!.Value.Select(p => p.ToTypeOrWrapper()));
-			string indexerValueType = indexer.Type.ToTypeOrWrapper();
-			string getMemberIdRef = memberIdPrefix + memberIds.GetIndexerGetIdentifier(indexer);
-			string setMemberIdRef = memberIdPrefix + memberIds.GetIndexerSetIdentifier(indexer);
-			string getterBufferType = "global::Mockolate.Interactions.FastIndexerGetterBuffer<"
-			                          + indexerKeyTypeArgs + ">";
-			string setterBufferType = "global::Mockolate.Interactions.FastIndexerSetterBuffer<"
-			                          + indexerKeyTypeArgs + ", " + indexerValueType + ">";
-
-			sb.Append(indent)
-				.Append(
-					"[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append(indent).Append("private ").Append(getterBufferType).Append(' ')
-				.Append(memberIds.GetIndexerGetterBufferFieldName(indexer)).AppendLine();
-			sb.Append(indent).Append("\t=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)")
-				.Append(mockRegistryRef).Append(".Interactions).GetOrCreateBuffer<").Append(getterBufferType)
-				.Append(">(").Append(getMemberIdRef).Append(", static fast => new ").Append(getterBufferType)
-				.Append("(fast)));").AppendLine();
-
-			sb.Append(indent)
-				.Append(
-					"[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append(indent).Append("private ").Append(setterBufferType).Append(' ')
-				.Append(memberIds.GetIndexerSetterBufferFieldName(indexer)).AppendLine();
-			sb.Append(indent).Append("\t=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)")
-				.Append(mockRegistryRef).Append(".Interactions).GetOrCreateBuffer<").Append(setterBufferType)
-				.Append(">(").Append(setMemberIdRef).Append(", static fast => new ").Append(setterBufferType)
-				.Append("(fast)));").AppendLine();
-		}
-
-		foreach (Method method in @class.AllMethods())
-		{
-			if (method.IsStatic || !IsFastBufferEligibleMethod(method))
-			{
-				continue;
-			}
-
-			int arity = method.Parameters.Count;
-			string typeArgs = arity == 0
-				? string.Empty
-				: "<" + string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper())) + ">";
-			string memberIdRef = memberIdPrefix + memberIds.GetMethodIdentifier(method);
-			string bufferType = "global::Mockolate.Interactions.FastMethod" + arity + "Buffer" + typeArgs;
-			sb.Append(indent)
-				.Append(
-					"[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append(indent).Append("private ").Append(bufferType).Append(' ')
-				.Append(memberIds.GetMethodBufferFieldName(method)).AppendLine();
-			sb.Append(indent).Append("\t=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)")
-				.Append(mockRegistryRef).Append(".Interactions).GetOrCreateBuffer<").Append(bufferType)
-				.Append(">(").Append(memberIdRef).Append(", static fast => new ").Append(bufferType)
-				.Append("(fast)));").AppendLine();
-		}
-	}
-
-	/// <summary>
-	///     Properties get a typed per-member buffer when they are not static. Static property recordings stay on
-	///     the legacy <c>RegisterInteraction</c> path because their member id is shared across <c>AsyncLocal</c>
-	///     contexts whereas the buffer instance is stored on a single registry, so per-context isolation breaks.
-	/// </summary>
-	private static bool IsFastBufferEligibleProperty(Property property)
-		=> !property.IsStatic;
-
-	/// <summary>
-	///     Indexers with up to four key parameters and a non-ref-struct signature get a typed per-member buffer.
-	/// </summary>
-	private static bool IsFastBufferEligibleIndexer(Property indexer)
-	{
-		if (indexer.IsStatic ||
-		    indexer.IndexerParameters is null ||
-		    indexer.IndexerParameters.Value.Count == 0 ||
-		    indexer.IndexerParameters.Value.Count > 4)
-		{
-			return false;
-		}
-
-		foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
-		{
-			if (parameter.NeedsRefStructPipeline())
-			{
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/// <summary>
-	///     Events get a typed per-member buffer when they are not static (see <see cref="IsFastBufferEligibleProperty" />
-	///     for the rationale).
-	/// </summary>
-	private static bool IsFastBufferEligibleEvent(Event @event)
-		=> !@event.IsStatic;
-
-	/// <summary>
-	///     Methods with non-generic, non-ref-struct signatures get a typed per-member buffer; everything
-	///     else (open generics, ref-struct params) records via the legacy <c>RegisterInteraction</c> fallback.
-	/// </summary>
-	private static bool IsFastBufferEligibleMethod(Method method)
-	{
-		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
-		{
-			return false;
-		}
-
-		foreach (MethodParameter parameter in method.Parameters)
-		{
-			if (parameter.NeedsRefStructPipeline())
-			{
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/// <summary>
-	///     A <c>T?</c> return where <c>T</c> is one of the method's generic parameters and is
-	///     constrained to a reference type (or any other non-value-type constraint such as
-	///     <c>class</c>, <c>class?</c>, an interface, or <c>notnull</c>) cannot be expressed in
-	///     the explicit setup-interface implementation: CS0460 forbids restating the inherited
-	///     constraint, and <c>where T : default</c> (CS8822) conflicts with those constraints.
-	///     Without a constraint clause the compiler resolves the bare <c>T?</c> as
-	///     <c>Nullable&lt;T&gt;</c> and reports CS0453/CS9334/CS0738/CS0266.
-	///     The fix is to drop the trailing <c>?</c> from the setup-side return type
-	///     (<c>IReturnMethodSetup&lt;T&gt;</c> instead of <c>IReturnMethodSetup&lt;T?&gt;</c>) and from
-	///     the matching <c>ReturnMethodSetup&lt;T&gt;</c> construction. NRT annotations are erased at
-	///     runtime, so the underlying setup object is identical and the fluent API still composes.
-	///     The user-facing mock body keeps <c>T?</c> because the constraint is visible there.
-	/// </summary>
-	private static bool ShouldStripNullableGenericReturnAnnotation(Method method)
-	{
-		if (method.GenericParameters is null || method.GenericParameters.Value.Count == 0)
-		{
-			return false;
-		}
-
-		string fullname = method.ReturnType.Fullname;
-		if (fullname.Length < 2 || fullname[fullname.Length - 1] != '?')
-		{
-			return false;
-		}
-
-		string raw = fullname.Substring(0, fullname.Length - 1);
-		foreach (GenericParameter gp in method.GenericParameters.Value)
-		{
-			if (gp.Name == raw)
-			{
-				return !gp.IsStruct && !gp.IsUnmanaged;
-			}
-		}
-
-		return false;
-	}
-
-	/// <summary>
-	///     Emits the method's return type as it should appear inside the setup-side surface
-	///     (the <c>IReturnMethodSetup&lt;...&gt;</c> wrapper on the setup interface, the explicit
-	///     impl, and the <c>new ReturnMethodSetup&lt;...&gt;</c> construction). Strips a trailing
-	///     <c>?</c> when <see cref="ShouldStripNullableGenericReturnAnnotation" /> applies.
-	/// </summary>
-	private static void AppendSetupReturnType(StringBuilder sb, Method method)
-	{
-		if (ShouldStripNullableGenericReturnAnnotation(method))
-		{
-			string fullname = method.ReturnType.Fullname;
-			sb.Append(fullname, 0, fullname.Length - 1);
-			return;
-		}
-
-		sb.AppendTypeOrWrapper(method.ReturnType);
 	}
 
 #pragma warning disable S107 // Methods should not have too many parameters
@@ -1524,63 +1114,46 @@ internal static partial class Sources
 		bool hasEvents, bool hasProtectedMembers, bool hasProtectedEvents, bool hasStaticMembers, bool hasStaticEvents)
 	{
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append(
-				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-			.AppendLine();
+		sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
 		sb.Append("\t\tIMockSetupFor").Append(name).Append(" IMockFor").Append(name).Append(".Setup").AppendLine();
 		sb.Append("\t\t\t=> this;").AppendLine();
 
 		if (hasProtectedMembers)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" IMockFor").Append(name)
-				.Append(".SetupProtected").AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" IMockFor").Append(name).Append(".SetupProtected").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" global::Mockolate.MockExtensionsFor")
-				.Append(name).Append(".IMockSetupInitializationFor").Append(name).Append(".Protected").AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tIMockProtectedSetupFor").Append(name).Append(" global::Mockolate.MockExtensionsFor").Append(name).Append(".IMockSetupInitializationFor").Append(name).Append(".Protected").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 		}
 
 		if (hasStaticMembers)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append("\t\tIMockStaticSetupFor").Append(name).Append(" IMockFor").Append(name).Append(".SetupStatic")
-				.AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tIMockStaticSetupFor").Append(name).Append(" IMockFor").Append(name).Append(".SetupStatic").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 		}
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tIMockInScenarioFor").Append(name).Append(" IMockFor").Append(name)
-			.Append(".InScenario(string scenario)").AppendLine();
-		sb.Append("\t\t\t=> new MockInScenarioFor").Append(name).Append("(this.").Append(mockRegistryName)
-			.Append(", scenario);").AppendLine();
+		sb.Append("\t\tIMockInScenarioFor").Append(name).Append(" IMockFor").Append(name).Append(".InScenario(string scenario)").AppendLine();
+		sb.Append("\t\t\t=> new MockInScenarioFor").Append(name).Append("(this.").Append(mockRegistryName).Append(", scenario);").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tIMockFor").Append(name).Append(" IMockFor").Append(name)
-			.Append(".InScenario(string scenario, global::System.Action<IMockInScenarioFor").Append(name)
-			.Append("> setup)").AppendLine();
+		sb.Append("\t\tIMockFor").Append(name).Append(" IMockFor").Append(name).Append(".InScenario(string scenario, global::System.Action<IMockInScenarioFor").Append(name).Append("> setup)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tsetup.Invoke(new MockInScenarioFor").Append(name).Append("(this.").Append(mockRegistryName)
-			.Append(", scenario));").AppendLine();
+		sb.Append("\t\t\tsetup.Invoke(new MockInScenarioFor").Append(name).Append("(this.").Append(mockRegistryName).Append(", scenario));").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
 		sb.Append("\t\t}").AppendLine();
 		sb.AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tIMockFor").Append(name).Append(" IMockFor").Append(name)
-			.Append(".TransitionTo(string scenario)").AppendLine();
+		sb.Append("\t\tIMockFor").Append(name).Append(" IMockFor").Append(name).Append(".TransitionTo(string scenario)").AppendLine();
 		sb.Append("\t\t{").AppendLine();
 		sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(".TransitionTo(scenario);").AppendLine();
 		sb.Append("\t\t\treturn this;").AppendLine();
@@ -1589,9 +1162,7 @@ internal static partial class Sources
 		if (hasEvents)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
 			sb.Append("\t\tIMockRaiseOn").Append(name).Append(" IMockFor").Append(name).Append(".Raise").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 		}
@@ -1599,308 +1170,62 @@ internal static partial class Sources
 		if (hasProtectedEvents)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append("\t\tIMockProtectedRaiseOn").Append(name).Append(" IMockFor").Append(name)
-				.Append(".RaiseProtected").AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tIMockProtectedRaiseOn").Append(name).Append(" IMockFor").Append(name).Append(".RaiseProtected").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 		}
 
 		if (hasStaticEvents)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append("\t\tIMockStaticRaiseOn").Append(name).Append(" IMockFor").Append(name).Append(".RaiseStatic")
-				.AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tIMockStaticRaiseOn").Append(name).Append(" IMockFor").Append(name).Append(".RaiseStatic").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 		}
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append(
-				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-			.AppendLine();
+		sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
 		sb.Append("\t\tIMockVerifyFor").Append(name).Append(" IMockFor").Append(name).Append(".Verify").AppendLine();
 		sb.Append("\t\t\t=> this;").AppendLine();
 
 		if (hasProtectedMembers || hasProtectedEvents)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append("\t\tIMockProtectedVerifyFor").Append(name).Append(" IMockFor").Append(name)
-				.Append(".VerifyProtected").AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tIMockProtectedVerifyFor").Append(name).Append(" IMockFor").Append(name).Append(".VerifyProtected").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 		}
 
 		if (hasStaticMembers || hasStaticEvents)
 		{
 			sb.Append("\t\t/// <inheritdoc />").AppendLine();
-			sb.Append(
-					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-				.AppendLine();
-			sb.Append("\t\tIMockStaticVerifyFor").Append(name).Append(" IMockFor").Append(name).Append(".VerifyStatic")
-				.AppendLine();
+			sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append("\t\tIMockStaticVerifyFor").Append(name).Append(" IMockFor").Append(name).Append(".VerifyStatic").AppendLine();
 			sb.Append("\t\t\t=> this;").AppendLine();
 		}
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> IMockFor")
-			.Append(name).Append(".VerifySetup(global::Mockolate.Setup.IMethodSetup setup)").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Method<IMockVerifyFor").Append(name)
-			.Append(">(this, setup);").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> IMockFor").Append(name).Append(".VerifySetup(global::Mockolate.Setup.IMethodSetup setup)").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Method<IMockVerifyFor").Append(name).Append(">(this, setup);").AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
 		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllInteractionsAreVerified()").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName)
-			.Append(".Interactions.GetUnverifiedInteractions().Count == 0;").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Interactions.GetUnverifiedInteractions().Count == 0;").AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
 		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllSetupsAreUsed()").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".GetUnusedSetups(this.").Append(mockRegistryName)
-			.Append(".Interactions).Count == 0;").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".GetUnusedSetups(this.").Append(mockRegistryName).Append(".Interactions).Count == 0;").AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
 		sb.Append("\t\tvoid IMockFor").Append(name).Append(".ClearAllInteractions()").AppendLine();
 		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".ClearAllInteractions();").AppendLine();
 
 		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> IMockFor")
-			.Append(name).Append(".Monitor()").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> IMockFor").Append(name).Append(".Monitor()").AppendLine();
 		sb.Append("\t\t\t=> new global::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append(">(this.")
 			.Append(mockRegistryName).Append(".Interactions, interactions => new VerifyMonitor").Append(name)
 			.Append("(new global::Mockolate.MockRegistry(this.").Append(mockRegistryName).Append(", interactions)));")
 			.AppendLine();
-		sb.AppendLine();
-	}
-#pragma warning restore S107 // Methods should not have too many parameters
-
-	private static void AppendTypedCreateMockOverloads(StringBuilder sb, Class @class,
-		EquatableArray<Method> constructors, string setupType, string escapedClassName, string createMockReturns)
-	{
-		// Seeded signatures track the hand-written CreateMock overloads so typed overloads that
-		// would collide with them are skipped. The key order mirrors the emitted C# signature:
-		// "mockBehavior? | setup? | ctor-param-types...".
-		HashSet<string> emittedSignatures = new(StringComparer.Ordinal)
-		{
-			string.Empty,
-			"global::Mockolate.MockBehavior",
-			$"global::System.Action<{setupType}>",
-			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>",
-			"object?[]",
-			"global::Mockolate.MockBehavior|object?[]",
-			$"global::System.Action<{setupType}>|object?[]",
-			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>|object?[]",
-		};
-
-		foreach (Method constructor in constructors)
-		{
-			if (constructor.Parameters.Count == 0)
-			{
-				continue;
-			}
-
-			if (constructor.Parameters.Any(p => p.RefKind != RefKind.None || p.IsParams))
-			{
-				continue;
-			}
-
-			string mockBehaviorName = CreateUniqueParameterName(constructor.Parameters, "mockBehavior");
-			string setupName = CreateUniqueParameterName(constructor.Parameters, "setup");
-			string baseSig = string.Join("|",
-				constructor.Parameters.Select(p => p.Type.Fullname));
-
-			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
-				false, false, mockBehaviorName, setupName, baseSig,
-				emittedSignatures);
-			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
-				true, false, mockBehaviorName, setupName, baseSig,
-				emittedSignatures);
-			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
-				false, true, mockBehaviorName, setupName, baseSig,
-				emittedSignatures);
-			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
-				true, true, mockBehaviorName, setupName, baseSig,
-				emittedSignatures);
-		}
-	}
-
-	/// <summary>
-	///     Builds an XML-doc cref string and a matching short display text for the given
-	///     <paramref name="constructor" /> on <paramref name="class" />. The cref has the form
-	///     <c>{class-cref}({fully-qualified-param-types})</c>; the display has the form
-	///     <c>{simple-name}({short-param-types})</c>, intended as the inner text of
-	///     <c>&lt;see cref="..."&gt;...&lt;/see&gt;</c> so the rendered prose reads
-	///     <c>the MyClass(int) constructor</c>.
-	///     Returns <see langword="null" /> when no valid cref can be produced.
-	/// </summary>
-	/// <remarks>
-	///     Generic classes are skipped because the cref type-parameter-list syntax (e.g. <c>{T}</c>)
-	///     expects identifier tokens, not the concrete type arguments that closed generics carry —
-	///     emitting <c>MyClass{int}(int)</c> would surface CS1584/CS1658 on the consumer side.
-	/// </remarks>
-	private static (string Cref, string Display)? BuildConstructorCref(Class @class, Method constructor)
-	{
-		string fullName = @class.ClassFullName;
-
-		if (fullName.IndexOf('<') >= 0)
-		{
-			return null;
-		}
-
-		int lastDot = fullName.LastIndexOf('.');
-		string simpleName = lastDot >= 0 ? fullName.Substring(lastDot + 1) : fullName;
-
-		StringBuilder cref = new();
-		StringBuilder display = new();
-		cref.Append(fullName).Append('(');
-		display.Append(simpleName).Append('(');
-		bool first = true;
-		foreach (MethodParameter parameter in constructor.Parameters)
-		{
-			if (!first)
-			{
-				cref.Append(", ");
-				display.Append(", ");
-			}
-
-			first = false;
-			cref.Append(parameter.Type.Fullname.EscapeForXmlDoc());
-			// Inner text of <see> is XML content, so escape '<'/'>' as entities
-			// (unlike cref attributes, which use the '{...}' shorthand).
-			display.Append(parameter.Type.DisplayName.Replace("<", "&lt;").Replace(">", "&gt;"));
-		}
-
-		cref.Append(')');
-		display.Append(')');
-		return (cref.ToString(), display.ToString());
-	}
-
-#pragma warning disable S107 // Methods should not have too many parameters
-	private static void TryEmitTypedCreateMockOverload(StringBuilder sb, Class @class, Method constructor,
-		string setupType, string escapedClassName, string createMockReturns,
-		bool includeMockBehavior, bool includeSetup, string mockBehaviorName, string setupName, string baseSig,
-		HashSet<string> emittedSignatures)
-	{
-		// Build the signature key in the same order as the emitted method signature
-		// (mockBehavior, setup, then ctor parameters) so it correctly detects collisions against
-		// other typed overloads and against the hand-written seeded overloads.
-		string sig = baseSig;
-		if (includeSetup)
-		{
-			sig = $"global::System.Action<{setupType}>|{sig}";
-		}
-
-		if (includeMockBehavior)
-		{
-			sig = $"global::Mockolate.MockBehavior|{sig}";
-		}
-
-		if (!emittedSignatures.Add(sig))
-		{
-			return;
-		}
-
-		(string Cref, string Display)? constructorCref = BuildConstructorCref(@class, constructor);
-		string ctorPhrase = constructorCref is null
-			? "the base-class constructor"
-			: $"the <see cref=\"{constructorCref.Value.Cref}\">{constructorCref.Value.Display}</see> constructor";
-
-		if (includeMockBehavior && includeSetup)
-		{
-			sb.AppendXmlSummary(
-				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"{mockBehaviorName}\" />, applying the given <paramref name=\"{setupName}\" /> immediately, using the given constructor parameters to invoke {ctorPhrase}.");
-			sb.AppendXmlRemarks(
-				$"The provided <paramref name=\"{setupName}\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		}
-		else if (includeMockBehavior)
-		{
-			sb.AppendXmlSummary(
-				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"{mockBehaviorName}\" /> and the given constructor parameters to invoke {ctorPhrase}.");
-		}
-		else if (includeSetup)
-		{
-			sb.AppendXmlSummary(
-				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"{setupName}\" /> immediately, using the given constructor parameters to invoke {ctorPhrase}.");
-			sb.AppendXmlRemarks(
-				$"The provided <paramref name=\"{setupName}\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
-		}
-		else
-		{
-			sb.AppendXmlSummary(
-				$"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given constructor parameters to invoke {ctorPhrase}.");
-		}
-
-		if (includeMockBehavior)
-		{
-			sb.AppendXmlParam(mockBehaviorName,
-				"Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
-		}
-
-		if (includeSetup)
-		{
-			sb.AppendXmlParam(setupName,
-				"Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
-		}
-
-		foreach (MethodParameter parameter in constructor.Parameters)
-		{
-			sb.AppendXmlParam(parameter.Name, "Value forwarded to the base-class constructor.");
-		}
-
-		sb.AppendXmlReturns(createMockReturns);
-		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(");
-		bool needsLeadingComma = false;
-		if (includeMockBehavior)
-		{
-			sb.Append("global::Mockolate.MockBehavior ").Append(mockBehaviorName);
-			needsLeadingComma = true;
-		}
-
-		if (includeSetup)
-		{
-			if (needsLeadingComma)
-			{
-				sb.Append(", ");
-			}
-
-			sb.Append("global::System.Action<").Append(setupType).Append("> ").Append(setupName);
-			needsLeadingComma = true;
-		}
-
-		foreach (MethodParameter parameter in constructor.Parameters)
-		{
-			if (needsLeadingComma)
-			{
-				sb.Append(", ");
-			}
-
-			needsLeadingComma = true;
-			sb.Append(parameter.Type.Fullname).Append(' ').Append(parameter.Name);
-			if (parameter.HasExplicitDefaultValue)
-			{
-				sb.Append(" = ").Append(parameter.ExplicitDefaultValue);
-			}
-		}
-
-		sb.Append(")").AppendLine();
-		sb.Append("\t\t\t=> CreateMock(").Append(includeMockBehavior ? mockBehaviorName : "null").Append(", ")
-			.Append(includeSetup ? setupName : "null").Append(", new object?[] { ");
-		int argIndex = 0;
-		foreach (MethodParameter parameter in constructor.Parameters)
-		{
-			if (argIndex++ > 0)
-			{
-				sb.Append(", ");
-			}
-
-			sb.Append(parameter.Name);
-		}
-
-		sb.Append(" });").AppendLine();
 		sb.AppendLine();
 	}
 #pragma warning restore S107 // Methods should not have too many parameters
@@ -1913,9 +1238,7 @@ internal static partial class Sources
 		string mockRegistry = CreateUniqueParameterName(constructor.Parameters, "mockRegistry");
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
 		sb.Append(constructor.Attributes, "\t\t");
-		if (hasRequiredMembers &&
-		    constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") !=
-		    true)
+		if (hasRequiredMembers && constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") != true)
 		{
 			sb.Append("\t\t[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").AppendLine();
 		}
@@ -1973,21 +1296,11 @@ internal static partial class Sources
 		bool setsMockRegistryProvider)
 	{
 		sb.Append(indent).Append("/// <summary>").AppendLine();
-		sb.Append(indent)
-			.Append("///     Builds a <see cref=\"global::Mockolate.MockRegistry\" /> backed by a typed-buffer-sized ")
-			.Append(
-				"<see cref=\"global::Mockolate.Interactions.FastMockInteractions\" /> from <paramref name=\"behavior\" />.")
-			.AppendLine();
+		sb.Append(indent).Append("///     Builds a <see cref=\"global::Mockolate.MockRegistry\" /> backed by a typed-buffer-sized ").Append("<see cref=\"global::Mockolate.Interactions.FastMockInteractions\" /> from <paramref name=\"behavior\" />.").AppendLine();
 		sb.Append(indent).Append("/// </summary>").AppendLine();
-		sb.Append(indent)
-			.Append(
-				"private static global::Mockolate.MockRegistry MockolateCreateRegistryFromBehavior(global::Mockolate.MockBehavior behavior)")
-			.AppendLine();
+		sb.Append(indent).Append("private static global::Mockolate.MockRegistry MockolateCreateRegistryFromBehavior(global::Mockolate.MockBehavior behavior)").AppendLine();
 		sb.Append(indent).Append("{").AppendLine();
-		sb.Append(indent)
-			.Append(
-				"\tglobal::Mockolate.MockRegistry registry = new global::Mockolate.MockRegistry(behavior, CreateFastInteractions(behavior));")
-			.AppendLine();
+		sb.Append(indent).Append("\tglobal::Mockolate.MockRegistry registry = new global::Mockolate.MockRegistry(behavior, CreateFastInteractions(behavior));").AppendLine();
 		if (setsMockRegistryProvider)
 		{
 			sb.Append(indent).Append("\tMockRegistryProvider.Value = registry;").AppendLine();
@@ -2024,9 +1337,7 @@ internal static partial class Sources
 		string behavior = CreateUniqueParameterName(constructor.Parameters, "behavior");
 		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
 		sb.Append(constructor.Attributes, "\t\t");
-		if (hasRequiredMembers &&
-		    constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") !=
-		    true)
+		if (hasRequiredMembers && constructor.Attributes?.Any(a => a.Name == "global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers") != true)
 		{
 			sb.Append("\t\t[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").AppendLine();
 		}
@@ -2207,12 +1518,10 @@ internal static partial class Sources
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tif (value is not null)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(addCall).Append(@event.GetUniqueNameString())
-				.Append(", value.Target, value.Method);").AppendLine();
+			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(addCall).Append(@event.GetUniqueNameString()).Append(", value.Target, value.Method);").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
 			sb.Append("\t\t\t\t").Append(backingFieldAccess).Append(" += value;").AppendLine();
-			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className).Append(" wraps)")
-				.AppendLine();
+			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className).Append(" wraps)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\t\twraps.").Append(@event.Name).Append(" += value;").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
@@ -2229,12 +1538,10 @@ internal static partial class Sources
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tif (value is not null)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(removeCall).Append(@event.GetUniqueNameString())
-				.Append(", value.Target, value.Method);").AppendLine();
+			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(removeCall).Append(@event.GetUniqueNameString()).Append(", value.Target, value.Method);").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
 			sb.Append("\t\t\t\t").Append(backingFieldAccess).Append(" -= value;").AppendLine();
-			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className).Append(" wraps)")
-				.AppendLine();
+			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className).Append(" wraps)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\t\twraps.").Append(@event.Name).Append(" -= value;").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
@@ -2254,8 +1561,7 @@ internal static partial class Sources
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tif (value is not null)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(addCall).Append(@event.GetUniqueNameString())
-				.Append(", value.Target, value.Method);").AppendLine();
+			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(addCall).Append(@event.GetUniqueNameString()).Append(", value.Target, value.Method);").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
 			sb.Append("\t\t\t\t").Append(backingFieldAccess).Append(" += value;").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
@@ -2263,8 +1569,7 @@ internal static partial class Sources
 			sb.Append("\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\tif (value is not null)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(removeCall).Append(@event.GetUniqueNameString())
-				.Append(", value.Target, value.Method);").AppendLine();
+			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(removeCall).Append(@event.GetUniqueNameString()).Append(", value.Target, value.Method);").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
 			sb.Append("\t\t\t\t").Append(backingFieldAccess).Append(" -= value;").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
@@ -6008,4 +5313,450 @@ internal static partial class Sources
 	}
 
 	#endregion Verify Helpers
+
+	private static void AppendCreateFastInteractions(StringBuilder sb, string indent)
+	{
+		sb.Append(indent).Append("/// <summary>").AppendLine();
+		sb.Append(indent).Append("///     Creates a <see cref=\"global::Mockolate.Interactions.FastMockInteractions\" /> sized to ").Append("<see cref=\"MemberCount\" /> for use as the mock's interaction store.").AppendLine();
+		sb.Append(indent).Append("///     Per-member buffers are not allocated up-front: the recording hot paths call ").Append("<see cref=\"global::Mockolate.Interactions.FastMockInteractions.GetOrCreateBuffer{TBuffer}(int, global::System.Func{global::Mockolate.Interactions.FastMockInteractions, TBuffer})\" />").Append(" so a slot is materialized only when its member is first invoked.").AppendLine();
+		sb.Append(indent).Append("/// </summary>").AppendLine();
+		sb.Append(indent).Append("internal static global::Mockolate.Interactions.FastMockInteractions CreateFastInteractions(global::Mockolate.MockBehavior behavior)").AppendLine();
+		sb.Append(indent).Append("\t=> new global::Mockolate.Interactions.FastMockInteractions(MemberCount, behavior.SkipInteractionRecording);").AppendLine();
+	}
+
+	/// <summary>
+	///     Emits the declarations of the cached <c>MockolateSkipRecording</c> flag and per-member typed
+	///     buffer fields. These mirror values that <c>AppendCreateFastInteractions</c> writes into the
+	///     <c>FastMockInteractions.Buffers</c> array so the body emitters can read them as plain field
+	///     accesses instead of paying the cast / array-index / property-chain on every invocation. Static
+	///     members stay on the legacy path because the cached field would not flow through
+	///     <c>AsyncLocal</c>-resolved registries.
+	/// </summary>
+	/// <returns>
+	///     <see langword="true" /> when the class has at least one fast-eligible non-static indexer or
+	///     method, in which case the generator emits cached typed-buffer fields and a
+	///     <c>MockolateSkipRecording</c> flag that the recording hot paths read instead of paying the
+	///     per-call cast / array-index / property-chain.
+	/// </returns>
+	private static bool HasCachedBufferFields(Class @class)
+	{
+		foreach (Property property in @class.AllProperties())
+		{
+			if (property.IsIndexer && IsFastBufferEligibleIndexer(property))
+			{
+				return true;
+			}
+		}
+
+		foreach (Method method in @class.AllMethods())
+		{
+			if (!method.IsStatic && IsFastBufferEligibleMethod(method))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static void AppendCachedFieldDeclarations(StringBuilder sb, string indent, Class @class,
+		MemberIdTable memberIds, string memberIdPrefix, string mockRegistryName)
+	{
+		if (!HasCachedBufferFields(@class))
+		{
+			return;
+		}
+
+		string mockRegistryRef = "this." + mockRegistryName;
+
+		foreach (Property indexer in @class.AllProperties().Where(p => p.IsIndexer))
+		{
+			if (!IsFastBufferEligibleIndexer(indexer))
+			{
+				continue;
+			}
+
+			string indexerKeyTypeArgs =
+				string.Join(", ", indexer.IndexerParameters!.Value.Select(p => p.ToTypeOrWrapper()));
+			string indexerValueType = indexer.Type.ToTypeOrWrapper();
+			string getMemberIdRef = memberIdPrefix + memberIds.GetIndexerGetIdentifier(indexer);
+			string setMemberIdRef = memberIdPrefix + memberIds.GetIndexerSetIdentifier(indexer);
+			string getterBufferType = "global::Mockolate.Interactions.FastIndexerGetterBuffer<"
+			                          + indexerKeyTypeArgs + ">";
+			string setterBufferType = "global::Mockolate.Interactions.FastIndexerSetterBuffer<"
+			                          + indexerKeyTypeArgs + ", " + indexerValueType + ">";
+
+			sb.Append(indent).Append("[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append(indent).Append("private ").Append(getterBufferType).Append(' ').Append(memberIds.GetIndexerGetterBufferFieldName(indexer)).AppendLine();
+			sb.Append(indent).Append("\t=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)")
+				.Append(mockRegistryRef).Append(".Interactions).GetOrCreateBuffer<").Append(getterBufferType)
+				.Append(">(").Append(getMemberIdRef).Append(", static fast => new ").Append(getterBufferType)
+				.Append("(fast)));").AppendLine();
+
+			sb.Append(indent).Append("[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append(indent).Append("private ").Append(setterBufferType).Append(' ').Append(memberIds.GetIndexerSetterBufferFieldName(indexer)).AppendLine();
+			sb.Append(indent).Append("\t=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)")
+				.Append(mockRegistryRef).Append(".Interactions).GetOrCreateBuffer<").Append(setterBufferType)
+				.Append(">(").Append(setMemberIdRef).Append(", static fast => new ").Append(setterBufferType)
+				.Append("(fast)));").AppendLine();
+		}
+
+		foreach (Method method in @class.AllMethods())
+		{
+			if (method.IsStatic || !IsFastBufferEligibleMethod(method))
+			{
+				continue;
+			}
+
+			int arity = method.Parameters.Count;
+			string typeArgs = arity == 0
+				? string.Empty
+				: "<" + string.Join(", ", method.Parameters.Select(p => p.ToTypeOrWrapper())) + ">";
+			string memberIdRef = memberIdPrefix + memberIds.GetMethodIdentifier(method);
+			string bufferType = "global::Mockolate.Interactions.FastMethod" + arity + "Buffer" + typeArgs;
+			sb.Append(indent).Append("[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+			sb.Append(indent).Append("private ").Append(bufferType).Append(' ').Append(memberIds.GetMethodBufferFieldName(method)).AppendLine();
+			sb.Append(indent).Append("\t=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)")
+				.Append(mockRegistryRef).Append(".Interactions).GetOrCreateBuffer<").Append(bufferType)
+				.Append(">(").Append(memberIdRef).Append(", static fast => new ").Append(bufferType)
+				.Append("(fast)));").AppendLine();
+		}
+	}
+
+	/// <summary>
+	///     Properties get a typed per-member buffer when they are not static. Static property recordings stay on
+	///     the legacy <c>RegisterInteraction</c> path because their member id is shared across <c>AsyncLocal</c>
+	///     contexts whereas the buffer instance is stored on a single registry, so per-context isolation breaks.
+	/// </summary>
+	private static bool IsFastBufferEligibleProperty(Property property)
+		=> !property.IsStatic;
+
+	/// <summary>
+	///     Indexers with up to four key parameters and a non-ref-struct signature get a typed per-member buffer.
+	/// </summary>
+	private static bool IsFastBufferEligibleIndexer(Property indexer)
+	{
+		if (indexer.IsStatic ||
+		    indexer.IndexerParameters is null ||
+		    indexer.IndexerParameters.Value.Count == 0 ||
+		    indexer.IndexerParameters.Value.Count > 4)
+		{
+			return false;
+		}
+
+		foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+		{
+			if (parameter.NeedsRefStructPipeline())
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	///     Events get a typed per-member buffer when they are not static (see <see cref="IsFastBufferEligibleProperty" />
+	///     for the rationale).
+	/// </summary>
+	private static bool IsFastBufferEligibleEvent(Event @event)
+		=> !@event.IsStatic;
+
+	/// <summary>
+	///     Methods with non-generic, non-ref-struct signatures get a typed per-member buffer; everything
+	///     else (open generics, ref-struct params) records via the legacy <c>RegisterInteraction</c> fallback.
+	/// </summary>
+	private static bool IsFastBufferEligibleMethod(Method method)
+	{
+		if (method.GenericParameters is not null && method.GenericParameters.Value.Count > 0)
+		{
+			return false;
+		}
+
+		foreach (MethodParameter parameter in method.Parameters)
+		{
+			if (parameter.NeedsRefStructPipeline())
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	///     A <c>T?</c> return where <c>T</c> is one of the method's generic parameters and is
+	///     constrained to a reference type (or any other non-value-type constraint such as
+	///     <c>class</c>, <c>class?</c>, an interface, or <c>notnull</c>) cannot be expressed in
+	///     the explicit setup-interface implementation: CS0460 forbids restating the inherited
+	///     constraint, and <c>where T : default</c> (CS8822) conflicts with those constraints.
+	///     Without a constraint clause the compiler resolves the bare <c>T?</c> as
+	///     <c>Nullable&lt;T&gt;</c> and reports CS0453/CS9334/CS0738/CS0266.
+	///     The fix is to drop the trailing <c>?</c> from the setup-side return type
+	///     (<c>IReturnMethodSetup&lt;T&gt;</c> instead of <c>IReturnMethodSetup&lt;T?&gt;</c>) and from
+	///     the matching <c>ReturnMethodSetup&lt;T&gt;</c> construction. NRT annotations are erased at
+	///     runtime, so the underlying setup object is identical and the fluent API still composes.
+	///     The user-facing mock body keeps <c>T?</c> because the constraint is visible there.
+	/// </summary>
+	private static bool ShouldStripNullableGenericReturnAnnotation(Method method)
+	{
+		if (method.GenericParameters is null || method.GenericParameters.Value.Count == 0)
+		{
+			return false;
+		}
+
+		string fullname = method.ReturnType.Fullname;
+		if (fullname.Length < 2 || fullname[fullname.Length - 1] != '?')
+		{
+			return false;
+		}
+
+		string raw = fullname.Substring(0, fullname.Length - 1);
+		foreach (GenericParameter gp in method.GenericParameters.Value)
+		{
+			if (gp.Name == raw)
+			{
+				return !gp.IsStruct && !gp.IsUnmanaged;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	///     Emits the method's return type as it should appear inside the setup-side surface
+	///     (the <c>IReturnMethodSetup&lt;...&gt;</c> wrapper on the setup interface, the explicit
+	///     impl, and the <c>new ReturnMethodSetup&lt;...&gt;</c> construction). Strips a trailing
+	///     <c>?</c> when <see cref="ShouldStripNullableGenericReturnAnnotation" /> applies.
+	/// </summary>
+	private static void AppendSetupReturnType(StringBuilder sb, Method method)
+	{
+		if (ShouldStripNullableGenericReturnAnnotation(method))
+		{
+			string fullname = method.ReturnType.Fullname;
+			sb.Append(fullname, 0, fullname.Length - 1);
+			return;
+		}
+
+		sb.AppendTypeOrWrapper(method.ReturnType);
+	}
+
+	private static void AppendTypedCreateMockOverloads(StringBuilder sb, Class @class,
+		EquatableArray<Method> constructors, string setupType, string escapedClassName, string createMockReturns)
+	{
+		// Seeded signatures track the hand-written CreateMock overloads so typed overloads that
+		// would collide with them are skipped. The key order mirrors the emitted C# signature:
+		// "mockBehavior? | setup? | ctor-param-types...".
+		HashSet<string> emittedSignatures = new(StringComparer.Ordinal)
+		{
+			string.Empty,
+			"global::Mockolate.MockBehavior",
+			$"global::System.Action<{setupType}>",
+			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>",
+			"object?[]",
+			"global::Mockolate.MockBehavior|object?[]",
+			$"global::System.Action<{setupType}>|object?[]",
+			$"global::Mockolate.MockBehavior|global::System.Action<{setupType}>|object?[]",
+		};
+
+		foreach (Method constructor in constructors)
+		{
+			if (constructor.Parameters.Count == 0)
+			{
+				continue;
+			}
+
+			if (constructor.Parameters.Any(p => p.RefKind != RefKind.None || p.IsParams))
+			{
+				continue;
+			}
+
+			string mockBehaviorName = CreateUniqueParameterName(constructor.Parameters, "mockBehavior");
+			string setupName = CreateUniqueParameterName(constructor.Parameters, "setup");
+			string baseSig = string.Join("|",
+				constructor.Parameters.Select(p => p.Type.Fullname));
+
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				false, false, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				true, false, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				false, true, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+			TryEmitTypedCreateMockOverload(sb, @class, constructor, setupType, escapedClassName, createMockReturns,
+				true, true, mockBehaviorName, setupName, baseSig,
+				emittedSignatures);
+		}
+	}
+
+	/// <summary>
+	///     Builds an XML-doc cref string and a matching short display text for the given
+	///     <paramref name="constructor" /> on <paramref name="class" />. The cref has the form
+	///     <c>{class-cref}({fully-qualified-param-types})</c>; the display has the form
+	///     <c>{simple-name}({short-param-types})</c>, intended as the inner text of
+	///     <c>&lt;see cref="..."&gt;...&lt;/see&gt;</c> so the rendered prose reads
+	///     <c>the MyClass(int) constructor</c>.
+	///     Returns <see langword="null" /> when no valid cref can be produced.
+	/// </summary>
+	/// <remarks>
+	///     Generic classes are skipped because the cref type-parameter-list syntax (e.g. <c>{T}</c>)
+	///     expects identifier tokens, not the concrete type arguments that closed generics carry —
+	///     emitting <c>MyClass{int}(int)</c> would surface CS1584/CS1658 on the consumer side.
+	/// </remarks>
+	private static (string Cref, string Display)? BuildConstructorCref(Class @class, Method constructor)
+	{
+		string fullName = @class.ClassFullName;
+
+		if (fullName.IndexOf('<') >= 0)
+		{
+			return null;
+		}
+
+		int lastDot = fullName.LastIndexOf('.');
+		string simpleName = lastDot >= 0 ? fullName.Substring(lastDot + 1) : fullName;
+
+		StringBuilder cref = new();
+		StringBuilder display = new();
+		cref.Append(fullName).Append('(');
+		display.Append(simpleName).Append('(');
+		bool first = true;
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			if (!first)
+			{
+				cref.Append(", ");
+				display.Append(", ");
+			}
+
+			first = false;
+			cref.Append(parameter.Type.Fullname.EscapeForXmlDoc());
+			// Inner text of <see> is XML content, so escape '<'/'>' as entities
+			// (unlike cref attributes, which use the '{...}' shorthand).
+			display.Append(parameter.Type.DisplayName.Replace("<", "&lt;").Replace(">", "&gt;"));
+		}
+
+		cref.Append(')');
+		display.Append(')');
+		return (cref.ToString(), display.ToString());
+	}
+
+#pragma warning disable S107 // Methods should not have too many parameters
+	private static void TryEmitTypedCreateMockOverload(StringBuilder sb, Class @class, Method constructor,
+		string setupType, string escapedClassName, string createMockReturns,
+		bool includeMockBehavior, bool includeSetup, string mockBehaviorName, string setupName, string baseSig,
+		HashSet<string> emittedSignatures)
+	{
+		// Build the signature key in the same order as the emitted method signature
+		// (mockBehavior, setup, then ctor parameters) so it correctly detects collisions against
+		// other typed overloads and against the hand-written seeded overloads.
+		string sig = baseSig;
+		if (includeSetup)
+		{
+			sig = $"global::System.Action<{setupType}>|{sig}";
+		}
+
+		if (includeMockBehavior)
+		{
+			sig = $"global::Mockolate.MockBehavior|{sig}";
+		}
+
+		if (!emittedSignatures.Add(sig))
+		{
+			return;
+		}
+
+		(string Cref, string Display)? constructorCref = BuildConstructorCref(@class, constructor);
+		string ctorPhrase = constructorCref is null
+			? "the base-class constructor"
+			: $"the <see cref=\"{constructorCref.Value.Cref}\">{constructorCref.Value.Display}</see> constructor";
+
+		if (includeMockBehavior && includeSetup)
+		{
+			sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"{mockBehaviorName}\" />, applying the given <paramref name=\"{setupName}\" /> immediately, using the given constructor parameters to invoke {ctorPhrase}.");
+			sb.AppendXmlRemarks($"The provided <paramref name=\"{setupName}\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		}
+		else if (includeMockBehavior)
+		{
+			sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given <paramref name=\"{mockBehaviorName}\" /> and the given constructor parameters to invoke {ctorPhrase}.");
+		}
+		else if (includeSetup)
+		{
+			sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> applying the given <paramref name=\"{setupName}\" /> immediately, using the given constructor parameters to invoke {ctorPhrase}.");
+			sb.AppendXmlRemarks($"The provided <paramref name=\"{setupName}\" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.");
+		}
+		else
+		{
+			sb.AppendXmlSummary($"Creates a new mock of <see cref=\"{escapedClassName}\" /> using the given constructor parameters to invoke {ctorPhrase}.");
+		}
+
+		if (includeMockBehavior)
+		{
+			sb.AppendXmlParam(mockBehaviorName, "Controls how the mock responds when members are invoked without a matching setup; see <see cref=\"global::Mockolate.MockBehavior\" />.");
+		}
+
+		if (includeSetup)
+		{
+			sb.AppendXmlParam(setupName, "Callback that receives the mock's setup surface and registers initial setups before the mock is returned.");
+		}
+
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			sb.AppendXmlParam(parameter.Name, "Value forwarded to the base-class constructor.");
+		}
+
+		sb.AppendXmlReturns(createMockReturns);
+		sb.Append("\t\tpublic static ").Append(@class.ClassFullName).Append(" CreateMock(");
+		bool needsLeadingComma = false;
+		if (includeMockBehavior)
+		{
+			sb.Append("global::Mockolate.MockBehavior ").Append(mockBehaviorName);
+			needsLeadingComma = true;
+		}
+
+		if (includeSetup)
+		{
+			if (needsLeadingComma)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append("global::System.Action<").Append(setupType).Append("> ").Append(setupName);
+			needsLeadingComma = true;
+		}
+
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			if (needsLeadingComma)
+			{
+				sb.Append(", ");
+			}
+
+			needsLeadingComma = true;
+			sb.Append(parameter.Type.Fullname).Append(' ').Append(parameter.Name);
+			if (parameter.HasExplicitDefaultValue)
+			{
+				sb.Append(" = ").Append(parameter.ExplicitDefaultValue);
+			}
+		}
+
+		sb.Append(")").AppendLine();
+		sb.Append("\t\t\t=> CreateMock(").Append(includeMockBehavior ? mockBehaviorName : "null").Append(", ")
+			.Append(includeSetup ? setupName : "null").Append(", new object?[] { ");
+		int argIndex = 0;
+		foreach (MethodParameter parameter in constructor.Parameters)
+		{
+			if (argIndex++ > 0)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append(parameter.Name);
+		}
+
+		sb.Append(" });").AppendLine();
+		sb.AppendLine();
+	}
+#pragma warning restore S107 // Methods should not have too many parameters
 }

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockCombination.cs
@@ -44,182 +44,13 @@ internal static partial class Sources
 		sb.Append("namespace Mockolate;").AppendLine();
 		sb.AppendLine();
 
-		#region Extensions
-
-		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" /> that also implements<br />\n///      - {string.Join("<br />\n///      - ", additionalInterfaces.Select(x => $"<see cref=\"{x.Class.ClassFullName.EscapeForXmlDoc()}\" />"))}.", "");
-#if !DEBUG
-		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
-#endif
-		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("internal static partial class MockExtensionsFor").Append(fileName).AppendLine();
-		sb.Append("{").AppendLine();
-
-		#region Implementing
-
-		(string Name, Class Class) lastInterface = additionalInterfaces[additionalInterfaces.Length - 1];
-		sb.AppendXmlSummary($"Extends this mock so the returned instance also implements <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-		sb.AppendXmlRemarks([
-			$"The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" /> to exercise the extra surface or use <c>.Mock.As&lt;{lastInterface.Class.ClassName}&gt;()</c> to reach the Setup/Verify surface of the additional interface.",
-		]);
-		sb.AppendXmlParam("sut", "The mock instance to extend.");
-		sb.AppendXmlParam("setups", "Optional setup callbacks registered on the additional interface before the mock is returned.");
-		sb.AppendXmlReturns($"A mock of the original type that additionally implements <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
-		sb.Append("\tpublic static ").Append(@class.ClassFullName).Append(" Implementing<TInterface>(this ").Append(@class.ClassFullName).Append(" sut, params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[] setups)").AppendLine();
-		sb.Append("\t\twhere TInterface : ").Append(lastInterface.Class.ClassFullName).AppendLine();
-		sb.Append("\t{").AppendLine();
-		sb.Append("\t\tif (sut is not global::Mockolate.IMock mock)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Mock.").Append(fileName).Append(" value;").AppendLine();
-
-		bool useTryCast = false;
-		bool useTryCastWithDefaultValue = false;
-		if (!@class.IsInterface && constructors?.Count > 0)
-		{
-			sb.Append("\t\tif (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)").AppendLine();
-			sb.Append("\t\t{").AppendLine();
-			if (constructors.Value.Any(m => m.Parameters.Count == 0))
-			{
-				sb.Append("\t\t\tvalue = new global::Mockolate.Mock.").Append(fileName).Append("(mock.MockRegistry);").AppendLine();
-			}
-			else
-			{
-				sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"No parameterless constructor found for '").Append(@class.DisplayString).Append("'. Please provide constructor parameters.\");").AppendLine();
-			}
-
-			sb.Append("\t\t}").AppendLine();
-			int constructorIndex = 0;
-			foreach (EquatableArray<MethodParameter> constructorParameters in constructors.Value
-				         .Select(constructor => constructor.Parameters))
-			{
-				constructorIndex++;
-				int requiredParameters = constructorParameters.Count(c => !c.HasExplicitDefaultValue);
-				if (requiredParameters < constructorParameters.Count)
-				{
-					sb.Append("\t\telse if (mock.MockRegistry.ConstructorParameters.Length >= ")
-						.Append(requiredParameters).Append(" && mock.MockRegistry.ConstructorParameters.Length <= ")
-						.Append(constructorParameters.Count);
-				}
-				else
-				{
-					sb.Append("\t\telse if (mock.MockRegistry.ConstructorParameters.Length == ")
-						.Append(constructorParameters.Count);
-				}
-
-				int constructorParameterIndex = 0;
-				foreach (MethodParameter parameter in constructorParameters)
-				{
-					useTryCast = useTryCast || !parameter.HasExplicitDefaultValue;
-					useTryCastWithDefaultValue = useTryCastWithDefaultValue || parameter.HasExplicitDefaultValue;
-					sb.AppendLine().Append("\t\t    && ")
-						.Append(parameter.HasExplicitDefaultValue ? "TryCastWithDefaultValue" : "TryCast")
-						.Append("(mock.MockRegistry.ConstructorParameters, ")
-						.Append(constructorParameterIndex++)
-						.Append(parameter.HasExplicitDefaultValue ? $", {parameter.ExplicitDefaultValue}" : "")
-						.Append(", mock.MockRegistry.Behavior, out ").Append(parameter.Type.Fullname).Append(" c")
-						.Append(constructorIndex)
-						.Append('p')
-						.Append(constructorParameterIndex).Append(")");
-				}
-
-				sb.Append(")").AppendLine();
-				sb.Append("\t\t{").AppendLine();
-				sb.Append("\t\t\tvalue = new global::Mockolate.Mock.").Append(fileName)
-					.Append("(mock.MockRegistry");
-				for (int j = 1; j <= constructorParameters.Count; j++)
-				{
-					sb.Append(", ").Append('c').Append(constructorIndex).Append('p').Append(j);
-				}
-
-				sb.Append(");").AppendLine();
-				sb.Append("\t\t}").AppendLine();
-			}
-
-			sb.Append("\t\telse").AppendLine();
-			sb.Append("\t\t{").AppendLine();
-			sb.Append(
-					"\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"Could not find any constructor for '")
-				.Append(@class.DisplayString).Append("' that matches the {mock.MockRegistry.ConstructorParameters.Length} given parameters ({string.Join(\", \", mock.MockRegistry.ConstructorParameters)}).\");")
-				.AppendLine();
-			sb.Append("\t\t}").AppendLine();
-		}
-		else
-		{
-			sb.Append("\t\tvalue = new global::Mockolate.Mock.").Append(fileName).Append("(mock.MockRegistry);").AppendLine();
-		}
-
-		sb.Append("\t\tIMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mock.MockRegistry.Behavior;").AppendLine();
-		sb.Append("\t\tif (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[]?>(out var additionalSetups))").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tif (setups.Length > 0)").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tvar concatenatedSetups = new global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[additionalSetups.Length + setups.Length];").AppendLine();
-		sb.Append("\t\t\t\tadditionalSetups.CopyTo(concatenatedSetups, 0);").AppendLine();
-		sb.Append("\t\t\t\tsetups.CopyTo(concatenatedSetups, additionalSetups.Length);").AppendLine();
-		sb.Append("\t\t\t\tsetups = concatenatedSetups;").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t\telse").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tsetups = additionalSetups;").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.Append("\t\tif (setups.Length > 0)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tforeach (var setup in setups)").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tsetup.Invoke(value);").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.Append("\t\treturn value;").AppendLine();
-		if (useTryCast)
-		{
-			sb.Append("""
-			          		static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
-			          		{
-			          		    var value = values[index];
-			          			if (value is TValue typedValue)
-			          			{
-			          				result = typedValue;
-			          				return true;
-			          			}
-
-			          			result = default!;
-			          			return value is null;
-			          		}
-			          """).AppendLine();
-		}
-
-		if (useTryCastWithDefaultValue)
-		{
-			sb.Append("""
-			          		static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
-			          		{
-			          			if (values.Length > index && values[index] is TValue typedValue)
-			          			{
-			          				result = typedValue;
-			          				return true;
-			          			}
-
-			          			result = defaultValue;
-			          			return true;
-			          		}
-			          """).AppendLine();
-		}
-
-		sb.Append("\t}").AppendLine();
-
-		#endregion Implementing
-
-		sb.Append("}").AppendLine();
-		sb.AppendLine();
-
-		#endregion Extensions
-
-		#region MockForXXX
+		#region Mock
 
 		sb.Append("internal static partial class Mock").AppendLine();
 		sb.Append("{").AppendLine();
+		
+		#region MockForXXX
+		
 		sb.AppendXmlSummary($"A mock implementation for <see cref=\"{escapedClassName}\" /> that also implements<br />\n\t///      - {string.Join("<br />\n\t///      - ", additionalInterfaces.Select(x => $"<see cref=\"{x.Class.ClassFullName.EscapeForXmlDoc()}\" />"))}.", "\t");
 		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
 #if !DEBUG
@@ -341,8 +172,7 @@ internal static partial class Sources
 		else
 		{
 			sb.Append("\t\t/// <inheritdoc cref=\"").Append(fileName).Append("\" />").AppendLine();
-			sb.Append("\t\tpublic ").Append(fileName).Append("(global::Mockolate.MockRegistry mockRegistry)")
-				.AppendLine();
+			sb.Append("\t\tpublic ").Append(fileName).Append("(global::Mockolate.MockRegistry mockRegistry)").AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(" = mockRegistry;").AppendLine();
 			if (hasAnyStaticMembers || hasAnyStaticEvents)
@@ -356,35 +186,37 @@ internal static partial class Sources
 
 		Dictionary<string, int> signatureIndices = new();
 		int[] nextSignatureIndex = [0,];
+		
 		// Combined mocks reuse the base mock's MockRegistry (and thus its FastMockInteractions sized
 		// to the base MemberCount). Combined member ids would index past those buffers, so emit the
 		// legacy RegisterInteraction path instead — recordings still flow through FastMockInteractions'
 		// fallback buffer and remain shared with the base mock.
-		AppendMockSubject_ImplementClass(sb, @class, mockRegistryName, null, memberIds, memberIdPrefix,
-			signatureIndices, nextSignatureIndex, false);
+		AppendMockSubject_ImplementClass(sb, @class, mockRegistryName, null, memberIds, memberIdPrefix, signatureIndices, nextSignatureIndex, false);
+		
 		foreach ((string Name, Class Class) item in additionalInterfaces)
 		{
 			sb.AppendLine();
-			AppendMockSubject_ImplementClass(sb, item.Class, mockRegistryName, @class as MockClass,
-				memberIds, memberIdPrefix, signatureIndices, nextSignatureIndex, false);
+			AppendMockSubject_ImplementClass(sb, item.Class, mockRegistryName, @class as MockClass, memberIds, memberIdPrefix, signatureIndices, nextSignatureIndex, false);
 		}
 
 		sb.AppendLine();
 
-		#region IMockSetupForXXX
+		#region Setup implementations
 
 		sb.Append("\t\t#region IMockSetupFor").Append(name).AppendLine();
 		sb.AppendLine();
-		ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public,
-			memberIds, memberIdPrefix);
+		
+		ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockSetupFor{name}", MemberType.Public, memberIds, memberIdPrefix);
+		
 		sb.Append("\t\t#endregion IMockSetupFor").Append(name).AppendLine();
 		if (hasProtectedMembers)
 		{
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockProtectedSetupFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}", MemberType.Protected,
-				memberIds, memberIdPrefix);
+			
+			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockProtectedSetupFor{name}", MemberType.Protected, memberIds, memberIdPrefix);
+			
 			sb.Append("\t\t#endregion IMockProtectedSetupFor").Append(name).AppendLine();
 		}
 
@@ -393,8 +225,9 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockStaticSetupFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockStaticSetupFor{name}", MemberType.Static,
-				memberIds, memberIdPrefix);
+			
+			ImplementSetupInterface(sb, @class, mockRegistryName, $"IMockStaticSetupFor{name}", MemberType.Static, memberIds, memberIdPrefix);
+			
 			sb.Append("\t\t#endregion IMockStaticSetupFor").Append(name).AppendLine();
 		}
 
@@ -403,8 +236,9 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockSetupFor").Append(item.Name).AppendLine();
 			sb.AppendLine();
-			ImplementSetupInterface(sb, item.Class, mockRegistryName, $"IMockSetupFor{item.Name}", MemberType.Public,
-				memberIds, memberIdPrefix);
+			
+			ImplementSetupInterface(sb, item.Class, mockRegistryName, $"IMockSetupFor{item.Name}", MemberType.Public, memberIds, memberIdPrefix);
+			
 			sb.Append("\t\t#endregion IMockSetupFor").Append(item.Name).AppendLine();
 
 			if (item.Class.AllMethods().Any(x => x.IsStatic) || item.Class.AllProperties().Any(x => x.IsStatic))
@@ -412,51 +246,50 @@ internal static partial class Sources
 				sb.AppendLine();
 				sb.Append("\t\t#region IMockStaticSetupFor").Append(item.Name).AppendLine();
 				sb.AppendLine();
-				ImplementSetupInterface(sb, item.Class, mockRegistryName, $"IMockStaticSetupFor{item.Name}", MemberType.Static,
-					memberIds, memberIdPrefix);
+				
+				ImplementSetupInterface(sb, item.Class, mockRegistryName, $"IMockStaticSetupFor{item.Name}", MemberType.Static, memberIds, memberIdPrefix);
+				
 				sb.Append("\t\t#endregion IMockStaticSetupFor").Append(item.Name).AppendLine();
 			}
 		}
 
-		#endregion IMockSetupForXXX
+		#endregion Setup implementations
 
-		#region IMockRaiseOnXXX
+		#region Raise implementations
 
 		if (hasEvents)
 		{
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockRaiseOn").Append(name).AppendLine();
 			sb.AppendLine();
+			
 			ImplementRaiseInterface(sb, @class, mockRegistryName, $"IMockRaiseOn{name}", MemberType.Public);
+			
 			sb.Append("\t\t#endregion IMockRaiseOn").Append(name).AppendLine();
 		}
 
 		if (hasProtectedEvents)
 		{
-			#region IMockProtectedRaiseOnXXX
-
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockProtectedRaiseOn").Append(name).AppendLine();
 			sb.AppendLine();
+			
 			ImplementRaiseInterface(sb, @class, mockRegistryName, $"IMockProtectedRaiseOn{name}", MemberType.Protected);
+			
 			sb.Append("\t\t#endregion IMockProtectedRaiseOn").Append(name).AppendLine();
-
-			#endregion IMockProtectedRaiseOnXXX
 		}
 
 		if (hasStaticEvents)
 		{
-			#region IMockStaticRaiseOnXXX
-
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockStaticRaiseOn").Append(name).AppendLine();
 			sb.AppendLine();
+			
 			ImplementRaiseInterface(sb, @class, mockRegistryName, $"IMockStaticRaiseOn{name}", MemberType.Static);
+			
 			sb.Append("\t\t#endregion IMockStaticRaiseOn").Append(name).AppendLine();
-
-			#endregion IMockStaticRaiseOnXXX
 		}
-#pragma warning disable S3267 // Loops should be simplified using the "Where" LINQ method
+		
 		foreach ((string Name, Class Class) item in additionalInterfaces)
 		{
 			if (item.Class.AllEvents().Any(x => !x.IsStatic))
@@ -464,7 +297,9 @@ internal static partial class Sources
 				sb.AppendLine();
 				sb.Append("\t\t#region IMockRaiseOn").Append(item.Name).AppendLine();
 				sb.AppendLine();
+				
 				ImplementRaiseInterface(sb, item.Class, mockRegistryName, $"IMockRaiseOn{item.Name}", MemberType.Public);
+				
 				sb.Append("\t\t#endregion IMockRaiseOn").Append(item.Name).AppendLine();
 			}
 
@@ -473,15 +308,16 @@ internal static partial class Sources
 				sb.AppendLine();
 				sb.Append("\t\t#region IMockStaticRaiseOn").Append(item.Name).AppendLine();
 				sb.AppendLine();
+				
 				ImplementRaiseInterface(sb, item.Class, mockRegistryName, $"IMockStaticRaiseOn{item.Name}", MemberType.Static);
+				
 				sb.Append("\t\t#endregion IMockStaticRaiseOn").Append(item.Name).AppendLine();
 			}
 		}
-#pragma warning restore S3267 // Loops should be simplified using the "Where" LINQ method
 
-		#endregion IMockRaiseOnXXX
+		#endregion Raise implementations
 
-		#region IMockVerifyForXXX
+		#region Verify implementation
 
 		sb.AppendLine();
 		sb.Append("\t\t#region IMockVerifyFor").Append(name).AppendLine();
@@ -491,16 +327,16 @@ internal static partial class Sources
 		// memberIds enumerate a different (typically larger) set, so they cannot be used to fetch the
 		// base buffers — emit the slow Verify path here instead. Recordings flow through the
 		// FastMockInteractions fallback buffer (see AppendMockSubject_ImplementClass useFastBuffers: false).
-		ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockVerifyFor{name}", MemberType.Public,
-			memberIds, memberIdPrefix, false);
+		ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockVerifyFor{name}", MemberType.Public, memberIds, memberIdPrefix, false);
 		sb.Append("\t\t#endregion IMockVerifyFor").Append(name).AppendLine();
 		if (hasProtectedMembers || hasProtectedEvents)
 		{
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockProtectedVerifyFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockProtectedVerifyFor{name}",
-				MemberType.Protected, memberIds, memberIdPrefix, false);
+			
+			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockProtectedVerifyFor{name}", MemberType.Protected, memberIds, memberIdPrefix, false);
+			
 			sb.Append("\t\t#endregion IMockProtectedVerifyFor").Append(name).AppendLine();
 		}
 
@@ -509,8 +345,9 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockStaticVerifyFor").Append(name).AppendLine();
 			sb.AppendLine();
-			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockStaticVerifyFor{name}", MemberType.Static,
-				memberIds, memberIdPrefix, false);
+			
+			ImplementVerifyInterface(sb, @class, mockRegistryName, $"IMockStaticVerifyFor{name}", MemberType.Static, memberIds, memberIdPrefix, false);
+			
 			sb.Append("\t\t#endregion IMockStaticVerifyFor").Append(name).AppendLine();
 		}
 
@@ -519,8 +356,9 @@ internal static partial class Sources
 			sb.AppendLine();
 			sb.Append("\t\t#region IMockVerifyFor").Append(item.Name).AppendLine();
 			sb.AppendLine();
-			ImplementVerifyInterface(sb, item.Class, mockRegistryName, $"IMockVerifyFor{item.Name}", MemberType.Public,
-				memberIds, memberIdPrefix, false);
+			
+			ImplementVerifyInterface(sb, item.Class, mockRegistryName, $"IMockVerifyFor{item.Name}", MemberType.Public, memberIds, memberIdPrefix, false);
+			
 			sb.Append("\t\t#endregion IMockVerifyFor").Append(item.Name).AppendLine();
 
 			if (item.Class.AllMethods().Any(x => x.IsStatic) || item.Class.AllProperties().Any(x => x.IsStatic) ||
@@ -529,20 +367,190 @@ internal static partial class Sources
 				sb.AppendLine();
 				sb.Append("\t\t#region IMockStaticVerifyFor").Append(item.Name).AppendLine();
 				sb.AppendLine();
-				ImplementVerifyInterface(sb, item.Class, mockRegistryName, $"IMockStaticVerifyFor{item.Name}", MemberType.Static,
-					memberIds, memberIdPrefix, false);
+				
+				ImplementVerifyInterface(sb, item.Class, mockRegistryName, $"IMockStaticVerifyFor{item.Name}", MemberType.Static, memberIds, memberIdPrefix, false);
+				
 				sb.Append("\t\t#endregion IMockStaticVerifyFor").Append(item.Name).AppendLine();
 			}
 		}
 
-		#endregion IMockVerifyForXXX
+		#endregion Verify implementation
 
 		sb.AppendLine("\t}");
-
+		
 		#endregion MockForXXX
+		
+		sb.Append("}").AppendLine();
+		sb.AppendLine();
+
+		#endregion Mock
+
+		#region Extensions
+
+		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" /> that also implements<br />\n///      - {string.Join("<br />\n///      - ", additionalInterfaces.Select(x => $"<see cref=\"{x.Class.ClassFullName.EscapeForXmlDoc()}\" />"))}.", "");
+#if !DEBUG
+		sb.Append("[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.Append("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
+		sb.Append("internal static partial class MockExtensionsFor").Append(fileName).AppendLine();
+		sb.Append("{").AppendLine();
+
+		#region Implementing
+
+		(string Name, Class Class) lastInterface = additionalInterfaces[additionalInterfaces.Length - 1];
+		sb.AppendXmlSummary($"Extends this mock so the returned instance also implements <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+		sb.AppendXmlRemarks([$"The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" /> to exercise the extra surface or use <c>.Mock.As&lt;{lastInterface.Class.ClassName}&gt;()</c> to reach the Setup/Verify surface of the additional interface.",]);
+		sb.AppendXmlParam("sut", "The mock instance to extend.");
+		sb.AppendXmlParam("setups", "Optional setup callbacks registered on the additional interface before the mock is returned.");
+		sb.AppendXmlReturns($"A mock of the original type that additionally implements <see cref=\"{lastInterface.Class.ClassFullName.EscapeForXmlDoc()}\" />.");
+		sb.Append("\tpublic static ").Append(@class.ClassFullName).Append(" Implementing<TInterface>(this ").Append(@class.ClassFullName).Append(" sut, params global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[] setups)").AppendLine();
+		sb.Append("\t\twhere TInterface : ").Append(lastInterface.Class.ClassFullName).AppendLine();
+		sb.Append("\t{").AppendLine();
+		sb.Append("\t\tif (sut is not global::Mockolate.IMock mock)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"The subject is no mock.\");").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Mock.").Append(fileName).Append(" value;").AppendLine();
+
+		bool useTryCast = false;
+		bool useTryCastWithDefaultValue = false;
+		if (!@class.IsInterface && constructors?.Count > 0)
+		{
+			sb.Append("\t\tif (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)").AppendLine();
+			sb.Append("\t\t{").AppendLine();
+			if (constructors.Value.Any(m => m.Parameters.Count == 0))
+			{
+				sb.Append("\t\t\tvalue = new global::Mockolate.Mock.").Append(fileName).Append("(mock.MockRegistry);").AppendLine();
+			}
+			else
+			{
+				sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException(\"No parameterless constructor found for '").Append(@class.DisplayString).Append("'. Please provide constructor parameters.\");").AppendLine();
+			}
+
+			sb.Append("\t\t}").AppendLine();
+			int constructorIndex = 0;
+			foreach (EquatableArray<MethodParameter> constructorParameters in constructors.Value
+				         .Select(constructor => constructor.Parameters))
+			{
+				constructorIndex++;
+				int requiredParameters = constructorParameters.Count(c => !c.HasExplicitDefaultValue);
+				if (requiredParameters < constructorParameters.Count)
+				{
+					sb.Append("\t\telse if (mock.MockRegistry.ConstructorParameters.Length >= ")
+						.Append(requiredParameters).Append(" && mock.MockRegistry.ConstructorParameters.Length <= ")
+						.Append(constructorParameters.Count);
+				}
+				else
+				{
+					sb.Append("\t\telse if (mock.MockRegistry.ConstructorParameters.Length == ")
+						.Append(constructorParameters.Count);
+				}
+
+				int constructorParameterIndex = 0;
+				foreach (MethodParameter parameter in constructorParameters)
+				{
+					useTryCast = useTryCast || !parameter.HasExplicitDefaultValue;
+					useTryCastWithDefaultValue = useTryCastWithDefaultValue || parameter.HasExplicitDefaultValue;
+					sb.AppendLine().Append("\t\t    && ")
+						.Append(parameter.HasExplicitDefaultValue ? "TryCastWithDefaultValue" : "TryCast")
+						.Append("(mock.MockRegistry.ConstructorParameters, ")
+						.Append(constructorParameterIndex++)
+						.Append(parameter.HasExplicitDefaultValue ? $", {parameter.ExplicitDefaultValue}" : "")
+						.Append(", mock.MockRegistry.Behavior, out ").Append(parameter.Type.Fullname).Append(" c")
+						.Append(constructorIndex)
+						.Append('p')
+						.Append(constructorParameterIndex).Append(")");
+				}
+
+				sb.Append(")").AppendLine();
+				sb.Append("\t\t{").AppendLine();
+				sb.Append("\t\t\tvalue = new global::Mockolate.Mock.").Append(fileName).Append("(mock.MockRegistry");
+				for (int j = 1; j <= constructorParameters.Count; j++)
+				{
+					sb.Append(", ").Append('c').Append(constructorIndex).Append('p').Append(j);
+				}
+
+				sb.Append(");").AppendLine();
+				sb.Append("\t\t}").AppendLine();
+			}
+
+			sb.Append("\t\telse").AppendLine();
+			sb.Append("\t\t{").AppendLine();
+			sb.Append("\t\t\tthrow new global::Mockolate.Exceptions.MockException($\"Could not find any constructor for '").Append(@class.DisplayString).Append("' that matches the {mock.MockRegistry.ConstructorParameters.Length} given parameters ({string.Join(\", \", mock.MockRegistry.ConstructorParameters)}).\");").AppendLine();
+			sb.Append("\t\t}").AppendLine();
+		}
+		else
+		{
+			sb.Append("\t\tvalue = new global::Mockolate.Mock.").Append(fileName).Append("(mock.MockRegistry);").AppendLine();
+		}
+
+		sb.Append("\t\tIMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mock.MockRegistry.Behavior;").AppendLine();
+		sb.Append("\t\tif (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[]?>(out var additionalSetups))").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tif (setups.Length > 0)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tvar concatenatedSetups = new global::System.Action<global::Mockolate.Mock.IMockSetupFor").Append(lastInterface.Name).Append(">[additionalSetups.Length + setups.Length];").AppendLine();
+		sb.Append("\t\t\t\tadditionalSetups.CopyTo(concatenatedSetups, 0);").AppendLine();
+		sb.Append("\t\t\t\tsetups.CopyTo(concatenatedSetups, additionalSetups.Length);").AppendLine();
+		sb.Append("\t\t\t\tsetups = concatenatedSetups;").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t\telse").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tsetups = additionalSetups;").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.Append("\t\tif (setups.Length > 0)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tforeach (var setup in setups)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tsetup.Invoke(value);").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.Append("\t\treturn value;").AppendLine();
+		if (useTryCast)
+		{
+			sb.Append("""
+			          		static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
+			          		{
+			          		    var value = values[index];
+			          			if (value is TValue typedValue)
+			          			{
+			          				result = typedValue;
+			          				return true;
+			          			}
+
+			          			result = default!;
+			          			return value is null;
+			          		}
+			          """).AppendLine();
+		}
+
+		if (useTryCastWithDefaultValue)
+		{
+			sb.Append("""
+			          		static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
+			          		{
+			          			if (values.Length > index && values[index] is TValue typedValue)
+			          			{
+			          				result = typedValue;
+			          				return true;
+			          			}
+
+			          			result = defaultValue;
+			          			return true;
+			          		}
+			          """).AppendLine();
+		}
+
+		sb.Append("\t}").AppendLine();
+
+		#endregion Implementing
 
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
+
+		#endregion Extensions
+
 		sb.AppendLine("#nullable disable annotations");
 		return sb.ToString();
 	}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockDelegate.cs
@@ -19,6 +19,406 @@ internal static partial class Sources
 		sb.Append("namespace Mockolate;").AppendLine();
 		sb.AppendLine();
 
+		#region Mock
+
+		sb.Append("internal static partial class Mock").AppendLine();
+		sb.Append("{").AppendLine();
+		
+		#region MockForXXX
+
+		sb.Append("\t/// <summary>").AppendLine();
+		sb.Append("\t///     A mock implementation for <see cref=\"").Append(escapedClassName).Append("\" />.").AppendLine();
+		sb.Append("\t/// </summary>").AppendLine();
+		sb.Append("\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]").AppendLine();
+#if !DEBUG
+		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
+		sb.Append("\tinternal class ").Append(name).Append(" :").AppendLine();
+		sb.Append("\t\tIMockFor").Append(name).Append(',').AppendLine();
+		sb.Append("\t\tglobal::Mockolate.IMock").AppendLine();
+		sb.Append("\t{").AppendLine();
+		memberIds.Emit(sb, "\t\t");
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc />").AppendLine();
+		sb.Append("\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.MockRegistry global::Mockolate.IMock.MockRegistry => this.").Append(mockRegistryName).Append(';').AppendLine();
+		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
+		sb.Append("\t\tpublic ").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry)").AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(" = mockRegistry;").AppendLine();
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+		sb.AppendXmlSummary("Returns the actual delegate with the mock as target.");
+		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Object => new(Invoke);").AppendLine();
+		sb.Append("\t\tprivate ").Append(delegateMethod.ReturnType == Type.Void ? "void" : delegateMethod.ReturnType.Fullname).Append(" Invoke(")
+			.Append(string.Join(", ", delegateMethod.Parameters.Select(p => $"{p.RefKind.GetString()}{p.Type.Fullname} {p.Name}"))).Append(')').AppendLine();
+		sb.Append("\t\t{").AppendLine();
+		string methodSetup = Helpers.GetUniqueLocalVariableName("methodSetup", delegateMethod.Parameters);
+		string methodSetupType = (delegateMethod.ReturnType == Type.Void, delegateMethod.Parameters.Count) switch
+		{
+			(true, 0) => "global::Mockolate.Setup.VoidMethodSetup",
+			(true, _) => $"global::Mockolate.Setup.VoidMethodSetup<{string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
+			(_, 0) => $"global::Mockolate.Setup.ReturnMethodSetup<{delegateMethod.ReturnType.ToTypeOrWrapper()}>",
+			(_, _) => $"global::Mockolate.Setup.ReturnMethodSetup<{delegateMethod.ReturnType.ToTypeOrWrapper()}, {string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
+		};
+		bool hasOutParams = delegateMethod.Parameters.Any(p => p.RefKind is RefKind.Out);
+		bool hasRefParams = delegateMethod.Parameters.Any(p => p.RefKind is RefKind.Ref);
+		string wpc = Helpers.GetUniqueLocalVariableName("wpc", delegateMethod.Parameters);
+
+		StringBuilder sb2 = new();
+		int i = 0;
+		foreach (MethodParameter p in delegateMethod.Parameters)
+		{
+			if (i++ > 0)
+			{
+				sb2.Append(", ");
+			}
+
+			if (p.RefKind == RefKind.Ref)
+			{
+				string paramRef = Helpers.GetUniqueLocalVariableName($"ref_{p.Name}", delegateMethod.Parameters);
+
+				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.Name).Append(';').AppendLine();
+				sb2.Append(paramRef);
+			}
+			else if (p.Type.SpecialGenericType == SpecialGenericType.Span ||
+			         p.Type.SpecialGenericType == SpecialGenericType.ReadOnlySpan)
+			{
+				string paramRef = Helpers.GetUniqueLocalVariableName($"ref_{p.Name}", delegateMethod.Parameters);
+
+				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.ToNameOrWrapper()).Append(';').AppendLine();
+				sb2.Append(paramRef);
+			}
+			else
+			{
+				sb2.Append(p.RefKind switch
+					{
+						RefKind.Out => "default",
+						_ => p.ToNameOrWrapper(),
+					});
+			}
+		}
+
+		string memberIdRef = memberIdPrefix + memberIds.GetMethodIdentifier(delegateMethod);
+		bool isGeneric = delegateMethod.GenericParameters is not null &&
+		                 delegateMethod.GenericParameters.Value.Count > 0;
+		EmitFastMethodSetupLookup(sb, "\t\t\t", $"this.{mockRegistryName}", methodSetup, methodSetupType,
+			memberIdRef, delegateMethod.GetUniqueNameString(), sb2.ToString(), isGeneric);
+
+		if (hasOutParams)
+		{
+			foreach (MethodParameter parameter in delegateMethod.Parameters.Where(p => p.RefKind == RefKind.Out))
+			{
+				sb.Append("\t\t\t").Append(parameter.Name).Append(" = default!;").AppendLine();
+			}
+		}
+
+		if (hasOutParams || hasRefParams)
+		{
+			string outParamBase = Helpers.GetUniqueIndexedLocalVariableBase("outParam", delegateMethod.Parameters);
+			string refParamBase = Helpers.GetUniqueIndexedLocalVariableBase("refParam", delegateMethod.Parameters);
+			sb.Append("\t\t\tif (").Append(methodSetup).Append(" is ").Append(methodSetupType).Append(".WithParameterCollection ").Append(wpc).Append(')').AppendLine();
+			sb.Append("\t\t\t{").AppendLine();
+			int parameterIndex = 0;
+			foreach (MethodParameter parameter in delegateMethod.Parameters)
+			{
+				parameterIndex++;
+				if (parameter.RefKind == RefKind.Out)
+				{
+					sb.Append("\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex)
+						.Append(" is not global::Mockolate.Parameters.IOutParameter<")
+						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(outParamBase)
+						.Append(parameterIndex)
+						.Append(" || !").Append(outParamBase).Append(parameterIndex).Append(".TryGetValue(out ")
+						.Append(parameter.Name).Append("))").AppendLine();
+					sb.Append("\t\t\t\t{").AppendLine();
+					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = ").AppendDefaultValueGeneratorFor(parameter.Type, $"this.{mockRegistryName}.Behavior.DefaultValue").Append(';').AppendLine();
+					sb.Append("\t\t\t\t}").AppendLine();
+				}
+				else if (parameter.RefKind == RefKind.Ref)
+				{
+					sb.Append("\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex).Append(" is global::Mockolate.Parameters.IRefParameter<").Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(refParamBase).Append(parameterIndex).Append(")").AppendLine();
+					sb.Append("\t\t\t\t{").AppendLine();
+					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = ").Append(refParamBase).Append(parameterIndex).Append(".GetValue(").Append(parameter.Name).Append(");").AppendLine();
+					sb.Append("\t\t\t\t}").AppendLine();
+				}
+			}
+
+			sb.Append("\t\t\t}").AppendLine();
+		}
+
+		sb.Append("\t\t\tif (").Append(mockRegistryName).Append(".Behavior.SkipInteractionRecording == false)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\t").Append(mockRegistryName).Append(".RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation");
+		if (delegateMethod.Parameters.Count > 0)
+		{
+			sb.Append('<').Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))).Append('>');
+		}
+
+		sb.Append("(").Append(delegateMethod.GetUniqueNameString());
+		if (delegateMethod.Parameters.Count > 0)
+		{
+			sb.Append(", ").Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToNameOrWrapper())));
+		}
+
+		sb.Append("));").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+
+		string displayDelegateName =
+			$"{delegateMethod.ContainingType}.{delegateMethod.Name}({string.Join(", ", delegateMethod.Parameters.Select(p => p.Type.DisplayName))})";
+		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && this.").Append(mockRegistryName).Append(".Behavior.ThrowWhenNotSetup)").AppendLine();
+		sb.Append("\t\t\t{").AppendLine();
+		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockNotSetupException(\"The method '").Append(displayDelegateName).Append("' was invoked without prior setup.\");").AppendLine();
+		sb.Append("\t\t\t}").AppendLine();
+
+		AppendTriggerCallbacks(sb, "\t\t\t", methodSetup, delegateMethod.Parameters);
+
+		if (delegateMethod.ReturnType != Type.Void)
+		{
+			string returnValue = Helpers.GetUniqueLocalVariableName("returnValue", delegateMethod.Parameters);
+			sb.Append("\t\t\treturn ").Append(methodSetup).Append("?.TryGetReturnValue(");
+			if (delegateMethod.Parameters.Count > 0)
+			{
+				sb.Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToNameOrWrapper()))).Append(", ");
+			}
+
+			sb.Append("out var ").Append(returnValue).Append(") == true ? ").Append(returnValue).Append(" : ")
+				.AppendDefaultValueGeneratorFor(delegateMethod.ReturnType, $"this.{mockRegistryName}.Behavior.DefaultValue")
+				.Append(';').AppendLine();
+		}
+
+		sb.Append("\t\t}").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc />").AppendLine();
+		sb.Append("\t\tstring global::Mockolate.IMock.ToString()").AppendLine();
+		sb.Append("\t\t\t=> \"").Append(@class.DisplayString).Append(" mock\";").AppendLine();
+		sb.AppendLine();
+
+		AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, memberIds, memberIdPrefix, "Setup");
+		
+		if (delegateMethod.Parameters.Count > 0)
+		{
+			AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", true, memberIds, memberIdPrefix, "Setup");
+		}
+
+		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
+		{
+			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
+			{
+				AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, memberIds, memberIdPrefix, "Setup", valueFlags);
+			}
+		}
+		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
+		{
+			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
+			if (allValueFlags.Any(f => f))
+			{
+				AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false, memberIds, memberIdPrefix, "Setup", allValueFlags);
+			}
+		}
+
+		// Delegate mocks use a plain MockRegistry (no FastMockInteractions), so emit the slow Verify path.
+		AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false, memberIds, memberIdPrefix, false, "Verify");
+		if (delegateMethod.Parameters.Count > 0)
+		{
+			AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", true, memberIds, memberIdPrefix, false, "Verify");
+		}
+
+		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
+		{
+			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
+			{
+				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false, memberIds, memberIdPrefix, false, "Verify", valueFlags);
+			}
+		}
+		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
+		{
+			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
+			if (allValueFlags.Any(f => f))
+			{
+				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false,
+					memberIds, memberIdPrefix, false, "Verify", allValueFlags);
+			}
+		}
+
+		sb.Append("\t\t/// <inheritdoc />").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> IMockFor").Append(name).Append(".VerifySetup(global::Mockolate.Setup.IMethodSetup setup)").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Method<IMockVerifyFor").Append(name).Append(">(this, setup);").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc />").AppendLine();
+		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllInteractionsAreVerified()").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Interactions.GetUnverifiedInteractions().Count == 0;").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc />").AppendLine();
+		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllSetupsAreUsed()").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".GetUnusedSetups(this.").Append(mockRegistryName).Append(".Interactions).Count == 0;").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc />").AppendLine();
+		sb.Append("\t\tvoid IMockFor").Append(name).Append(".ClearAllInteractions()").AppendLine();
+		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".ClearAllInteractions();").AppendLine();
+		sb.AppendLine();
+
+		sb.Append("\t\t/// <inheritdoc />").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> IMockFor").Append(name).Append(".Monitor()").AppendLine();
+		sb.Append("\t\t\t=> new global::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append(">(this.")
+			.Append(mockRegistryName).Append(".Interactions, interactions => new VerifyMonitor").Append(name)
+			.Append("(new global::Mockolate.MockRegistry(this.").Append(mockRegistryName).Append(", interactions)));").AppendLine();
+		sb.AppendLine("\t}");
+		sb.AppendLine();
+		
+#if !DEBUG
+		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
+		sb.Append("\tprivate sealed class VerifyMonitor").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor").Append(name).AppendLine();
+		sb.Append("\t{").AppendLine();
+		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; } = mockRegistry;").AppendLine();
+		sb.AppendLine();
+		
+		sb.Append("\t\t#region IMockVerifyFor").Append(name).AppendLine();
+		sb.AppendLine();
+		
+		// Delegate mocks use a plain MockRegistry (no FastMockInteractions), so emit the slow Verify path.
+		AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false, memberIds, memberIdPrefix, false, "Verify");
+		
+		if (delegateMethod.Parameters.Count > 0)
+		{
+			AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", true, memberIds, memberIdPrefix, false, "Verify");
+		}
+
+		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
+		{
+			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
+			{
+				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false, memberIds, memberIdPrefix, false, "Verify", valueFlags);
+			}
+		}
+		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
+		{
+			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
+			if (allValueFlags.Any(f => f))
+			{
+				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false, memberIds, memberIdPrefix, false, "Verify", allValueFlags);
+			}
+		}
+
+		sb.Append("\t\t#endregion IMockVerifyFor").Append(name).AppendLine();
+		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
+
+		#endregion MockForXXX
+
+		#region Mock Interfaces
+
+		#region IMockForXXX
+
+		sb.AppendXmlSummary($"Accesses the mock of <see cref=\"{escapedClassName}\" />.", "\t");
+		sb.Append("\tinternal interface IMockFor").Append(name).Append(" :").AppendLine();
+		sb.Append("\t\t IMockSetupFor").Append(name).Append(", IMockVerifyFor").Append(name).AppendLine();
+		sb.Append("\t{").AppendLine();
+		sb.AppendXmlSummary("Verifies the method invocations for the <paramref name=\"setup\" /> on the mock.");
+		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
+		sb.AppendLine();
+		sb.AppendXmlSummary("Gets a value indicating whether all expected interactions have been verified.");
+		sb.Append("\t\tbool VerifyThatAllInteractionsAreVerified();").AppendLine();
+		sb.AppendLine();
+		sb.AppendXmlSummary("Gets a value indicating whether all registered setups were used.");
+		sb.Append("\t\tbool VerifyThatAllSetupsAreUsed();").AppendLine();
+		sb.AppendLine();
+		sb.AppendXmlSummary("Clears all interactions recorded by the mock object.");
+		sb.Append("\t\tvoid ClearAllInteractions();").AppendLine();
+		sb.AppendLine();
+		sb.AppendXmlSummary("Provides monitoring capabilities for a mocked instance of the specified type, allowing inspection of accessed properties, invoked methods, and event subscriptions.");
+		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();").AppendLine();
+		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
+
+		#endregion IMockForXXX
+
+		#region IMockSetupForXXX
+
+		sb.AppendXmlSummary($"Set up the mock of <see cref=\"{escapedClassName}\" />.", "\t");
+		sb.Append("\tinternal interface IMockSetupFor").Append(name).Append(" : global::Mockolate.Setup.IMockSetup<").Append(@class.ClassFullName).Append(">").AppendLine();
+		sb.Append("\t{").AppendLine();
+		
+		AppendMethodSetupDefinition(sb, @class, delegateMethod, false, "Setup");
+		
+		if (delegateMethod.Parameters.Count > 0)
+		{
+			AppendMethodSetupDefinition(sb, @class, delegateMethod, true, "Setup");
+		}
+
+		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
+		{
+			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
+			{
+				AppendMethodSetupDefinition(sb, @class, delegateMethod, false, "Setup", valueFlags);
+			}
+		}
+		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
+		{
+			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
+			if (allValueFlags.Any(f => f))
+			{
+				AppendMethodSetupDefinition(sb, @class, delegateMethod, false, "Setup", allValueFlags);
+			}
+		}
+
+		sb.Append("\t}").AppendLine();
+		sb.AppendLine();
+
+		#endregion IMockSetupForXXX
+
+		#region IMockVerifyForXXX
+
+		sb.AppendXmlSummary($"Verify interactions with the mock of <see cref=\"{escapedClassName}\" />.", "\t");
+		sb.Append("\tinternal interface IMockVerifyFor").Append(name).Append(" : global::Mockolate.Verify.IMockVerify<").Append(@class.ClassFullName).Append(">").AppendLine();
+		sb.Append("\t{").AppendLine();
+		
+		AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify");
+		
+		if (delegateMethod.Parameters.Count > 0)
+		{
+			AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", true, "Verify");
+		}
+
+		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
+		{
+			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
+			{
+				AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify", valueFlags);
+			}
+		}
+		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
+		{
+			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
+			if (allValueFlags.Any(f => f))
+			{
+				AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify",
+					allValueFlags);
+			}
+		}
+
+		sb.Append("\t}").AppendLine();
+
+		#endregion IMockVerifyForXXX
+
+		#endregion Mock Interfaces
+
+		sb.Append("}").AppendLine();
+		sb.AppendLine();
+		
+		#endregion Mock
+
 		#region MockForXXXExtensions
 
 		sb.AppendXmlSummary($"Mock extensions for <see cref=\"{escapedClassName}\" />.", "");
@@ -100,451 +500,7 @@ internal static partial class Sources
 		#endregion MockForXXXExtensions
 
 		#endregion MockForXXXExtensions
-
-		sb.AppendLine();
-
-		#region MockForXXX
-
-		sb.Append("internal static partial class Mock").AppendLine();
-		sb.Append("{").AppendLine();
-		sb.Append("\t/// <summary>").AppendLine();
-		sb.Append("\t///     A mock implementation for <see cref=\"").Append(escapedClassName).Append("\" />.")
-			.AppendLine();
-		sb.Append("\t/// </summary>").AppendLine();
-		sb.Append(
-				"\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]")
-			.AppendLine();
-#if !DEBUG
-		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
-#endif
-		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("\tinternal class ").Append(name).Append(" :").AppendLine();
-		sb.Append("\t\tIMockFor").Append(name).Append(',').AppendLine();
-		sb.Append("\t\tglobal::Mockolate.IMock").AppendLine();
-		sb.Append("\t{").AppendLine();
-		memberIds.Emit(sb, "\t\t");
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append(
-				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
-			.AppendLine();
-		sb.Append("\t\tglobal::Mockolate.MockRegistry global::Mockolate.IMock.MockRegistry => this.")
-			.Append(mockRegistryName).Append(';').AppendLine();
-		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName).Append(" { get; }")
-			.AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <inheritdoc cref=\"").Append(name).Append("\" />").AppendLine();
-		sb.Append("\t\tpublic ").Append(name).Append("(global::Mockolate.MockRegistry mockRegistry)").AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(" = mockRegistry;").AppendLine();
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
-		sb.AppendXmlSummary("Returns the actual delegate with the mock as target.");
-		sb.Append("\t\tpublic ").Append(@class.ClassFullName).Append(" Object => new(Invoke);").AppendLine();
-		sb.Append("\t\tprivate ")
-			.Append(delegateMethod.ReturnType == Type.Void
-				? "void"
-				: delegateMethod.ReturnType.Fullname)
-			.Append(" Invoke(")
-			.Append(string.Join(", ",
-				delegateMethod.Parameters.Select(p => $"{p.RefKind.GetString()}{p.Type.Fullname} {p.Name}")))
-			.Append(')').AppendLine();
-		sb.Append("\t\t{").AppendLine();
-		string methodSetup = Helpers.GetUniqueLocalVariableName("methodSetup", delegateMethod.Parameters);
-		string methodSetupType = (delegateMethod.ReturnType == Type.Void, delegateMethod.Parameters.Count) switch
-		{
-			(true, 0) => "global::Mockolate.Setup.VoidMethodSetup",
-			(true, _) =>
-				$"global::Mockolate.Setup.VoidMethodSetup<{string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
-			(_, 0) => $"global::Mockolate.Setup.ReturnMethodSetup<{delegateMethod.ReturnType.ToTypeOrWrapper()}>",
-			(_, _) =>
-				$"global::Mockolate.Setup.ReturnMethodSetup<{delegateMethod.ReturnType.ToTypeOrWrapper()}, {string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper()))}>",
-		};
-		bool hasOutParams = delegateMethod.Parameters.Any(p => p.RefKind is RefKind.Out);
-		bool hasRefParams = delegateMethod.Parameters.Any(p => p.RefKind is RefKind.Ref);
-		string wpc = Helpers.GetUniqueLocalVariableName("wpc", delegateMethod.Parameters);
-
-		StringBuilder sb2 = new();
-		int i = 0;
-		foreach (MethodParameter p in delegateMethod.Parameters)
-		{
-			if (i++ > 0)
-			{
-				sb2.Append(", ");
-			}
-
-			if (p.RefKind == RefKind.Ref)
-			{
-				string paramRef = Helpers.GetUniqueLocalVariableName($"ref_{p.Name}", delegateMethod.Parameters);
-
-				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.Name).Append(';').AppendLine();
-				sb2.Append(paramRef);
-			}
-			else if (p.Type.SpecialGenericType == SpecialGenericType.Span ||
-			         p.Type.SpecialGenericType == SpecialGenericType.ReadOnlySpan)
-			{
-				string paramRef = Helpers.GetUniqueLocalVariableName($"ref_{p.Name}", delegateMethod.Parameters);
-
-				sb.Append("\t\t\tvar ").Append(paramRef).Append(" = ").Append(p.ToNameOrWrapper()).Append(';')
-					.AppendLine();
-				sb2.Append(paramRef);
-			}
-			else
-			{
-				sb2.Append(
-					p.RefKind switch
-					{
-						RefKind.Out => "default",
-						_ => p.ToNameOrWrapper(),
-					});
-			}
-		}
-
-		string memberIdRef = memberIdPrefix + memberIds.GetMethodIdentifier(delegateMethod);
-		bool isGeneric = delegateMethod.GenericParameters is not null &&
-		                 delegateMethod.GenericParameters.Value.Count > 0;
-		EmitFastMethodSetupLookup(sb, "\t\t\t", $"this.{mockRegistryName}", methodSetup, methodSetupType,
-			memberIdRef, delegateMethod.GetUniqueNameString(), sb2.ToString(), isGeneric);
-
-		if (hasOutParams)
-		{
-			foreach (MethodParameter parameter in delegateMethod.Parameters.Where(p => p.RefKind == RefKind.Out))
-			{
-				sb.Append("\t\t\t").Append(parameter.Name).Append(" = default!;").AppendLine();
-			}
-		}
-
-		if (hasOutParams || hasRefParams)
-		{
-			string outParamBase = Helpers.GetUniqueIndexedLocalVariableBase("outParam", delegateMethod.Parameters);
-			string refParamBase = Helpers.GetUniqueIndexedLocalVariableBase("refParam", delegateMethod.Parameters);
-			sb.Append("\t\t\tif (").Append(methodSetup).Append(" is ").Append(methodSetupType)
-				.Append(".WithParameterCollection ").Append(wpc).Append(')').AppendLine();
-			sb.Append("\t\t\t{").AppendLine();
-			int parameterIndex = 0;
-			foreach (MethodParameter parameter in delegateMethod.Parameters)
-			{
-				parameterIndex++;
-				if (parameter.RefKind == RefKind.Out)
-				{
-					sb.Append("\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex)
-						.Append(" is not global::Mockolate.Parameters.IOutParameter<")
-						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(outParamBase)
-						.Append(parameterIndex)
-						.Append(" || !").Append(outParamBase).Append(parameterIndex).Append(".TryGetValue(out ")
-						.Append(parameter.Name).Append("))").AppendLine();
-					sb.Append("\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = ")
-						.AppendDefaultValueGeneratorFor(parameter.Type,
-							$"this.{mockRegistryName}.Behavior.DefaultValue")
-						.Append(';').AppendLine();
-					sb.Append("\t\t\t\t}").AppendLine();
-				}
-				else if (parameter.RefKind == RefKind.Ref)
-				{
-					sb.Append("\t\t\t\tif (").Append(wpc).Append(".Parameter").Append(parameterIndex)
-						.Append(" is global::Mockolate.Parameters.IRefParameter<")
-						.Append(parameter.Type.ToTypeOrWrapper()).Append("> ").Append(refParamBase)
-						.Append(parameterIndex)
-						.Append(")").AppendLine();
-					sb.Append("\t\t\t\t{").AppendLine();
-					sb.Append("\t\t\t\t\t").Append(parameter.Name).Append(" = ").Append(refParamBase)
-						.Append(parameterIndex)
-						.Append(".GetValue(").Append(parameter.Name).Append(");").AppendLine();
-					sb.Append("\t\t\t\t}").AppendLine();
-				}
-			}
-
-			sb.Append("\t\t\t}").AppendLine();
-		}
-
-		sb.Append("\t\t\tif (").Append(mockRegistryName).Append(".Behavior.SkipInteractionRecording == false)")
-			.AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\t").Append(mockRegistryName)
-			.Append(".RegisterInteraction(new global::Mockolate.Interactions.MethodInvocation");
-		if (delegateMethod.Parameters.Count > 0)
-		{
-			sb.Append('<').Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToTypeOrWrapper())))
-				.Append('>');
-		}
-
-		sb.Append("(").Append(delegateMethod.GetUniqueNameString());
-		if (delegateMethod.Parameters.Count > 0)
-		{
-			sb.Append(", ").Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToNameOrWrapper())));
-		}
-
-		sb.Append("));").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-
-		string displayDelegateName =
-			$"{delegateMethod.ContainingType}.{delegateMethod.Name}({string.Join(", ", delegateMethod.Parameters.Select(p => p.Type.DisplayName))})";
-		sb.Append("\t\t\tif (").Append(methodSetup).Append(" is null && this.").Append(mockRegistryName)
-			.Append(".Behavior.ThrowWhenNotSetup)").AppendLine();
-		sb.Append("\t\t\t{").AppendLine();
-		sb.Append("\t\t\t\tthrow new global::Mockolate.Exceptions.MockNotSetupException(\"The method '")
-			.Append(displayDelegateName).Append("' was invoked without prior setup.\");").AppendLine();
-		sb.Append("\t\t\t}").AppendLine();
-
-		AppendTriggerCallbacks(sb, "\t\t\t", methodSetup, delegateMethod.Parameters);
-
-		if (delegateMethod.ReturnType != Type.Void)
-		{
-			string returnValue = Helpers.GetUniqueLocalVariableName("returnValue", delegateMethod.Parameters);
-			sb.Append("\t\t\treturn ").Append(methodSetup).Append("?.TryGetReturnValue(");
-			if (delegateMethod.Parameters.Count > 0)
-			{
-				sb.Append(string.Join(", ", delegateMethod.Parameters.Select(p => p.ToNameOrWrapper()))).Append(", ");
-			}
-
-			sb.Append("out var ").Append(returnValue).Append(") == true ? ").Append(returnValue).Append(" : ")
-				.AppendDefaultValueGeneratorFor(delegateMethod.ReturnType,
-					$"this.{mockRegistryName}.Behavior.DefaultValue")
-				.Append(';').AppendLine();
-		}
-
-		sb.Append("\t\t}").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tstring global::Mockolate.IMock.ToString()").AppendLine();
-		sb.Append("\t\t\t=> \"").Append(@class.DisplayString).Append(" mock\";").AppendLine();
-		sb.AppendLine();
-
-		AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false,
-			memberIds, memberIdPrefix, "Setup");
-		if (delegateMethod.Parameters.Count > 0)
-		{
-			AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", true,
-				memberIds, memberIdPrefix, "Setup");
-		}
-
-		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
-		{
-			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
-			{
-				AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false,
-					memberIds, memberIdPrefix, "Setup", valueFlags);
-			}
-		}
-		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
-		{
-			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
-			if (allValueFlags.Any(f => f))
-			{
-				AppendMethodSetupImplementation(sb, delegateMethod, mockRegistryName, $"IMockSetupFor{name}", false,
-					memberIds, memberIdPrefix, "Setup", allValueFlags);
-			}
-		}
-
-		// Delegate mocks use a plain MockRegistry (no FastMockInteractions), so emit the slow Verify path.
-		AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false,
-			memberIds, memberIdPrefix, false, "Verify");
-		if (delegateMethod.Parameters.Count > 0)
-		{
-			AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", true,
-				memberIds, memberIdPrefix, false, "Verify");
-		}
-
-		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
-		{
-			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
-			{
-				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false,
-					memberIds, memberIdPrefix, false, "Verify", valueFlags);
-			}
-		}
-		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
-		{
-			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
-			if (allValueFlags.Any(f => f))
-			{
-				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false,
-					memberIds, memberIdPrefix, false, "Verify", allValueFlags);
-			}
-		}
-
-		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name).Append("> IMockFor")
-			.Append(name).Append(".VerifySetup(global::Mockolate.Setup.IMethodSetup setup)").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".Method<IMockVerifyFor").Append(name)
-			.Append(">(this, setup);").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllInteractionsAreVerified()").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName)
-			.Append(".Interactions.GetUnverifiedInteractions().Count == 0;").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tbool IMockFor").Append(name).Append(".VerifyThatAllSetupsAreUsed()").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".GetUnusedSetups(this.").Append(mockRegistryName)
-			.Append(".Interactions).Count == 0;").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tvoid IMockFor").Append(name).Append(".ClearAllInteractions()").AppendLine();
-		sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".ClearAllInteractions();").AppendLine();
-		sb.AppendLine();
-
-		sb.Append("\t\t/// <inheritdoc />").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> IMockFor")
-			.Append(name).Append(".Monitor()").AppendLine();
-		sb.Append("\t\t\t=> new global::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append(">(this.")
-			.Append(mockRegistryName).Append(".Interactions, interactions => new VerifyMonitor").Append(name)
-			.Append("(new global::Mockolate.MockRegistry(this.").Append(mockRegistryName).Append(", interactions)));")
-			.AppendLine();
-		sb.AppendLine("\t}");
-
-		sb.AppendLine();
-#if !DEBUG
-		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
-#endif
-		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
-		sb.Append("\tprivate sealed class VerifyMonitor").Append(name)
-			.Append("(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockVerifyFor")
-			.Append(name).AppendLine();
-		sb.Append("\t{").AppendLine();
-		sb.Append("\t\tprivate global::Mockolate.MockRegistry ").Append(mockRegistryName)
-			.Append(" { get; } = mockRegistry;").AppendLine();
-		sb.AppendLine();
-		sb.Append("\t\t#region IMockVerifyFor").Append(name).AppendLine();
-		sb.AppendLine();
-		// Delegate mocks use a plain MockRegistry (no FastMockInteractions), so emit the slow Verify path.
-		AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false,
-			memberIds, memberIdPrefix, false, "Verify");
-		if (delegateMethod.Parameters.Count > 0)
-		{
-			AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", true,
-				memberIds, memberIdPrefix, false, "Verify");
-		}
-
-		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
-		{
-			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
-			{
-				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false,
-					memberIds, memberIdPrefix, false, "Verify", valueFlags);
-			}
-		}
-		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
-		{
-			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
-			if (allValueFlags.Any(f => f))
-			{
-				AppendMethodVerifyImplementation(sb, delegateMethod, mockRegistryName, $"IMockVerifyFor{name}", false,
-					memberIds, memberIdPrefix, false, "Verify", allValueFlags);
-			}
-		}
-
-		sb.Append("\t\t#endregion IMockVerifyFor").Append(name).AppendLine();
-		sb.Append("\t}").AppendLine();
-
-		#endregion MockForXXX
-
-		sb.AppendLine();
-
-		#region IMockForXXX
-
-		sb.AppendXmlSummary($"Accesses the mock of <see cref=\"{escapedClassName}\" />.", "\t");
-		sb.Append("\tinternal interface IMockFor").Append(name).Append(" :").AppendLine();
-		sb.Append("\t\t IMockSetupFor").Append(name).Append(", IMockVerifyFor").Append(name).AppendLine();
-		sb.Append("\t{").AppendLine();
-		sb.AppendXmlSummary("Verifies the method invocations for the <paramref name=\"setup\" /> on the mock.");
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationResult<IMockVerifyFor").Append(name)
-			.Append("> VerifySetup(global::Mockolate.Setup.IMethodSetup setup);").AppendLine();
-		sb.AppendLine();
-		sb.AppendXmlSummary("Gets a value indicating whether all expected interactions have been verified.");
-		sb.Append("\t\tbool VerifyThatAllInteractionsAreVerified();").AppendLine();
-		sb.AppendLine();
-		sb.AppendXmlSummary("Gets a value indicating whether all registered setups were used.");
-		sb.Append("\t\tbool VerifyThatAllSetupsAreUsed();").AppendLine();
-		sb.AppendLine();
-		sb.AppendXmlSummary("Clears all interactions recorded by the mock object.");
-		sb.Append("\t\tvoid ClearAllInteractions();").AppendLine();
-		sb.AppendLine();
-		sb.AppendXmlSummary(
-			"Provides monitoring capabilities for a mocked instance of the specified type, allowing inspection of accessed properties, invoked methods, and event subscriptions.");
-		sb.Append("\t\tglobal::Mockolate.Monitor.MockMonitor<IMockVerifyFor").Append(name).Append("> Monitor();")
-			.AppendLine();
-		sb.Append("\t}").AppendLine();
-
-		#endregion IMockForXXX
-
-		sb.AppendLine();
-
-		#region IMockSetupForXXX
-
-		sb.AppendXmlSummary($"Set up the mock of <see cref=\"{escapedClassName}\" />.", "\t");
-		sb.Append("\tinternal interface IMockSetupFor").Append(name).Append(" : global::Mockolate.Setup.IMockSetup<")
-			.Append(@class.ClassFullName).Append(">").AppendLine();
-		sb.Append("\t{").AppendLine();
-		AppendMethodSetupDefinition(sb, @class, delegateMethod, false, "Setup");
-		if (delegateMethod.Parameters.Count > 0)
-		{
-			AppendMethodSetupDefinition(sb, @class, delegateMethod, true, "Setup");
-		}
-
-		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
-		{
-			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
-			{
-				AppendMethodSetupDefinition(sb, @class, delegateMethod, false, "Setup", valueFlags);
-			}
-		}
-		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
-		{
-			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
-			if (allValueFlags.Any(f => f))
-			{
-				AppendMethodSetupDefinition(sb, @class, delegateMethod, false, "Setup", allValueFlags);
-			}
-		}
-
-		sb.Append("\t}").AppendLine();
-
-		#endregion IMockSetupForXXX
-
-		sb.AppendLine();
-
-		#region IMockVerifyForXXX
-
-		sb.AppendXmlSummary($"Verify interactions with the mock of <see cref=\"{escapedClassName}\" />.", "\t");
-		sb.Append("\tinternal interface IMockVerifyFor").Append(name).Append(" : global::Mockolate.Verify.IMockVerify<")
-			.Append(@class.ClassFullName).Append(">").AppendLine();
-		sb.Append("\t{").AppendLine();
-		AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify");
-		if (delegateMethod.Parameters.Count > 0)
-		{
-			AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", true, "Verify");
-		}
-
-		if (delegateMethod.Parameters.Count is > 0 and <= MaxExplicitParameters)
-		{
-			foreach (bool[] valueFlags in GenerateValueFlagCombinations(delegateMethod.Parameters))
-			{
-				AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify", valueFlags);
-			}
-		}
-		else if (delegateMethod.Parameters.Count > MaxExplicitParameters)
-		{
-			bool[] allValueFlags = delegateMethod.Parameters.Select(p => p.CanUseNullableParameterOverload()).ToArray();
-			if (allValueFlags.Any(f => f))
-			{
-				AppendMethodVerifyDefinition(sb, delegateMethod, $"IMockVerifyFor{name}", false, "Verify",
-					allValueFlags);
-			}
-		}
-
-		sb.Append("\t}").AppendLine();
-
-		#endregion IMockVerifyForXXX
-
-		sb.Append("}").AppendLine();
+		
 		sb.AppendLine("#nullable disable annotations");
 		return sb.ToString();
 	}

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass.g.cs
@@ -10,487 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForComprehensiveAbstractClass
-{
-	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</exception>
-		public global::Mockolate.Mock.IMockForComprehensiveAbstractClass Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForComprehensiveAbstractClass mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="constructorParameters" /> to invoke the base-class constructor.
-		/// </summary>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(object?[] constructorParameters)
-			=> CreateMock(null, null, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)
-			=> CreateMock(mockBehavior, null, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, object?[] constructorParameters)
-			=> CreateMock(null, setup, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int v, string text = "x")
-			=> CreateMock(null, null, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int v, string text = "x")
-			=> CreateMock(mockBehavior, null, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
-			=> CreateMock(null, setup, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
-			=> CreateMock(mockBehavior, setup, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int mockRegistry, bool _)
-			=> CreateMock(null, null, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int mockRegistry, bool _)
-			=> CreateMock(mockBehavior, null, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
-			=> CreateMock(null, setup, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
-			=> CreateMock(mockBehavior, setup, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(string name)
-			=> CreateMock(null, null, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, string name)
-			=> CreateMock(mockBehavior, null, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
-			=> CreateMock(null, setup, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
-			=> CreateMock(mockBehavior, setup, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass>(out object?[]? parameters))
-				{
-					constructorParameters = parameters;
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup)
-		{
-			if (constructorParameters is null || constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
-			}
-			else if (constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
-			}
-			else if (constructorParameters.Length >= 1 && constructorParameters.Length <= 2
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c2p1)
-			    && TryCastWithDefaultValue(constructorParameters, 1, "x", mockRegistry.Behavior, out string c2p2))
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c2p1, c2p2);
-			}
-			else if (constructorParameters.Length == 2
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c3p1)
-			    && TryCast(constructorParameters, 1, mockRegistry.Behavior, out bool c3p2))
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c3p1, c3p2);
-			}
-			else if (constructorParameters.Length == 1
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out string c4p1))
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c4p1);
-			}
-			else
-			{
-				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
-			}
-			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
-			{
-			    var value = values[index];
-				if (value is TValue typedValue)
-				{
-					result = typedValue;
-					return true;
-				}
-				
-				result = default!;
-				return value is null;
-			}
-			static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
-			{
-				if (values.Length > index && values[index] is TValue typedValue)
-				{
-					result = typedValue;
-					return true;
-				}
-				
-				result = defaultValue;
-				return true;
-			}
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Wrapping(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-	internal interface IMockSetupInitializationForComprehensiveAbstractClass : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass
-	{
-		/// <summary>
-		///     Setup protected members
-		/// </summary>
-		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass Protected { get; }
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass, global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass, IMockSetupInitializationForComprehensiveAbstractClass
-	{
-		/// <inheritdoc />
-		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass IMockSetupInitializationForComprehensiveAbstractClass.Protected => this;
-		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
-
-		#region IMockSetupForComprehensiveAbstractClass
-
-		/// <inheritdoc />
-		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.V
-		{
-			get
-			{
-				var propertySetup = new global::Mockolate.Setup.PropertySetup<int>(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.V");
-				this.MockRegistry.SetupProperty(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_V_Get, propertySetup);
-				return propertySetup;
-			}
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.A()
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.A");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_A, methodSetup);
-			return methodSetup;
-		}
-
-		#endregion IMockSetupForComprehensiveAbstractClass
-
-		#region IMockProtectedSetupForComprehensiveAbstractClass
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass.P()
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.P");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_P, methodSetup);
-			return methodSetup;
-		}
-
-		#endregion IMockProtectedSetupForComprehensiveAbstractClass
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -1141,6 +660,486 @@ internal static partial class Mock
 		/// </summary>
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForComprehensiveAbstractClass>.IgnoreParameters P();
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForComprehensiveAbstractClass
+{
+	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</exception>
+		public global::Mockolate.Mock.IMockForComprehensiveAbstractClass Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForComprehensiveAbstractClass mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="constructorParameters" /> to invoke the base-class constructor.
+		/// </summary>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(object?[] constructorParameters)
+			=> CreateMock(null, null, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)
+			=> CreateMock(mockBehavior, null, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, object?[] constructorParameters)
+			=> CreateMock(null, setup, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int v, string text = "x")
+			=> CreateMock(null, null, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int v, string text = "x")
+			=> CreateMock(mockBehavior, null, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
+			=> CreateMock(null, setup, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
+			=> CreateMock(mockBehavior, setup, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int mockRegistry, bool _)
+			=> CreateMock(null, null, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int mockRegistry, bool _)
+			=> CreateMock(mockBehavior, null, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
+			=> CreateMock(null, setup, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
+			=> CreateMock(mockBehavior, setup, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(string name)
+			=> CreateMock(null, null, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, string name)
+			=> CreateMock(mockBehavior, null, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
+			=> CreateMock(null, setup, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
+			=> CreateMock(mockBehavior, setup, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass>(out object?[]? parameters))
+				{
+					constructorParameters = parameters;
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup)
+		{
+			if (constructorParameters is null || constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
+			}
+			else if (constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
+			}
+			else if (constructorParameters.Length >= 1 && constructorParameters.Length <= 2
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c2p1)
+			    && TryCastWithDefaultValue(constructorParameters, 1, "x", mockRegistry.Behavior, out string c2p2))
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c2p1, c2p2);
+			}
+			else if (constructorParameters.Length == 2
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c3p1)
+			    && TryCast(constructorParameters, 1, mockRegistry.Behavior, out bool c3p2))
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c3p1, c3p2);
+			}
+			else if (constructorParameters.Length == 1
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out string c4p1))
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c4p1);
+			}
+			else
+			{
+				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
+			}
+			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
+			{
+			    var value = values[index];
+				if (value is TValue typedValue)
+				{
+					result = typedValue;
+					return true;
+				}
+				
+				result = default!;
+				return value is null;
+			}
+			static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
+			{
+				if (values.Length > index && values[index] is TValue typedValue)
+				{
+					result = typedValue;
+					return true;
+				}
+				
+				result = defaultValue;
+				return true;
+			}
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Wrapping(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+	internal interface IMockSetupInitializationForComprehensiveAbstractClass : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass
+	{
+		/// <summary>
+		///     Setup protected members
+		/// </summary>
+		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass Protected { get; }
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass, global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass, IMockSetupInitializationForComprehensiveAbstractClass
+	{
+		/// <inheritdoc />
+		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass IMockSetupInitializationForComprehensiveAbstractClass.Protected => this;
+		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
+
+		#region IMockSetupForComprehensiveAbstractClass
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.V
+		{
+			get
+			{
+				var propertySetup = new global::Mockolate.Setup.PropertySetup<int>(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.V");
+				this.MockRegistry.SetupProperty(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_V_Get, propertySetup);
+				return propertySetup;
+			}
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.A()
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.A");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_A, methodSetup);
+			return methodSetup;
+		}
+
+		#endregion IMockSetupForComprehensiveAbstractClass
+
+		#region IMockProtectedSetupForComprehensiveAbstractClass
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass.P()
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.P");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_P, methodSetup);
+			return methodSetup;
+		}
+
+		#endregion IMockProtectedSetupForComprehensiveAbstractClass
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA.g.cs
@@ -10,108 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that also implements<br />
-///      - <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForComprehensiveAbstractClass__ICombinationMockA
-{
-		/// <summary>
-		///     Extends this mock so the returned instance also implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> to exercise the extra surface or use <c>.Mock.As&lt;ICombinationMockA&gt;()</c> to reach the Setup/Verify surface of the additional interface.
-		/// </remarks>
-		/// <param name="sut">The mock instance to extend.</param>
-		/// <param name="setups">Optional setup callbacks registered on the additional interface before the mock is returned.</param>
-		/// <returns>A mock of the original type that additionally implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
-	public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Implementing<TInterface>(this global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass sut, params global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>[] setups)
-		where TInterface : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA
-	{
-		if (sut is not global::Mockolate.IMock mock)
-		{
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-		global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA value;
-		if (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length == 0)
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length >= 1 && mock.MockRegistry.ConstructorParameters.Length <= 2
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c2p1)
-		    && TryCastWithDefaultValue(mock.MockRegistry.ConstructorParameters, 1, "x", mock.MockRegistry.Behavior, out string c2p2))
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry, c2p1, c2p2);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length == 2
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c3p1)
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 1, mock.MockRegistry.Behavior, out bool c3p2))
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry, c3p1, c3p2);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length == 1
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out string c4p1))
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry, c4p1);
-		}
-		else
-		{
-			throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {mock.MockRegistry.ConstructorParameters.Length} given parameters ({string.Join(", ", mock.MockRegistry.ConstructorParameters)}).");
-		}
-		IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mock.MockRegistry.Behavior;
-		if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>[]?>(out var additionalSetups))
-		{
-			if (setups.Length > 0)
-			{
-				var concatenatedSetups = new global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>[additionalSetups.Length + setups.Length];
-				additionalSetups.CopyTo(concatenatedSetups, 0);
-				setups.CopyTo(concatenatedSetups, additionalSetups.Length);
-				setups = concatenatedSetups;
-			}
-			else
-			{
-				setups = additionalSetups;
-			}
-		}
-		if (setups.Length > 0)
-		{
-			foreach (var setup in setups)
-			{
-				setup.Invoke(value);
-			}
-		}
-		return value;
-		static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
-		{
-		    var value = values[index];
-			if (value is TValue typedValue)
-			{
-				result = typedValue;
-				return true;
-			}
-
-			result = default!;
-			return value is null;
-		}
-		static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
-		{
-			if (values.Length > index && values[index] is TValue typedValue)
-			{
-				result = typedValue;
-				return true;
-			}
-
-			result = defaultValue;
-			return true;
-		}
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -577,6 +475,108 @@ internal static partial class Mock
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForICombinationMockA>.IgnoreParameters IMockVerifyForICombinationMockA.Run()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForICombinationMockA, global::Mockolate.Interactions.MethodInvocation>(this, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Run", __i => true, () => $"Run()");
 		#endregion IMockVerifyForICombinationMockA
+	}
+}
+
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that also implements<br />
+///      - <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForComprehensiveAbstractClass__ICombinationMockA
+{
+		/// <summary>
+		///     Extends this mock so the returned instance also implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> to exercise the extra surface or use <c>.Mock.As&lt;ICombinationMockA&gt;()</c> to reach the Setup/Verify surface of the additional interface.
+		/// </remarks>
+		/// <param name="sut">The mock instance to extend.</param>
+		/// <param name="setups">Optional setup callbacks registered on the additional interface before the mock is returned.</param>
+		/// <returns>A mock of the original type that additionally implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
+	public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Implementing<TInterface>(this global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass sut, params global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>[] setups)
+		where TInterface : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA
+	{
+		if (sut is not global::Mockolate.IMock mock)
+		{
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+		global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA value;
+		if (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length == 0)
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length >= 1 && mock.MockRegistry.ConstructorParameters.Length <= 2
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c2p1)
+		    && TryCastWithDefaultValue(mock.MockRegistry.ConstructorParameters, 1, "x", mock.MockRegistry.Behavior, out string c2p2))
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry, c2p1, c2p2);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length == 2
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c3p1)
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 1, mock.MockRegistry.Behavior, out bool c3p2))
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry, c3p1, c3p2);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length == 1
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out string c4p1))
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA(mock.MockRegistry, c4p1);
+		}
+		else
+		{
+			throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {mock.MockRegistry.ConstructorParameters.Length} given parameters ({string.Join(", ", mock.MockRegistry.ConstructorParameters)}).");
+		}
+		IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mock.MockRegistry.Behavior;
+		if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>[]?>(out var additionalSetups))
+		{
+			if (setups.Length > 0)
+			{
+				var concatenatedSetups = new global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>[additionalSetups.Length + setups.Length];
+				additionalSetups.CopyTo(concatenatedSetups, 0);
+				setups.CopyTo(concatenatedSetups, additionalSetups.Length);
+				setups = concatenatedSetups;
+			}
+			else
+			{
+				setups = additionalSetups;
+			}
+		}
+		if (setups.Length > 0)
+		{
+			foreach (var setup in setups)
+			{
+				setup.Invoke(value);
+			}
+		}
+		return value;
+		static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
+		{
+		    var value = values[index];
+			if (value is TValue typedValue)
+			{
+				result = typedValue;
+				return true;
+			}
+
+			result = default!;
+			return value is null;
+		}
+		static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
+		{
+			if (values.Length > index && values[index] is TValue typedValue)
+			{
+				result = typedValue;
+				return true;
+			}
+
+			result = defaultValue;
+			return true;
+		}
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB.g.cs
@@ -10,109 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that also implements<br />
-///      - <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see><br />
-///      - <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB
-{
-		/// <summary>
-		///     Extends this mock so the returned instance also implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> to exercise the extra surface or use <c>.Mock.As&lt;ICombinationMockB&gt;()</c> to reach the Setup/Verify surface of the additional interface.
-		/// </remarks>
-		/// <param name="sut">The mock instance to extend.</param>
-		/// <param name="setups">Optional setup callbacks registered on the additional interface before the mock is returned.</param>
-		/// <returns>A mock of the original type that additionally implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
-	public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Implementing<TInterface>(this global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass sut, params global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>[] setups)
-		where TInterface : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB
-	{
-		if (sut is not global::Mockolate.IMock mock)
-		{
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-		global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB value;
-		if (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length == 0)
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length >= 1 && mock.MockRegistry.ConstructorParameters.Length <= 2
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c2p1)
-		    && TryCastWithDefaultValue(mock.MockRegistry.ConstructorParameters, 1, "x", mock.MockRegistry.Behavior, out string c2p2))
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry, c2p1, c2p2);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length == 2
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c3p1)
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 1, mock.MockRegistry.Behavior, out bool c3p2))
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry, c3p1, c3p2);
-		}
-		else if (mock.MockRegistry.ConstructorParameters.Length == 1
-		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out string c4p1))
-		{
-			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry, c4p1);
-		}
-		else
-		{
-			throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {mock.MockRegistry.ConstructorParameters.Length} given parameters ({string.Join(", ", mock.MockRegistry.ConstructorParameters)}).");
-		}
-		IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mock.MockRegistry.Behavior;
-		if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>[]?>(out var additionalSetups))
-		{
-			if (setups.Length > 0)
-			{
-				var concatenatedSetups = new global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>[additionalSetups.Length + setups.Length];
-				additionalSetups.CopyTo(concatenatedSetups, 0);
-				setups.CopyTo(concatenatedSetups, additionalSetups.Length);
-				setups = concatenatedSetups;
-			}
-			else
-			{
-				setups = additionalSetups;
-			}
-		}
-		if (setups.Length > 0)
-		{
-			foreach (var setup in setups)
-			{
-				setup.Invoke(value);
-			}
-		}
-		return value;
-		static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
-		{
-		    var value = values[index];
-			if (value is TValue typedValue)
-			{
-				result = typedValue;
-				return true;
-			}
-
-			result = default!;
-			return value is null;
-		}
-		static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
-		{
-			if (values.Length > index && values[index] is TValue typedValue)
-			{
-				result = typedValue;
-				return true;
-			}
-
-			result = defaultValue;
-			return true;
-		}
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -727,6 +624,109 @@ internal static partial class Mock
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForICombinationMockB>.IgnoreParameters IMockVerifyForICombinationMockB.Run()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForICombinationMockB, global::Mockolate.Interactions.MethodInvocation>(this, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Run", __i => true, () => $"Run()");
 		#endregion IMockVerifyForICombinationMockB
+	}
+}
+
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that also implements<br />
+///      - <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see><br />
+///      - <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB
+{
+		/// <summary>
+		///     Extends this mock so the returned instance also implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a brand-new mock that shares the mock registry (recorded interactions, scenario state, setups) of this one. Cast it to <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> to exercise the extra surface or use <c>.Mock.As&lt;ICombinationMockB&gt;()</c> to reach the Setup/Verify surface of the additional interface.
+		/// </remarks>
+		/// <param name="sut">The mock instance to extend.</param>
+		/// <param name="setups">Optional setup callbacks registered on the additional interface before the mock is returned.</param>
+		/// <returns>A mock of the original type that additionally implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
+	public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Implementing<TInterface>(this global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass sut, params global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>[] setups)
+		where TInterface : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB
+	{
+		if (sut is not global::Mockolate.IMock mock)
+		{
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+		global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB value;
+		if (mock.MockRegistry.ConstructorParameters is null || mock.MockRegistry.ConstructorParameters.Length == 0)
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length == 0)
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length >= 1 && mock.MockRegistry.ConstructorParameters.Length <= 2
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c2p1)
+		    && TryCastWithDefaultValue(mock.MockRegistry.ConstructorParameters, 1, "x", mock.MockRegistry.Behavior, out string c2p2))
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry, c2p1, c2p2);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length == 2
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out int c3p1)
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 1, mock.MockRegistry.Behavior, out bool c3p2))
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry, c3p1, c3p2);
+		}
+		else if (mock.MockRegistry.ConstructorParameters.Length == 1
+		    && TryCast(mock.MockRegistry.ConstructorParameters, 0, mock.MockRegistry.Behavior, out string c4p1))
+		{
+			value = new global::Mockolate.Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB(mock.MockRegistry, c4p1);
+		}
+		else
+		{
+			throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {mock.MockRegistry.ConstructorParameters.Length} given parameters ({string.Join(", ", mock.MockRegistry.ConstructorParameters)}).");
+		}
+		IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mock.MockRegistry.Behavior;
+		if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>[]?>(out var additionalSetups))
+		{
+			if (setups.Length > 0)
+			{
+				var concatenatedSetups = new global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>[additionalSetups.Length + setups.Length];
+				additionalSetups.CopyTo(concatenatedSetups, 0);
+				setups.CopyTo(concatenatedSetups, additionalSetups.Length);
+				setups = concatenatedSetups;
+			}
+			else
+			{
+				setups = additionalSetups;
+			}
+		}
+		if (setups.Length > 0)
+		{
+			foreach (var setup in setups)
+			{
+				setup.Invoke(value);
+			}
+		}
+		return value;
+		static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
+		{
+		    var value = values[index];
+			if (value is TValue typedValue)
+			{
+				result = typedValue;
+				return true;
+			}
+
+			result = default!;
+			return value is null;
+		}
+		static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
+		{
+			if (values.Length > index && values[index] is TValue typedValue)
+			{
+				result = typedValue;
+				return true;
+			}
+
+			result = defaultValue;
+			return true;
+		}
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockA.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockA.g.cs
@@ -10,187 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForICombinationMockA
-{
-	/// <inheritdoc cref="MockExtensionsForICombinationMockA" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</exception>
-		public global::Mockolate.Mock.IMockForICombinationMockA Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForICombinationMockA mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
-		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ICombinationMockA.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>? setup)
-		{
-			var value = new global::Mockolate.Mock.ICombinationMockA(mockRegistry);
-			if (setup is not null)
-			{
-				setup.Invoke(value);
-			}
-			return value;
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA Wrapping(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ICombinationMockA.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForICombinationMockA" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -610,6 +429,186 @@ internal static partial class Mock
 		/// </summary>
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForICombinationMockA>.IgnoreParameters Run();
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForICombinationMockA
+{
+	/// <inheritdoc cref="MockExtensionsForICombinationMockA" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</exception>
+		public global::Mockolate.Mock.IMockForICombinationMockA Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForICombinationMockA mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see>.</returns>
+		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ICombinationMockA.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA>? setup)
+		{
+			var value = new global::Mockolate.Mock.ICombinationMockA(mockRegistry);
+			if (setup is not null)
+			{
+				setup.Invoke(value);
+			}
+			return value;
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA Wrapping(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ICombinationMockA.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForICombinationMockA" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA">ICombinationMockA</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockA> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockB.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockB.g.cs
@@ -10,187 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForICombinationMockB
-{
-	/// <inheritdoc cref="MockExtensionsForICombinationMockB" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</exception>
-		public global::Mockolate.Mock.IMockForICombinationMockB Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForICombinationMockB mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
-		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ICombinationMockB.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>? setup)
-		{
-			var value = new global::Mockolate.Mock.ICombinationMockB(mockRegistry);
-			if (setup is not null)
-			{
-				setup.Invoke(value);
-			}
-			return value;
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB Wrapping(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ICombinationMockB.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForICombinationMockB" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -610,6 +429,186 @@ internal static partial class Mock
 		/// </summary>
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForICombinationMockB>.IgnoreParameters Run();
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForICombinationMockB
+{
+	/// <inheritdoc cref="MockExtensionsForICombinationMockB" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</exception>
+		public global::Mockolate.Mock.IMockForICombinationMockB Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForICombinationMockB mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see>.</returns>
+		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ICombinationMockB.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB>? setup)
+		{
+			var value = new global::Mockolate.Mock.ICombinationMockB(mockRegistry);
+			if (setup is not null)
+			{
+				setup.Invoke(value);
+			}
+			return value;
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB Wrapping(global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ICombinationMockB.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForICombinationMockB" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB">ICombinationMockB</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForICombinationMockB> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveAbstractClass_CanBeCreated/Mock.ComprehensiveAbstractClass.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveAbstractClass_CanBeCreated/Mock.ComprehensiveAbstractClass.g.cs
@@ -10,487 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForComprehensiveAbstractClass
-{
-	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</exception>
-		public global::Mockolate.Mock.IMockForComprehensiveAbstractClass Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForComprehensiveAbstractClass mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="constructorParameters" /> to invoke the base-class constructor.
-		/// </summary>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(object?[] constructorParameters)
-			=> CreateMock(null, null, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)
-			=> CreateMock(mockBehavior, null, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, object?[] constructorParameters)
-			=> CreateMock(null, setup, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int v, string text = "x")
-			=> CreateMock(null, null, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int v, string text = "x")
-			=> CreateMock(mockBehavior, null, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
-			=> CreateMock(null, setup, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="v">Value forwarded to the base-class constructor.</param>
-		/// <param name="text">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
-			=> CreateMock(mockBehavior, setup, new object?[] { v, text });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int mockRegistry, bool _)
-			=> CreateMock(null, null, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int mockRegistry, bool _)
-			=> CreateMock(mockBehavior, null, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
-			=> CreateMock(null, setup, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
-		/// <param name="_">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
-			=> CreateMock(mockBehavior, setup, new object?[] { mockRegistry, _ });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(string name)
-			=> CreateMock(null, null, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, string name)
-			=> CreateMock(mockBehavior, null, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
-			=> CreateMock(null, setup, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="name">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
-			=> CreateMock(mockBehavior, setup, new object?[] { name });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass>(out object?[]? parameters))
-				{
-					constructorParameters = parameters;
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup)
-		{
-			if (constructorParameters is null || constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
-			}
-			else if (constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
-			}
-			else if (constructorParameters.Length >= 1 && constructorParameters.Length <= 2
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c2p1)
-			    && TryCastWithDefaultValue(constructorParameters, 1, "x", mockRegistry.Behavior, out string c2p2))
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c2p1, c2p2);
-			}
-			else if (constructorParameters.Length == 2
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c3p1)
-			    && TryCast(constructorParameters, 1, mockRegistry.Behavior, out bool c3p2))
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c3p1, c3p2);
-			}
-			else if (constructorParameters.Length == 1
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out string c4p1))
-			{
-				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c4p1);
-			}
-			else
-			{
-				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
-			}
-			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
-			{
-			    var value = values[index];
-				if (value is TValue typedValue)
-				{
-					result = typedValue;
-					return true;
-				}
-				
-				result = default!;
-				return value is null;
-			}
-			static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
-			{
-				if (values.Length > index && values[index] is TValue typedValue)
-				{
-					result = typedValue;
-					return true;
-				}
-				
-				result = defaultValue;
-				return true;
-			}
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Wrapping(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-	internal interface IMockSetupInitializationForComprehensiveAbstractClass : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass
-	{
-		/// <summary>
-		///     Setup protected members
-		/// </summary>
-		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass Protected { get; }
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass, global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass, IMockSetupInitializationForComprehensiveAbstractClass
-	{
-		/// <inheritdoc />
-		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass IMockSetupInitializationForComprehensiveAbstractClass.Protected => this;
-		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
-
-		#region IMockSetupForComprehensiveAbstractClass
-
-		/// <inheritdoc />
-		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.V
-		{
-			get
-			{
-				var propertySetup = new global::Mockolate.Setup.PropertySetup<int>(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.V");
-				this.MockRegistry.SetupProperty(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_V_Get, propertySetup);
-				return propertySetup;
-			}
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.A()
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.A");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_A, methodSetup);
-			return methodSetup;
-		}
-
-		#endregion IMockSetupForComprehensiveAbstractClass
-
-		#region IMockProtectedSetupForComprehensiveAbstractClass
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass.P()
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.P");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_P, methodSetup);
-			return methodSetup;
-		}
-
-		#endregion IMockProtectedSetupForComprehensiveAbstractClass
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -1141,6 +660,486 @@ internal static partial class Mock
 		/// </summary>
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForComprehensiveAbstractClass>.IgnoreParameters P();
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForComprehensiveAbstractClass
+{
+	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</exception>
+		public global::Mockolate.Mock.IMockForComprehensiveAbstractClass Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForComprehensiveAbstractClass mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="constructorParameters" /> to invoke the base-class constructor.
+		/// </summary>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(object?[] constructorParameters)
+			=> CreateMock(null, null, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)
+			=> CreateMock(mockBehavior, null, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, object?[] constructorParameters)
+			=> CreateMock(null, setup, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int v, string text = "x")
+			=> CreateMock(null, null, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int v, string text = "x")
+			=> CreateMock(mockBehavior, null, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
+			=> CreateMock(null, setup, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, string)">ComprehensiveAbstractClass(int, string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="v">Value forwarded to the base-class constructor.</param>
+		/// <param name="text">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int v, string text = "x")
+			=> CreateMock(mockBehavior, setup, new object?[] { v, text });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(int mockRegistry, bool _)
+			=> CreateMock(null, null, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, int mockRegistry, bool _)
+			=> CreateMock(mockBehavior, null, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
+			=> CreateMock(null, setup, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(int, bool)">ComprehensiveAbstractClass(int, bool)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="mockRegistry">Value forwarded to the base-class constructor.</param>
+		/// <param name="_">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, int mockRegistry, bool _)
+			=> CreateMock(mockBehavior, setup, new object?[] { mockRegistry, _ });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(string name)
+			=> CreateMock(null, null, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, string name)
+			=> CreateMock(mockBehavior, null, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
+			=> CreateMock(null, setup, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass(string)">ComprehensiveAbstractClass(string)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="name">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup, string name)
+			=> CreateMock(mockBehavior, setup, new object?[] { name });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass>(out object?[]? parameters))
+				{
+					constructorParameters = parameters;
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass>? setup)
+		{
+			if (constructorParameters is null || constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
+			}
+			else if (constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry);
+			}
+			else if (constructorParameters.Length >= 1 && constructorParameters.Length <= 2
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c2p1)
+			    && TryCastWithDefaultValue(constructorParameters, 1, "x", mockRegistry.Behavior, out string c2p2))
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c2p1, c2p2);
+			}
+			else if (constructorParameters.Length == 2
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out int c3p1)
+			    && TryCast(constructorParameters, 1, mockRegistry.Behavior, out bool c3p2))
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c3p1, c3p2);
+			}
+			else if (constructorParameters.Length == 1
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out string c4p1))
+			{
+				global::Mockolate.Mock.ComprehensiveAbstractClass.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForComprehensiveAbstractClass.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.ComprehensiveAbstractClass(mockRegistry, c4p1);
+			}
+			else
+			{
+				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
+			}
+			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
+			{
+			    var value = values[index];
+				if (value is TValue typedValue)
+				{
+					result = typedValue;
+					return true;
+				}
+				
+				result = default!;
+				return value is null;
+			}
+			static bool TryCastWithDefaultValue<TValue>(object?[] values, int index, TValue defaultValue, global::Mockolate.MockBehavior behavior, out TValue result)
+			{
+				if (values.Length > index && values[index] is TValue typedValue)
+				{
+					result = typedValue;
+					return true;
+				}
+				
+				result = defaultValue;
+				return true;
+			}
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass Wrapping(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.ComprehensiveAbstractClass.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForComprehensiveAbstractClass" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass">ComprehensiveAbstractClass</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForComprehensiveAbstractClass> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+	internal interface IMockSetupInitializationForComprehensiveAbstractClass : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass
+	{
+		/// <summary>
+		///     Setup protected members
+		/// </summary>
+		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass Protected { get; }
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass, global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass, IMockSetupInitializationForComprehensiveAbstractClass
+	{
+		/// <inheritdoc />
+		global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass IMockSetupInitializationForComprehensiveAbstractClass.Protected => this;
+		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
+
+		#region IMockSetupForComprehensiveAbstractClass
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.V
+		{
+			get
+			{
+				var propertySetup = new global::Mockolate.Setup.PropertySetup<int>(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.V");
+				this.MockRegistry.SetupProperty(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_V_Get, propertySetup);
+				return propertySetup;
+			}
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForComprehensiveAbstractClass.A()
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.A");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_A, methodSetup);
+			return methodSetup;
+		}
+
+		#endregion IMockSetupForComprehensiveAbstractClass
+
+		#region IMockProtectedSetupForComprehensiveAbstractClass
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockProtectedSetupForComprehensiveAbstractClass.P()
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.ComprehensiveAbstractClass.P");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.ComprehensiveAbstractClass.MemberId_P, methodSetup);
+			return methodSetup;
+		}
+
+		#endregion IMockProtectedSetupForComprehensiveAbstractClass
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveDelegate_CanBeCreated/Mock.ComprehensiveDelegate.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveDelegate_CanBeCreated/Mock.ComprehensiveDelegate.g.cs
@@ -10,68 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForComprehensiveDelegate
-{
-	/// <inheritdoc cref="MockExtensionsForComprehensiveDelegate" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate mock)
-	{
-		/// <summary>
-		///     Get access to the mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see>.
-		/// </summary>
-		public global::Mockolate.Mock.IMockForComprehensiveDelegate Mock
-		{
-			get
-			{
-				if (mock.Target is global::Mockolate.Mock.IMockForComprehensiveDelegate mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Create a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate CreateMock()
-			=> CreateMock(null, []);
-
-		/// <summary>
-		///     Create a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     All provided <paramref name="setups" /> are immediately applied to the mock.
-		/// </remarks>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate CreateMock(params global::System.Action<global::Mockolate.Mock.IMockSetupForComprehensiveDelegate>[] setups)
-			=> CreateMock(null, setups);
-
-		/// <summary>
-		///     Create a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <remarks>
-		///     All provided <paramref name="setups" /> are immediately applied to the mock.
-		/// </remarks>
-		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate CreateMock(global::Mockolate.MockBehavior? mockBehavior = null, params global::System.Action<global::Mockolate.Mock.IMockSetupForComprehensiveDelegate>[] setups)
-		{
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			var mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, new global::Mockolate.Interactions.FastMockInteractions(0, mockBehavior.SkipInteractionRecording));
-			global::Mockolate.Mock.ComprehensiveDelegate mockTarget = new global::Mockolate.Mock.ComprehensiveDelegate(mockRegistry);
-			if (setups.Length > 0)
-			{
-				foreach (var setup in setups)
-				{
-					setup.Invoke(mockTarget);
-				}
-			}
-			return mockTarget.Object;
-		}
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -426,6 +364,68 @@ internal static partial class Mock
 		/// </remarks>
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForComprehensiveDelegate> Verify(int x, global::Mockolate.Parameters.IVerifyRefParameter<int> y, global::Mockolate.Parameters.IVerifyOutParameter<string> z, long w);
 
+	}
+}
+
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForComprehensiveDelegate
+{
+	/// <inheritdoc cref="MockExtensionsForComprehensiveDelegate" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate mock)
+	{
+		/// <summary>
+		///     Get access to the mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see>.
+		/// </summary>
+		public global::Mockolate.Mock.IMockForComprehensiveDelegate Mock
+		{
+			get
+			{
+				if (mock.Target is global::Mockolate.Mock.IMockForComprehensiveDelegate mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Create a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate CreateMock()
+			=> CreateMock(null, []);
+
+		/// <summary>
+		///     Create a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     All provided <paramref name="setups" /> are immediately applied to the mock.
+		/// </remarks>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate CreateMock(params global::System.Action<global::Mockolate.Mock.IMockSetupForComprehensiveDelegate>[] setups)
+			=> CreateMock(null, setups);
+
+		/// <summary>
+		///     Create a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate">ComprehensiveDelegate</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <remarks>
+		///     All provided <paramref name="setups" /> are immediately applied to the mock.
+		/// </remarks>
+		public static global::Mockolate.Tests.GeneratorCoverage.ComprehensiveDelegate CreateMock(global::Mockolate.MockBehavior? mockBehavior = null, params global::System.Action<global::Mockolate.Mock.IMockSetupForComprehensiveDelegate>[] setups)
+		{
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			var mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, new global::Mockolate.Interactions.FastMockInteractions(0, mockBehavior.SkipInteractionRecording));
+			global::Mockolate.Mock.ComprehensiveDelegate mockTarget = new global::Mockolate.Mock.ComprehensiveDelegate(mockRegistry);
+			if (setups.Length > 0)
+			{
+				foreach (var setup in setups)
+				{
+					setup.Invoke(mockTarget);
+				}
+			}
+			return mockTarget.Object;
+		}
 	}
 }
 #nullable disable annotations

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -10,190 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForIComprehensiveInterface
-{
-	/// <inheritdoc cref="MockExtensionsForIComprehensiveInterface" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item><br />
-		///       <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword="static" /> members on interface mocks.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</exception>
-		public global::Mockolate.Mock.IMockForIComprehensiveInterface Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForIComprehensiveInterface mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///       <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
-		private static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IComprehensiveInterface.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface>? setup)
-		{
-			var value = new global::Mockolate.Mock.IComprehensiveInterface(mockRegistry);
-			if (setup is not null)
-			{
-				setup.Invoke(value);
-			}
-			return value;
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface Wrapping(global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IComprehensiveInterface.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForIComprehensiveInterface" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -6019,6 +5835,189 @@ internal static partial class Mock
 		/// </summary>
 		global::Mockolate.Verify.VerificationResult<IMockStaticVerifyForIComprehensiveInterface>.IgnoreParameters StaticAbstractMethod();
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForIComprehensiveInterface
+{
+	/// <inheritdoc cref="MockExtensionsForIComprehensiveInterface" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item><br />
+		///       <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword="static" /> members on interface mocks.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</exception>
+		public global::Mockolate.Mock.IMockForIComprehensiveInterface Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForIComprehensiveInterface mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///       <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see>.</returns>
+		private static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IComprehensiveInterface.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface>? setup)
+		{
+			var value = new global::Mockolate.Mock.IComprehensiveInterface(mockRegistry);
+			if (setup is not null)
+			{
+				setup.Invoke(value);
+			}
+			return value;
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface Wrapping(global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IComprehensiveInterface.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForIComprehensiveInterface" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface">IComprehensiveInterface</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIComprehensiveInterface> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpClient.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpClient.g.cs
@@ -10,507 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForHttpClient
-{
-	/// <inheritdoc cref="MockExtensionsForHttpClient" />
-	extension(global::System.Net.Http.HttpClient mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::System.Net.Http.HttpClient">HttpClient</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</exception>
-		public global::Mockolate.Mock.IMockForHttpClient Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForHttpClient mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::System.Net.Http.HttpClient">HttpClient</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="constructorParameters" /> to invoke the base-class constructor.
-		/// </summary>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(object?[] constructorParameters)
-			=> CreateMock(null, null, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" /> and <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)
-			=> CreateMock(mockBehavior, null, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup, object?[] constructorParameters)
-			=> CreateMock(null, setup, constructorParameters);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
-		/// </summary>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::System.Net.Http.HttpMessageHandler handler)
-			=> CreateMock(null, null, new object?[] { handler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Net.Http.HttpMessageHandler handler)
-			=> CreateMock(mockBehavior, null, new object?[] { handler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler)
-			=> CreateMock(null, setup, new object?[] { handler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler)
-			=> CreateMock(mockBehavior, setup, new object?[] { handler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
-		/// </summary>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
-			=> CreateMock(null, null, new object?[] { handler, disposeHandler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
-			=> CreateMock(mockBehavior, null, new object?[] { handler, disposeHandler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
-			=> CreateMock(null, setup, new object?[] { handler, disposeHandler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <param name="handler">Value forwarded to the base-class constructor.</param>
-		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
-			=> CreateMock(mockBehavior, setup, new object?[] { handler, disposeHandler });
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
-		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForHttpClient>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::System.Net.Http.HttpClient>(out object?[]? parameters))
-				{
-					constructorParameters = parameters;
-				}
-			}
-
-			global::Mockolate.MockBehavior effectiveBehavior = mockBehavior ?? global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(effectiveBehavior, global::Mockolate.Mock.HttpClient.CreateFastInteractions(effectiveBehavior), constructorParameters);
-			if (constructorParameters is null)
-			{
-				constructorParameters = [new global::Mockolate.Mock.HttpMessageHandler(mockRegistry),];
-				mockRegistry = new global::Mockolate.MockRegistry(mockRegistry, constructorParameters);
-			}
-			else if (constructorParameters.Length > 0 && constructorParameters[0] is global::Mockolate.Mock.HttpMessageHandler && constructorParameters[0] is global::Mockolate.IMock httpMessageHandlerMock)
-			{
-				if (mockBehavior is not null && httpMessageHandlerMock.MockRegistry.Behavior != mockBehavior)
-				{
-					throw new global::Mockolate.Exceptions.MockException($"Mock of type 'System.Net.Http.HttpClient' cannot be created with behavior '{mockBehavior}' because it shares its mock registry with a mock of type 'System.Net.Http.HttpMessageHandler' that has behavior '{httpMessageHandlerMock.MockRegistry.Behavior}'.");
-				}
-				mockRegistry = new global::Mockolate.MockRegistry(httpMessageHandlerMock.MockRegistry, constructorParameters);
-			}
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::System.Net.Http.HttpClient CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForHttpClient>? setup)
-		{
-			if (constructorParameters is null || constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.HttpClient(mockRegistry);
-			}
-			else if (constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.HttpClient(mockRegistry);
-			}
-			else if (constructorParameters.Length == 1
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out global::System.Net.Http.HttpMessageHandler c2p1))
-			{
-				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.HttpClient(mockRegistry, c2p1);
-			}
-			else if (constructorParameters.Length == 2
-			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out global::System.Net.Http.HttpMessageHandler c3p1)
-			    && TryCast(constructorParameters, 1, mockRegistry.Behavior, out bool c3p2))
-			{
-				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.HttpClient(mockRegistry, c3p1, c3p2);
-			}
-			else
-			{
-				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'System.Net.Http.HttpClient' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
-			}
-			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
-			{
-			    var value = values[index];
-				if (value is TValue typedValue)
-				{
-					result = typedValue;
-					return true;
-				}
-				
-				result = default!;
-				return value is null;
-			}
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> that delegates to <paramref name="instance" />.</returns>
-		public global::System.Net.Http.HttpClient Wrapping(global::System.Net.Http.HttpClient instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.HttpClient.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForHttpClient" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::System.Net.Http.HttpClient">HttpClient</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForHttpClient> setup)
-			where T : global::System.Net.Http.HttpClient
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-	internal interface IMockSetupInitializationForHttpClient : global::Mockolate.Mock.IMockSetupForHttpClient
-	{
-		/// <summary>
-		///     Setup protected members
-		/// </summary>
-		global::Mockolate.Mock.IMockProtectedSetupForHttpClient Protected { get; }
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForHttpClient, global::Mockolate.Mock.IMockProtectedSetupForHttpClient, IMockSetupInitializationForHttpClient
-	{
-		/// <inheritdoc />
-		global::Mockolate.Mock.IMockProtectedSetupForHttpClient IMockSetupInitializationForHttpClient.Protected => this;
-		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
-
-		#region IMockSetupForHttpClient
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::Mockolate.Parameters.IParameters parameters)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", parameters, "request", "cancellationToken");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::Mockolate.Parameters.IParameters parameters)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", parameters, "request", "cancellationToken");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		#endregion IMockSetupForHttpClient
-
-		#region IMockProtectedSetupForHttpClient
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(global::Mockolate.Parameters.IParameters parameters)
-		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", parameters, "disposing");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing)
-		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", CovariantParameterAdapter<bool>.Wrap(disposing ?? global::Mockolate.It.IsNull<bool>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(bool disposing)
-		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
-			return methodSetup;
-		}
-
-		#endregion IMockProtectedSetupForHttpClient
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -1650,6 +1149,506 @@ internal static partial class Mock
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpClient>.IgnoreParameters Dispose(bool disposing);
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForHttpClient
+{
+	/// <inheritdoc cref="MockExtensionsForHttpClient" />
+	extension(global::System.Net.Http.HttpClient mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::System.Net.Http.HttpClient">HttpClient</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</exception>
+		public global::Mockolate.Mock.IMockForHttpClient Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForHttpClient mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::System.Net.Http.HttpClient">HttpClient</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="constructorParameters" /> to invoke the base-class constructor.
+		/// </summary>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(object?[] constructorParameters)
+			=> CreateMock(null, null, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" /> and <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, object?[] constructorParameters)
+			=> CreateMock(mockBehavior, null, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor. Required when no parameterless constructor exists.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup, object?[] constructorParameters)
+			=> CreateMock(null, setup, constructorParameters);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
+		/// </summary>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::System.Net.Http.HttpMessageHandler handler)
+			=> CreateMock(null, null, new object?[] { handler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Net.Http.HttpMessageHandler handler)
+			=> CreateMock(mockBehavior, null, new object?[] { handler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler)
+			=> CreateMock(null, setup, new object?[] { handler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler)">HttpClient(HttpMessageHandler)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler)
+			=> CreateMock(mockBehavior, setup, new object?[] { handler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
+		/// </summary>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
+			=> CreateMock(null, null, new object?[] { handler, disposeHandler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" /> and the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
+			=> CreateMock(mockBehavior, null, new object?[] { handler, disposeHandler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
+			=> CreateMock(null, setup, new object?[] { handler, disposeHandler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given constructor parameters to invoke the <see cref="global::System.Net.Http.HttpClient(global::System.Net.Http.HttpMessageHandler, bool)">HttpClient(HttpMessageHandler, bool)</see> constructor.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <param name="handler">Value forwarded to the base-class constructor.</param>
+		/// <param name="disposeHandler">Value forwarded to the base-class constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient> setup, global::System.Net.Http.HttpMessageHandler handler, bool disposeHandler)
+			=> CreateMock(mockBehavior, setup, new object?[] { handler, disposeHandler });
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpClient">HttpClient</see>.</returns>
+		public static global::System.Net.Http.HttpClient CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForHttpClient>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForHttpClient>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::System.Net.Http.HttpClient>(out object?[]? parameters))
+				{
+					constructorParameters = parameters;
+				}
+			}
+
+			global::Mockolate.MockBehavior effectiveBehavior = mockBehavior ?? global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(effectiveBehavior, global::Mockolate.Mock.HttpClient.CreateFastInteractions(effectiveBehavior), constructorParameters);
+			if (constructorParameters is null)
+			{
+				constructorParameters = [new global::Mockolate.Mock.HttpMessageHandler(mockRegistry),];
+				mockRegistry = new global::Mockolate.MockRegistry(mockRegistry, constructorParameters);
+			}
+			else if (constructorParameters.Length > 0 && constructorParameters[0] is global::Mockolate.Mock.HttpMessageHandler && constructorParameters[0] is global::Mockolate.IMock httpMessageHandlerMock)
+			{
+				if (mockBehavior is not null && httpMessageHandlerMock.MockRegistry.Behavior != mockBehavior)
+				{
+					throw new global::Mockolate.Exceptions.MockException($"Mock of type 'System.Net.Http.HttpClient' cannot be created with behavior '{mockBehavior}' because it shares its mock registry with a mock of type 'System.Net.Http.HttpMessageHandler' that has behavior '{httpMessageHandlerMock.MockRegistry.Behavior}'.");
+				}
+				mockRegistry = new global::Mockolate.MockRegistry(httpMessageHandlerMock.MockRegistry, constructorParameters);
+			}
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::System.Net.Http.HttpClient CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForHttpClient>? setup)
+		{
+			if (constructorParameters is null || constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.HttpClient(mockRegistry);
+			}
+			else if (constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.HttpClient(mockRegistry);
+			}
+			else if (constructorParameters.Length == 1
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out global::System.Net.Http.HttpMessageHandler c2p1))
+			{
+				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.HttpClient(mockRegistry, c2p1);
+			}
+			else if (constructorParameters.Length == 2
+			    && TryCast(constructorParameters, 0, mockRegistry.Behavior, out global::System.Net.Http.HttpMessageHandler c3p1)
+			    && TryCast(constructorParameters, 1, mockRegistry.Behavior, out bool c3p2))
+			{
+				global::Mockolate.Mock.HttpClient.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForHttpClient.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.HttpClient(mockRegistry, c3p1, c3p2);
+			}
+			else
+			{
+				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'System.Net.Http.HttpClient' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
+			}
+			static bool TryCast<TValue>(object?[] values, int index, global::Mockolate.MockBehavior behavior, out TValue result)
+			{
+			    var value = values[index];
+				if (value is TValue typedValue)
+				{
+					result = typedValue;
+					return true;
+				}
+				
+				result = default!;
+				return value is null;
+			}
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::System.Net.Http.HttpClient">HttpClient</see> that delegates to <paramref name="instance" />.</returns>
+		public global::System.Net.Http.HttpClient Wrapping(global::System.Net.Http.HttpClient instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.HttpClient.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForHttpClient" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::System.Net.Http.HttpClient">HttpClient</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForHttpClient> setup)
+			where T : global::System.Net.Http.HttpClient
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+	internal interface IMockSetupInitializationForHttpClient : global::Mockolate.Mock.IMockSetupForHttpClient
+	{
+		/// <summary>
+		///     Setup protected members
+		/// </summary>
+		global::Mockolate.Mock.IMockProtectedSetupForHttpClient Protected { get; }
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForHttpClient, global::Mockolate.Mock.IMockProtectedSetupForHttpClient, IMockSetupInitializationForHttpClient
+	{
+		/// <inheritdoc />
+		global::Mockolate.Mock.IMockProtectedSetupForHttpClient IMockSetupInitializationForHttpClient.Protected => this;
+		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
+
+		#region IMockSetupForHttpClient
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", parameters, "request", "cancellationToken");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", parameters, "request", "cancellationToken");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		#endregion IMockSetupForHttpClient
+
+		#region IMockProtectedSetupForHttpClient
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", parameters, "disposing");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", CovariantParameterAdapter<bool>.Wrap(disposing ?? global::Mockolate.It.IsNull<bool>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(bool disposing)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
+			return methodSetup;
+		}
+
+		#endregion IMockProtectedSetupForHttpClient
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpMessageHandler.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpMessageHandler.g.cs
@@ -10,339 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForHttpMessageHandler
-{
-	/// <inheritdoc cref="MockExtensionsForHttpMessageHandler" />
-	extension(global::System.Net.Http.HttpMessageHandler mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</exception>
-		public global::Mockolate.Mock.IMockForHttpMessageHandler Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForHttpMessageHandler mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
-		public static global::System.Net.Http.HttpMessageHandler CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
-		public static global::System.Net.Http.HttpMessageHandler CreateMock(global::System.Action<IMockSetupInitializationForHttpMessageHandler> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
-		public static global::System.Net.Http.HttpMessageHandler CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
-		public static global::System.Net.Http.HttpMessageHandler CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpMessageHandler> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
-		private static global::System.Net.Http.HttpMessageHandler CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForHttpMessageHandler>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForHttpMessageHandler>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::System.Net.Http.HttpMessageHandler>(out object?[]? parameters))
-				{
-					constructorParameters = parameters;
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.HttpMessageHandler.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::System.Net.Http.HttpMessageHandler CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForHttpMessageHandler>? setup)
-		{
-			if (constructorParameters is null || constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.HttpMessageHandler.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForHttpMessageHandler.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.HttpMessageHandler(mockRegistry);
-			}
-			else if (constructorParameters.Length == 0)
-			{
-				global::Mockolate.Mock.HttpMessageHandler.MockRegistryProvider.Value = mockRegistry;
-				global::Mockolate.MockExtensionsForHttpMessageHandler.MockSetup? setupTarget = null;
-				if (setup is not null)
-				{
-					setupTarget ??= new(mockRegistry);
-					setup.Invoke(setupTarget);
-				}
-				return new global::Mockolate.Mock.HttpMessageHandler(mockRegistry);
-			}
-			else
-			{
-				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'System.Net.Http.HttpMessageHandler' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
-			}
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> that delegates to <paramref name="instance" />.</returns>
-		public global::System.Net.Http.HttpMessageHandler Wrapping(global::System.Net.Http.HttpMessageHandler instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.HttpMessageHandler.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForHttpMessageHandler" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForHttpMessageHandler> setup)
-			where T : global::System.Net.Http.HttpMessageHandler
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-	internal interface IMockSetupInitializationForHttpMessageHandler : global::Mockolate.Mock.IMockSetupForHttpMessageHandler
-	{
-		/// <summary>
-		///     Setup protected members
-		/// </summary>
-		global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler Protected { get; }
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForHttpMessageHandler, global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler, IMockSetupInitializationForHttpMessageHandler
-	{
-		/// <inheritdoc />
-		global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler IMockSetupInitializationForHttpMessageHandler.Protected => this;
-		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
-
-		#region IMockSetupForHttpMessageHandler
-
-		#endregion IMockSetupForHttpMessageHandler
-
-		#region IMockProtectedSetupForHttpMessageHandler
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::Mockolate.Parameters.IParameters parameters)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", parameters, "request", "cancellationToken");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::Mockolate.Parameters.IParameters parameters)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", parameters, "request", "cancellationToken");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(global::Mockolate.Parameters.IParameters parameters)
-		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", parameters, "disposing");
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing)
-		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", CovariantParameterAdapter<bool>.Wrap(disposing ?? global::Mockolate.It.IsNull<bool>("null")));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
-			return methodSetup;
-		}
-
-		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(bool disposing)
-		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
-			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
-			return methodSetup;
-		}
-
-		#endregion IMockProtectedSetupForHttpMessageHandler
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -1364,6 +1031,338 @@ internal static partial class Mock
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler>.IgnoreParameters Dispose(bool disposing);
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForHttpMessageHandler
+{
+	/// <inheritdoc cref="MockExtensionsForHttpMessageHandler" />
+	extension(global::System.Net.Http.HttpMessageHandler mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>SetupProtected</c> / <c>VerifyProtected</c> / <c>RaiseProtected</c> - target <see langword="protected" /> members on class mocks.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</exception>
+		public global::Mockolate.Mock.IMockForHttpMessageHandler Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForHttpMessageHandler mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
+		public static global::System.Net.Http.HttpMessageHandler CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
+		public static global::System.Net.Http.HttpMessageHandler CreateMock(global::System.Action<IMockSetupInitializationForHttpMessageHandler> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
+		public static global::System.Net.Http.HttpMessageHandler CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
+		public static global::System.Net.Http.HttpMessageHandler CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<IMockSetupInitializationForHttpMessageHandler> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see>.</returns>
+		private static global::System.Net.Http.HttpMessageHandler CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<IMockSetupInitializationForHttpMessageHandler>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<IMockSetupInitializationForHttpMessageHandler>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+				if (constructorParameters is null && mockBehaviorAccess.TryGetConstructorParameters<global::System.Net.Http.HttpMessageHandler>(out object?[]? parameters))
+				{
+					constructorParameters = parameters;
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.HttpMessageHandler.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::System.Net.Http.HttpMessageHandler CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<IMockSetupInitializationForHttpMessageHandler>? setup)
+		{
+			if (constructorParameters is null || constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.HttpMessageHandler.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForHttpMessageHandler.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.HttpMessageHandler(mockRegistry);
+			}
+			else if (constructorParameters.Length == 0)
+			{
+				global::Mockolate.Mock.HttpMessageHandler.MockRegistryProvider.Value = mockRegistry;
+				global::Mockolate.MockExtensionsForHttpMessageHandler.MockSetup? setupTarget = null;
+				if (setup is not null)
+				{
+					setupTarget ??= new(mockRegistry);
+					setup.Invoke(setupTarget);
+				}
+				return new global::Mockolate.Mock.HttpMessageHandler(mockRegistry);
+			}
+			else
+			{
+				throw new global::Mockolate.Exceptions.MockException($"Could not find any constructor for 'System.Net.Http.HttpMessageHandler' that matches the {constructorParameters.Length} given parameters ({string.Join(", ", constructorParameters)}).");
+			}
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> that delegates to <paramref name="instance" />.</returns>
+		public global::System.Net.Http.HttpMessageHandler Wrapping(global::System.Net.Http.HttpMessageHandler instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.HttpMessageHandler.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForHttpMessageHandler" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::System.Net.Http.HttpMessageHandler">HttpMessageHandler</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<IMockSetupInitializationForHttpMessageHandler> setup)
+			where T : global::System.Net.Http.HttpMessageHandler
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+	internal interface IMockSetupInitializationForHttpMessageHandler : global::Mockolate.Mock.IMockSetupForHttpMessageHandler
+	{
+		/// <summary>
+		///     Setup protected members
+		/// </summary>
+		global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler Protected { get; }
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	internal sealed class MockSetup(global::Mockolate.MockRegistry mockRegistry) : global::Mockolate.Mock.IMockSetupForHttpMessageHandler, global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler, IMockSetupInitializationForHttpMessageHandler
+	{
+		/// <inheritdoc />
+		global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler IMockSetupInitializationForHttpMessageHandler.Protected => this;
+		private global::Mockolate.MockRegistry MockRegistry { get; } = mockRegistry;
+
+		#region IMockSetupForHttpMessageHandler
+
+		#endregion IMockSetupForHttpMessageHandler
+
+		#region IMockProtectedSetupForHttpMessageHandler
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", parameters, "request", "cancellationToken");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", parameters, "request", "cancellationToken");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::Mockolate.Parameters.IParameter<global::System.Threading.CancellationToken>? cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), CovariantParameterAdapter<global::System.Threading.CancellationToken>.Wrap(cancellationToken ?? global::Mockolate.It.IsNull<global::System.Threading.CancellationToken>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupWithCallback<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::Mockolate.Parameters.IParameter<global::System.Net.Http.HttpRequestMessage>? request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", CovariantParameterAdapter<global::System.Net.Http.HttpRequestMessage>.Wrap(request ?? global::Mockolate.It.IsNull<global::System.Net.Http.HttpRequestMessage>("null")), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
+		{
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(global::Mockolate.Parameters.IParameters parameters)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameters(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", parameters, "disposing");
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(global::Mockolate.Parameters.IParameter<bool>? disposing)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", CovariantParameterAdapter<bool>.Wrap(disposing ?? global::Mockolate.It.IsNull<bool>("null")));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(bool disposing)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
+			return methodSetup;
+		}
+
+		#endregion IMockProtectedSetupForHttpMessageHandler
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
@@ -10,189 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForIKeywordEdgeCases
-{
-	/// <inheritdoc cref="MockExtensionsForIKeywordEdgeCases" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</exception>
-		public global::Mockolate.Mock.IMockForIKeywordEdgeCases Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForIKeywordEdgeCases mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///       <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
-		private static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IKeywordEdgeCases.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases>? setup)
-		{
-			var value = new global::Mockolate.Mock.IKeywordEdgeCases(mockRegistry);
-			if (setup is not null)
-			{
-				setup.Invoke(value);
-			}
-			return value;
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases Wrapping(global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IKeywordEdgeCases.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForIKeywordEdgeCases" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -1498,6 +1315,188 @@ internal static partial class Mock
 		/// </summary>
 		global::Mockolate.Verify.VerificationEventResult<IMockVerifyForIKeywordEdgeCases> @event { get; }
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForIKeywordEdgeCases
+{
+	/// <inheritdoc cref="MockExtensionsForIKeywordEdgeCases" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>Raise</c> - trigger events declared on the mocked type.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</exception>
+		public global::Mockolate.Mock.IMockForIKeywordEdgeCases Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForIKeywordEdgeCases mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///       <item><description><c>.Mock.Raise</c> triggers events declared on the mocked type.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see>.</returns>
+		private static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IKeywordEdgeCases.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases>? setup)
+		{
+			var value = new global::Mockolate.Mock.IKeywordEdgeCases(mockRegistry);
+			if (setup is not null)
+			{
+				setup.Invoke(value);
+			}
+			return value;
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases Wrapping(global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IKeywordEdgeCases.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForIKeywordEdgeCases" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases">IKeywordEdgeCases</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/RefStructConsumer_CanBeCreated/Mock.IRefStructConsumer.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/RefStructConsumer_CanBeCreated/Mock.IRefStructConsumer.g.cs
@@ -10,187 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForIRefStructConsumer
-{
-	/// <inheritdoc cref="MockExtensionsForIRefStructConsumer" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</exception>
-		public global::Mockolate.Mock.IMockForIRefStructConsumer Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForIRefStructConsumer mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
-		private static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IRefStructConsumer.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer>? setup)
-		{
-			var value = new global::Mockolate.Mock.IRefStructConsumer(mockRegistry);
-			if (setup is not null)
-			{
-				setup.Invoke(value);
-			}
-			return value;
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer Wrapping(global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IRefStructConsumer.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForIRefStructConsumer" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -599,6 +418,186 @@ internal static partial class Mock
 	/// </summary>
 	internal interface IMockVerifyForIRefStructConsumer : global::Mockolate.Verify.IMockVerify<global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer>
 	{
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForIRefStructConsumer
+{
+	/// <inheritdoc cref="MockExtensionsForIRefStructConsumer" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</exception>
+		public global::Mockolate.Mock.IMockForIRefStructConsumer Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForIRefStructConsumer mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see>.</returns>
+		private static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IRefStructConsumer.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer>? setup)
+		{
+			var value = new global::Mockolate.Mock.IRefStructConsumer(mockRegistry);
+			if (setup is not null)
+			{
+				setup.Invoke(value);
+			}
+			return value;
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer Wrapping(global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IRefStructConsumer.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForIRefStructConsumer" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer">IRefStructConsumer</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIRefStructConsumer> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.IRefStructConsumer
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/StaticAbstractMembers_CanBeCreated/Mock.IStaticAbstractMembers.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/StaticAbstractMembers_CanBeCreated/Mock.IStaticAbstractMembers.g.cs
@@ -10,188 +10,6 @@
 #nullable enable annotations
 namespace Mockolate;
 
-/// <summary>
-///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.
-/// </summary>
-[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal static partial class MockExtensionsForIStaticAbstractMembers
-{
-	/// <inheritdoc cref="MockExtensionsForIStaticAbstractMembers" />
-	extension(global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers mock)
-	{
-		/// <summary>
-		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> - the entry point for configuring setups, verifying interactions and raising events.
-		/// </summary>
-		/// <remarks>
-		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
-		///     Through it you can:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
-		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
-		///       <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword="static" /> members on interface mocks.</description></item><br />
-		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
-		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
-		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
-		///     </list>
-		/// </remarks>
-		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</exception>
-		public global::Mockolate.Mock.IMockForIStaticAbstractMembers Mock
-		{
-			get
-			{
-				if (mock is global::Mockolate.Mock.IMockForIStaticAbstractMembers mockInterface)
-				{
-					return mockInterface;
-				}
-				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-			}
-		}
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
-		/// </summary>
-		/// <remarks>
-		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
-		///     <list type="bullet"><br />
-		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
-		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
-		///     </list><br />
-		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
-		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
-		/// </remarks>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock()
-			=> CreateMock(null, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers> setup)
-			=> CreateMock(null, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the given <paramref name="mockBehavior" />.
-		/// </summary>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::Mockolate.MockBehavior mockBehavior)
-			=> CreateMock(mockBehavior, null, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
-		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers> setup)
-			=> CreateMock(mockBehavior, setup, (object?[]?)null);
-
-		/// <summary>
-		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
-		/// </summary>
-		/// <remarks>
-		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
-		/// </remarks>
-		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
-		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
-		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
-		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
-		private static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers>? setup, object?[]? constructorParameters)
-		{
-			if (mockBehavior is not null)
-			{
-				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
-				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers>?>(out var additionalSetup))
-				{
-					if (setup is null)
-					{
-						setup = additionalSetup;
-					}
-					else
-					{
-						var originalSetup = setup;
-						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
-					}
-				}
-			}
-
-			mockBehavior ??= global::Mockolate.MockBehavior.Default;
-			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IStaticAbstractMembers.CreateFastInteractions(mockBehavior), constructorParameters);
-			return CreateMockInstance(mockRegistry, constructorParameters, setup);
-		}
-
-		private static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers>? setup)
-		{
-			var value = new global::Mockolate.Mock.IStaticAbstractMembers(mockRegistry);
-			if (setup is not null)
-			{
-				setup.Invoke(value);
-			}
-			return value;
-		}
-		/// <summary>
-		///     Creates a mock that wraps the given <paramref name="instance" />.
-		/// </summary>
-		/// <remarks>
-		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
-		/// </remarks>
-		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
-		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> that delegates to <paramref name="instance" />.</returns>
-		public global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers Wrapping(global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers instance)
-		{
-			if (mock is global::Mockolate.IMock mockInterface)
-			{
-				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
-				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IStaticAbstractMembers.CreateFastInteractions(wrappingRegistry.Behavior));
-				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
-			}
-			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
-		}
-
-	}
-
-	/// <inheritdoc cref="MockExtensionsForIStaticAbstractMembers" />
-	extension(global::Mockolate.MockBehavior behavior)
-	{
-		/// <summary>
-		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
-		/// </summary>
-		/// <remarks>
-		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
-		/// </remarks>
-		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> that this setup should apply to.</typeparam>
-		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
-		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
-		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers> setup)
-			where T : global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers
-		{
-			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
-			return behaviorAccess.Set(setup);
-		}
-	}
-
-	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
-	{
-		public bool Matches(T value) => inner.Matches(value);
-		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
-		public override string? ToString() => inner.ToString();
-
-		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
-			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
-				? direct
-				: new CovariantParameterAdapter<T>(parameter);
-	}
-}
-
 internal static partial class Mock
 {
 	/// <summary>
@@ -855,6 +673,187 @@ internal static partial class Mock
 		/// </summary>
 		global::Mockolate.Verify.VerificationEventResult<IMockStaticVerifyForIStaticAbstractMembers> AbstractStaticEvent { get; }
 
+	}
+}
+/// <summary>
+///     Mock extensions for <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.
+/// </summary>
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+internal static partial class MockExtensionsForIStaticAbstractMembers
+{
+	/// <inheritdoc cref="MockExtensionsForIStaticAbstractMembers" />
+	extension(global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers mock)
+	{
+		/// <summary>
+		///     Gets the mock accessor for <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> - the entry point for configuring setups, verifying interactions and raising events.
+		/// </summary>
+		/// <remarks>
+		///     The accessor is the bridge between the strongly-typed instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> returned by <c>CreateMock(...)</c> and the underlying mock registry where setups and recorded interactions live.<br />
+		///     Through it you can:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>Setup</c> - configure how members respond when invoked (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, ...).</description></item><br />
+		///       <item><description><c>Verify</c> - assert how often (and in which order) members were invoked.</description></item><br />
+		///       <item><description><c>SetupStatic</c> / <c>VerifyStatic</c> / <c>RaiseStatic</c> - target <see langword="static" /> members on interface mocks.</description></item><br />
+		///       <item><description><c>InScenario</c> / <c>TransitionTo</c> - scope setups and behavior to a named scenario and switch between scenarios.</description></item><br />
+		///       <item><description><c>Monitor</c>, <c>ClearAllInteractions</c>, <c>VerifyThatAllInteractionsAreVerified</c>, <c>VerifyThatAllSetupsAreUsed</c> - manage recorded interactions.</description></item><br />
+		///       <item><description><c>VerifySetup</c> - verify how often a specific setup matched.</description></item><br />
+		///     </list>
+		/// </remarks>
+		/// <exception cref="global::Mockolate.Exceptions.MockException">The instance is not a Mockolate-generated mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</exception>
+		public global::Mockolate.Mock.IMockForIStaticAbstractMembers Mock
+		{
+			get
+			{
+				if (mock is global::Mockolate.Mock.IMockForIStaticAbstractMembers mockInterface)
+				{
+					return mockInterface;
+				}
+				throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+			}
+		}
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.
+		/// </summary>
+		/// <remarks>
+		///     The returned instance is a strongly-typed mock generated at compile time - it implements <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> and exposes the Mockolate surface through <c>.Mock</c>:<br />
+		///     <list type="bullet"><br />
+		///       <item><description><c>.Mock.Setup</c> configures how members respond (<c>Returns</c>, <c>Throws</c>, <c>Do</c>, <c>InitializeWith</c>, sequences, callbacks).</description></item><br />
+		///       <item><description><c>.Mock.Verify</c> asserts how often and in which order members were invoked.</description></item><br />
+		///     </list><br />
+		///     With the default behavior, un-configured members return <c>default</c> values (empty collections / strings, completed tasks, <see langword="null" /> otherwise) and base-class implementations are invoked for class mocks. Use one of the overloads that accepts a <see cref="global::Mockolate.MockBehavior">MockBehavior</see> to customize this (for example to make un-configured calls throw or to skip the base class).<br />
+		///     Overloads allow you to additionally pass constructor parameters (for class mocks), apply an initial <c>setup</c> callback before the instance is returned, or combine both.
+		/// </remarks>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock()
+			=> CreateMock(null, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the default <see cref="global::Mockolate.MockBehavior">MockBehavior</see>, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers> setup)
+			=> CreateMock(null, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the given <paramref name="mockBehavior" />.
+		/// </summary>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::Mockolate.MockBehavior mockBehavior)
+			=> CreateMock(mockBehavior, null, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> with the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup; see <see cref="global::Mockolate.MockBehavior">MockBehavior</see>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
+		public static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::Mockolate.MockBehavior mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers> setup)
+			=> CreateMock(mockBehavior, setup, (object?[]?)null);
+
+		/// <summary>
+		///     Creates a new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> using the given <paramref name="mockBehavior" />, applying the given <paramref name="setup" /> immediately, using the given <paramref name="constructorParameters" />.
+		/// </summary>
+		/// <remarks>
+		///     The provided <paramref name="setup" /> is immediately applied to the mock. Use this overload when you want setups to cover virtual interactions triggered inside the constructor.
+		/// </remarks>
+		/// <param name="mockBehavior">Controls how the mock responds when members are invoked without a matching setup, or <see langword="null" /> for <c>MockBehavior.Default</c>.</param>
+		/// <param name="setup">Callback that receives the mock's setup surface and registers initial setups before the mock is returned, or <see langword="null" /> to skip.</param>
+		/// <param name="constructorParameters">Values forwarded to a matching base-class constructor, or <see langword="null" /> to use the parameterless constructor.</param>
+		/// <returns>A new mock instance of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see>.</returns>
+		private static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMock(global::Mockolate.MockBehavior? mockBehavior, global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers>? setup, object?[]? constructorParameters)
+		{
+			if (mockBehavior is not null)
+			{
+				IMockBehaviorAccess mockBehaviorAccess = (global::Mockolate.IMockBehaviorAccess)mockBehavior;
+				if (mockBehaviorAccess.TryGet<global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers>?>(out var additionalSetup))
+				{
+					if (setup is null)
+					{
+						setup = additionalSetup;
+					}
+					else
+					{
+						var originalSetup = setup;
+						setup = s => { additionalSetup.Invoke(s); originalSetup.Invoke(s); };
+					}
+				}
+			}
+
+			mockBehavior ??= global::Mockolate.MockBehavior.Default;
+			global::Mockolate.MockRegistry mockRegistry = new global::Mockolate.MockRegistry(mockBehavior, global::Mockolate.Mock.IStaticAbstractMembers.CreateFastInteractions(mockBehavior), constructorParameters);
+			return CreateMockInstance(mockRegistry, constructorParameters, setup);
+		}
+
+		private static global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers CreateMockInstance(global::Mockolate.MockRegistry mockRegistry, object?[]? constructorParameters, global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers>? setup)
+		{
+			var value = new global::Mockolate.Mock.IStaticAbstractMembers(mockRegistry);
+			if (setup is not null)
+			{
+				setup.Invoke(value);
+			}
+			return value;
+		}
+		/// <summary>
+		///     Creates a mock that wraps the given <paramref name="instance" />.
+		/// </summary>
+		/// <remarks>
+		///     Public members on the mock forward to <paramref name="instance" /> unless overridden by a setup; protected members still go through the base-class implementation. All forwarded interactions are recorded and can be verified the same as on a plain mock.
+		/// </remarks>
+		/// <param name="instance">The real object whose calls should be forwarded. Must not be <see langword="null" />.</param>
+		/// <returns>A new mock of <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> that delegates to <paramref name="instance" />.</returns>
+		public global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers Wrapping(global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers instance)
+		{
+			if (mock is global::Mockolate.IMock mockInterface)
+			{
+				global::Mockolate.MockRegistry wrappingRegistry = new global::Mockolate.MockRegistry(mockInterface.MockRegistry, instance);
+				wrappingRegistry = new global::Mockolate.MockRegistry(wrappingRegistry, global::Mockolate.Mock.IStaticAbstractMembers.CreateFastInteractions(wrappingRegistry.Behavior));
+				return CreateMockInstance(wrappingRegistry, mockInterface.MockRegistry.ConstructorParameters, null);
+			}
+			throw new global::Mockolate.Exceptions.MockException("The subject is no mock.");
+		}
+
+	}
+
+	/// <inheritdoc cref="MockExtensionsForIStaticAbstractMembers" />
+	extension(global::Mockolate.MockBehavior behavior)
+	{
+		/// <summary>
+		///     Initializes mocks of type <typeparamref name="T" /> with the given <paramref name="setup" />.
+		/// </summary>
+		/// <remarks>
+		///     The <paramref name="setup" /> is applied to the mock before the constructor is executed. Calling <c>Initialize</c> again overlays additional setups on top of any previously registered ones.
+		/// </remarks>
+		/// <typeparam name="T">The mockable type derived from <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers">IStaticAbstractMembers</see> that this setup should apply to.</typeparam>
+		/// <param name="setup">Callback invoked when a new mock of <typeparamref name="T" /> is created.</param>
+		/// <returns>A new <see cref="global::Mockolate.MockBehavior">MockBehavior</see> with the registered initializer. The original instance is unchanged.</returns>
+		public global::Mockolate.MockBehavior Initialize<T>(global::System.Action<global::Mockolate.Mock.IMockSetupForIStaticAbstractMembers> setup)
+			where T : global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers
+		{
+			var behaviorAccess = (global::Mockolate.IMockBehaviorAccess)behavior;
+			return behaviorAccess.Set(setup);
+		}
+	}
+
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	private sealed class CovariantParameterAdapter<T>(global::Mockolate.Parameters.IParameter inner) : global::Mockolate.Parameters.IParameterMatch<T>
+	{
+		public bool Matches(T value) => inner.Matches(value);
+		public void InvokeCallbacks(T value) => inner.InvokeCallbacks(value);
+		public override string? ToString() => inner.ToString();
+
+		public static global::Mockolate.Parameters.IParameterMatch<T> Wrap(global::Mockolate.Parameters.IParameter<T> parameter)
+			=> parameter is global::Mockolate.Parameters.IParameterMatch<T> direct
+				? direct
+				: new CovariantParameterAdapter<T>(parameter);
 	}
 }
 


### PR DESCRIPTION
This pull request refactors the code generation logic in `Sources.MockDelegate.cs` to improve code readability and maintainability by consolidating and simplifying string building operations. The changes primarily focus on flattening multi-line string concatenations into single lines where possible, removing redundant regions, and streamlining the structure of generated code for mock delegates.

**Refactoring and Code Simplification:**

* Consolidated multi-line string concatenations into single-line statements throughout the `MockDelegate` method, making the code easier to read and maintain.

**Structural and Organizational Improvements:**

* Removed the `MockForXXXExtensions` region and merged its logic into the main `Mock` class, reducing unnecessary indirection and clarifying the generated class structure.

**Consistency and Formatting:**

* Standardized formatting for method and property generation, including XML summaries, attribute annotations, and method bodies, to ensure consistent output from the source generator.
**Parameter Handling:**

* Simplified logic for handling delegate method parameters, especially in scenarios involving `ref` and `out` parameters, by flattening conditional and loop structures.

**Mock Setup and Verification:**

* Streamlined the generation of setup and verification methods by consolidating method calls and reducing code duplication for different parameter combinations.