### PR TITLE
fix: make source generator snapshot build configuration invariant

### DIFF
--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -123,7 +121,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -141,7 +138,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -161,7 +157,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -187,7 +182,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveAbstractClass_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveAbstractClass_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -123,7 +121,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -141,7 +138,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -161,7 +157,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -187,7 +182,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveDelegate_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveDelegate_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -123,7 +121,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -141,7 +138,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -161,7 +157,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -187,7 +182,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -123,7 +121,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -141,7 +138,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -161,7 +157,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -187,7 +182,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns an empty <see cref="global::System.Net.Http.HttpResponseMessage">HttpResponseMessage</see> with the specified
 	///     <paramref name="statusCode" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private sealed class HttpResponseMessageFactory(global::System.Net.HttpStatusCode statusCode) : IDefaultValueFactory
 	{
@@ -93,7 +91,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -140,7 +137,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -158,7 +154,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -178,7 +173,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -204,7 +198,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -123,7 +121,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -141,7 +138,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -161,7 +157,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -187,7 +182,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/RefStructConsumer_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/RefStructConsumer_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -123,7 +121,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -141,7 +138,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -161,7 +157,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -187,7 +182,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/RefStructConsumer_CanBeCreated/RefStructMethodSetups.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/RefStructConsumer_CanBeCreated/RefStructMethodSetups.g.cs
@@ -33,7 +33,6 @@ namespace Mockolate.Setup
 	///     Concrete ref-struct-compatible void setup for arity 5. See <see cref="global::Mockolate.Setup.RefStructVoidMethodSetup{T}">RefStructVoidMethodSetup&lt;T&gt;</see>.
 	/// </summary>
 #if !DEBUG
-	[global::System.Diagnostics.DebuggerNonUserCode]
 #endif
 	public sealed class RefStructVoidMethodSetup<T1, T2, T3, T4, T5> : global::Mockolate.Setup.MethodSetup, global::Mockolate.Setup.IRefStructVoidMethodSetup<T1, T2, T3, T4, T5>
 		where T1 : allows ref struct
@@ -147,7 +146,6 @@ namespace Mockolate.Setup
 	///     Concrete ref-struct-compatible indexer getter setup for arity 5. See <see cref="global::Mockolate.Setup.RefStructIndexerGetterSetup{TValue, T}">RefStructIndexerGetterSetup&lt;TValue, T&gt;</see>.
 	/// </summary>
 #if !DEBUG
-	[global::System.Diagnostics.DebuggerNonUserCode]
 #endif
 	public sealed class RefStructIndexerGetterSetup<TValue, T1, T2, T3, T4, T5> : global::Mockolate.Setup.MethodSetup, global::Mockolate.Setup.IRefStructIndexerGetterSetup<TValue, T1, T2, T3, T4, T5>
 		where T1 : allows ref struct
@@ -373,7 +371,6 @@ namespace Mockolate.Setup
 	///     Concrete ref-struct-compatible indexer setter setup for arity 5. See <see cref="global::Mockolate.Setup.RefStructIndexerSetterSetup{TValue, T}">RefStructIndexerSetterSetup&lt;TValue, T&gt;</see>.
 	/// </summary>
 #if !DEBUG
-	[global::System.Diagnostics.DebuggerNonUserCode]
 #endif
 	public sealed class RefStructIndexerSetterSetup<TValue, T1, T2, T3, T4, T5> : global::Mockolate.Setup.MethodSetup, global::Mockolate.Setup.IRefStructIndexerSetterSetup<TValue, T1, T2, T3, T4, T5>
 		where T1 : allows ref struct
@@ -493,7 +490,6 @@ namespace Mockolate.Setup
 	///     Concrete ref-struct-compatible combined indexer setup for arity 5. See <see cref="global::Mockolate.Setup.RefStructIndexerSetup{TValue, T}">RefStructIndexerSetup&lt;TValue, T&gt;</see>.
 	/// </summary>
 #if !DEBUG
-	[global::System.Diagnostics.DebuggerNonUserCode]
 #endif
 	public sealed class RefStructIndexerSetup<TValue, T1, T2, T3, T4, T5> : global::Mockolate.Setup.MethodSetup, global::Mockolate.Setup.IRefStructIndexerSetup<TValue, T1, T2, T3, T4, T5>
 		where T1 : allows ref struct

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/StaticAbstractMembers_CanBeCreated/MockBehaviorExtensions.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/StaticAbstractMembers_CanBeCreated/MockBehaviorExtensions.g.cs
@@ -61,7 +61,6 @@ internal static partial class Mock
 	///     A <see cref="IDefaultValueFactory">IDefaultValueFactory</see> that returns a specified <paramref name="value" /> for the given type
 	///     parameter <typeparamref name="T" />.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	internal class TypedDefaultValueFactory<T>(T value) : IDefaultValueFactory
 	{
@@ -77,7 +76,6 @@ internal static partial class Mock
 	/// <summary>
 	///     Provides default values for common types used in mocking scenarios.
 	/// </summary>
-	[global::System.Diagnostics.DebuggerNonUserCode]
 	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 	private class DefaultValueGenerator : IDefaultValueGenerator
 	{
@@ -123,7 +121,6 @@ internal static partial class Mock
 			value = null;
 			return false;
 
-			[global::System.Diagnostics.DebuggerNonUserCode]
 			bool Predicate(global::Mockolate.Mock.IDefaultValueFactory f)
 				=> f.IsMatch(type);
 		}
@@ -141,7 +138,6 @@ internal static partial class Mock
 			return false;
 		}
 
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableTaskFactory : IDefaultValueFactory
 		{
@@ -161,7 +157,6 @@ internal static partial class Mock
 			}
 		}
 	#if NET8_0_OR_GREATER
