### PR TITLE
docs: notify Testably.Site when documentation changes

### DIFF
--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,22 @@
+name: Notify Docs Site
+
+on:
+    push:
+        branches: [ main ]
+        paths:
+            - 'Docs/pages/**'
+            - '.github/workflows/notify-docs-site.yml'
+    workflow_dispatch:
+
+jobs:
+    dispatch:
+        name: Trigger Site rebuild
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Dispatch extension-documentation-updated-event to Testably/Testably.Site
+                uses: peter-evans/repository-dispatch@v3
+                with:
+                    token: ${{ secrets.SITE_DISPATCH_TOKEN }}
+                    repository: Testably/Testably.Site
+                    event-type: extension-documentation-updated-event
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -5,11 +5,11 @@ on:
         branches: [ main ]
         paths:
             - 'Docs/pages/**'
-            - '.github/workflows/notify-docs-site.yml'
     workflow_dispatch:
 
 jobs:
     dispatch:
+        if: github.ref == 'refs/heads/main'
         name: Trigger Site rebuild
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
Adds a workflow that fires the extension-documentation-updated-event repository dispatch at Testably/Testably.Site whenever Docs/pages/** changes on main. Site responds by re-fetching this repo'\''s docs and redeploying https://docs.testably.org. Requires a SITE_DISPATCH_TOKEN secret with repo write on Testably/Testably.Site.