### PR TITLE
refactor: update repository references from aweXpect to Testably

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ publish-test-results, build-pages, benchmarks, static-code-analysis, pack, mutation-tests ]
+        needs: [ publish-test-results, benchmarks, static-code-analysis, pack, mutation-tests ]
         permissions:
             contents: write
         steps:
@@ -257,18 +257,3 @@ jobs:
                         state: released
                     skip-label: |
                         state: released
-    
-    build-pages:
-        name: Update Pages
-        runs-on: ubuntu-latest
-        needs: [ benchmarks ]
-        steps:
-            -   name: Trigger pages update in aweXpect Repo
-                run: |
-                    curl -L \
-                      -X POST \
-                      -H "Accept: application/vnd.github+json" \
-                      -H "Authorization: Bearer ${{ secrets.REPOSITORY_DISPATCH }}" \
-                      -H "X-GitHub-Api-Version: 2022-11-28" \
-                      https://api.github.com/repos/aweXpect/aweXpect/dispatches \
-                      -d "{\"event_type\": \"extension-documentation-updated-event\"}"

--- a/Mockolate.slnx
+++ b/Mockolate.slnx
@@ -1,82 +1,83 @@
 <Solution>
 	<Folder Name="/Benchmarks/">
-		<Project Path="Benchmarks/Mockolate.Benchmarks/Mockolate.Benchmarks.csproj"/>
+		<Project Path="Benchmarks/Mockolate.Benchmarks/Mockolate.Benchmarks.csproj" />
 	</Folder>
 	<Folder Name="/Pipeline/">
 		<Project Path="Pipeline/Build.csproj">
-			<Build Project="false"/>
+			<Build Project="false" />
 		</Project>
-		<Project Path="Tests/Build.Tests/Build.Tests.csproj"/>
+		<Project Path="Tests/Build.Tests/Build.Tests.csproj" />
 	</Folder>
 	<Folder Name="/Tests/">
-		<File Path="Tests/Directory.Build.props"/>
-		<Project Path="Tests/Mockolate.Analyzers.Tests/Mockolate.Analyzers.Tests.csproj"/>
-		<Project Path="Tests/Mockolate.Api.Tests/Mockolate.Api.Tests.csproj"/>
-		<Project Path="Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj"/>
-		<Project Path="Tests/Mockolate.Internal.Tests/Mockolate.Internal.Tests.csproj"/>
-		<Project Path="Tests/Mockolate.SourceGenerators.Tests/Mockolate.SourceGenerators.Tests.csproj"/>
-		<Project Path="Tests/Mockolate.Tests/Mockolate.Tests.csproj"/>
+		<File Path="Tests/Directory.Build.props" />
+		<Project Path="Tests/Mockolate.Analyzers.Tests/Mockolate.Analyzers.Tests.csproj" />
+		<Project Path="Tests/Mockolate.Api.Tests/Mockolate.Api.Tests.csproj" />
+		<Project Path="Tests/Mockolate.ExampleTests/Mockolate.ExampleTests.csproj" />
+		<Project Path="Tests/Mockolate.Internal.Tests/Mockolate.Internal.Tests.csproj" />
+		<Project Path="Tests/Mockolate.SourceGenerators.Tests/Mockolate.SourceGenerators.Tests.csproj" />
+		<Project Path="Tests/Mockolate.Tests/Mockolate.Tests.csproj" />
 	</Folder>
 	<Folder Name="/Tests/Aot/">
-		<File Path="Tests/Aot/Directory.Build.props"/>
-		<Project Path="Tests/Aot/Mockolate.AotCompatibility.TestApp/Mockolate.AotCompatibility.TestApp.csproj"/>
+		<File Path="Tests/Aot/Directory.Build.props" />
+		<Project Path="Tests/Aot/Mockolate.AotCompatibility.TestApp/Mockolate.AotCompatibility.TestApp.csproj" />
 	</Folder>
 	<Folder Name="/_/">
-		<File Path=".editorconfig"/>
-		<File Path=".gitattributes"/>
-		<File Path=".gitignore"/>
-		<File Path="CODE_OF_CONDUCT.md"/>
-		<File Path="CONTRIBUTING.md"/>
-		<File Path="Directory.Build.props"/>
-		<File Path="Directory.Packages.props"/>
-		<File Path="global.json"/>
-		<File Path="LICENSE"/>
-		<File Path="Mockolate.sln.DotSettings"/>
-		<File Path="nuget.config"/>
-		<File Path="README.md"/>
+		<File Path=".editorconfig" />
+		<File Path=".gitattributes" />
+		<File Path=".gitignore" />
+		<File Path="CODE_OF_CONDUCT.md" />
+		<File Path="CONTRIBUTING.md" />
+		<File Path="Directory.Build.props" />
+		<File Path="Directory.Packages.props" />
+		<File Path="global.json" />
+		<File Path="LICENSE" />
+		<File Path="Mockolate.sln.DotSettings" />
+		<File Path="nuget.config" />
+		<File Path="README.md" />
 	</Folder>
