### PR TITLE
refactor: update SonarCloud project key references from aweXpect to Testably

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/summary/overall?id=aweXpect_Mockolate&branch=main) with quality gate requiring
+using [SonarCloud](https://sonarcloud.io/summary/overall?id=Testably_Mockolate&branch=main) with quality gate requiring
 to
 
 - solve all issues reported by SonarCloud

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -17,7 +17,7 @@ partial class Build
 		{
 			SonarScannerTasks.SonarScannerBegin(s => s
 				.SetOrganization("awexpect")
-				.SetProjectKey("aweXpect_Mockolate")
+				.SetProjectKey("Testably_Mockolate")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, GitVersion)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Nuget](https://img.shields.io/nuget/v/Mockolate)](https://www.nuget.org/packages/Mockolate)
 [![Build](https://github.com/Testably/Mockolate/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/Mockolate/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_Mockolate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_Mockolate)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_Mockolate&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_Mockolate)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_Mockolate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_Mockolate)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_Mockolate&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_Mockolate)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FMockolate%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Mockolate/main)
 
 **Mockolate** is a modern, strongly-typed, AOT-compatible mocking library for .NET, powered by source generators.


### PR DESCRIPTION
This pull request updates all references to the SonarCloud project from the old `aweXpect_Mockolate` identifier to the new `Testably_Mockolate` identifier, ensuring consistency across documentation, build scripts, and badges.

**SonarCloud project reference updates:**

* Updated SonarCloud badge URLs in `README.md` to use the `Testably_Mockolate` project identifier instead of `aweXpect_Mockolate`.
* Changed the SonarCloud project key in the static code analysis section of `CONTRIBUTING.md` to `Testably_Mockolate`.
* Modified the `Build.CodeAnalysis.cs` pipeline script to set the SonarCloud project key to `Testably_Mockolate`.