### PR TITLE
fix: restore case-insensitive URI test coverage

### DIFF
--- a/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/Web/HttpClientExtensionsTests.cs
@@ -138,9 +138,9 @@ public sealed partial class HttpClientExtensionsTests
 				.Monitor(out IParameterMonitor<string> monitor))
 			.ReturnsAsync(HttpStatusCode.OK);
 
-		await httpClient.GetAsync("https://www.testably.org/foo", CancellationToken.None);
-		await httpClient.PostAsync("https://www.testably.org/bar", null, CancellationToken.None);
-		await httpClient.GetAsync("https://www.testably.org/baz", CancellationToken.None);
+		await httpClient.GetAsync("https://www.Testably.org/foo", CancellationToken.None);
+		await httpClient.PostAsync("https://www.Testably.org/bar", null, CancellationToken.None);
+		await httpClient.GetAsync("https://www.Testably.org/baz", CancellationToken.None);
 
 		await That(monitor.Values).IsEqualTo([
 			"https://www.testably.org/foo",

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpRequestMessageTests.WhoseUriIsTests.cs
@@ -18,7 +18,7 @@ public sealed partial class ItExtensionsTests
 			{
 				HttpClient httpClient = HttpClient.CreateMock();
 				httpClient.Mock.Setup
-					.SendAsync(It.IsHttpRequestMessage().WhoseUriIs("*testably*", u => u.ForHttps()))
+					.SendAsync(It.IsHttpRequestMessage().WhoseUriIs("*Testably*", u => u.ForHttps()))
 					.ReturnsAsync(HttpStatusCode.OK);
 
 				HttpResponseMessage result = await httpClient.GetAsync(uri, CancellationToken.None);

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithHostTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsUriTests.WithHostTests.cs
@@ -14,7 +14,7 @@ public sealed partial class ItExtensionsTests
 			[Theory]
 			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "www.testably.org", true)]
 			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*testably*", true)]
-			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*testably*", true)]
+			[InlineData("https://www.testably.org/foo/bar?x=123&y=234", "*Testably*", true)]
 			[InlineData("http://www.testably.org/foo/bar?x=123&y=234", "mockolate.com", false)]
 			public async Task ShouldVerifyHost(string uri, string hostPattern, bool expectMatch)
 			{


### PR DESCRIPTION
The aweXpect→testably rename in #761 collapsed a few test cases that relied on the casing difference between `aweXpect` and `awexpect`:

- `WithHostTests.ShouldVerifyHost` ended up with a duplicate `[InlineData]` (`*testably*` twice), flagged by Sonar.
- `WhoseUriIsTests.ShouldSupportPatternWithUriConfiguration` no longer exercised case-insensitive host pattern matching.
- `HttpClientExtensionsTests.ShouldSupportMonitoring` no longer exercised URI host-case normalization in the captured monitor values.

Reintroduce mixed-case variants so each scenario is covered again.