-	<Folder Name="/_/.github/"/>
+	<Folder Name="/_/.github/" />
 	<Folder Name="/_/.github/workflows/">
-		<File Path=".github/workflows/build.yml"/>
-		<File Path=".github/workflows/ci-analysis.yml"/>
-		<File Path=".github/workflows/ci.yml"/>
+		<File Path=".github/workflows/build.yml" />
+		<File Path=".github/workflows/ci-analysis.yml" />
+		<File Path=".github/workflows/ci.yml" />
+		<File Path=".github/workflows/notify-docs-site.yml" />
 	</Folder>
 	<Folder Name="/_/Docs/">
-		<File Path="Docs/pages/00-index.md"/>
-		<File Path="Docs/pages/01-create-mocks.md"/>
-		<File Path="Docs/pages/03-mock-events.md"/>
-		<File Path="Docs/pages/04-verify-interactions.md"/>
-		<File Path="Docs/pages/07-analyzers.md"/>
-		<File Path="Docs/pages/08-comparison.md"/>
+		<File Path="Docs/pages/00-index.md" />
+		<File Path="Docs/pages/01-create-mocks.md" />
+		<File Path="Docs/pages/03-mock-events.md" />
+		<File Path="Docs/pages/04-verify-interactions.md" />
+		<File Path="Docs/pages/07-analyzers.md" />
+		<File Path="Docs/pages/08-comparison.md" />
 	</Folder>
 	<Folder Name="/_/Docs/advanced-features/">
-		<File Path="Docs/pages/advanced-features/01-protected-members.md"/>
-		<File Path="Docs/pages/advanced-features/02-static-interface-members.md"/>
-		<File Path="Docs/pages/advanced-features/03-advanced-callback-features.md"/>
-		<File Path="Docs/pages/advanced-features/04-monitor-interactions.md"/>
-		<File Path="Docs/pages/advanced-features/05-check-for-unexpected-interactions.md"/>
-		<File Path="Docs/pages/advanced-features/_category_.json"/>
+		<File Path="Docs/pages/advanced-features/01-protected-members.md" />
+		<File Path="Docs/pages/advanced-features/02-static-interface-members.md" />
+		<File Path="Docs/pages/advanced-features/03-advanced-callback-features.md" />
+		<File Path="Docs/pages/advanced-features/04-monitor-interactions.md" />
+		<File Path="Docs/pages/advanced-features/05-check-for-unexpected-interactions.md" />
+		<File Path="Docs/pages/advanced-features/_category_.json" />
 	</Folder>
 	<Folder Name="/_/Docs/setup/">
-		<File Path="Docs/pages/setup/01-properties.md"/>
-		<File Path="Docs/pages/setup/02-methods.md"/>
-		<File Path="Docs/pages/setup/03-indexers.md"/>
-		<File Path="Docs/pages/setup/04-parameter-matching.md"/>
-		<File Path="Docs/pages/setup/_category_.json"/>
+		<File Path="Docs/pages/setup/01-properties.md" />
+		<File Path="Docs/pages/setup/02-methods.md" />
+		<File Path="Docs/pages/setup/03-indexers.md" />
+		<File Path="Docs/pages/setup/04-parameter-matching.md" />
+		<File Path="Docs/pages/setup/_category_.json" />
 	</Folder>
 	<Folder Name="/_/Docs/special-types/">
-		<File Path="Docs/pages/special-types/01-httpclient.md"/>
-		<File Path="Docs/pages/special-types/02-delegates.md"/>
-		<File Path="Docs/pages/special-types/_category_.json"/>
+		<File Path="Docs/pages/special-types/01-httpclient.md" />
+		<File Path="Docs/pages/special-types/02-delegates.md" />
+		<File Path="Docs/pages/special-types/_category_.json" />
 	</Folder>
 	<Folder Name="/_/Source/">
-		<File Path="Source/Directory.Build.props"/>
+		<File Path="Source/Directory.Build.props" />
 	</Folder>
 	<Folder Name="/_/Tests/">
-		<File Path="Tests/Directory.Build.props"/>
+		<File Path="Tests/Directory.Build.props" />
 	</Folder>