-		[global::System.Diagnostics.DebuggerNonUserCode]
 		[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 		private sealed class CancellableValueTaskFactory : IDefaultValueFactory
 		{
@@ -187,7 +182,6 @@ internal static partial class Mock
 /// <summary>
 ///     Extensions on <see cref="IDefaultValueGenerator">IDefaultValueGenerator</see>
 /// </summary>
-[global::System.Diagnostics.DebuggerNonUserCode]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class DefaultValueGeneratorExtensions
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/MockGenerationSnapshotAcceptance.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/MockGenerationSnapshotAcceptance.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Mockolate.SourceGenerators.Tests.Snapshot;
 
 public sealed class MockGenerationSnapshotAcceptance
@@ -9,14 +7,14 @@ public sealed class MockGenerationSnapshotAcceptance
 	///     <see cref="MockGenerationSnapshotTests" /> with the current generator output.
 	/// </summary>
 	[Fact(Explicit = true)]
-	public void AcceptSnapshotChanges()
-	{
-		foreach (SnapshotScenario scenario in MockGenerationSnapshotTests.Scenarios)
-		{
-			GeneratorResult result = MockGenerationSnapshotTests.RunGenerator(scenario);
-			IReadOnlyDictionary<string, string> generated =
-				MockGenerationSnapshotTests.NormalizeSources(result);
-			SnapshotStorage.SetExpected(scenario.Name, generated);
-		}
-	}
+    public void AcceptSnapshotChanges()
+    {
+        foreach (var scenario in MockGenerationSnapshotTests.Scenarios)
+        {
+            var result = MockGenerationSnapshotTests.RunGenerator(scenario);
+            var generated =
+                MockGenerationSnapshotTests.NormalizeSources(result);
+            SnapshotStorage.SetExpected(scenario.Name, generated);
+        }
+    }
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/MockGenerationSnapshotTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/MockGenerationSnapshotTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 
 namespace Mockolate.SourceGenerators.Tests.Snapshot;
@@ -17,160 +16,139 @@ namespace Mockolate.SourceGenerators.Tests.Snapshot;
 ///     When a scenario fails because the change was intentional, run
 ///     <see cref="MockGenerationSnapshotAcceptance.AcceptSnapshotChanges" />.
 /// </summary>
-public sealed partial class MockGenerationSnapshotTests
+public sealed class MockGenerationSnapshotTests
 {
-	[Theory]
-	[MemberData(nameof(ScenarioNames))]
-	public async Task GeneratorOutput_MatchesExpectedSnapshot(string scenarioName)
-	{
-		SnapshotScenario scenario = Scenarios.Single(s => s.Name == scenarioName);
-		GeneratorResult result = RunGenerator(scenario);
-		await That(result.Diagnostics).IsEmpty();
+    [Theory]
+    [MemberData(nameof(ScenarioNames))]
+    public async Task GeneratorOutput_MatchesExpectedSnapshot(string scenarioName)
+    {
+        var scenario = Scenarios.Single(s => s.Name == scenarioName);
+        var result = RunGenerator(scenario);
+        await That(result.Diagnostics).IsEmpty();
 
-		IReadOnlyDictionary<string, string> generated = NormalizeSources(result);
-		IReadOnlyDictionary<string, string> expected = SnapshotStorage.GetExpected(scenarioName);
+        var generated = NormalizeSources(result);
+        var expected = SnapshotStorage.GetExpected(scenarioName);
 
-		await That(generated.Keys).IsEqualTo(expected.Keys).InAnyOrder();
+        await That(generated.Keys).IsEqualTo(expected.Keys).InAnyOrder();
 
-		foreach (string fileName in expected.Keys)
-		{
-			await That(StripConfigSpecificLines(generated[fileName]))
-				.IsEqualTo(StripConfigSpecificLines(expected[fileName]))
-				.IgnoringNewlineStyle();
-		}
-	}
+        foreach (var fileName in expected.Keys)
+            await That(SnapshotStorage.StripConfigSpecificLines(generated[fileName]))
+                .IsEqualTo(SnapshotStorage.StripConfigSpecificLines(expected[fileName]))
+                .IgnoringNewlineStyle();
+    }
 
-	internal static readonly IReadOnlyList<SnapshotScenario> Scenarios =
-	[
-		new(
-			"BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated",
-			["ComprehensiveAbstractClass.cs", "ICombinationParts.cs",],
-			"""
-			ComprehensiveAbstractClass sut = ComprehensiveAbstractClass.CreateMock()
-				.Implementing<ICombinationMockA>()
-				.Implementing<ICombinationMockB>();
-			""",
-			[]),
-		new(
-			"ComprehensiveAbstractClass_CanBeCreated",
-			["ComprehensiveAbstractClass.cs",],
-			"""
-			ComprehensiveAbstractClass sut = ComprehensiveAbstractClass.CreateMock();
-			""",
-			[]),
-		new(
-			"ComprehensiveDelegate_CanBeCreated",
-			["ComprehensiveDelegate.cs",],
-			"""
-			ComprehensiveDelegate sut = ComprehensiveDelegate.CreateMock();
-			""",
-			[]),
-		new(
-			"ComprehensiveInterface_CanBeCreated",
-			["ComprehensiveDelegate.cs", "IComprehensiveInterface.cs",],
-			"""
-			IComprehensiveInterface sut = IComprehensiveInterface.CreateMock();
-			""",
-			[]),
-		new(
-			"HttpClient_CanBeCreated",
-			[],
-			"""
-			System.Net.Http.HttpClient sut = System.Net.Http.HttpClient.CreateMock();
-			""",
-			[typeof(HttpClient), typeof(HttpStatusCode),]),
-		new(
-			"KeywordEdgeCases_CanBeCreated",
-			["KeywordEdgeCases.cs",],
-			"""
-			IKeywordEdgeCases sut = IKeywordEdgeCases.CreateMock();
-			""",
-			[]),
-		new(
-			"RefStructConsumer_CanBeCreated",
-			["IRefStructConsumer.cs",],
-			"""
-			IRefStructConsumer sut = IRefStructConsumer.CreateMock();
-			""",
-			[]),
-		new(
-			"StaticAbstractMembers_CanBeCreated",
-			["IStaticAbstractMembers.cs",],
-			"""
-			IStaticAbstractMembers sut = IStaticAbstractMembers.CreateMock();
-			""",
-			[]),
-	];
+    internal static readonly IReadOnlyList<SnapshotScenario> Scenarios =
+    [
+        new(
+            "BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated",
+            ["ComprehensiveAbstractClass.cs", "ICombinationParts.cs",],
+            """
+            ComprehensiveAbstractClass sut = ComprehensiveAbstractClass.CreateMock()
+            	.Implementing<ICombinationMockA>()
+            	.Implementing<ICombinationMockB>();
+            """,
+            []),
+        new(
+            "ComprehensiveAbstractClass_CanBeCreated",
+            ["ComprehensiveAbstractClass.cs",],
+            """
+            ComprehensiveAbstractClass sut = ComprehensiveAbstractClass.CreateMock();
+            """,
+            []),
+        new(
+            "ComprehensiveDelegate_CanBeCreated",
+            ["ComprehensiveDelegate.cs",],
+            """
+            ComprehensiveDelegate sut = ComprehensiveDelegate.CreateMock();
+            """,
+            []),
+        new(
+            "ComprehensiveInterface_CanBeCreated",
+            ["ComprehensiveDelegate.cs", "IComprehensiveInterface.cs",],
+            """
+            IComprehensiveInterface sut = IComprehensiveInterface.CreateMock();
+            """,
+            []),
+        new(
+            "HttpClient_CanBeCreated",
+            [],
+            """
+            System.Net.Http.HttpClient sut = System.Net.Http.HttpClient.CreateMock();
+            """,
+            [typeof(HttpClient), typeof(HttpStatusCode),]),
+        new(
+            "KeywordEdgeCases_CanBeCreated",
+            ["KeywordEdgeCases.cs",],
+            """
+            IKeywordEdgeCases sut = IKeywordEdgeCases.CreateMock();
+            """,
+            []),
+        new(
+            "RefStructConsumer_CanBeCreated",
+            ["IRefStructConsumer.cs",],
+            """
+            IRefStructConsumer sut = IRefStructConsumer.CreateMock();
+            """,
+            []),
+        new(
+            "StaticAbstractMembers_CanBeCreated",
+            ["IStaticAbstractMembers.cs",],
+            """
+            IStaticAbstractMembers sut = IStaticAbstractMembers.CreateMock();
+            """,
+            []),
+    ];
 
-	public static TheoryData<string> ScenarioNames
-	{
-		get
-		{
-			TheoryData<string> data = new();
-			foreach (SnapshotScenario scenario in Scenarios)
-			{
-				data.Add(scenario.Name);
-			}
+    public static TheoryData<string> ScenarioNames
+    {
+        get
+        {
+            TheoryData<string> data = new();
+            foreach (var scenario in Scenarios) data.Add(scenario.Name);
 
-			return data;
-		}
-	}
+            return data;
+        }
+    }
 
-	internal static GeneratorResult RunGenerator(SnapshotScenario scenario)
-	{
-		List<string> sources = new();
-		foreach (string coverageFile in scenario.CoverageFiles)
-		{
-			sources.Add("#nullable enable\n" + SnapshotStorage.ReadCoverageFile(coverageFile));
-		}
+    internal static GeneratorResult RunGenerator(SnapshotScenario scenario)
+    {
+        List<string> sources = new();
+        foreach (var coverageFile in scenario.CoverageFiles) sources.Add("#nullable enable\n" + SnapshotStorage.ReadCoverageFile(coverageFile));
 
-		string usingDirective = scenario.CoverageFiles.Length > 0
-			? "using Mockolate.Tests.GeneratorCoverage;\n"
-			: string.Empty;
-		string program = $$"""
-		                   #nullable enable
-		                   using System;
-		                   using Mockolate;
-		                   {{usingDirective}}
-		                   namespace Mockolate.SourceGenerators.Tests.SnapshotDriver;
+        var usingDirective = scenario.CoverageFiles.Length > 0
+            ? "using Mockolate.Tests.GeneratorCoverage;\n"
+            : string.Empty;
+        var program = $$"""
+                        #nullable enable
+                        using System;
+                        using Mockolate;
+                        {{usingDirective}}
+                        namespace Mockolate.SourceGenerators.Tests.SnapshotDriver;
 
-		                   public class Program
-		                   {
-		                   	public static void Main(string[] args)
-		                   	{
-		                   		{{scenario.MainBody}}
-		                   	}
-		                   }
-		                   """;
-		sources.Add(program);
+                        public class Program
+                        {
+                        	public static void Main(string[] args)
+                        	{
+                        		{{scenario.MainBody}}
+                        	}
+                        }
+                        """;
+        sources.Add(program);
 
-		return Generator.Run(
-			sources.ToArray(),
-			DocumentationMode.Parse,
-			["NET9_0_OR_GREATER", "NET10_0_OR_GREATER",],
-			scenario.AssemblyTypes);
-	}
+        return Generator.Run(
+            sources.ToArray(),
+            DocumentationMode.Parse,
+            ["NET9_0_OR_GREATER", "NET10_0_OR_GREATER",],
+            scenario.AssemblyTypes);
+    }
 
-	internal static IReadOnlyDictionary<string, string> NormalizeSources(GeneratorResult result)
-	{
-		Dictionary<string, string> normalized = new();
-		foreach (KeyValuePair<string, string> source in result.Sources
-			         .OrderBy(s => s.Key, StringComparer.Ordinal))
-		{
-			normalized[source.Key] = source.Value.Replace("\r\n", "\n");
-		}
+    internal static IReadOnlyDictionary<string, string> NormalizeSources(GeneratorResult result)
+    {
+        Dictionary<string, string> normalized = new();
+        foreach (var source in result.Sources
+                     .OrderBy(s => s.Key, StringComparer.Ordinal))
+            normalized[source.Key] = source.Value.Replace("\r\n", "\n");
 
-		return normalized;
-	}
-
-	// The source generator gates `[DebuggerNonUserCode]` behind `#if !DEBUG`, so its output
-	// depends on whether the generator dll was built in Debug or Release. Strip those tokens
-	// on both sides so the snapshot test passes regardless of the build configuration used to
-	// produce the generator. The attribute appears either on its own indented line or inline
-	// directly after an opening brace, so the pattern allows optional leading tabs/spaces.
-	[GeneratedRegex(@"[ \t]*\[global::System\.Diagnostics\.DebuggerNonUserCode\]\r?\n?", RegexOptions.Compiled)]
-	private static partial Regex DebuggerNonUserCodeRegex { get; }
-
-	private static string StripConfigSpecificLines(string content)
-		=> DebuggerNonUserCodeRegex.Replace(content, string.Empty);
+        return normalized;
+    }
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/SnapshotScenario.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/SnapshotScenario.cs
@@ -1,7 +1,7 @@
 namespace Mockolate.SourceGenerators.Tests.Snapshot;
 
 internal sealed record SnapshotScenario(
-	string Name,
-	string[] CoverageFiles,
-	string MainBody,
-	Type[] AssemblyTypes);
+    string Name,
+    string[] CoverageFiles,
+    string MainBody,
+    Type[] AssemblyTypes);

--- a/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/SnapshotStorage.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/SnapshotStorage.cs
@@ -2,60 +2,68 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Mockolate.SourceGenerators.Tests.TestHelpers;
 
-public static class SnapshotStorage
+public static partial class SnapshotStorage
 {
-	public static string ReadCoverageFile(string coverageFileName)
-	{
-		string path = CombinedPaths("Tests", "Mockolate.Tests", "GeneratorCoverage",
-			coverageFileName);
-		return File.ReadAllText(path);
-	}
+    [GeneratedRegex(@"[ \t]*\[global::System\.Diagnostics\.DebuggerNonUserCode\]\r?\n?", RegexOptions.Compiled)]
+    private static partial Regex DebuggerNonUserCodeRegex { get; }
 
-	public static IReadOnlyDictionary<string, string> GetExpected(string scenario)
-	{
-		string folder = ExpectedFolder(scenario);
-		Dictionary<string, string> result = new();
-		if (!Directory.Exists(folder))
-		{
-			return result;
-		}
+    public static string ReadCoverageFile(string coverageFileName)
+    {
+        var path = CombinedPaths("Tests", "Mockolate.Tests", "GeneratorCoverage",
+            coverageFileName);
+        return File.ReadAllText(path);
+    }
 
-		foreach (string file in Directory.GetFiles(folder).OrderBy(f => f, StringComparer.Ordinal))
-		{
-			string content = File.ReadAllText(file).Replace("\r\n", "\n");
-			result[Path.GetFileName(file)] = content;
-		}
+    public static IReadOnlyDictionary<string, string> GetExpected(string scenario)
+    {
+        var folder = ExpectedFolder(scenario);
+        Dictionary<string, string> result = new();
+        if (!Directory.Exists(folder)) return result;
 
-		return result;
-	}
+        foreach (var file in Directory.GetFiles(folder).OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var content = File.ReadAllText(file).Replace("\r\n", "\n");
+            result[Path.GetFileName(file)] = content;
+        }
 
-	public static void SetExpected(string scenario, IReadOnlyDictionary<string, string> sources)
-	{
-		string folder = ExpectedFolder(scenario);
-		if (Directory.Exists(folder))
-		{
-			Directory.Delete(folder, true);
-		}
+        return result;
+    }
 
-		Directory.CreateDirectory(folder);
-		foreach (KeyValuePair<string, string> source in sources)
-		{
-			string content = source.Value
-				.Replace("\r\n", "\n")
-				.Replace("\n", Environment.NewLine);
-			File.WriteAllText(Path.Combine(folder, source.Key), content);
-		}
-	}
+    public static void SetExpected(string scenario, IReadOnlyDictionary<string, string> sources)
+    {
+        var folder = ExpectedFolder(scenario);
+        if (Directory.Exists(folder)) Directory.Delete(folder, true);
 
-	private static string ExpectedFolder(string scenario) =>
-		CombinedPaths("Tests", "Mockolate.SourceGenerators.Tests", "Snapshot", "Expected", scenario);
+        Directory.CreateDirectory(folder);
+        foreach (var source in sources)
+        {
+            var content = StripConfigSpecificLines(source.Value
+                .Replace("\r\n", "\n")
+                .Replace("\n", Environment.NewLine));
+            File.WriteAllText(Path.Combine(folder, source.Key), content);
+        }
+    }
 
-	private static string CombinedPaths(params string[] paths) =>
-		Path.GetFullPath(Path.Combine(paths.Prepend(GetSolutionDirectory()).ToArray()));
+    /// <summary>
+    ///     The source generator gates `[DebuggerNonUserCode]` behind `#if !DEBUG`, so its output
+    ///     depends on whether the generator dll was built in Debug or Release. Strip those tokens
+    ///     on both sides so the snapshot test passes regardless of the build configuration used to
+    ///     produce the generator. The attribute appears either on its own indented line or inline
+    ///     directly after an opening brace, so the pattern allows optional leading tabs/spaces.
+    /// </summary>
+    internal static string StripConfigSpecificLines(string content)
+        => DebuggerNonUserCodeRegex.Replace(content, string.Empty);
 
-	private static string GetSolutionDirectory([CallerFilePath] string path = "") =>
-		Path.Combine(Path.GetDirectoryName(path)!, "..", "..", "..");
+    private static string ExpectedFolder(string scenario) =>
+        CombinedPaths("Tests", "Mockolate.SourceGenerators.Tests", "Snapshot", "Expected", scenario);
+
+    private static string CombinedPaths(params string[] paths) =>
+        Path.GetFullPath(Path.Combine(paths.Prepend(GetSolutionDirectory()).ToArray()));
+
+    private static string GetSolutionDirectory([CallerFilePath] string path = "") =>
+        Path.Combine(Path.GetDirectoryName(path)!, "..", "..", "..");
 }

--- a/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/SnapshotStorage.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/SnapshotStorage.cs
@@ -8,7 +8,7 @@ namespace Mockolate.SourceGenerators.Tests.TestHelpers;
 
 public static partial class SnapshotStorage
 {
-    [GeneratedRegex(@"[ \t]*\[global::System\.Diagnostics\.DebuggerNonUserCode\]\r?\n?", RegexOptions.Compiled)]
+    [GeneratedRegex(@"[ \t]*\[global::System\.Diagnostics\.DebuggerNonUserCode\]\r?\n?")]
     private static partial Regex DebuggerNonUserCodeRegex { get; }
 
     public static string ReadCoverageFile(string coverageFileName)


### PR DESCRIPTION
This pull request removes the `[DebuggerNonUserCode]` attribute from several classes and methods in multiple generated test files. The change is consistently applied across different snapshot files related to mock behavior extensions, aiming to simplify the generated code and avoid suppressing debugger stepping for these code sections.

The most important changes are:

**Attribute Removal (Code Simplification):**
* Removed the `[DebuggerNonUserCode]` attribute from internal classes such as `TypedDefaultValueFactory<T>`, `DefaultValueGenerator`, `CancellableTaskFactory`, `CancellableValueTaskFactory`, and `HttpResponseMessageFactory` in all affected snapshot files. This makes the generated code more transparent during debugging.

**Consistency Across Snapshots:**
* Ensured that the removal of `[DebuggerNonUserCode]` is applied consistently in all snapshot files for different test scenarios (BaseClass_WithMultipleAdditionalInterfaces, ComprehensiveAbstractClass, ComprehensiveDelegate, ComprehensiveInterface, HttpClient).

**Debugging Experience:**
* By removing this attribute, the generated code will no longer be hidden from the debugger, which can help developers step through and diagnose issues more effectively in test scenarios.

No functional logic is altered; this is a code generation and debugging experience improvement.