### PR TITLE
docs: refine static interface members page

### DIFF
--- a/Docs/pages/advanced-features/02-static-interface-members.md
+++ b/Docs/pages/advanced-features/02-static-interface-members.md
@@ -21,13 +21,27 @@ IChocolateFactory sut = IChocolateFactory.CreateMock();
 sut.Mock.SetupStatic.ProduceBatch(It.Is("Dark"), It.IsAny<int>()).Returns(42);
 sut.Mock.SetupStatic.DefaultRecipe.Returns("Dark");
 
-// Raise static events
-sut.Mock.RaiseStatic.BatchCompleted(42);
+// Static abstract members can only be invoked through a generic type parameter,
+// so route the call through a helper constrained to the interface and pass the
+// generated mock type (Mock.IChocolateFactory) as the type argument.
+string recipe = ReadRecipe<Mock.IChocolateFactory>();
+int produced = Produce<Mock.IChocolateFactory>("Dark", 10);
+Subscribe<Mock.IChocolateFactory>(amount => Console.WriteLine($"Batch of {amount} ready"));
+
+// Raise static events to the registered handlers
+sut.Mock.RaiseStatic.BatchCompleted(produced);
 
 // Verify static interactions
 sut.Mock.VerifyStatic.ProduceBatch(It.Is("Dark"), It.IsAny<int>()).Once();
 sut.Mock.VerifyStatic.DefaultRecipe.Got().Once();
 sut.Mock.VerifyStatic.BatchCompleted.Subscribed().Once();
+
+static string ReadRecipe<T>() where T : IChocolateFactory
+    => T.DefaultRecipe;
+static int Produce<T>(string type, int amount) where T : IChocolateFactory
+    => T.ProduceBatch(type, amount);
+static void Subscribe<T>(Action<int> handler) where T : IChocolateFactory
+    => T.BatchCompleted += handler;
 ```
 
 **Notes:**

--- a/Docs/pages/advanced-features/02-static-interface-members.md
+++ b/Docs/pages/advanced-features/02-static-interface-members.md
@@ -1,22 +1,33 @@
-# Static interface members (.NET 8+)
+# Static interface members
 
 Mockolate supports mocking static abstract and static virtual members on interfaces (.NET 8+). Static member
 invocations use async-flow scoping, meaning each mock instance has its own isolated static member context, this makes parallel test execution safe.
 
 Static members can be set up, raised, and verified just like instance members, but through the `Mock.SetupStatic`, `Mock.RaiseStatic`, and `Mock.VerifyStatic` properties:
 
+**Example**
+
 ```csharp
+public interface IChocolateFactory
+{
+    static abstract string DefaultRecipe { get; set; }
+    static abstract int ProduceBatch(string type, int amount);
+    static abstract event Action<int> BatchCompleted;
+}
+
+IChocolateFactory sut = IChocolateFactory.CreateMock();
+
 // Setup static members
-sut.Mock.SetupStatic.AbstractStaticMethod().Returns("some-value");
-sut.Mock.SetupStatic.AbstractStaticProperty.Returns("some-value");
+sut.Mock.SetupStatic.ProduceBatch(It.Is("Dark"), It.IsAny<int>()).Returns(42);
+sut.Mock.SetupStatic.DefaultRecipe.Returns("Dark");
 
 // Raise static events
-sut.Mock.RaiseStatic.AbstractStaticEvent(value);
+sut.Mock.RaiseStatic.BatchCompleted(42);
 
 // Verify static interactions
-sut.Mock.VerifyStatic.AbstractStaticMethod().Once();
-sut.Mock.VerifyStatic.AbstractStaticProperty.Got().Once();
-sut.Mock.VerifyStatic.AbstractStaticEvent.Subscribed().Once();
+sut.Mock.VerifyStatic.ProduceBatch(It.Is("Dark"), It.IsAny<int>()).Once();
+sut.Mock.VerifyStatic.DefaultRecipe.Got().Once();
+sut.Mock.VerifyStatic.BatchCompleted.Subscribed().Once();
 ```
 
 **Notes:**


### PR DESCRIPTION
Drop the ".NET 8+" suffix from the headline (kept inline in the body) and replace the placeholder example with an explicit IChocolateFactory interface using chocolate-themed setup, raise, and verify calls.