-	<Project Path="Source/Mockolate.Analyzers.CodeFixers/Mockolate.Analyzers.CodeFixers.csproj"/>
-	<Project Path="Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj"/>
-	<Project Path="Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj"/>
-	<Project Path="Source/Mockolate/Mockolate.csproj"/>
+	<Project Path="Source/Mockolate.Analyzers.CodeFixers/Mockolate.Analyzers.CodeFixers.csproj" />
+	<Project Path="Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj" />
+	<Project Path="Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj" />
+	<Project Path="Source/Mockolate/Mockolate.csproj" />
 </Solution>

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -97,7 +97,7 @@ partial class Build
 				Credentials tokenAuth = new(GithubToken);
 				gitHubClient.Credentials = tokenAuth;
 				IReadOnlyList<IssueComment> comments =
-					await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "Mockolate", prId);
+					await gitHubClient.Issue.Comment.GetAllForIssue(BuildExtensions.Owner, BuildExtensions.Repo, prId);
 				long? commentId = null;
 				Log.Information($"Found {comments.Count} comments");
 				foreach (IssueComment comment in comments)
@@ -112,12 +112,12 @@ partial class Build
 				if (commentId == null)
 				{
 					Log.Information($"Create comment:\n{body}");
-					await gitHubClient.Issue.Comment.Create("Testably", "Mockolate", prId, body);
+					await gitHubClient.Issue.Comment.Create(BuildExtensions.Owner, BuildExtensions.Repo, prId, body);
 				}
 				else
 				{
 					Log.Information($"Update comment:\n{body}");
-					await gitHubClient.Issue.Comment.Update("Testably", "Mockolate", commentId.Value, body);
+					await gitHubClient.Issue.Comment.Update(BuildExtensions.Owner, BuildExtensions.Repo, commentId.Value, body);
 				}
 			}
 		});

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -97,7 +97,7 @@ partial class Build
 				Credentials tokenAuth = new(GithubToken);
 				gitHubClient.Credentials = tokenAuth;
 				IReadOnlyList<IssueComment> comments =
-					await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "Mockolate", prId);
+					await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "Mockolate", prId);
 				long? commentId = null;
 				Log.Information($"Found {comments.Count} comments");
 				foreach (IssueComment comment in comments)
@@ -112,12 +112,12 @@ partial class Build
 				if (commentId == null)
 				{
 					Log.Information($"Create comment:\n{body}");
-					await gitHubClient.Issue.Comment.Create("aweXpect", "Mockolate", prId, body);
+					await gitHubClient.Issue.Comment.Create("Testably", "Mockolate", prId, body);
 				}
 				else
 				{
 					Log.Information($"Update comment:\n{body}");
-					await gitHubClient.Issue.Comment.Update("aweXpect", "Mockolate", commentId.Value, body);
+					await gitHubClient.Issue.Comment.Update("Testably", "Mockolate", commentId.Value, body);
 				}
 			}
 		});

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -180,7 +180,7 @@ partial class Build
 					Credentials tokenAuth = new(GithubToken);
 					gitHubClient.Credentials = tokenAuth;
 					IReadOnlyList<IssueComment> comments =
-						await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "Mockolate", prId);
+						await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "Mockolate", prId);
 					long? commentId = null;
 					Log.Information($"Found {comments.Count} comments");
 					foreach (IssueComment comment in comments)
@@ -195,12 +195,12 @@ partial class Build
 					if (commentId == null)
 					{
 						Log.Information($"Create comment:\n{body}");
-						await gitHubClient.Issue.Comment.Create("aweXpect", "Mockolate", prId, body);
+						await gitHubClient.Issue.Comment.Create("Testably", "Mockolate", prId, body);
 					}
 					else
 					{
 						Log.Information($"Update comment:\n{body}");
-						await gitHubClient.Issue.Comment.Update("aweXpect", "Mockolate", commentId.Value, body);
+						await gitHubClient.Issue.Comment.Update("Testably", "Mockolate", commentId.Value, body);
 					}
 				}
 			}

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -71,7 +71,7 @@ partial class Build
 				                      {
 				                      	"stryker-config": {
 				                      		"project-info": {
-				                      			"name": "github.com/aweXpect/Mockolate",
+				                      			"name": "github.com/{{BuildExtensions.Owner}}/{{BuildExtensions.Repo}}",
 				                      			"module": "{{project.Key.Name}}",
 				                      			"version": "{{branchName}}"
 				                      		},
@@ -128,7 +128,7 @@ partial class Build
 
 			string body = "## :alien: Mutation Results"
 			              + Environment.NewLine
-			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FMockolate%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/Mockolate/pull/{prId}/merge)"
+			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2F{BuildExtensions.Owner}%2F{BuildExtensions.Repo}%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/{BuildExtensions.Owner}/{BuildExtensions.Repo}/pull/{prId}/merge)"
 			              + Environment.NewLine
 			              + MutationCommentBody;
 			File.WriteAllText(ArtifactsDirectory / "PR_Comment.md", body);
