### PR TITLE
fix: update URLs from aweXpect to testably in documentation and code references

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/CallbackBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CallbackBenchmarks.cs
@@ -16,7 +16,7 @@ namespace Mockolate.Benchmarks;
 public class CallbackBenchmarks : BenchmarksBase
 {
 	/// <summary>
-	///     <see href="https://awexpect.com/Mockolate" />
+	///     <see href="https://docs.testably.org/Mockolate" />
 	/// </summary>
 	[Benchmark(Baseline = true)]
 	public int Callback_Mockolate()

--- a/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
@@ -19,7 +19,7 @@ namespace Mockolate.Benchmarks;
 public class CompleteEventBenchmarks : BenchmarksBase
 {
 	/// <summary>
-	///     <see href="https://awexpect.com/Mockolate" />
+	///     <see href="https://docs.testably.org/Mockolate" />
 	/// </summary>
 	[Benchmark(Baseline = true)]
 	public void Event_Mockolate()

--- a/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteIndexerBenchmarks.cs
@@ -20,7 +20,7 @@ public class CompleteIndexerBenchmarks : BenchmarksBase
 	[Params(1, 10)] public int N { get; set; }
 
 	/// <summary>
-	///     <see href="https://awexpect.com/Mockolate" />
+	///     <see href="https://docs.testably.org/Mockolate" />
 	/// </summary>
 	[Benchmark(Baseline = true)]
 	public void Indexer_Mockolate()

--- a/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteMethodBenchmarks.cs
@@ -20,7 +20,7 @@ public class CompleteMethodBenchmarks : BenchmarksBase
 	[Params(1, 10)] public int N { get; set; }
 
 	/// <summary>
-	///     <see href="https://awexpect.com/Mockolate" />
+	///     <see href="https://docs.testably.org/Mockolate" />
 	/// </summary>
 	[Benchmark(Baseline = true)]
 	public void Method_Mockolate()

--- a/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompletePropertyBenchmarks.cs
@@ -20,7 +20,7 @@ public class CompletePropertyBenchmarks : BenchmarksBase
 	[Params(1, 10)] public int N { get; set; }
 
 	/// <summary>
-	///     <see href="https://awexpect.com/Mockolate" />
+	///     <see href="https://docs.testably.org/Mockolate" />
 	/// </summary>
 	[Benchmark(Baseline = true)]
 	public void Property_Mockolate()

--- a/Docs/pages/04-verify-interactions.md
+++ b/Docs/pages/04-verify-interactions.md
@@ -35,7 +35,7 @@ In both cases, it will block the test execution until the expected interaction o
 If the interaction does not occur within the specified time, a `MockVerificationException` will be thrown.
 
 If you need truly asynchronous verification without blocking the test thread, you can use the
-[aweXpect.Mockolate](https://awexpect.com/aweXpect.Mockolate) extension package which has an asynchronous `Within(TimeSpan)` variant.
+[aweXpect.Mockolate](https://docs.testably.org/extensions/aweXpect.Mockolate) extension package which has an asynchronous `Within(TimeSpan)` variant.
 
 ## Properties
 

--- a/Docs/pages/setup/01-properties.md
+++ b/Docs/pages/setup/01-properties.md
@@ -77,4 +77,4 @@ sut.Mock.Setup.TotalDispensed.OnGet
 - Use `.SkippingBaseClass(…)` to override the base class behavior for a specific property (only for class mocks).
 - All callbacks and return values support more advanced features like conditional execution, frequency control,
   parallel execution, and access to the invocation counter.
-  See [Advanced callback features](https://docs.testably.org/mockolate/advanced-features/advanced-callback-features) for details.
+  See [Advanced callback features](../advanced-features/advanced-callback-features) for details.

--- a/Docs/pages/setup/01-properties.md
+++ b/Docs/pages/setup/01-properties.md
@@ -77,4 +77,4 @@ sut.Mock.Setup.TotalDispensed.OnGet
 - Use `.SkippingBaseClass(…)` to override the base class behavior for a specific property (only for class mocks).
 - All callbacks and return values support more advanced features like conditional execution, frequency control,
   parallel execution, and access to the invocation counter.
-  See [Advanced callback features](https://awexpect.com/docs/mockolate/advanced-features/advanced-callback-features) for details.
+  See [Advanced callback features](https://docs.testably.org/mockolate/advanced-features/advanced-callback-features) for details.

--- a/Docs/pages/setup/02-methods.md
+++ b/Docs/pages/setup/02-methods.md
@@ -66,4 +66,4 @@ sut.Mock.Setup.Dispense(It.Is("White"), It.IsAny<int>())
 - When you specify overlapping setups, the most recently defined setup takes precedence.
 - All callbacks and return values support more advanced features like conditional execution, frequency control,
   parallel execution, and access to the invocation counter.
-  See [Advanced callback features](https://docs.testably.org/mockolate/advanced-features/advanced-callback-features) for details.
+  See [Advanced callback features](../advanced-features/advanced-callback-features) for details.

--- a/Docs/pages/setup/02-methods.md
+++ b/Docs/pages/setup/02-methods.md
@@ -66,4 +66,4 @@ sut.Mock.Setup.Dispense(It.Is("White"), It.IsAny<int>())
 - When you specify overlapping setups, the most recently defined setup takes precedence.
 - All callbacks and return values support more advanced features like conditional execution, frequency control,
   parallel execution, and access to the invocation counter.
-  See [Advanced callback features](https://awexpect.com/docs/mockolate/advanced-features/advanced-callback-features) for details.
+  See [Advanced callback features](https://docs.testably.org/mockolate/advanced-features/advanced-callback-features) for details.

--- a/Docs/pages/setup/03-indexers.md
+++ b/Docs/pages/setup/03-indexers.md
@@ -77,10 +77,10 @@ sut.Mock.Setup[It.IsAny<string>()].OnGet
 
 - All callbacks support more advanced features like conditional execution, frequency control, parallel execution, and
   access to the invocation counter.
-  See [Advanced callback features](https://docs.testably.org/mockolate/advanced-features/advanced-callback-features) for
+  See [Advanced callback features](../advanced-features/advanced-callback-features) for
   details.
-- You can use the same [parameter matching](https://docs.testably.org/mockolate/setup/parameter-matching)
-  and [interaction](https://docs.testably.org/mockolate/setup/parameter-matching#parameter-interaction) options as for
+- You can use the same [parameter matching](parameter-matching)
+  and [interaction](parameter-matching#parameter-interaction) options as for
   methods.
 - Use `.SkippingBaseClass(…)` to override the base class behavior for a specific indexer (only for class mocks).
 - When you specify overlapping setups, the most recently defined setup takes precedence.

--- a/Docs/pages/setup/03-indexers.md
+++ b/Docs/pages/setup/03-indexers.md
@@ -77,10 +77,10 @@ sut.Mock.Setup[It.IsAny<string>()].OnGet
 
 - All callbacks support more advanced features like conditional execution, frequency control, parallel execution, and
   access to the invocation counter.
-  See [Advanced callback features](https://awexpect.com/docs/mockolate/advanced-features/advanced-callback-features) for
+  See [Advanced callback features](https://docs.testably.org/mockolate/advanced-features/advanced-callback-features) for
   details.
-- You can use the same [parameter matching](https://awexpect.com/docs/mockolate/setup/parameter-matching)
-  and [interaction](https://awexpect.com/docs/mockolate/setup/parameter-matching#parameter-interaction) options as for
+- You can use the same [parameter matching](https://docs.testably.org/mockolate/setup/parameter-matching)
+  and [interaction](https://docs.testably.org/mockolate/setup/parameter-matching#parameter-interaction) options as for
   methods.
 - Use `.SkippingBaseClass(…)` to override the base class behavior for a specific indexer (only for class mocks).
 - When you specify overlapping setups, the most recently defined setup takes precedence.

--- a/Docs/pages/special-types/01-httpclient.md
+++ b/Docs/pages/special-types/01-httpclient.md
@@ -13,14 +13,14 @@ httpClient.Mock.Setup
         It.IsHttpContent())
     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
-HttpResponseMessage result = await httpClient.PostAsync("https://aweXpect.com/api/chocolate/dispense",
+HttpResponseMessage result = await httpClient.PostAsync("https://testably.org/api/chocolate/dispense",
     new StringContent("""
                       { "type": "Dark", "amount": 3 }
                       """, Encoding.UTF8, "application/json"));
 
 await That(result.IsSuccessStatusCode).IsTrue();
 httpClient.Mock.Verify.PostAsync(
-    It.IsUri("*aweXpect.com/api/chocolate/dispense*").ForHttps(),
+    It.IsUri("*testably.org/api/chocolate/dispense*").ForHttps(),
     It.IsHttpContent("application/json").WithStringMatching("*\"type\": \"Dark\"*\"amount\": 3*")).Once();
 ```
 
@@ -86,12 +86,12 @@ Filter requests by URI scheme using `.ForHttps()` or `.ForHttp()`:
 ```csharp
 // Match only HTTPS requests
 httpClient.Mock.Verify
-    .GetAsync(It.IsUri("*aweXpect.com*").ForHttps())
+    .GetAsync(It.IsUri("*testably.org*").ForHttps())
     .Once();
 
 // Match only HTTP requests
 httpClient.Mock.Verify
-    .GetAsync(It.IsUri("*aweXpect.com*").ForHttp())
+    .GetAsync(It.IsUri("*testably.org*").ForHttp())
     .Never();
 ```
 
@@ -101,7 +101,7 @@ Filter requests by host using `.WithHost(string)`. You can provide a wildcard pa
 
 ```csharp
 httpClient.Mock.Verify
-    .GetAsync(It.IsUri().WithHost("*aweXpect.com*"))
+    .GetAsync(It.IsUri().WithHost("*testably.org*"))
     .Once();
 ```
 

--- a/Docs/pages/special-types/02-delegates.md
+++ b/Docs/pages/special-types/02-delegates.md
@@ -43,7 +43,7 @@ processor.Mock.Setup(It.IsAny<int>(), It.IsRef<int>(v => v + 1), It.IsOut(() => 
 - Use `.Returns(…)` to specify the return value for `Func<T>` delegates.
 - Use `.Throws(…)` to specify an exception to throw.
 - Use `.Returns(…)` and `.Throws(…)` repeatedly to define a sequence of behaviors.
-- Full [parameter matching](https://docs.testably.org/mockolate/setup/parameter-matching) support for delegate
+- Full [parameter matching](../setup/parameter-matching) support for delegate
   parameters including `ref` and `out` parameters.
 
 ## Verification
@@ -89,4 +89,4 @@ processor.Mock.Verify(It.IsAny<int>(), It.IsRef<int>(), It.IsOut<int>()).Once();
 
 **Note:**  
 Delegate parameters also
-support [argument matchers](https://docs.testably.org/mockolate/verify-interactions#argument-matchers).
+support [argument matchers](../verify-interactions#argument-matchers).

--- a/Docs/pages/special-types/02-delegates.md
+++ b/Docs/pages/special-types/02-delegates.md
@@ -43,7 +43,7 @@ processor.Mock.Setup(It.IsAny<int>(), It.IsRef<int>(v => v + 1), It.IsOut(() => 
 - Use `.Returns(…)` to specify the return value for `Func<T>` delegates.
 - Use `.Throws(…)` to specify an exception to throw.
 - Use `.Returns(…)` and `.Throws(…)` repeatedly to define a sequence of behaviors.
-- Full [parameter matching](https://awexpect.com/docs/mockolate/setup#parameter-matching) support for delegate
+- Full [parameter matching](https://docs.testably.org/mockolate/setup/parameter-matching) support for delegate
   parameters including `ref` and `out` parameters.
 
 ## Verification
@@ -89,4 +89,4 @@ processor.Mock.Verify(It.IsAny<int>(), It.IsRef<int>(), It.IsOut<int>()).Once();
 
 **Note:**  
 Delegate parameters also
-support [argument matchers](https://awexpect.com/docs/mockolate/verify-interactions#argument-matchers).
+support [argument matchers](https://docs.testably.org/mockolate/verify-interactions#argument-matchers).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It enables fast, compile-time validated mocking with .NET Standard 2.0, .NET 8, 
 | Hot path       | dynamic-proxy dispatch                       | direct dispatch            |
 
 For side-by-side setup, usage, and verification syntax against Moq, NSubstitute, and FakeItEasy, see the
-[full code comparison](https://awexpect.com/docs/mockolate/comparison).
+[full code comparison](https://docs.testably.org/mockolate/comparison).
 
 Already on Moq or NSubstitute? The companion package [`Mockolate.Migration`](https://github.com/Testably/Mockolate.Migration)
 ships analyzers and code fixers that translate common Moq and NSubstitute patterns to Mockolate syntax in-place: point it
@@ -800,8 +800,8 @@ In both cases, it will block the test execution until the expected interaction o
 If the interaction does not occur within the specified time, a `MockVerificationException` will be thrown.
 
 If you need truly asynchronous verification without blocking the test thread, you can use the
-[aweXpect.Mockolate](https://awexpect.com/aweXpect.Mockolate) NuGet package, which integrates Mockolate's verification
-API with [aweXpect](https://awexpect.com) and offers an awaitable `Within(TimeSpan)` variant.
+[aweXpect.Mockolate](https://docs.testably.org/extensions/aweXpect.Mockolate/) NuGet package, which integrates Mockolate's verification
+API with [aweXpect](https://docs.testably.org/aweXpect) and offers an awaitable `Within(TimeSpan)` variant.
 
 ### Properties
 
@@ -1258,14 +1258,14 @@ httpClient.Mock.Setup
         It.IsHttpContent())
     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
-HttpResponseMessage result = await httpClient.PostAsync("https://aweXpect.com/api/chocolate/dispense",
+HttpResponseMessage result = await httpClient.PostAsync("https://testably.org/api/chocolate/dispense",
     new StringContent("""
                       { "type": "Dark", "amount": 3 }
                       """, Encoding.UTF8, "application/json"));
 
 await That(result.IsSuccessStatusCode).IsTrue();
 httpClient.Mock.Verify.PostAsync(
-    It.IsUri("*aweXpect.com/api/chocolate/dispense*").ForHttps(),
+    It.IsUri("*testably.org/api/chocolate/dispense*").ForHttps(),
     It.IsHttpContent("application/json").WithStringMatching("*\"type\": \"Dark\"*\"amount\": 3*")).Once();
 ```
 
@@ -1331,12 +1331,12 @@ Filter requests by URI scheme using `.ForHttps()` or `.ForHttp()`:
 ```csharp
 // Match only HTTPS requests
 httpClient.Mock.Verify
-    .GetAsync(It.IsUri("*aweXpect.com*").ForHttps())
+    .GetAsync(It.IsUri("*testably.org*").ForHttps())
     .Once();
 
 // Match only HTTP requests
 httpClient.Mock.Verify
-    .GetAsync(It.IsUri("*aweXpect.com*").ForHttp())
+    .GetAsync(It.IsUri("*testably.org*").ForHttp())
     .Never();
 ```
 
@@ -1346,7 +1346,7 @@ Filter requests by host using `.WithHost(string)`. You can provide a wildcard pa
 
 ```csharp
 httpClient.Mock.Verify
-    .GetAsync(It.IsUri().WithHost("*aweXpect.com*"))
+    .GetAsync(It.IsUri().WithHost("*testably.org*"))
     .Once();
 ```
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -9,6 +9,7 @@
 		<Copyright>Copyright (c) 2025 - $([System.DateTime]::Now.ToString('yyyy')) Valentin Breuß</Copyright>
 		<RepositoryUrl>https://github.com/Testably/Mockolate.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+		<PackageProjectUrl>https://docs.testably.org/Mockolate</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo.png</PackageIcon>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.ReturnsAsyncTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.ReturnsAsyncTests.cs
@@ -21,7 +21,7 @@ public sealed partial class HttpClientExtensionsTests
 				.GetAsync(It.IsAny<Uri>())
 				.ReturnsAsync(statusCode);
 
-			HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 			await That(result.StatusCode).IsEqualTo(statusCode);
 #if NET8_0_OR_GREATER
@@ -43,7 +43,7 @@ public sealed partial class HttpClientExtensionsTests
 				.GetAsync(It.IsAny<Uri>())
 				.ReturnsAsync(statusCode, bytes);
 
-			HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 			await That(result.StatusCode).IsEqualTo(statusCode);
 			await That(result.Content).Is<ByteArrayContent>();
@@ -65,7 +65,7 @@ public sealed partial class HttpClientExtensionsTests
 				.GetAsync(It.IsAny<Uri>())
 				.ReturnsAsync(statusCode, content);
 
-			HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 			await That(result.StatusCode).IsEqualTo(statusCode);
 			await That(result.Content).Is<ByteArrayContent>();
@@ -84,7 +84,7 @@ public sealed partial class HttpClientExtensionsTests
 				.GetAsync(It.IsAny<Uri>())
 				.ReturnsAsync(statusCode, content);
 
-			HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 			await That(result.StatusCode).IsEqualTo(statusCode);
 			await That(result.Content).Is<StringContent>();
@@ -105,7 +105,7 @@ public sealed partial class HttpClientExtensionsTests
 				.GetAsync(It.IsAny<Uri>())
 				.ReturnsAsync(statusCode, bytes, mediaType);
 
-			HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 			await That(result.StatusCode).IsEqualTo(statusCode);
 			await That(result.Content).Is<ByteArrayContent>();
@@ -125,7 +125,7 @@ public sealed partial class HttpClientExtensionsTests
 				.GetAsync(It.IsAny<Uri>())
 				.ReturnsAsync(statusCode, content, mediaType);
 
-			HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 			await That(result.StatusCode).IsEqualTo(statusCode);
 			await That(result.Content).Is<StringContent>();

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.DeleteTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.DeleteTests.cs
@@ -21,11 +21,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.DeleteAsync(It.Matches("*aweXpect.com*"))
+					.DeleteAsync(It.Matches("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -33,9 +33,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", false)]
 			[InlineData("*foo*", false)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, bool expectSuccess)
 			{
@@ -45,7 +45,7 @@ public sealed partial class HttpClientExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -59,12 +59,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.DeleteAsync(
-						It.Matches("*aweXpect.com*"),
+						It.Matches("*testably.org*"),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(tokenMatches ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -78,7 +78,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.DeleteAsync(It.Matches("*aweXpect.com*"))
+						.DeleteAsync(It.Matches("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 
@@ -96,11 +96,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.DeleteAsync(It.IsUri("*aweXpect.com*"))
+					.DeleteAsync(It.IsUri("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -108,9 +108,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", true)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{
@@ -120,7 +120,7 @@ public sealed partial class HttpClientExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -134,12 +134,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.DeleteAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(tokenMatches ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -153,7 +153,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.DeleteAsync(It.IsUri("*aweXpect.com*"))
+						.DeleteAsync(It.IsUri("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.GetTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.GetTests.cs
@@ -21,11 +21,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.GetAsync(It.Matches("*aweXpect.com*"))
+					.GetAsync(It.Matches("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -33,9 +33,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", false)]
 			[InlineData("*foo*", false)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, bool expectSuccess)
 			{
@@ -45,7 +45,7 @@ public sealed partial class HttpClientExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -59,12 +59,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.GetAsync(
-						It.Matches("*aweXpect.com*"),
+						It.Matches("*testably.org*"),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(tokenMatches ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -78,7 +78,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.GetAsync(It.Matches("*aweXpect.com*"))
+						.GetAsync(It.Matches("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 
@@ -96,11 +96,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.GetAsync(It.IsUri("*aweXpect.com*"))
+					.GetAsync(It.IsUri("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -108,9 +108,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", true)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{
@@ -120,7 +120,7 @@ public sealed partial class HttpClientExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -134,12 +134,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.GetAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(tokenMatches ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -153,7 +153,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.GetAsync(It.IsUri("*aweXpect.com*"))
+						.GetAsync(It.IsUri("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PatchTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PatchTests.cs
@@ -25,7 +25,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PatchAsync(It.IsAny<string>(), It.IsHttpContent("application/json"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PatchAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent("", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -43,11 +43,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.PatchAsync(It.Matches("*aweXpect.com*"))
+					.PatchAsync(It.Matches("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -55,9 +55,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", false)]
 			[InlineData("*foo*", false)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, bool expectSuccess)
 			{
@@ -66,7 +66,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PatchAsync(It.Matches(pattern))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PatchAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -82,12 +82,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.PatchAsync(
-						It.Matches("*aweXpect.com*"),
+						It.Matches("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PatchAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -103,7 +103,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.PatchAsync(It.Matches("*aweXpect.com*"))
+						.PatchAsync(It.Matches("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 
@@ -123,7 +123,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PatchAsync(It.IsAny<Uri>(), It.IsHttpContent("application/json"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PatchAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent("", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -141,11 +141,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.PatchAsync(It.IsUri("*aweXpect.com*"))
+					.PatchAsync(It.IsUri("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -153,9 +153,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", true)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{
@@ -164,7 +164,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PatchAsync(It.IsUri(pattern))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PatchAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -180,12 +180,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.PatchAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PatchAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -201,7 +201,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.PatchAsync(It.IsUri("*aweXpect.com*"))
+						.PatchAsync(It.IsUri("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PostTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PostTests.cs
@@ -24,7 +24,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PostAsync(It.IsAny<string>(), It.IsHttpContent("application/json"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent("", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -41,11 +41,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.PostAsync(It.Matches("*aweXpect.com*"))
+					.PostAsync(It.Matches("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -53,9 +53,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", false)]
 			[InlineData("*foo*", false)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, bool expectSuccess)
 			{
@@ -64,7 +64,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PostAsync(It.Matches(pattern))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -80,12 +80,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.PostAsync(
-						It.Matches("*aweXpect.com*"),
+						It.Matches("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -101,7 +101,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.PostAsync(It.Matches("*aweXpect.com*"))
+						.PostAsync(It.Matches("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 
@@ -121,7 +121,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent("application/json"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent("", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -138,11 +138,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.PostAsync(It.IsUri("*aweXpect.com*"))
+					.PostAsync(It.IsUri("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -150,9 +150,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", true)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{
@@ -161,7 +161,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PostAsync(It.IsUri(pattern))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -177,12 +177,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.PostAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -198,7 +198,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.PostAsync(It.IsUri("*aweXpect.com*"))
+						.PostAsync(It.IsUri("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PutTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Setup.PutTests.cs
@@ -24,7 +24,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PutAsync(It.IsAny<string>(), It.IsHttpContent("application/json"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PutAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PutAsync("https://www.testably.org",
 					new StringContent("", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -41,11 +41,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.PutAsync(It.Matches("*aweXpect.com*"))
+					.PutAsync(It.Matches("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -53,9 +53,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", false)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", false)]
 			[InlineData("*foo*", false)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, bool expectSuccess)
 			{
@@ -64,7 +64,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PutAsync(It.Matches(pattern))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PutAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PutAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -80,12 +80,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.PutAsync(
-						It.Matches("*aweXpect.com*"),
+						It.Matches("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PutAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PutAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -101,7 +101,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.PutAsync(It.Matches("*aweXpect.com*"))
+						.PutAsync(It.Matches("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 
@@ -121,7 +121,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PutAsync(It.IsAny<Uri>(), It.IsHttpContent("application/json"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PutAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PutAsync("https://www.testably.org",
 					new StringContent("", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -138,11 +138,11 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.PutAsync(It.IsUri("*aweXpect.com*"))
+					.PutAsync(It.IsUri("*testably.org*"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(result.StatusCode)
@@ -150,9 +150,9 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", true)]
-			[InlineData("*aweXpect.com", true)]
-			[InlineData("aweXpect.com*", true)]
+			[InlineData("*testably.org*", true)]
+			[InlineData("*testably.org", true)]
+			[InlineData("testably.org*", true)]
 			[InlineData("*foo*", false)]
 			public async Task Uri_ShouldVerifyUri(string pattern, bool expectSuccess)
 			{
@@ -161,7 +161,7 @@ public sealed partial class HttpClientExtensionsTests
 					.PutAsync(It.IsUri(pattern))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PutAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PutAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -177,12 +177,12 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.PutAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PutAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PutAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -198,7 +198,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Setup
-						.PutAsync(It.IsUri("*aweXpect.com*"))
+						.PutAsync(It.IsUri("*testably.org*"))
 						.ReturnsAsync(HttpStatusCode.OK);
 				}
 

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.ToStringTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.ToStringTests.cs
@@ -16,11 +16,11 @@ public sealed partial class HttpClientExtensionsTests
 
 			void Act()
 			{
-				httpClient.Mock.Verify.GetAsync(It.Matches("*aweXpect.com*")).Once();
+				httpClient.Mock.Verify.GetAsync(It.Matches("*testably.org*")).Once();
 			}
 
 			await That(Act).Throws<MockVerificationException>()
-				.WithMessage("*GET-Request with Uri matching It.Matches(\"*aweXpect.com*\")*").AsWildcard();
+				.WithMessage("*GET-Request with Uri matching It.Matches(\"*testably.org*\")*").AsWildcard();
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.DeleteTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.DeleteTests.cs
@@ -22,7 +22,7 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.DeleteAsync(
@@ -31,15 +31,15 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 0)]
 			[InlineData("*foo*", 0)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.DeleteAsync(
 						It.Matches(pattern),
@@ -54,7 +54,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.DeleteAsync(
 						It.Matches("*"),
@@ -70,7 +70,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.DeleteAsync(It.Matches("*aweXpect.com*")).Never();
+						.DeleteAsync(It.Matches("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()
@@ -88,24 +88,24 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.DeleteAsync(
-						It.IsUri("*aweXpect.com*")))
+						It.IsUri("*testably.org*")))
 					.Exactly(expected);
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 1)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.DeleteAsync(
 						It.IsUri(pattern)))
@@ -119,10 +119,10 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.DeleteAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.DeleteAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.DeleteAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.Satisfies<CancellationToken>(_ => tokenMatches)))
 					.Exactly(tokenMatches ? 1 : 0);
 			}
@@ -135,7 +135,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.DeleteAsync(It.IsUri("*aweXpect.com*")).Never();
+						.DeleteAsync(It.IsUri("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.ExpectationMessageTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.ExpectationMessageTests.cs
@@ -18,7 +18,7 @@ public sealed partial class HttpClientExtensionsTests
 
 				void Act()
 				{
-					httpClient.Mock.Verify.DeleteAsync(It.Matches("*aweXpect*")).AtLeastOnce();
+					httpClient.Mock.Verify.DeleteAsync(It.Matches("*testably*")).AtLeastOnce();
 				}
 
 				await That(Act).Throws<MockVerificationException>()
@@ -32,7 +32,7 @@ public sealed partial class HttpClientExtensionsTests
 
 				void Act()
 				{
-					httpClient.Mock.Verify.DeleteAsync(It.IsUri("*aweXpect*")).AtLeastOnce();
+					httpClient.Mock.Verify.DeleteAsync(It.IsUri("*testably*")).AtLeastOnce();
 				}
 
 				await That(Act).Throws<MockVerificationException>()
@@ -46,7 +46,7 @@ public sealed partial class HttpClientExtensionsTests
 
 				void Act()
 				{
-					httpClient.Mock.Verify.PutAsync(It.Matches("*aweXpect*"), It.IsAny<HttpContent>()).AtLeastOnce();
+					httpClient.Mock.Verify.PutAsync(It.Matches("*testably*"), It.IsAny<HttpContent>()).AtLeastOnce();
 				}
 
 				await That(Act).Throws<MockVerificationException>()
@@ -60,7 +60,7 @@ public sealed partial class HttpClientExtensionsTests
 
 				void Act()
 				{
-					httpClient.Mock.Verify.PutAsync(It.IsUri("*aweXpect*"), It.IsAny<HttpContent>()).AtLeastOnce();
+					httpClient.Mock.Verify.PutAsync(It.IsUri("*testably*"), It.IsAny<HttpContent>()).AtLeastOnce();
 				}
 
 				await That(Act).Throws<MockVerificationException>()
@@ -75,7 +75,7 @@ public sealed partial class HttpClientExtensionsTests
 
 				void Act()
 				{
-					httpClient.Mock.Verify.PatchAsync(It.Matches("*aweXpect*"), It.IsAny<HttpContent>()).AtLeastOnce();
+					httpClient.Mock.Verify.PatchAsync(It.Matches("*testably*"), It.IsAny<HttpContent>()).AtLeastOnce();
 				}
 
 				await That(Act).Throws<MockVerificationException>()
@@ -89,7 +89,7 @@ public sealed partial class HttpClientExtensionsTests
 
 				void Act()
 				{
-					httpClient.Mock.Verify.PatchAsync(It.IsUri("*aweXpect*"), It.IsAny<HttpContent>()).AtLeastOnce();
+					httpClient.Mock.Verify.PatchAsync(It.IsUri("*testably*"), It.IsAny<HttpContent>()).AtLeastOnce();
 				}
 
 				await That(Act).Throws<MockVerificationException>()

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.GetTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.GetTests.cs
@@ -22,7 +22,7 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.GetAsync(
@@ -31,15 +31,15 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 0)]
 			[InlineData("*foo*", 0)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.GetAsync(
 						It.Matches(pattern),
@@ -54,7 +54,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.GetAsync(
 						It.Matches("*"),
@@ -70,7 +70,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.GetAsync(It.Matches("*aweXpect.com*")).Never();
+						.GetAsync(It.Matches("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()
@@ -88,24 +88,24 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.GetAsync(
-						It.IsUri("*aweXpect.com*")))
+						It.IsUri("*testably.org*")))
 					.Exactly(expected);
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 1)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.GetAsync(
 						It.IsUri(pattern)))
@@ -119,10 +119,10 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.GetAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.Satisfies<CancellationToken>(_ => tokenMatches)))
 					.Exactly(tokenMatches ? 1 : 0);
 			}
@@ -135,7 +135,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.GetAsync(It.IsUri("*aweXpect.com*")).Never();
+						.GetAsync(It.IsUri("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PatchTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PatchTests.cs
@@ -22,7 +22,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PatchAsync("https://www.aweXpect.com",
+				await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -43,7 +43,7 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PatchAsync(
@@ -53,15 +53,15 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 0)]
 			[InlineData("*foo*", 0)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PatchAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PatchAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PatchAsync(
 						It.Matches(pattern),
@@ -77,7 +77,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PatchAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PatchAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PatchAsync(
 						It.Matches("*"),
@@ -94,7 +94,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.PatchAsync(It.Matches("*aweXpect.com*")).Never();
+						.PatchAsync(It.Matches("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()
@@ -110,12 +110,12 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PatchAsync("https://www.aweXpect.com",
+				await httpClient.PatchAsync("https://www.testably.org",
 					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PatchAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
@@ -131,25 +131,25 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PatchAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>()))
 					.Exactly(expected);
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 1)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PatchAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PatchAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PatchAsync(
 						It.IsUri(pattern),
@@ -164,10 +164,10 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PatchAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PatchAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PatchAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches)))
 					.Exactly(tokenMatches ? 1 : 0);
@@ -181,7 +181,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.PatchAsync(It.IsUri("*aweXpect.com*")).Never();
+						.PatchAsync(It.IsUri("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PostTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PostTests.cs
@@ -21,7 +21,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PostAsync("https://www.aweXpect.com",
+				await httpClient.PostAsync("https://www.testably.org",
 					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -41,7 +41,7 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PostAsync(
@@ -51,15 +51,15 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 0)]
 			[InlineData("*foo*", 0)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PostAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PostAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PostAsync(
 						It.Matches(pattern),
@@ -75,7 +75,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PostAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PostAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PostAsync(
 						It.Matches("*"),
@@ -92,7 +92,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.PostAsync(It.Matches("*aweXpect.com*")).Never();
+						.PostAsync(It.Matches("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()
@@ -108,12 +108,12 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PostAsync("https://www.aweXpect.com",
+				await httpClient.PostAsync("https://www.testably.org",
 					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PostAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
@@ -128,25 +128,25 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PostAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>()))
 					.Exactly(expected);
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 1)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PostAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PostAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PostAsync(
 						It.IsUri(pattern),
@@ -161,10 +161,10 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PostAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PostAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PostAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches)))
 					.Exactly(tokenMatches ? 1 : 0);
@@ -178,7 +178,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.PostAsync(It.IsUri("*aweXpect.com*")).Never();
+						.PostAsync(It.IsUri("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PutTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.Verify.PutTests.cs
@@ -21,7 +21,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PutAsync("https://www.aweXpect.com",
+				await httpClient.PutAsync("https://www.testably.org",
 					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
@@ -41,7 +41,7 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PutAsync(
@@ -51,15 +51,15 @@ public sealed partial class HttpClientExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 0)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 0)]
 			[InlineData("*foo*", 0)]
 			public async Task StringUri_ShouldVerifyUriString(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PutAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PutAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PutAsync(
 						It.Matches(pattern),
@@ -75,7 +75,7 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PutAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PutAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PutAsync(
 						It.Matches("*"),
@@ -92,7 +92,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.PutAsync(It.Matches("*aweXpect.com*")).Never();
+						.PutAsync(It.Matches("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()
@@ -108,12 +108,12 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PutAsync("https://www.aweXpect.com",
+				await httpClient.PutAsync("https://www.testably.org",
 					new StringContent("{}", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PutAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsHttpContent("application/json").WithString("{}")))
 					.Exactly(expected);
 			}
@@ -128,25 +128,25 @@ public sealed partial class HttpClientExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 
 				await httpClient.SendAsync(
-					new HttpRequestMessage(new HttpMethod(method), "https://www.aweXpect.com"),
+					new HttpRequestMessage(new HttpMethod(method), "https://www.testably.org"),
 					CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PutAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>()))
 					.Exactly(expected);
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com*", 1)]
-			[InlineData("*aweXpect.com", 1)]
-			[InlineData("aweXpect.com*", 1)]
+			[InlineData("*testably.org*", 1)]
+			[InlineData("*testably.org", 1)]
+			[InlineData("testably.org*", 1)]
 			[InlineData("*foo*", 0)]
 			public async Task Uri_ShouldVerifyUri(string pattern, int expected)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PutAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PutAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PutAsync(
 						It.IsUri(pattern),
@@ -161,10 +161,10 @@ public sealed partial class HttpClientExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 
-				await httpClient.PutAsync("https://www.aweXpect.com", new StringContent(""), CancellationToken.None);
+				await httpClient.PutAsync("https://www.testably.org", new StringContent(""), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify.PutAsync(
-						It.IsUri("*aweXpect.com*"),
+						It.IsUri("*testably.org*"),
 						It.IsAny<HttpContent>(),
 						It.Satisfies<CancellationToken>(_ => tokenMatches)))
 					.Exactly(tokenMatches ? 1 : 0);
@@ -178,7 +178,7 @@ public sealed partial class HttpClientExtensionsTests
 				void Act()
 				{
 					httpClient.Mock.Verify
-						.PutAsync(It.IsUri("*aweXpect.com*")).Never();
+						.PutAsync(It.IsUri("*testably.org*")).Never();
 				}
 
 				await That(Act).Throws<MockException>()

--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
@@ -37,10 +37,10 @@ public sealed partial class HttpClientExtensionsTests
 	{
 		HttpClient httpClient = HttpClient.CreateMock();
 		IMethodSetup setup = httpClient
-			.Mock.Setup.GetAsync(It.IsUri("https://www.aweXpect.com"))
+			.Mock.Setup.GetAsync(It.IsUri("https://www.testably.org"))
 			.ReturnsAsync(HttpStatusCode.Accepted);
 		HttpResponseMessage result =
-			await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 		await That(result.StatusCode)
 			.IsEqualTo(HttpStatusCode.Accepted);
@@ -138,20 +138,20 @@ public sealed partial class HttpClientExtensionsTests
 				.Monitor(out IParameterMonitor<string> monitor))
 			.ReturnsAsync(HttpStatusCode.OK);
 
-		await httpClient.GetAsync("https://www.aweXpect.com/foo", CancellationToken.None);
-		await httpClient.PostAsync("https://www.aweXpect.com/bar", null, CancellationToken.None);
-		await httpClient.GetAsync("https://www.aweXpect.com/baz", CancellationToken.None);
+		await httpClient.GetAsync("https://www.testably.org/foo", CancellationToken.None);
+		await httpClient.PostAsync("https://www.testably.org/bar", null, CancellationToken.None);
+		await httpClient.GetAsync("https://www.testably.org/baz", CancellationToken.None);
 
 		await That(monitor.Values).IsEqualTo([
-			"https://www.awexpect.com/foo",
-			"https://www.awexpect.com/baz",
+			"https://www.testably.org/foo",
+			"https://www.testably.org/baz",
 		]);
 		await That(callbackCount).IsEqualTo(2);
 	}
 
 	[Theory]
-	[InlineData("*aweXpect.com")]
-	[InlineData("*aweXpect.com/")]
+	[InlineData("*testably.org")]
+	[InlineData("*testably.org/")]
 	public async Task TrailingSlash_ShouldBeIgnored(string matchPattern)
 	{
 		HttpClient httpClient = HttpClient.CreateMock();
@@ -160,7 +160,7 @@ public sealed partial class HttpClientExtensionsTests
 			.ReturnsAsync(HttpStatusCode.OK);
 
 		HttpResponseMessage result =
-			await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+			await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 		await That(result.StatusCode)
 			.IsEqualTo(HttpStatusCode.OK);
@@ -171,11 +171,11 @@ public sealed partial class HttpClientExtensionsTests
 	{
 		HttpClient httpClient = HttpClient.CreateMock();
 		httpClient.Mock.Setup
-			.GetAsync(It.Matches("*www.aweXpect.com/foo/"))
+			.GetAsync(It.Matches("*www.testably.org/foo/"))
 			.ReturnsAsync(HttpStatusCode.OK);
 
 		HttpResponseMessage result =
-			await httpClient.GetAsync("https://www.aweXpect.com/foo", CancellationToken.None);
+			await httpClient.GetAsync("https://www.testably.org/foo", CancellationToken.None);
 
 		await That(result.StatusCode)
 			.IsEqualTo(HttpStatusCode.NotImplemented);

--- a/Tests/Mockolate.Tests/Web/HttpClientTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientTests.cs
@@ -16,10 +16,10 @@ public class HttpClientTests
 		HttpClient client1 = HttpClient.CreateMock([handler,]);
 		HttpClient client2 = HttpClient.CreateMock([handler,]);
 		IMethodSetup setup = client1.Mock.Setup
-			.GetAsync(It.IsUri("aweXpect.com"))
+			.GetAsync(It.IsUri("testably.org"))
 			.ReturnsAsync(HttpStatusCode.Accepted);
 
-		HttpResponseMessage response = await client2.GetAsync("https://aweXpect.com", CancellationToken.None);
+		HttpResponseMessage response = await client2.GetAsync("https://testably.org", CancellationToken.None);
 
 		await That(response.StatusCode).IsEqualTo(HttpStatusCode.Accepted);
 		await That(client1.Mock.VerifySetup(setup)).Once();

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithBytesTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithBytesTests.cs
@@ -20,7 +20,7 @@ public sealed partial class ItExtensionsTests
 					1, 2, 3,
 				};
 
-				await httpClient.PostAsync("https://aweXpect.com", new ByteArrayContent(payload), CancellationToken.None);
+				await httpClient.PostAsync("https://testably.org", new ByteArrayContent(payload), CancellationToken.None);
 
 				// The first WithBytes predicate matches (length == 3) while the second does not.
 				// Original (??=): first wins, verification succeeds.
@@ -63,7 +63,7 @@ public sealed partial class ItExtensionsTests
 						It.IsHttpContent().WithBytes(b => b.Length > 0 && b[0] == expectedFirstByte))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new ByteArrayContent(body),
 					CancellationToken.None);
 
@@ -108,7 +108,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithBytes(expected))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new ByteArrayContent(body),
 					CancellationToken.None);
 
@@ -126,7 +126,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient
-					.PostAsync("https://www.aweXpect.com", new ByteArrayContent(body), CancellationToken.None);
+					.PostAsync("https://www.testably.org", new ByteArrayContent(body), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify
 						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithBytes(body)))

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithFormDataTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithFormDataTests.cs
@@ -47,7 +47,7 @@ public sealed partial class ItExtensionsTests
 				};
 
 				HttpResponseMessage result =
-					await httpClient.PostAsync("https://www.aweXpect.com", content, CancellationToken.None);
+					await httpClient.PostAsync("https://www.testably.org", content, CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -72,7 +72,7 @@ public sealed partial class ItExtensionsTests
 				};
 
 				HttpResponseMessage result =
-					await httpClient.PostAsync("https://www.aweXpect.com", content, CancellationToken.None);
+					await httpClient.PostAsync("https://www.testably.org", content, CancellationToken.None);
 
 				await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
 			}
@@ -109,7 +109,7 @@ public sealed partial class ItExtensionsTests
 				};
 
 				HttpResponseMessage result =
-					await httpClient.PostAsync("https://www.aweXpect.com", content, CancellationToken.None);
+					await httpClient.PostAsync("https://www.testably.org", content, CancellationToken.None);
 
 				await That(httpClient.Mock.Verify
 						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithFormData(values)))
@@ -148,7 +148,7 @@ public sealed partial class ItExtensionsTests
 				};
 
 				HttpResponseMessage result =
-					await httpClient.PostAsync("https://www.aweXpect.com", content, CancellationToken.None);
+					await httpClient.PostAsync("https://www.testably.org", content, CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectMatch ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -189,7 +189,7 @@ public sealed partial class ItExtensionsTests
 				};
 
 				HttpResponseMessage result =
-					await httpClient.PostAsync("https://www.aweXpect.com", content, CancellationToken.None);
+					await httpClient.PostAsync("https://www.testably.org", content, CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectMatch ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithHeadersTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithHeadersTests.cs
@@ -24,7 +24,7 @@ public sealed partial class ItExtensionsTests
 				StringContent content = new("");
 				content.Headers.Add("foo", "my-value");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -43,7 +43,7 @@ public sealed partial class ItExtensionsTests
 				StringContent content = new("");
 				content.Headers.Add("foo", "my-value");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -68,7 +68,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("x-myHeader2", "bar");
 				content.Headers.Add("x-myHeader3", "baz");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -94,7 +94,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("x-myHeader2", "bar");
 				content.Headers.Add("x-myHeader3", "baz");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -120,7 +120,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("x-myHeader2", "bar");
 				content.Headers.Add("x-myHeader3", "baz");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -140,7 +140,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("x-myHeader", "bar");
 				content.Headers.Add("x-myHeader", "baz");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -160,7 +160,7 @@ public sealed partial class ItExtensionsTests
 				StringContent content = new("");
 				content.Headers.Add(key, "my-value");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -181,7 +181,7 @@ public sealed partial class ItExtensionsTests
 				StringContent content = new("");
 				content.Headers.Add("x-myHeader", value);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -207,7 +207,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("bar", "my-bar-value");
 				content.Headers.Add("baz", "my-baz-value");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -233,7 +233,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("x-myHeader2", "bar");
 				content.Headers.Add("x-myHeader3", "baz");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -266,7 +266,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("x-myHeader2", "bar");
 				content.Headers.Add("x-myHeader3", "baz");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithMediaTypeTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithMediaTypeTests.cs
@@ -23,7 +23,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithMediaType("application/json"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent("", Encoding.UTF8, mediaType),
 					CancellationToken.None);
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringMatchingTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringMatchingTests.cs
@@ -25,7 +25,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithStringMatching(pattern).AsRegex().IgnoringCase())
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -44,7 +44,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithStringMatching(pattern).AsRegex())
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -61,7 +61,7 @@ public sealed partial class ItExtensionsTests
 						It.IsHttpContent().WithStringMatching("F[A-Z]*").AsRegex(RegexOptions.IgnoreCase))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent("foo"),
 					CancellationToken.None);
 
@@ -79,7 +79,7 @@ public sealed partial class ItExtensionsTests
 
 				Task Act()
 				{
-					return httpClient.PostAsync("https://www.aweXpect.com",
+					return httpClient.PostAsync("https://www.testably.org",
 						new StringContent("foo"),
 						CancellationToken.None);
 				}
@@ -104,7 +104,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithStringMatching(pattern).IgnoringCase())
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -129,7 +129,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithStringMatching(pattern))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -162,7 +162,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), isHttpContent)
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithStringTests.cs
@@ -28,7 +28,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString(expected).Exactly().IgnoringCase())
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -49,7 +49,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString(expected).Exactly())
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -71,7 +71,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString(expected).IgnoringCase())
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -93,7 +93,7 @@ public sealed partial class ItExtensionsTests
 						.WithString(c => c.Equals(c.ToLowerInvariant(), StringComparison.Ordinal)))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(content),
 					CancellationToken.None);
 
@@ -114,7 +114,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString(expected))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -132,7 +132,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString("foo"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new ByteArrayContent(bytes),
 					CancellationToken.None);
 
@@ -158,7 +158,7 @@ public sealed partial class ItExtensionsTests
 
 				foreach (StringContent response in responses)
 				{
-					await httpClient.PostAsync("https://www.aweXpect.com", response, CancellationToken.None);
+					await httpClient.PostAsync("https://www.testably.org", response, CancellationToken.None);
 				}
 
 #if !NETFRAMEWORK
@@ -181,7 +181,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 				StringContent content = new("foo", Encoding.UTF8, "text/plain");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -203,7 +203,7 @@ public sealed partial class ItExtensionsTests
 				ByteArrayContent content = new(bytes);
 
 				HttpResponseMessage result = await httpClient.PostAsync(
-					"https://www.aweXpect.com", content, CancellationToken.None);
+					"https://www.testably.org", content, CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(HttpStatusCode.OK);
@@ -229,7 +229,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("Content-Type", $"text/plain; charset={charsetHeader}");
 
 				HttpResponseMessage result = await httpClient.PostAsync(
-					"https://www.aweXpect.com", content, CancellationToken.None);
+					"https://www.testably.org", content, CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -244,7 +244,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient
-					.PostAsync("https://www.aweXpect.com", new StringContent("foo"), CancellationToken.None);
+					.PostAsync("https://www.testably.org", new StringContent("foo"), CancellationToken.None);
 
 				await That(httpClient.Mock.Verify
 						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithString("foo")))
@@ -271,7 +271,7 @@ public sealed partial class ItExtensionsTests
 				};
 
 				HttpResponseMessage result = await httpClient.PostAsync(
-					"https://www.aweXpect.com", content, CancellationToken.None);
+					"https://www.testably.org", content, CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(HttpStatusCode.OK);
@@ -302,7 +302,7 @@ public sealed partial class ItExtensionsTests
 					.PostAsync(It.IsAny<Uri>(), isHttpContent)
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.cs
@@ -95,7 +95,7 @@ public sealed partial class ItExtensionsTests
 
 			foreach (ByteArrayContent response in responses)
 			{
-				await httpClient.PostAsync("https://www.aweXpect.com", response, CancellationToken.None);
+				await httpClient.PostAsync("https://www.testably.org", response, CancellationToken.None);
 			}
 
 #if !NETFRAMEWORK
@@ -121,7 +121,7 @@ public sealed partial class ItExtensionsTests
 			ByteArrayContent content = new(bytes);
 			content.Headers.Add("x-my-header", "my-value");
 
-			HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+			HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 				content,
 				CancellationToken.None);
 
@@ -141,7 +141,7 @@ public sealed partial class ItExtensionsTests
 			ByteArrayContent content = new(bytes);
 			content.Headers.Add("x-my-header", "my-value");
 
-			HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+			HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 				content,
 				CancellationToken.None);
 
@@ -161,7 +161,7 @@ public sealed partial class ItExtensionsTests
 			ByteArrayContent content = new([]);
 			content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
-			HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+			HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 				content,
 				CancellationToken.None);
 
@@ -192,7 +192,7 @@ public sealed partial class ItExtensionsTests
 			ByteArrayContent content = new([]);
 			content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
-			HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+			HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 				content,
 				CancellationToken.None);
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseContentIsTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseContentIsTests.cs
@@ -25,7 +25,7 @@ public sealed partial class ItExtensionsTests
 					.SendAsync(It.IsHttpRequestMessage().WhoseContentIs(c => c.WithString("foo")))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new ByteArrayContent(bytes),
 					CancellationToken.None);
 
@@ -45,7 +45,7 @@ public sealed partial class ItExtensionsTests
 				ByteArrayContent content = new([]);
 				content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -65,7 +65,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 				StringContent content = new("foo", Encoding.UTF8, "text/plain");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -103,7 +103,7 @@ public sealed partial class ItExtensionsTests
 					.SendAsync(It.IsHttpRequestMessage().WhoseContentIs(c => c.WithBytes(b => b.Length > 0 && b[0] == expectedFirstByte)))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new ByteArrayContent(body),
 					CancellationToken.None);
 
@@ -148,7 +148,7 @@ public sealed partial class ItExtensionsTests
 					.SendAsync(It.IsHttpRequestMessage().WhoseContentIs(c => c.WithBytes(expected)))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new ByteArrayContent(body),
 					CancellationToken.None);
 
@@ -169,7 +169,7 @@ public sealed partial class ItExtensionsTests
 				ByteArrayContent content = new([]);
 				content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -189,7 +189,7 @@ public sealed partial class ItExtensionsTests
 					.SendAsync(It.IsHttpRequestMessage().WhoseContentIs(c => c.WithString(expected).IgnoringCase()))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -211,7 +211,7 @@ public sealed partial class ItExtensionsTests
 						.WithString(v => v.Equals(v.ToLowerInvariant(), StringComparison.Ordinal))))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(content),
 					CancellationToken.None);
 
@@ -231,7 +231,7 @@ public sealed partial class ItExtensionsTests
 					.SendAsync(It.IsHttpRequestMessage().WhoseContentIs(c => c.WithString(expected)))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -253,7 +253,7 @@ public sealed partial class ItExtensionsTests
 						.WhoseContentIs(c => c.WithStringMatching(pattern).AsRegex().IgnoringCase()))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -274,7 +274,7 @@ public sealed partial class ItExtensionsTests
 						.WhoseContentIs(c => c.WithStringMatching(pattern).AsRegex()))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -291,7 +291,7 @@ public sealed partial class ItExtensionsTests
 						.WithStringMatching("F[A-Z]*").AsRegex(RegexOptions.IgnoreCase)))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent("foo"),
 					CancellationToken.None);
 
@@ -309,7 +309,7 @@ public sealed partial class ItExtensionsTests
 
 				Task Act()
 				{
-					return httpClient.PostAsync("https://www.aweXpect.com",
+					return httpClient.PostAsync("https://www.testably.org",
 						new StringContent("foo"),
 						CancellationToken.None);
 				}
@@ -335,7 +335,7 @@ public sealed partial class ItExtensionsTests
 						.WithStringMatching(pattern).IgnoringCase()))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 
@@ -359,7 +359,7 @@ public sealed partial class ItExtensionsTests
 						.WithStringMatching(pattern)))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(body),
 					CancellationToken.None);
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
@@ -18,7 +18,7 @@ public sealed partial class ItExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.SendAsync(It.IsHttpRequestMessage().WhoseUriIs("*awexpect*", u => u.ForHttps()))
+					.SendAsync(It.IsHttpRequestMessage().WhoseUriIs("*testably*", u => u.ForHttps()))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.GetAsync(uri, CancellationToken.None);

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
@@ -12,8 +12,8 @@ public sealed partial class ItExtensionsTests
 		public sealed class WhoseUriIsTests
 		{
 			[Theory]
-			[InlineData("https://www.aweXpect.com", true)]
-			[InlineData("http://www.aweXpect.com", false)]
+			[InlineData("https://www.testably.org", true)]
+			[InlineData("http://www.testably.org", false)]
 			public async Task ShouldSupportPatternWithUriConfiguration(string uri, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
@@ -28,8 +28,8 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("https://www.aweXpect.com", true)]
-			[InlineData("http://www.aweXpect.com", false)]
+			[InlineData("https://www.testably.org", true)]
+			[InlineData("http://www.testably.org", false)]
 			public async Task ShouldSupportUriConfiguration(string uri, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
@@ -44,20 +44,20 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123&y=4",
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/bar?x=123&y=4",
 				true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "http://www.aweXpect.com/foo/bar?x=123&y=4",
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "http://www.testably.org/foo/bar?x=123&y=4",
 				false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/baz?x=123&y=4",
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/baz?x=123&y=4",
 				false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=124&y=4",
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/bar?x=124&y=4",
 				false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*www.aweXpect.com*", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*/foo/bar*", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*x=123*", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*y=4*", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/bar?x=123", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*www.testably.org*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*/foo/bar*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*x=123*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*y=4*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https*", true)]
 			public async Task ShouldVerifyFullUriWithWildcardMatch(string uri, string pattern, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
@@ -72,8 +72,8 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("*aweXpect.com")]
-			[InlineData("*aweXpect.com/")]
+			[InlineData("*testably.org")]
+			[InlineData("*testably.org/")]
 			public async Task TrailingSlash_ShouldBeIgnored(string matchPattern)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
@@ -83,7 +83,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+					await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(HttpStatusCode.OK);
@@ -95,11 +95,11 @@ public sealed partial class ItExtensionsTests
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
 					.SendAsync(It.IsHttpRequestMessage()
-						.WhoseUriIs("*www.aweXpect.com/foo/"))
+						.WhoseUriIs("*www.testably.org/foo/"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result =
-					await httpClient.GetAsync("https://www.aweXpect.com/foo", CancellationToken.None);
+					await httpClient.GetAsync("https://www.testably.org/foo", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(HttpStatusCode.NotImplemented);

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WithHeadersTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WithHeadersTests.cs
@@ -30,7 +30,7 @@ public sealed partial class ItExtensionsTests
 				StringContent content = new("");
 				content.Headers.Add("x-myHeader", "foo");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -56,7 +56,7 @@ public sealed partial class ItExtensionsTests
 				StringContent content = new("");
 				content.Headers.Add("x-myHeader", "foo");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -82,7 +82,7 @@ public sealed partial class ItExtensionsTests
 				StringContent content = new("");
 				content.Headers.Add("x-myHeader", "foo");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -109,7 +109,7 @@ public sealed partial class ItExtensionsTests
 				content.Headers.Add("x-myHeader2", "bar");
 				content.Headers.Add("x-myHeader3", "baz");
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					content,
 					CancellationToken.None);
 
@@ -130,7 +130,7 @@ public sealed partial class ItExtensionsTests
 						             """))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -150,7 +150,7 @@ public sealed partial class ItExtensionsTests
 					.SendAsync(It.IsHttpRequestMessage().WithHeaders(key, "Basic abcdef"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -171,7 +171,7 @@ public sealed partial class ItExtensionsTests
 					.SendAsync(It.IsHttpRequestMessage().WithHeaders("Authorization", $"Basic {value}"))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -195,7 +195,7 @@ public sealed partial class ItExtensionsTests
 							("Accept", "application/json")))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 
@@ -219,7 +219,7 @@ public sealed partial class ItExtensionsTests
 							("Accept", "application/json")))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+				HttpResponseMessage result = await httpClient.PostAsync("https://www.testably.org",
 					new StringContent(""),
 					CancellationToken.None);
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ItExtensionsTests
 			HttpRequestMessage? captured = null;
 			sut.Do(message => captured = message);
 
-			HttpRequestMessage target = new(HttpMethod.Get, "https://www.aweXpect.com");
+			HttpRequestMessage target = new(HttpMethod.Get, "https://www.testably.org");
 			sut.InvokeCallbacks(target);
 
 			await That(captured).IsSameAs(target);
@@ -52,7 +52,7 @@ public sealed partial class ItExtensionsTests
 		{
 			ItExtensions.IHttpRequestMessageParameter sut = It.IsHttpRequestMessage();
 
-			bool result = sut.Matches(new HttpRequestMessage(HttpMethod.Get, "https://www.aweXpect.com"));
+			bool result = sut.Matches(new HttpRequestMessage(HttpMethod.Get, "https://www.testably.org"));
 
 			await That(result).IsTrue();
 		}
@@ -74,7 +74,7 @@ public sealed partial class ItExtensionsTests
 
 			foreach (ByteArrayContent response in responses)
 			{
-				await httpClient.PostAsync("https://www.aweXpect.com", response, CancellationToken.None);
+				await httpClient.PostAsync("https://www.testably.org", response, CancellationToken.None);
 			}
 
 #if !NETFRAMEWORK
@@ -91,9 +91,9 @@ public sealed partial class ItExtensionsTests
 		{
 			ItExtensions.IHttpRequestMessageParameter sut = It.IsHttpRequestMessage()
 				.WithHeaders(("x-correlation", "abc"));
-			HttpRequestMessage withoutContent = new(HttpMethod.Get, "https://www.aweXpect.com");
+			HttpRequestMessage withoutContent = new(HttpMethod.Get, "https://www.testably.org");
 			withoutContent.Headers.Add("x-correlation", "abc");
-			HttpRequestMessage withContent = new(HttpMethod.Post, "https://www.aweXpect.com")
+			HttpRequestMessage withContent = new(HttpMethod.Post, "https://www.testably.org")
 			{
 				Content = new StringContent("body"),
 			};
@@ -118,7 +118,7 @@ public sealed partial class ItExtensionsTests
 				.SendAsync(It.IsHttpRequestMessage(new HttpMethod(method)))
 				.ReturnsAsync(HttpStatusCode.OK);
 
-			HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com",
+			HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org",
 				CancellationToken.None);
 
 			await That(result.StatusCode).IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.ForHttpAndHttpsTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.ForHttpAndHttpsTests.cs
@@ -12,9 +12,9 @@ public sealed partial class ItExtensionsTests
 		public sealed class ForHttpAndHttpsTests
 		{
 			[Theory]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", true)]
-			[InlineData("HTTP://www.aweXpect.com/foo/bar?x=123&y=234", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", false)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", true)]
+			[InlineData("HTTP://www.testably.org/foo/bar?x=123&y=234", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", false)]
 			public async Task ForHttp_ShouldVerifyHttpScheme(string uri, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
@@ -29,9 +29,9 @@ public sealed partial class ItExtensionsTests
 			}
 
 			[Theory]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", true)]
-			[InlineData("HTTPS://www.aweXpect.com/foo/bar?x=123&y=234", true)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", true)]
+			[InlineData("HTTPS://www.testably.org/foo/bar?x=123&y=234", true)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", false)]
 			public async Task ForHttps_ShouldVerifyHttpsScheme(string uri, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithHostTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithHostTests.cs
@@ -13,8 +13,8 @@ public sealed partial class ItExtensionsTests
 		{
 			[Theory]
 			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "www.testably.org", true)]
-			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*awexpect*", true)]
-			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*aweXpect*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*testably*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*testably*", true)]
 			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "mockolate.com", false)]
 			public async Task ShouldVerifyHost(string uri, string hostPattern, bool expectMatch)
 			{

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithHostTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithHostTests.cs
@@ -12,10 +12,10 @@ public sealed partial class ItExtensionsTests
 		public sealed class WithHostTests
 		{
 			[Theory]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "www.awexpect.com", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "*awexpect*", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "*aweXpect*", true)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", "mockolate.com", false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "www.testably.org", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*awexpect*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*aweXpect*", true)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "mockolate.com", false)]
 			public async Task ShouldVerifyHost(string uri, string hostPattern, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithPathTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithPathTests.cs
@@ -12,11 +12,11 @@ public sealed partial class ItExtensionsTests
 		public sealed class WithPathTests
 		{
 			[Theory]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "/foo/bar", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "*foo*", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "*FOO*", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "*bar*", true)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", "*baz*", false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "/foo/bar", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*foo*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*FOO*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*bar*", true)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "*baz*", false)]
 			public async Task ShouldVerifyPath(string uri, string pathPattern, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithPortTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithPortTests.cs
@@ -12,11 +12,11 @@ public sealed partial class ItExtensionsTests
 		public sealed class WithPortTests
 		{
 			[Theory]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", 443, true)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", 80, true)]
-			[InlineData("https://www.aweXpect.com:8080/foo/bar?x=123&y=234", 8080, true)]
-			[InlineData("https://www.aweXpect.com:442/foo/bar?x=123&y=234", 443, false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", 442, false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", 443, true)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", 80, true)]
+			[InlineData("https://www.testably.org:8080/foo/bar?x=123&y=234", 8080, true)]
+			[InlineData("https://www.testably.org:442/foo/bar?x=123&y=234", 443, false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", 442, false)]
 			public async Task ShouldVerifyPort(string uri, int port, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithQueryTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithQueryTests.cs
@@ -26,7 +26,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient
-					.GetAsync("https://www.aweXpect.com/foo/bar?x=123&y=234&z=345", CancellationToken.None);
+					.GetAsync("https://www.testably.org/foo/bar?x=123&y=234&z=345", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -46,7 +46,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient
-					.GetAsync("https://www.aweXpect.com/foo/bar?x=123&y=234&z=345", CancellationToken.None);
+					.GetAsync("https://www.testably.org/foo/bar?x=123&y=234&z=345", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -66,7 +66,7 @@ public sealed partial class ItExtensionsTests
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient
-					.GetAsync("https://www.aweXpect.com/foo/bar?x=123&y=234&z=345", CancellationToken.None);
+					.GetAsync("https://www.testably.org/foo/bar?x=123&y=234&z=345", CancellationToken.None);
 
 				await That(result.StatusCode)
 					.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
@@ -81,20 +81,20 @@ public sealed partial class ItExtensionsTests
 					.GetAsync(It.IsUri().WithQuery(key, value))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com/?x%3c%3e=1%3c2%3e+3",
+				HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org/?x%3c%3e=1%3c2%3e+3",
 					CancellationToken.None);
 
 				await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
 			}
 
 			[Theory]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "x", "123", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "y", "234", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "x", "", false)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", "y", "", false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "x", "234", false)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", "y", "123", false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&foo&y=234", "foo", "", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "x", "123", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "y", "234", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "x", "", false)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "y", "", false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "x", "234", false)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "y", "123", false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&foo&y=234", "foo", "", true)]
 			public async Task WithQueryParameter_ShouldVerifyQueryParameters(string uri, string key, string value,
 				bool expectMatch)
 			{
@@ -125,23 +125,23 @@ public sealed partial class ItExtensionsTests
 					.GetAsync(It.IsUri().WithQuery(queryParameters))
 					.ReturnsAsync(HttpStatusCode.OK);
 
-				HttpResponseMessage result = await httpClient.GetAsync("https://www.aweXpect.com?x=123&y=234&z=345",
+				HttpResponseMessage result = await httpClient.GetAsync("https://www.testably.org?x=123&y=234&z=345",
 					CancellationToken.None);
 
 				await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
 			}
 
 			[Theory]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "?x=123&y=234", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "?y=234&x=123&", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "x=123", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "y=234", true)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "x", false)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", "y", false)]
-			[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=234", "x=234", false)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", "y=123", false)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&y=234", "x=123&y=23", false)]
-			[InlineData("http://www.aweXpect.com/foo/bar?x=123&foo&y=234", "foo", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "?x=123&y=234", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "?y=234&x=123&", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "x=123", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "y=234", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "x", false)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "y", false)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "x=234", false)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "y=123", false)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "x=123&y=23", false)]
+			[InlineData("http://www.testably.org/foo/bar?x=123&foo&y=234", "foo", true)]
 			public async Task WithQueryString_ShouldVerifyQueryParameters(string uri, string query, bool expectMatch)
 			{
 				HttpClient httpClient = HttpClient.CreateMock();

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.cs
@@ -83,31 +83,31 @@ public sealed partial class ItExtensionsTests
 				.Do(_ => callbackCount++)
 				.Monitor(out IParameterMonitor<Uri?> monitor));
 
-			await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
-			await httpClient.GetAsync("https://www.aweXpect.com/foo", CancellationToken.None);
-			await httpClient.GetAsync("https://www.aweXpect.com/bar", CancellationToken.None);
+			await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
+			await httpClient.GetAsync("https://www.testably.org/foo", CancellationToken.None);
+			await httpClient.GetAsync("https://www.testably.org/bar", CancellationToken.None);
 
 			await That(monitor.Values.Select(u => u?.ToString()))
 				.IsEqualTo([
-					"https://www.aweXpect.com/",
-					"https://www.aweXpect.com/foo",
-					"https://www.aweXpect.com/bar",
+					"https://www.testably.org/",
+					"https://www.testably.org/foo",
+					"https://www.testably.org/bar",
 				]).IgnoringCase();
 			await That(callbackCount).IsEqualTo(3);
 		}
 
 		[Theory]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "aweXpect.com*x=123", true)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123&y=4", true)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "http://www.aweXpect.com/foo/bar?x=123&y=4", false)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/baz?x=123&y=4", false)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=124&y=4", false)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https://www.aweXpect.com/foo/bar?x=123", true)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*www.aweXpect.com*", true)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*/foo/bar*", true)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*x=123*", true)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "*y=4*", true)]
-		[InlineData("https://www.aweXpect.com/foo/bar?x=123&y=4", "https*", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "testably.org*x=123", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/bar?x=123&y=4", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "http://www.testably.org/foo/bar?x=123&y=4", false)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/baz?x=123&y=4", false)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/bar?x=124&y=4", false)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https://www.testably.org/foo/bar?x=123", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*www.testably.org*", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*/foo/bar*", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*x=123*", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "*y=4*", true)]
+		[InlineData("https://www.testably.org/foo/bar?x=123&y=4", "https*", true)]
 		public async Task ShouldVerifyFullUriWithWildcardMatch(string uri, string pattern, bool expectMatch)
 		{
 			HttpClient httpClient = HttpClient.CreateMock();
@@ -121,8 +121,8 @@ public sealed partial class ItExtensionsTests
 		}
 
 		[Theory]
-		[InlineData("*aweXpect.com")]
-		[InlineData("*aweXpect.com/")]
+		[InlineData("*testably.org")]
+		[InlineData("*testably.org/")]
 		public async Task TrailingSlash_ShouldBeIgnored(string matchPattern)
 		{
 			HttpClient httpClient = HttpClient.CreateMock();
@@ -131,7 +131,7 @@ public sealed partial class ItExtensionsTests
 				.ReturnsAsync(HttpStatusCode.OK);
 
 			HttpResponseMessage result =
-				await httpClient.GetAsync("https://www.aweXpect.com", CancellationToken.None);
+				await httpClient.GetAsync("https://www.testably.org", CancellationToken.None);
 
 			await That(result.StatusCode)
 				.IsEqualTo(HttpStatusCode.OK);
@@ -142,11 +142,11 @@ public sealed partial class ItExtensionsTests
 		{
 			HttpClient httpClient = HttpClient.CreateMock();
 			httpClient.Mock.Setup
-				.GetAsync(It.IsUri("*www.aweXpect.com/foo/"))
+				.GetAsync(It.IsUri("*www.testably.org/foo/"))
 				.ReturnsAsync(HttpStatusCode.OK);
 
 			HttpResponseMessage result =
-				await httpClient.GetAsync("https://www.aweXpect.com/foo", CancellationToken.None);
+				await httpClient.GetAsync("https://www.testably.org/foo", CancellationToken.None);
 
 			await That(result.StatusCode)
 				.IsEqualTo(HttpStatusCode.NotImplemented);
@@ -181,9 +181,9 @@ public sealed partial class ItExtensionsTests
 		{
 			HttpClient httpClient = HttpClient.CreateMock();
 
-			await httpClient.GetAsync("https://aweXpect.com/", CancellationToken.None);
+			await httpClient.GetAsync("https://testably.org/", CancellationToken.None);
 
-			await That(httpClient.Mock.Verify.GetAsync(It.IsUri("https://aweXpect.com")))
+			await That(httpClient.Mock.Verify.GetAsync(It.IsUri("https://testably.org")))
 				.Once();
 		}
 	}


### PR DESCRIPTION
This pull request primarily updates documentation links and example/test data to reflect the new canonical domain (`testably.org` and `docs.testably.org`) instead of the old `awexpect.com` domain. It also adds a `PackageProjectUrl` property to the package metadata. These changes ensure consistency across code, documentation, and tests, and help users find the correct resources.

**Documentation and Link Updates:**

* Updated all documentation and code comments to use `docs.testably.org` and `testably.org` domains instead of `awexpect.com` for Mockolate and related packages. This includes benchmark summaries, README, markdown docs, and code comments.

**Example and Test Data Updates:**

* Changed all example URLs and test URIs in documentation and test files from `aweXpect.com` to `testably.org` to match the new domain and ensure test relevance.

**Package Metadata:**

* Added the `PackageProjectUrl` property to the `Directory.Build.props` file, pointing to the new documentation site.

**Relative Link Improvements:**

* Updated several markdown links to use relative paths instead of absolute URLs, improving maintainability and portability of the documentation.

No functional code changes were made; all updates are related to documentation, metadata, or test data consistency.