@@ -165,7 +165,7 @@ partial class Build
 				client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
 				// https://stryker-mutator.io/docs/General/dashboard/#send-a-report-via-curl
 				await client.PutAsync(
-					$"https://dashboard.stryker-mutator.io/api/reports/github.com/aweXpect/Mockolate/{branchName}?module={project.Key.Name}",
+					$"https://dashboard.stryker-mutator.io/api/reports/github.com/{BuildExtensions.Owner}/{BuildExtensions.Repo}/{branchName}?module={project.Key.Name}",
 					new StringContent(reportComment, new MediaTypeHeaderValue("application/json")));
 			}
 
@@ -180,7 +180,7 @@ partial class Build
 					Credentials tokenAuth = new(GithubToken);
 					gitHubClient.Credentials = tokenAuth;
 					IReadOnlyList<IssueComment> comments =
-						await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "Mockolate", prId);
+						await gitHubClient.Issue.Comment.GetAllForIssue(BuildExtensions.Owner, BuildExtensions.Repo, prId);
 					long? commentId = null;
 					Log.Information($"Found {comments.Count} comments");
 					foreach (IssueComment comment in comments)
@@ -195,12 +195,12 @@ partial class Build
 					if (commentId == null)
 					{
 						Log.Information($"Create comment:\n{body}");
-						await gitHubClient.Issue.Comment.Create("Testably", "Mockolate", prId, body);
+						await gitHubClient.Issue.Comment.Create(BuildExtensions.Owner, BuildExtensions.Repo, prId, body);
 					}
 					else
 					{
 						Log.Information($"Update comment:\n{body}");
-						await gitHubClient.Issue.Comment.Update("Testably", "Mockolate", commentId.Value, body);
+						await gitHubClient.Issue.Comment.Update(BuildExtensions.Owner, BuildExtensions.Repo, commentId.Value, body);
 					}
 				}
 			}

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -29,7 +29,7 @@ partial class Build
 			string[] lines = File.ReadAllLines(Solution.Directory / "README.md");
 			sb.AppendLine(lines.First());
 			sb.AppendLine(
-				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/aweXpect/Mockolate/releases/tag/v{version})");
+				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/{BuildExtensions.Owner}/{BuildExtensions.Repo}/releases/tag/v{version})");
 			bool foundBadge = false;
 			bool addedImage = false;
 			foreach (string line in lines.Skip(1))
@@ -40,7 +40,7 @@ partial class Build
 					continue;
 				}
 
-				if (line.StartsWith("[![Build](https://github.com/aweXpect/Mockolate/actions/workflows/build.yml") ||
+				if (line.StartsWith($"[![Build](https://github.com/{BuildExtensions.Owner}/{BuildExtensions.Repo}/actions/workflows/build.yml") ||
 				    line.StartsWith("[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure"))
 				{
 					foundBadge = true;
@@ -65,7 +65,7 @@ partial class Build
 				if (foundBadge && string.IsNullOrWhiteSpace(line) && !addedImage)
 				{
 					sb.AppendLine();
-					sb.AppendLine("![Mockolate logo](https://raw.githubusercontent.com/aweXpect/Mockolate/main/Docs/logo_256x256.png)  ");
+					sb.AppendLine($"![Mockolate logo](https://raw.githubusercontent.com/{BuildExtensions.Owner}/{BuildExtensions.Repo}/main/Docs/logo_256x256.png)  ");
 					addedImage = true;
 				}
 

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -15,7 +15,7 @@ namespace Build;
 
 public static class BuildExtensions
 {
-	private const string RepositoryApiBaseUrl = "https://api.github.com/repos/aweXpect/Mockolate";
+x	private const string RepositoryApiBaseUrl = "https://api.github.com/repos/Testably/Mockolate";
 
 	public static SonarScannerBeginSettings SetPullRequestOrBranchName(
 		this SonarScannerBeginSettings settings,

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -15,7 +15,9 @@ namespace Build;
 
 public static class BuildExtensions
 {
-x	private const string RepositoryApiBaseUrl = "https://api.github.com/repos/Testably/Mockolate";
+	internal const string Owner = "Testably";
+	internal const string Repo = "Mockolate";
+	private const string RepositoryApiBaseUrl = "https://api.github.com/repos/" + Owner + "/" + Repo;
 
 	public static SonarScannerBeginSettings SetPullRequestOrBranchName(
 		this SonarScannerBeginSettings settings,

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 <img align="right" width="200" src="Docs/logo_256x256.png" alt="Mockolate logo" />
 
 [![Nuget](https://img.shields.io/nuget/v/Mockolate)](https://www.nuget.org/packages/Mockolate)
-[![Build](https://github.com/aweXpect/Mockolate/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/Mockolate/actions/workflows/build.yml)
+[![Build](https://github.com/Testably/Mockolate/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/Mockolate/actions/workflows/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_Mockolate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_Mockolate)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_Mockolate&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_Mockolate)
-[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FMockolate%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/Mockolate/main)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FMockolate%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Mockolate/main)
 
 **Mockolate** is a modern, strongly-typed, AOT-compatible mocking library for .NET, powered by source generators.
 It enables fast, compile-time validated mocking with .NET Standard 2.0, .NET 8, .NET 10 and .NET Framework 4.8.
@@ -29,7 +29,7 @@ It enables fast, compile-time validated mocking with .NET Standard 2.0, .NET 8, 
 For side-by-side setup, usage, and verification syntax against Moq, NSubstitute, and FakeItEasy, see the
 [full code comparison](https://awexpect.com/docs/mockolate/comparison).
 
-Already on Moq or NSubstitute? The companion package [`Mockolate.Migration`](https://github.com/aweXpect/Mockolate.Migration)
+Already on Moq or NSubstitute? The companion package [`Mockolate.Migration`](https://github.com/Testably/Mockolate.Migration)
 ships analyzers and code fixers that translate common Moq and NSubstitute patterns to Mockolate syntax in-place: point it
 at an existing test project and apply the suggested fixes.
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -7,7 +7,7 @@
 		<Authors>Mockolate</Authors>
 		<Description>A modern, strongly-typed, AOT-compatible mocking library for .NET, powered by source generators.</Description>
 		<Copyright>Copyright (c) 2025 - $([System.DateTime]::Now.ToString('yyyy')) Valentin Breuß</Copyright>
-		<RepositoryUrl>https://github.com/aweXpect/Mockolate.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Testably/Mockolate.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -1,6 +1,6 @@
 [assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
 [assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/Mockolate.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Mockolate.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Mockolate.Internal.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100917b2e28a0dcd1de99a208f70383c300caa03729b1f9cdad97cb11a127f822aa36aad08225cc24312de1fadf3aeafc7ab6c2c4b588d5e88c2b61f0a56e02df1b6aa11d0c3e4ee6675f24b20dbd75ee4fc229f82b0eeeafe1a5bc376d5e5f9a5c4320267921d9a962cc5f58ccc94e7127db3119bafedfb76fd3a7b1f2d22155ac")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace Mockolate.Behavior

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -1,5 +1,5 @@
 [assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/Mockolate.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Mockolate.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Mockolate.Internal.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100917b2e28a0dcd1de99a208f70383c300caa03729b1f9cdad97cb11a127f822aa36aad08225cc24312de1fadf3aeafc7ab6c2c4b588d5e88c2b61f0a56e02df1b6aa11d0c3e4ee6675f24b20dbd75ee4fc229f82b0eeeafe1a5bc376d5e5f9a5c4320267921d9a962cc5f58ccc94e7127db3119bafedfb76fd3a7b1f2d22155ac")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace Mockolate.Behavior

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/Mockolate.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Mockolate.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Mockolate.Internal.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100917b2e28a0dcd1de99a208f70383c300caa03729b1f9cdad97cb11a127f822aa36aad08225cc24312de1fadf3aeafc7ab6c2c4b588d5e88c2b61f0a56e02df1b6aa11d0c3e4ee6675f24b20dbd75ee4fc229f82b0eeeafe1a5bc376d5e5f9a5c4320267921d9a962cc5f58ccc94e7127db3119bafedfb76fd3a7b1f2d22155ac")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Mockolate.Behavior


### PR DESCRIPTION
Updates CI/build automation to reflect the repository move from `aweXpect/Mockolate` to `Testably/Mockolate`, aligning GitHub API usage and workflows with the new org.

**Changes:**
- Update GitHub API base URL and PR-comment posting targets to `Testably/Mockolate` in Pipeline build scripts.
- Remove the in-workflow docs-site dispatch job from `build.yml` (docs notification is handled via a dedicated workflow).
- Normalize `Mockolate.slnx` XML formatting and include the docs-site notification workflow file.