### PR TITLE
perf: fuse literal values into setup and verify paths

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3711,25 +3711,50 @@ internal static partial class Sources
 		}
 		else
 		{
-			sb.Append(".WithParameterCollection(").Append(mockRegistryName).Append(", ")
-				.Append(method.GetUniqueNameString());
-			int j = 0;
-			foreach (MethodParameter parameter in method.Parameters)
+			// Fused literal path: when the call site is the bare-value overload (every parameter is a
+			// literal value) we can store the values directly on the setup via WithLiteralValues and
+			// skip the per-parameter IParameterMatch<T> allocations that WithParameterCollection
+			// would otherwise force via It.IsValue<T>(...). Gated to 1..4 parameters because that is
+			// the arity range covered by the WithLiteralValues nested types.
+			bool useLiteralValues = valueFlags is { Length: > 0 and <= MaxExplicitParameters, } &&
+			                        valueFlags.All(x => x) &&
+			                        !method.Parameters.Any(p => p.RefKind == RefKind.Out ||
+			                                                    p.RefKind == RefKind.Ref ||
+			                                                    p.RefKind == RefKind.RefReadOnlyParameter);
+			if (useLiteralValues)
 			{
-				sb.Append(", ");
-				if (valueFlags?[j] == true)
+				sb.Append(".WithLiteralValues(").Append(mockRegistryName).Append(", ")
+					.Append(method.GetUniqueNameString());
+				foreach (MethodParameter parameter in method.Parameters)
 				{
-					AppendNamedValueParameter(sb, parameter);
-				}
-				else
-				{
-					AppendNamedParameter(sb, parameter);
+					sb.Append(", ").Append(parameter.Name);
 				}
 
-				j++;
+				sb.Append(");").AppendLine();
+			}
+			else
+			{
+				sb.Append(".WithParameterCollection(").Append(mockRegistryName).Append(", ")
+					.Append(method.GetUniqueNameString());
+				int j = 0;
+				foreach (MethodParameter parameter in method.Parameters)
+				{
+					sb.Append(", ");
+					if (valueFlags?[j] == true)
+					{
+						AppendNamedValueParameter(sb, parameter);
+					}
+					else
+					{
+						AppendNamedParameter(sb, parameter);
+					}
+
+					j++;
+				}
+
+				sb.Append(");").AppendLine();
 			}
 
-			sb.Append(");").AppendLine();
 			sb.Append("\t\t\tthis.").Append(mockRegistryName).Append(".SetupMethod(")
 				.Append(memberIdRef).Append(", ").Append(scopePrefix).Append(methodSetupVar).Append(");").AppendLine();
 			sb.Append("\t\t\treturn ").Append(methodSetupVar).Append(';').AppendLine();
@@ -5211,14 +5236,47 @@ internal static partial class Sources
 
 		sb.AppendLine();
 
+		bool noRefStruct = !method.Parameters.Any(p
+			=> p.RefKind == RefKind.Out || p.RefKind == RefKind.Ref ||
+			   p.RefKind == RefKind.RefReadOnlyParameter);
+		bool baseEligible = !useParameters
+		                    && method.Parameters.Count is > 0 and <= 4
+		                    && (method.GenericParameters is null || method.GenericParameters.Value.Count == 0)
+		                    && noRefStruct;
+
+		bool canUseLiteralVerify = baseEligible &&
+		                           valueFlags is { Length: > 0 and <= 4, } &&
+		                           valueFlags.All(x => x);
 		bool canUseTypedVerify = useFastForMethod
 		                         && !useParameters
 		                         && method.Parameters.Count <= 4
 		                         && (method.GenericParameters is null || method.GenericParameters.Value.Count == 0)
 		                         && (valueFlags is null || !valueFlags.Any(x => x))
-		                         && !method.Parameters.Any(p
-			                         => p.RefKind == RefKind.Out || p.RefKind == RefKind.Ref ||
-			                            p.RefKind == RefKind.RefReadOnlyParameter);
+		                         && noRefStruct;
+
+		if (canUseLiteralVerify)
+		{
+			// Bare-value verify path: every parameter is a literal value, so we can route through the
+			// MockRegistry.VerifyMethod overload that takes the values directly (no IParameterMatch<T>
+			// allocation) and uses Method{N}LiteralCountSource for the allocation-free fast path. The
+			// memberId may be -1 here when fast buffers are off, which the runtime overload handles by
+			// dispatching to the slow predicate-based VerifyMethod.
+			sb.Append("\t\t\t=> this.").Append(mockRegistryName).Append(".VerifyMethod<").Append(verifyName);
+			foreach (MethodParameter parameter in method.Parameters)
+			{
+				sb.Append(", ").Append(parameter.ToTypeOrWrapper());
+			}
+
+			sb.Append(">(this, ").Append(methodMemberId).Append(", ").Append(method.GetUniqueNameString());
+			foreach (MethodParameter parameter in method.Parameters)
+			{
+				sb.Append(", ").Append(parameter.Name);
+			}
+
+			sb.Append(", () => $\"").Append(method.Name).Append("(")
+				.Append(string.Join(", ", method.Parameters.Select(p => $"{{{p.Name}}}"))).Append(")\");").AppendLine();
+			return;
+		}
 
 		if (canUseTypedVerify)
 		{

--- a/Source/Mockolate/Interactions/FastMethodBuffer.cs
+++ b/Source/Mockolate/Interactions/FastMethodBuffer.cs
@@ -221,6 +221,33 @@ public sealed class FastMethod1Buffer<T1> : IFastMemberBuffer
 		return matches;
 	}
 
+	/// <summary>
+	///     Literal-value variant of <see cref="ConsumeMatching(IParameterMatch{T1})" /> — compares each
+	///     recorded parameter against <paramref name="value1" /> using
+	///     <see cref="EqualityComparer{T}.Default" />, sparing the per-call <see cref="IParameterMatch{T1}" />
+	///     allocation that the matcher overload requires.
+	/// </summary>
+	public int ConsumeMatchingLiteral(T1 value1)
+	{
+		int matches = 0;
+		EqualityComparer<T1> cmp = EqualityComparer<T1>.Default;
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				ref Record r = ref _storage.SlotUnderLock(slot);
+				if (cmp.Equals(value1, r.P1))
+				{
+					matches++;
+					_storage.VerifiedUnderLock(slot) = true;
+				}
+			}
+		}
+
+		return matches;
+	}
+
 	internal int ConsumeAll()
 	{
 		lock (_storage.Lock)
@@ -340,6 +367,34 @@ public sealed class FastMethod2Buffer<T1, T2> : IFastMemberBuffer
 			{
 				ref Record r = ref _storage.SlotUnderLock(slot);
 				if (match1.Matches(r.P1) && match2.Matches(r.P2))
+				{
+					matches++;
+					_storage.VerifiedUnderLock(slot) = true;
+				}
+			}
+		}
+
+		return matches;
+	}
+
+	/// <summary>
+	///     Literal-value variant of
+	///     <see cref="ConsumeMatching(IParameterMatch{T1}, IParameterMatch{T2})" /> — compares each
+	///     recorded parameter against <paramref name="value1" /> / <paramref name="value2" /> using
+	///     <see cref="EqualityComparer{T}.Default" />, sparing the per-call matcher allocations.
+	/// </summary>
+	public int ConsumeMatchingLiteral(T1 value1, T2 value2)
+	{
+		int matches = 0;
+		EqualityComparer<T1> cmp1 = EqualityComparer<T1>.Default;
+		EqualityComparer<T2> cmp2 = EqualityComparer<T2>.Default;
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				ref Record r = ref _storage.SlotUnderLock(slot);
+				if (cmp1.Equals(value1, r.P1) && cmp2.Equals(value2, r.P2))
 				{
 					matches++;
 					_storage.VerifiedUnderLock(slot) = true;
@@ -480,6 +535,35 @@ public sealed class FastMethod3Buffer<T1, T2, T3> : IFastMemberBuffer
 		return matches;
 	}
 
+	/// <summary>
+	///     Literal-value variant of
+	///     <see cref="ConsumeMatching(IParameterMatch{T1}, IParameterMatch{T2}, IParameterMatch{T3})" />
+	///     — compares each recorded parameter against the supplied values using
+	///     <see cref="EqualityComparer{T}.Default" />, sparing the per-call matcher allocations.
+	/// </summary>
+	public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3)
+	{
+		int matches = 0;
+		EqualityComparer<T1> cmp1 = EqualityComparer<T1>.Default;
+		EqualityComparer<T2> cmp2 = EqualityComparer<T2>.Default;
+		EqualityComparer<T3> cmp3 = EqualityComparer<T3>.Default;
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				ref Record r = ref _storage.SlotUnderLock(slot);
+				if (cmp1.Equals(value1, r.P1) && cmp2.Equals(value2, r.P2) && cmp3.Equals(value3, r.P3))
+				{
+					matches++;
+					_storage.VerifiedUnderLock(slot) = true;
+				}
+			}
+		}
+
+		return matches;
+	}
+
 	internal int ConsumeAll()
 	{
 		lock (_storage.Lock)
@@ -602,6 +686,37 @@ public sealed class FastMethod4Buffer<T1, T2, T3, T4> : IFastMemberBuffer
 			{
 				ref Record r = ref _storage.SlotUnderLock(slot);
 				if (match1.Matches(r.P1) && match2.Matches(r.P2) && match3.Matches(r.P3) && match4.Matches(r.P4))
+				{
+					matches++;
+					_storage.VerifiedUnderLock(slot) = true;
+				}
+			}
+		}
+
+		return matches;
+	}
+
+	/// <summary>
+	///     Literal-value variant of
+	///     <see cref="ConsumeMatching(IParameterMatch{T1}, IParameterMatch{T2}, IParameterMatch{T3}, IParameterMatch{T4})" />
+	///     — compares each recorded parameter against the supplied values using
+	///     <see cref="EqualityComparer{T}.Default" />, sparing the per-call matcher allocations.
+	/// </summary>
+	public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3, T4 value4)
+	{
+		int matches = 0;
+		EqualityComparer<T1> cmp1 = EqualityComparer<T1>.Default;
+		EqualityComparer<T2> cmp2 = EqualityComparer<T2>.Default;
+		EqualityComparer<T3> cmp3 = EqualityComparer<T3>.Default;
+		EqualityComparer<T4> cmp4 = EqualityComparer<T4>.Default;
+		lock (_storage.Lock)
+		{
+			int n = _storage.PublishedUnderLock;
+			for (int slot = 0; slot < n; slot++)
+			{
+				ref Record r = ref _storage.SlotUnderLock(slot);
+				if (cmp1.Equals(value1, r.P1) && cmp2.Equals(value2, r.P2) &&
+				    cmp3.Equals(value3, r.P3) && cmp4.Equals(value4, r.P4))
 				{
 					matches++;
 					_storage.VerifiedUnderLock(slot) = true;

--- a/Source/Mockolate/MockRegistry.Verify.cs
+++ b/Source/Mockolate/MockRegistry.Verify.cs
@@ -504,6 +504,95 @@ public partial class MockRegistry
 	}
 
 	/// <summary>
+	///     Literal-value fast-path Verify for 1-parameter methods. Avoids allocating an
+	///     <see cref="IParameterMatch{T1}" /> wrapper around <paramref name="literalValue1" /> by
+	///     comparing it inline with <see cref="EqualityComparer{T}.Default" />.
+	/// </summary>
+	public VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1>(T subject, int memberId, string methodName,
+		T1 literalValue1, Func<string> expectation)
+	{
+		IFastMemberBuffer? buffer = TryGetBuffer(memberId);
+		if (buffer is FastMethod1Buffer<T1> typed)
+		{
+			Method1LiteralCountSource<T1> source = new(typed, literalValue1);
+			return new VerificationResult<T>.IgnoreParameters(
+				subject, Interactions, buffer, source, methodName,
+				source.Matches,
+				() => $"invoked method {expectation()}");
+		}
+
+		return VerifyMethod<T, MethodInvocation<T1>>(subject, methodName,
+			m => EqualityComparer<T1>.Default.Equals(literalValue1, m.Parameter1), expectation);
+	}
+
+	/// <summary>
+	///     Literal-value fast-path Verify for 2-parameter methods.
+	/// </summary>
+	public VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2>(T subject, int memberId, string methodName,
+		T1 literalValue1, T2 literalValue2, Func<string> expectation)
+	{
+		IFastMemberBuffer? buffer = TryGetBuffer(memberId);
+		if (buffer is FastMethod2Buffer<T1, T2> typed)
+		{
+			Method2LiteralCountSource<T1, T2> source = new(typed, literalValue1, literalValue2);
+			return new VerificationResult<T>.IgnoreParameters(
+				subject, Interactions, buffer, source, methodName,
+				source.Matches,
+				() => $"invoked method {expectation()}");
+		}
+
+		return VerifyMethod<T, MethodInvocation<T1, T2>>(subject, methodName,
+			m => EqualityComparer<T1>.Default.Equals(literalValue1, m.Parameter1) &&
+			     EqualityComparer<T2>.Default.Equals(literalValue2, m.Parameter2), expectation);
+	}
+
+	/// <summary>
+	///     Literal-value fast-path Verify for 3-parameter methods.
+	/// </summary>
+	public VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3>(T subject, int memberId, string methodName,
+		T1 literalValue1, T2 literalValue2, T3 literalValue3, Func<string> expectation)
+	{
+		IFastMemberBuffer? buffer = TryGetBuffer(memberId);
+		if (buffer is FastMethod3Buffer<T1, T2, T3> typed)
+		{
+			Method3LiteralCountSource<T1, T2, T3> source = new(typed, literalValue1, literalValue2, literalValue3);
+			return new VerificationResult<T>.IgnoreParameters(
+				subject, Interactions, buffer, source, methodName,
+				source.Matches,
+				() => $"invoked method {expectation()}");
+		}
+
+		return VerifyMethod<T, MethodInvocation<T1, T2, T3>>(subject, methodName,
+			m => EqualityComparer<T1>.Default.Equals(literalValue1, m.Parameter1) &&
+			     EqualityComparer<T2>.Default.Equals(literalValue2, m.Parameter2) &&
+			     EqualityComparer<T3>.Default.Equals(literalValue3, m.Parameter3), expectation);
+	}
+
+	/// <summary>
+	///     Literal-value fast-path Verify for 4-parameter methods.
+	/// </summary>
+	public VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3, T4>(T subject, int memberId, string methodName,
+		T1 literalValue1, T2 literalValue2, T3 literalValue3, T4 literalValue4, Func<string> expectation)
+	{
+		IFastMemberBuffer? buffer = TryGetBuffer(memberId);
+		if (buffer is FastMethod4Buffer<T1, T2, T3, T4> typed)
+		{
+			Method4LiteralCountSource<T1, T2, T3, T4> source = new(typed,
+				literalValue1, literalValue2, literalValue3, literalValue4);
+			return new VerificationResult<T>.IgnoreParameters(
+				subject, Interactions, buffer, source, methodName,
+				source.Matches,
+				() => $"invoked method {expectation()}");
+		}
+
+		return VerifyMethod<T, MethodInvocation<T1, T2, T3, T4>>(subject, methodName,
+			m => EqualityComparer<T1>.Default.Equals(literalValue1, m.Parameter1) &&
+			     EqualityComparer<T2>.Default.Equals(literalValue2, m.Parameter2) &&
+			     EqualityComparer<T3>.Default.Equals(literalValue3, m.Parameter3) &&
+			     EqualityComparer<T4>.Default.Equals(literalValue4, m.Parameter4), expectation);
+	}
+
+	/// <summary>
 	///     Typed fast-path Verify for property getter accesses.
 	/// </summary>
 	public VerificationResult<T> VerifyPropertyTyped<T>(T subject, int memberId, string propertyName)

--- a/Source/Mockolate/Setup/MethodSetup.cs
+++ b/Source/Mockolate/Setup/MethodSetup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Mockolate.Interactions;
 using Mockolate.Internals;
 
@@ -30,6 +31,33 @@ public abstract class MethodSetup : IMethodSetup, IVerifiableMethodSetup
 	/// </summary>
 	protected static string FormatType(Type type)
 		=> type.FormatType();
+
+	/// <summary>
+	///     Renders <paramref name="value" /> for inclusion in a setup's <see cref="object.ToString" />,
+	///     mirroring the formatting that the <c>It.IsValue&lt;T&gt;</c> matcher uses for diagnostics:
+	///     strings are quoted, <see cref="IFormattable" /> values are rendered with
+	///     <see cref="CultureInfo.InvariantCulture" /> (so failure messages don't drift with the host
+	///     locale), and everything else falls through to <see cref="object.ToString" />.
+	/// </summary>
+	protected static string FormatLiteralValue<T>(T value)
+	{
+		if (value is null)
+		{
+			return "null";
+		}
+
+		if (value is string s)
+		{
+			return $"\"{s}\"";
+		}
+
+		if (value is IFormattable formattable)
+		{
+			return formattable.ToString(null, CultureInfo.InvariantCulture);
+		}
+
+		return value.ToString() ?? "null";
+	}
 
 	/// <inheritdoc cref="IVerifiableMethodSetup.Matches(IMethodInteraction)" />
 	bool IVerifiableMethodSetup.Matches(IMethodInteraction interaction)

--- a/Source/Mockolate/Setup/ReturnMethodSetup.cs
+++ b/Source/Mockolate/Setup/ReturnMethodSetup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Mockolate.Interactions;
 using Mockolate.Internals;
@@ -646,6 +647,40 @@ public abstract class ReturnMethodSetup<TReturn, T1> : MethodSetup,
 		public override string ToString()
 			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({Parameter1})";
 	}
+
+	/// <summary>
+	///     Setup for a method with one parameter where the expected value is stored directly on the
+	///     setup, avoiding the per-call <see cref="IParameterMatch{T1}" /> allocation that
+	///     <see cref="WithParameterCollection" /> requires.
+	/// </summary>
+	public class WithLiteralValues : ReturnMethodSetup<TReturn, T1>,
+		IReturnMethodSetupParameterIgnorer<TReturn, T1>
+	{
+		private readonly T1 _value1;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name, T1 value1)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+		}
+
+		/// <inheritdoc cref="IReturnMethodSetupParameterIgnorer{TReturn, T1}.AnyParameters()" />
+		IReturnMethodSetup<TReturn, T1> IReturnMethodSetupParameterIgnorer<TReturn, T1>.AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1}.Matches(T1)" />
+		public override bool Matches(T1 p1Value)
+			=> _matchAnyParameters || EqualityComparer<T1>.Default.Equals(_value1, p1Value);
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)})";
+	}
 }
 
 /// <summary>
@@ -1041,6 +1076,45 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2> : MethodSetup,
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({Parameter1}, {Parameter2})";
+	}
+
+	/// <summary>
+	///     Setup for a method with two parameters where the expected values are stored directly on
+	///     the setup, avoiding the per-call <see cref="IParameterMatch{T1}" /> /
+	///     <see cref="IParameterMatch{T2}" /> allocations that <see cref="WithParameterCollection" />
+	///     requires.
+	/// </summary>
+	public class WithLiteralValues : ReturnMethodSetup<TReturn, T1, T2>,
+		IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>
+	{
+		private readonly T1 _value1;
+		private readonly T2 _value2;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name, T1 value1, T2 value2)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+			_value2 = value2;
+		}
+
+		/// <inheritdoc cref="IReturnMethodSetupParameterIgnorer{TReturn, T1, T2}.AnyParameters()" />
+		IReturnMethodSetup<TReturn, T1, T2> IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>.AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2}.Matches(T1, T2)" />
+		public override bool Matches(T1 p1Value, T2 p2Value)
+			=> _matchAnyParameters ||
+			   (EqualityComparer<T1>.Default.Equals(_value1, p1Value) &&
+			    EqualityComparer<T2>.Default.Equals(_value2, p2Value));
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)}, {FormatLiteralValue(_value2)})";
 	}
 }
 
@@ -1457,6 +1531,47 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3> : MethodSetup,
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({Parameter1}, {Parameter2}, {Parameter3})";
+	}
+
+	/// <summary>
+	///     Setup for a method with three parameters where the expected values are stored directly on
+	///     the setup, avoiding the per-call <see cref="IParameterMatch{T}" /> allocations that
+	///     <see cref="WithParameterCollection" /> requires.
+	/// </summary>
+	public class WithLiteralValues : ReturnMethodSetup<TReturn, T1, T2, T3>,
+		IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>
+	{
+		private readonly T1 _value1;
+		private readonly T2 _value2;
+		private readonly T3 _value3;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+			_value2 = value2;
+			_value3 = value3;
+		}
+
+		/// <inheritdoc cref="IReturnMethodSetupParameterIgnorer{TReturn, T1, T2, T3}.AnyParameters()" />
+		IReturnMethodSetup<TReturn, T1, T2, T3> IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>.AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3}.Matches(T1, T2, T3)" />
+		public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value)
+			=> _matchAnyParameters ||
+			   (EqualityComparer<T1>.Default.Equals(_value1, p1Value) &&
+			    EqualityComparer<T2>.Default.Equals(_value2, p2Value) &&
+			    EqualityComparer<T3>.Default.Equals(_value3, p3Value));
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)}, {FormatLiteralValue(_value2)}, {FormatLiteralValue(_value3)})";
 	}
 }
 
@@ -1893,6 +2008,52 @@ public abstract class ReturnMethodSetup<TReturn, T1, T2, T3, T4> : MethodSetup,
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({Parameter1}, {Parameter2}, {Parameter3}, {Parameter4})";
+	}
+
+	/// <summary>
+	///     Setup for a method with four parameters where the expected values are stored directly on
+	///     the setup, avoiding the per-call <see cref="IParameterMatch{T}" /> allocations that
+	///     <see cref="WithParameterCollection" /> requires.
+	/// </summary>
+	public class WithLiteralValues : ReturnMethodSetup<TReturn, T1, T2, T3, T4>,
+		IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>
+	{
+		private readonly T1 _value1;
+		private readonly T2 _value2;
+		private readonly T3 _value3;
+		private readonly T4 _value4;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name,
+			T1 value1, T2 value2, T3 value3, T4 value4)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+			_value2 = value2;
+			_value3 = value3;
+			_value4 = value4;
+		}
+
+		/// <inheritdoc cref="IReturnMethodSetupParameterIgnorer{TReturn, T1, T2, T3, T4}.AnyParameters()" />
+		IReturnMethodSetup<TReturn, T1, T2, T3, T4> IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>.
+			AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="ReturnMethodSetup{TReturn, T1, T2, T3, T4}.Matches(T1, T2, T3, T4)" />
+		public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value)
+			=> _matchAnyParameters ||
+			   (EqualityComparer<T1>.Default.Equals(_value1, p1Value) &&
+			    EqualityComparer<T2>.Default.Equals(_value2, p2Value) &&
+			    EqualityComparer<T3>.Default.Equals(_value3, p3Value) &&
+			    EqualityComparer<T4>.Default.Equals(_value4, p4Value));
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"{FormatType(typeof(TReturn))} {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)}, {FormatLiteralValue(_value2)}, {FormatLiteralValue(_value3)}, {FormatLiteralValue(_value4)})";
 	}
 }
 #pragma warning restore S2436 // Types and methods should not have too many generic parameters

--- a/Source/Mockolate/Setup/VoidMethodSetup.cs
+++ b/Source/Mockolate/Setup/VoidMethodSetup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Mockolate.Interactions;
 using Mockolate.Internals;
@@ -568,6 +569,40 @@ public abstract class VoidMethodSetup<T1> : MethodSetup,
 		public override string ToString()
 			=> $"void {Name.SubstringAfterLast('.')}({Parameter1})";
 	}
+
+	/// <summary>
+	///     Setup for a method with one parameter where the expected value is stored directly on the
+	///     setup, avoiding the per-call <see cref="IParameterMatch{T1}" /> allocation that
+	///     <see cref="WithParameterCollection" /> requires.
+	/// </summary>
+	public class WithLiteralValues : VoidMethodSetup<T1>,
+		IVoidMethodSetupParameterIgnorer<T1>
+	{
+		private readonly T1 _value1;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="VoidMethodSetup{T1}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name, T1 value1)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+		}
+
+		/// <inheritdoc cref="IVoidMethodSetupParameterIgnorer{T1}.AnyParameters()" />
+		IVoidMethodSetup<T1> IVoidMethodSetupParameterIgnorer<T1>.AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1}.Matches(T1)" />
+		public override bool Matches(T1 p1Value)
+			=> _matchAnyParameters || EqualityComparer<T1>.Default.Equals(_value1, p1Value);
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"void {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)})";
+	}
 }
 
 /// <summary>
@@ -911,6 +946,44 @@ public abstract class VoidMethodSetup<T1, T2> : MethodSetup,
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> $"void {Name.SubstringAfterLast('.')}({Parameter1}, {Parameter2})";
+	}
+
+	/// <summary>
+	///     Setup for a method with two parameters where the expected values are stored directly on
+	///     the setup, avoiding the per-call <see cref="IParameterMatch{T}" /> allocations that
+	///     <see cref="WithParameterCollection" /> requires.
+	/// </summary>
+	public class WithLiteralValues : VoidMethodSetup<T1, T2>,
+		IVoidMethodSetupParameterIgnorer<T1, T2>
+	{
+		private readonly T1 _value1;
+		private readonly T2 _value2;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name, T1 value1, T2 value2)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+			_value2 = value2;
+		}
+
+		/// <inheritdoc cref="IVoidMethodSetupParameterIgnorer{T1, T2}.AnyParameters()" />
+		IVoidMethodSetup<T1, T2> IVoidMethodSetupParameterIgnorer<T1, T2>.AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2}.Matches(T1, T2)" />
+		public override bool Matches(T1 p1Value, T2 p2Value)
+			=> _matchAnyParameters ||
+			   (EqualityComparer<T1>.Default.Equals(_value1, p1Value) &&
+			    EqualityComparer<T2>.Default.Equals(_value2, p2Value));
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"void {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)}, {FormatLiteralValue(_value2)})";
 	}
 }
 
@@ -1268,6 +1341,48 @@ public abstract class VoidMethodSetup<T1, T2, T3> : MethodSetup,
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> $"void {Name.SubstringAfterLast('.')}({Parameter1}, {Parameter2}, {Parameter3})";
+	}
+
+	/// <summary>
+	///     Setup for a method with three parameters where the expected values are stored directly on
+	///     the setup, avoiding the per-call <see cref="IParameterMatch{T}" /> allocations that
+	///     <see cref="WithParameterCollection" /> requires.
+	/// </summary>
+	public class WithLiteralValues : VoidMethodSetup<T1, T2, T3>,
+		IVoidMethodSetupParameterIgnorer<T1, T2, T3>
+	{
+		private readonly T1 _value1;
+		private readonly T2 _value2;
+		private readonly T3 _value3;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name,
+			T1 value1, T2 value2, T3 value3)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+			_value2 = value2;
+			_value3 = value3;
+		}
+
+		/// <inheritdoc cref="IVoidMethodSetupParameterIgnorer{T1, T2, T3}.AnyParameters()" />
+		IVoidMethodSetup<T1, T2, T3> IVoidMethodSetupParameterIgnorer<T1, T2, T3>.AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3}.Matches(T1, T2, T3)" />
+		public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value)
+			=> _matchAnyParameters ||
+			   (EqualityComparer<T1>.Default.Equals(_value1, p1Value) &&
+			    EqualityComparer<T2>.Default.Equals(_value2, p2Value) &&
+			    EqualityComparer<T3>.Default.Equals(_value3, p3Value));
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"void {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)}, {FormatLiteralValue(_value2)}, {FormatLiteralValue(_value3)})";
 	}
 }
 
@@ -1636,5 +1751,50 @@ public abstract class VoidMethodSetup<T1, T2, T3, T4> : MethodSetup,
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> $"void {Name.SubstringAfterLast('.')}({Parameter1}, {Parameter2}, {Parameter3}, {Parameter4})";
+	}
+
+	/// <summary>
+	///     Setup for a method with four parameters where the expected values are stored directly on
+	///     the setup, avoiding the per-call <see cref="IParameterMatch{T}" /> allocations that
+	///     <see cref="WithParameterCollection" /> requires.
+	/// </summary>
+	public class WithLiteralValues : VoidMethodSetup<T1, T2, T3, T4>,
+		IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>
+	{
+		private readonly T1 _value1;
+		private readonly T2 _value2;
+		private readonly T3 _value3;
+		private readonly T4 _value4;
+		private bool _matchAnyParameters;
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}" />
+		public WithLiteralValues(MockRegistry mockRegistry, string name,
+			T1 value1, T2 value2, T3 value3, T4 value4)
+			: base(mockRegistry, name)
+		{
+			_value1 = value1;
+			_value2 = value2;
+			_value3 = value3;
+			_value4 = value4;
+		}
+
+		/// <inheritdoc cref="IVoidMethodSetupParameterIgnorer{T1, T2, T3, T4}.AnyParameters()" />
+		IVoidMethodSetup<T1, T2, T3, T4> IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>.AnyParameters()
+		{
+			_matchAnyParameters = true;
+			return this;
+		}
+
+		/// <inheritdoc cref="VoidMethodSetup{T1, T2, T3, T4}.Matches(T1, T2, T3, T4)" />
+		public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value)
+			=> _matchAnyParameters ||
+			   (EqualityComparer<T1>.Default.Equals(_value1, p1Value) &&
+			    EqualityComparer<T2>.Default.Equals(_value2, p2Value) &&
+			    EqualityComparer<T3>.Default.Equals(_value3, p3Value) &&
+			    EqualityComparer<T4>.Default.Equals(_value4, p4Value));
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> $"void {Name.SubstringAfterLast('.')}({FormatLiteralValue(_value1)}, {FormatLiteralValue(_value2)}, {FormatLiteralValue(_value3)}, {FormatLiteralValue(_value4)})";
 	}
 }

--- a/Source/Mockolate/Verify/MethodCountSources.cs
+++ b/Source/Mockolate/Verify/MethodCountSources.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Mockolate.Interactions;
 using Mockolate.Parameters;
 
@@ -105,6 +106,117 @@ internal sealed class Method4CountSource<T1, T2, T3, T4> : IFastMethodCountSourc
 
 	public int Count() => _buffer.ConsumeMatching(_match1, _match2, _match3, _match4);
 	public int CountAll() => _buffer.ConsumeAll();
+}
+
+/// <summary>
+///     Allocation-free count source backed by a 1-parameter method buffer and a captured literal value.
+///     Sibling of <see cref="Method1CountSource{T1}" /> that fuses the expected value into the source so
+///     no <see cref="IParameterMatch{T1}" /> wrapper has to be allocated for bare-value verifies.
+///     Also exposes <see cref="Matches" /> so the verify predicate can be passed as a method group on this
+///     instance instead of a capturing lambda, keeping the fast verify path free of closure allocations.
+/// </summary>
+internal sealed class Method1LiteralCountSource<T1> : IFastMethodCountSource
+{
+	private readonly FastMethod1Buffer<T1> _buffer;
+	private readonly T1 _value1;
+
+	public Method1LiteralCountSource(FastMethod1Buffer<T1> buffer, T1 value1)
+	{
+		_buffer = buffer;
+		_value1 = value1;
+	}
+
+	public int Count() => _buffer.ConsumeMatchingLiteral(_value1);
+	public int CountAll() => _buffer.ConsumeAll();
+
+	public bool Matches(IInteraction interaction)
+		=> interaction is MethodInvocation<T1> m &&
+		   EqualityComparer<T1>.Default.Equals(_value1, m.Parameter1);
+}
+
+/// <summary>
+///     Allocation-free count source backed by a 2-parameter method buffer and captured literal values.
+/// </summary>
+internal sealed class Method2LiteralCountSource<T1, T2> : IFastMethodCountSource
+{
+	private readonly FastMethod2Buffer<T1, T2> _buffer;
+	private readonly T1 _value1;
+	private readonly T2 _value2;
+
+	public Method2LiteralCountSource(FastMethod2Buffer<T1, T2> buffer, T1 value1, T2 value2)
+	{
+		_buffer = buffer;
+		_value1 = value1;
+		_value2 = value2;
+	}
+
+	public int Count() => _buffer.ConsumeMatchingLiteral(_value1, _value2);
+	public int CountAll() => _buffer.ConsumeAll();
+
+	public bool Matches(IInteraction interaction)
+		=> interaction is MethodInvocation<T1, T2> m &&
+		   EqualityComparer<T1>.Default.Equals(_value1, m.Parameter1) &&
+		   EqualityComparer<T2>.Default.Equals(_value2, m.Parameter2);
+}
+
+/// <summary>
+///     Allocation-free count source backed by a 3-parameter method buffer and captured literal values.
+/// </summary>
+internal sealed class Method3LiteralCountSource<T1, T2, T3> : IFastMethodCountSource
+{
+	private readonly FastMethod3Buffer<T1, T2, T3> _buffer;
+	private readonly T1 _value1;
+	private readonly T2 _value2;
+	private readonly T3 _value3;
+
+	public Method3LiteralCountSource(FastMethod3Buffer<T1, T2, T3> buffer, T1 value1, T2 value2, T3 value3)
+	{
+		_buffer = buffer;
+		_value1 = value1;
+		_value2 = value2;
+		_value3 = value3;
+	}
+
+	public int Count() => _buffer.ConsumeMatchingLiteral(_value1, _value2, _value3);
+	public int CountAll() => _buffer.ConsumeAll();
+
+	public bool Matches(IInteraction interaction)
+		=> interaction is MethodInvocation<T1, T2, T3> m &&
+		   EqualityComparer<T1>.Default.Equals(_value1, m.Parameter1) &&
+		   EqualityComparer<T2>.Default.Equals(_value2, m.Parameter2) &&
+		   EqualityComparer<T3>.Default.Equals(_value3, m.Parameter3);
+}
+
+/// <summary>
+///     Allocation-free count source backed by a 4-parameter method buffer and captured literal values.
+/// </summary>
+internal sealed class Method4LiteralCountSource<T1, T2, T3, T4> : IFastMethodCountSource
+{
+	private readonly FastMethod4Buffer<T1, T2, T3, T4> _buffer;
+	private readonly T1 _value1;
+	private readonly T2 _value2;
+	private readonly T3 _value3;
+	private readonly T4 _value4;
+
+	public Method4LiteralCountSource(FastMethod4Buffer<T1, T2, T3, T4> buffer,
+		T1 value1, T2 value2, T3 value3, T4 value4)
+	{
+		_buffer = buffer;
+		_value1 = value1;
+		_value2 = value2;
+		_value3 = value3;
+		_value4 = value4;
+	}
+
+	public int Count() => _buffer.ConsumeMatchingLiteral(_value1, _value2, _value3, _value4);
+	public int CountAll() => _buffer.ConsumeAll();
+
+	public bool Matches(IInteraction interaction)
+		=> interaction is MethodInvocation<T1, T2, T3, T4> m &&
+		   EqualityComparer<T1>.Default.Equals(_value1, m.Parameter1) &&
+		   EqualityComparer<T2>.Default.Equals(_value2, m.Parameter2) &&
+		   EqualityComparer<T3>.Default.Equals(_value3, m.Parameter3) &&
+		   EqualityComparer<T4>.Default.Equals(_value4, m.Parameter4);
 }
 
 /// <summary>

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -267,9 +267,13 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, TMethod>(T subject, int memberId, string methodName, System.Func<TMethod, bool> predicate, System.Func<string> expectation)
             where TMethod : Mockolate.Interactions.IMethodInteraction { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1>(T subject, int memberId, string methodName, T1 literalValue1, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, T3 literalValue3, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3, T4>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3, T4>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, T3 literalValue3, T4 literalValue4, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T> VerifyProperty<T>(T subject, int memberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> VerifyProperty<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
         public Mockolate.Verify.VerificationResult<T> VerifyPropertyTyped<T>(T subject, int memberId, string propertyName) { }
@@ -760,6 +764,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1) { }
+        public int ConsumeMatchingLiteral(T1 value1) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod2Buffer<T1, T2> : Mockolate.Interactions.IFastMemberBuffer
@@ -769,6 +774,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod3Buffer<T1, T2, T3> : Mockolate.Interactions.IFastMemberBuffer
@@ -778,6 +784,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2, T3 parameter3) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod4Buffer<T1, T2, T3, T4> : Mockolate.Interactions.IFastMemberBuffer
@@ -787,6 +794,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3, T4 value4) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} interactions")]
     public class FastMockInteractions : Mockolate.Interactions.IMockInteractions, System.Collections.Generic.IEnumerable<Mockolate.Interactions.IInteraction>, System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction>, System.Collections.IEnumerable
@@ -2346,6 +2354,7 @@ namespace Mockolate.Setup
         protected MethodSetup(string name) { }
         public string Name { get; }
         protected abstract bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction);
+        protected static string FormatLiteralValue<T>(T value) { }
         protected static string FormatType(System.Type type) { }
     }
     public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
@@ -2602,6 +2611,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1) { }
         public bool TryGetReturnValue(T1 p1, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1) { }
+            public override bool Matches(T1 p1Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
@@ -2626,6 +2641,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2) { }
+            public override bool Matches(T1 p1Value, T2 p2Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
@@ -2651,6 +2672,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, T3 p3, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
@@ -2677,6 +2704,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, T3 p3, T4 p4, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3, T4 value4) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
@@ -2723,6 +2756,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1) { }
+            public override bool Matches(T1 p1Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
@@ -2745,6 +2784,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2) { }
+            public override bool Matches(T1 p1Value, T2 p2Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
@@ -2768,6 +2813,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
@@ -2792,6 +2843,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3, T4 value4) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -260,9 +260,13 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, TMethod>(T subject, int memberId, string methodName, System.Func<TMethod, bool> predicate, System.Func<string> expectation)
             where TMethod : Mockolate.Interactions.IMethodInteraction { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1>(T subject, int memberId, string methodName, T1 literalValue1, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, T3 literalValue3, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3, T4>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3, T4>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, T3 literalValue3, T4 literalValue4, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T> VerifyProperty<T>(T subject, int memberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> VerifyProperty<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
         public Mockolate.Verify.VerificationResult<T> VerifyPropertyTyped<T>(T subject, int memberId, string propertyName) { }
@@ -751,6 +755,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1) { }
+        public int ConsumeMatchingLiteral(T1 value1) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod2Buffer<T1, T2> : Mockolate.Interactions.IFastMemberBuffer
@@ -760,6 +765,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod3Buffer<T1, T2, T3> : Mockolate.Interactions.IFastMemberBuffer
@@ -769,6 +775,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2, T3 parameter3) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod4Buffer<T1, T2, T3, T4> : Mockolate.Interactions.IFastMemberBuffer
@@ -778,6 +785,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3, T4 value4) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} interactions")]
     public class FastMockInteractions : Mockolate.Interactions.IMockInteractions, System.Collections.Generic.IEnumerable<Mockolate.Interactions.IInteraction>, System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction>, System.Collections.IEnumerable
@@ -2124,6 +2132,7 @@ namespace Mockolate.Setup
         protected MethodSetup(string name) { }
         public string Name { get; }
         protected abstract bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction);
+        protected static string FormatLiteralValue<T>(T value) { }
         protected static string FormatType(System.Type type) { }
     }
     public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
@@ -2192,6 +2201,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1) { }
         public bool TryGetReturnValue(T1 p1, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1) { }
+            public override bool Matches(T1 p1Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
@@ -2216,6 +2231,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2) { }
+            public override bool Matches(T1 p1Value, T2 p2Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
@@ -2241,6 +2262,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, T3 p3, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
@@ -2267,6 +2294,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, T3 p3, T4 p4, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3, T4 value4) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
@@ -2313,6 +2346,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1) { }
+            public override bool Matches(T1 p1Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
@@ -2335,6 +2374,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2) { }
+            public override bool Matches(T1 p1Value, T2 p2Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
@@ -2358,6 +2403,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
@@ -2382,6 +2433,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3, T4 value4) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -247,9 +247,13 @@ namespace Mockolate
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, TMethod>(T subject, int memberId, string methodName, System.Func<TMethod, bool> predicate, System.Func<string> expectation)
             where TMethod : Mockolate.Interactions.IMethodInteraction { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1>(T subject, int memberId, string methodName, T1 literalValue1, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, T3 literalValue3, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3, T4>(T subject, int memberId, string methodName, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> expectation) { }
+        public Mockolate.Verify.VerificationResult<T>.IgnoreParameters VerifyMethod<T, T1, T2, T3, T4>(T subject, int memberId, string methodName, T1 literalValue1, T2 literalValue2, T3 literalValue3, T4 literalValue4, System.Func<string> expectation) { }
         public Mockolate.Verify.VerificationResult<T> VerifyProperty<T>(T subject, int memberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> VerifyProperty<TSubject, TValue>(TSubject subject, int memberId, string propertyName, Mockolate.Parameters.IParameterMatch<TValue> value) { }
         public Mockolate.Verify.VerificationResult<T> VerifyPropertyTyped<T>(T subject, int memberId, string propertyName) { }
@@ -710,6 +714,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1) { }
+        public int ConsumeMatchingLiteral(T1 value1) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod2Buffer<T1, T2> : Mockolate.Interactions.IFastMemberBuffer
@@ -719,6 +724,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod3Buffer<T1, T2, T3> : Mockolate.Interactions.IFastMemberBuffer
@@ -728,6 +734,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2, T3 parameter3) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} method calls")]
     public sealed class FastMethod4Buffer<T1, T2, T3, T4> : Mockolate.Interactions.IFastMemberBuffer
@@ -737,6 +744,7 @@ namespace Mockolate.Interactions
         public void Append(string name, T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
         public void Clear() { }
         public int ConsumeMatching(Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4) { }
+        public int ConsumeMatchingLiteral(T1 value1, T2 value2, T3 value3, T4 value4) { }
     }
     [System.Diagnostics.DebuggerDisplay("{Count} interactions")]
     public class FastMockInteractions : Mockolate.Interactions.IMockInteractions, System.Collections.Generic.IEnumerable<Mockolate.Interactions.IInteraction>, System.Collections.Generic.IReadOnlyCollection<Mockolate.Interactions.IInteraction>, System.Collections.IEnumerable
@@ -2079,6 +2087,7 @@ namespace Mockolate.Setup
         protected MethodSetup(string name) { }
         public string Name { get; }
         protected abstract bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction);
+        protected static string FormatLiteralValue<T>(T value) { }
         protected static string FormatType(System.Type type) { }
     }
     public abstract class PropertySetup : Mockolate.Setup.IInteractivePropertySetup, Mockolate.Setup.ISetup
@@ -2140,6 +2149,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1) { }
         public bool TryGetReturnValue(T1 p1, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1) { }
+            public override bool Matches(T1 p1Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
@@ -2164,6 +2179,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2) { }
+            public override bool Matches(T1 p1Value, T2 p2Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
@@ -2189,6 +2210,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, T3 p3, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
@@ -2215,6 +2242,12 @@ namespace Mockolate.Setup
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
         public bool TryGetReturnValue(T1 p1, T2 p2, T3 p3, T4 p4, out TReturn returnValue) { }
+        public class WithLiteralValues : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3, T4 value4) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.ReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.IReturnMethodSetupParameterIgnorer<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetupWithCallback<TReturn, T1, T2, T3, T4>, Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4>, Mockolate.Setup.ISetup
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
@@ -2254,6 +2287,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1) { }
+            public override bool Matches(T1 p1Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1>, Mockolate.Setup.IVoidMethodSetup<T1>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
@@ -2276,6 +2315,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2) { }
+            public override bool Matches(T1 p1Value, T2 p2Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2>, Mockolate.Setup.IVoidMethodSetup<T1, T2>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
@@ -2299,6 +2344,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
@@ -2323,6 +2374,12 @@ namespace Mockolate.Setup
         protected override bool MatchesInteraction(Mockolate.Interactions.IMethodInteraction interaction) { }
         public bool SkipBaseClass(Mockolate.MockBehavior behavior) { }
         public virtual void TriggerCallbacks(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4) { }
+        public class WithLiteralValues : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
+        {
+            public WithLiteralValues(Mockolate.MockRegistry mockRegistry, string name, T1 value1, T2 value2, T3 value3, T4 value4) { }
+            public override bool Matches(T1 p1Value, T2 p2Value, T3 p3Value, T4 p4Value) { }
+            public override string ToString() { }
+        }
         public class WithParameterCollection : Mockolate.Setup.VoidMethodSetup<T1, T2, T3, T4>, Mockolate.Setup.IMethodSetup, Mockolate.Setup.ISetup, Mockolate.Setup.IVoidMethodSetupParameterIgnorer<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetupWithCallback<T1, T2, T3, T4>, Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4>
         {
             public WithParameterCollection(Mockolate.MockRegistry mockRegistry, string name, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -2441,7 +2441,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<string?, string?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetMaybeNull(string? s)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<string?, string?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", (global::Mockolate.Parameters.IParameterMatch<string?>)global::Mockolate.It.IsValue<string?>(s));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<string?, string?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", s);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, methodSetup);
 			return methodSetup;
 		}
@@ -2465,7 +2465,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(object? obj)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, methodSetup);
 			return methodSetup;
 		}
@@ -2505,7 +2505,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(first), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(second));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", first, second);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, methodSetup);
 			return methodSetup;
 		}
@@ -2545,7 +2545,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", n, obj);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, methodSetup);
 			return methodSetup;
 		}
@@ -2617,7 +2617,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::Mockolate.Setup.SpanWrapper<char>, int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetSpan(int n)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", n);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, methodSetup);
 			return methodSetup;
 		}
@@ -2641,7 +2641,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetROSpan(int n)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", n);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, methodSetup);
 			return methodSetup;
 		}
@@ -3067,8 +3067,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, string?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", s is null ? (global::Mockolate.Parameters.IParameterMatch<string?>)global::Mockolate.It.Is<string?>(default!) : CovariantParameterAdapter<string?>.Wrap(s), () => $"GetMaybeNull({s})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetMaybeNull(string? s)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<string?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", __i => 
-				(global::System.Collections.Generic.EqualityComparer<string?>.Default.Equals(s, __i.Parameter1)), () => $"GetMaybeNull({s})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, string?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", s, () => $"GetMaybeNull({s})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => parameters switch
@@ -3082,8 +3081,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(obj), () => $"TakeObject({obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeObject(object? obj)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter1)), () => $"TakeObject({obj})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj, () => $"TakeObject({obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => parameters switch
@@ -3107,9 +3105,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(first, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", first, second, () => $"TakeTwoObjects({first}, {second})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => parameters switch
@@ -3133,9 +3129,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", n, obj, () => $"TakeIntAndObject({n}, {obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.DoTask()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_DoTask, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask", () => $"DoTask()");
@@ -3167,8 +3161,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", n is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(n), () => $"GetSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetSpan(int n)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)), () => $"GetSpan({n})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", n, () => $"GetSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.GetROSpan(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", __i => parameters switch
@@ -3182,8 +3175,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", n is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(n), () => $"GetROSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetROSpan(int n)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)), () => $"GetROSpan({n})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", n, () => $"GetROSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetByRef()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetByRef, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetByRef", () => $"GetByRef()");
@@ -3598,8 +3590,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, string?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", s is null ? (global::Mockolate.Parameters.IParameterMatch<string?>)global::Mockolate.It.Is<string?>(default!) : CovariantParameterAdapter<string?>.Wrap(s), () => $"GetMaybeNull({s})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetMaybeNull(string? s)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<string?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", __i => 
-				(global::System.Collections.Generic.EqualityComparer<string?>.Default.Equals(s, __i.Parameter1)), () => $"GetMaybeNull({s})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, string?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", s, () => $"GetMaybeNull({s})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeObject(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => parameters switch
@@ -3613,8 +3604,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj is null ? (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.Is<object?>(default!) : CovariantParameterAdapter<object?>.Wrap(obj), () => $"TakeObject({obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeObject(object? obj)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", __i => 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter1)), () => $"TakeObject({obj})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj, () => $"TakeObject({obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeTwoObjects(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => parameters switch
@@ -3638,9 +3628,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<object?, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", __i => 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(first, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(second, __i.Parameter2)), () => $"TakeTwoObjects({first}, {second})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, object?, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", first, second, () => $"TakeTwoObjects({first}, {second})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.TakeIntAndObject(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => parameters switch
@@ -3664,9 +3652,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, object?>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(obj, __i.Parameter2)), () => $"TakeIntAndObject({n}, {obj})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int, object?>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", n, obj, () => $"TakeIntAndObject({n}, {obj})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.DoTask()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_DoTask, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.DoTask", () => $"DoTask()");
@@ -3698,8 +3684,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", n is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(n), () => $"GetSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetSpan(int n)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)), () => $"GetSpan({n})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", n, () => $"GetSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.GetROSpan(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", __i => parameters switch
@@ -3713,8 +3698,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", n is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(n), () => $"GetROSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetROSpan(int n)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(n, __i.Parameter1)), () => $"GetROSpan({n})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, int>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", n, () => $"GetROSpan({n})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface>.IgnoreParameters IMockVerifyForIComprehensiveInterface.GetByRef()
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetByRef, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetByRef", () => $"GetByRef()");
@@ -4173,7 +4157,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<string?, string?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetMaybeNull(string? s)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<string?, string?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", (global::Mockolate.Parameters.IParameterMatch<string?>)global::Mockolate.It.IsValue<string?>(s));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<string?, string?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetMaybeNull", s);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetMaybeNull, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -4197,7 +4181,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<bool, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeObject(object? obj)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<bool, object?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeObject", obj);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeObject, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -4237,7 +4221,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, object?, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeTwoObjects(object? first, object? second)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(first), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(second));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, object?, object?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeTwoObjects", first, second);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeTwoObjects, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -4277,7 +4261,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int, object?> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.TakeIntAndObject(int n, object? obj)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n), (global::Mockolate.Parameters.IParameterMatch<object?>)global::Mockolate.It.IsValue<object?>(obj));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int, object?>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.TakeIntAndObject", n, obj);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_TakeIntAndObject, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -4349,7 +4333,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::Mockolate.Setup.SpanWrapper<char>, int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetSpan(int n)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.SpanWrapper<char>, int>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSpan", n);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetSpan, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -4373,7 +4357,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetROSpan(int n)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(n));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::Mockolate.Setup.ReadOnlySpanWrapper<char>, int>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetROSpan", n);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetROSpan, _scenarioName, methodSetup);
 			return methodSetup;
 		}

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpClient.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpClient.g.cs
@@ -407,7 +407,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
 			return methodSetup;
 		}
@@ -447,7 +447,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
 			return methodSetup;
 		}
@@ -475,7 +475,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(bool disposing)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", disposing);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
 			return methodSetup;
 		}
@@ -507,9 +507,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"Send({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient>.IgnoreParameters IMockVerifyForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpClient.MemberId_Send, "global::System.Net.Http.HttpMessageInvoker.Send", __i => 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Net.Http.HttpRequestMessage>.Default.Equals(request, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"Send({request}, {cancellationToken})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>(this, global::Mockolate.Mock.HttpClient.MemberId_Send, "global::System.Net.Http.HttpMessageInvoker.Send", request, cancellationToken, () => $"Send({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient> IMockVerifyForHttpClient.SendAsync(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpClient.MemberId_SendAsync, "global::System.Net.Http.HttpMessageInvoker.SendAsync", __i => parameters switch
@@ -533,9 +531,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"SendAsync({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient>.IgnoreParameters IMockVerifyForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpClient.MemberId_SendAsync, "global::System.Net.Http.HttpMessageInvoker.SendAsync", __i => 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Net.Http.HttpRequestMessage>.Default.Equals(request, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"SendAsync({request}, {cancellationToken})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>(this, global::Mockolate.Mock.HttpClient.MemberId_SendAsync, "global::System.Net.Http.HttpMessageInvoker.SendAsync", request, cancellationToken, () => $"SendAsync({request}, {cancellationToken})");
 		#endregion IMockVerifyForHttpClient
 
 		#region IMockProtectedVerifyForHttpClient
@@ -553,8 +549,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpClient, bool>(this, global::Mockolate.Mock.HttpClient.MemberId_Dispose, "global::System.Net.Http.HttpMessageInvoker.Dispose", disposing is null ? (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.Is<bool>(default!) : CovariantParameterAdapter<bool>.Wrap(disposing), () => $"Dispose({disposing})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpClient>.IgnoreParameters IMockProtectedVerifyForHttpClient.Dispose(bool disposing)
-			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpClient, global::Mockolate.Interactions.MethodInvocation<bool>>(this, global::Mockolate.Mock.HttpClient.MemberId_Dispose, "global::System.Net.Http.HttpMessageInvoker.Dispose", __i => 
-				(global::System.Collections.Generic.EqualityComparer<bool>.Default.Equals(disposing, __i.Parameter1)), () => $"Dispose({disposing})");
+			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpClient, bool>(this, global::Mockolate.Mock.HttpClient.MemberId_Dispose, "global::System.Net.Http.HttpMessageInvoker.Dispose", disposing, () => $"Dispose({disposing})");
 		#endregion IMockProtectedVerifyForHttpClient
 	}
 
@@ -588,9 +583,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"Send({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient>.IgnoreParameters IMockVerifyForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpClient.MemberId_Send, "global::System.Net.Http.HttpMessageInvoker.Send", __i => 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Net.Http.HttpRequestMessage>.Default.Equals(request, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"Send({request}, {cancellationToken})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>(this, global::Mockolate.Mock.HttpClient.MemberId_Send, "global::System.Net.Http.HttpMessageInvoker.Send", request, cancellationToken, () => $"Send({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient> IMockVerifyForHttpClient.SendAsync(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpClient.MemberId_SendAsync, "global::System.Net.Http.HttpMessageInvoker.SendAsync", __i => parameters switch
@@ -614,9 +607,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"SendAsync({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForHttpClient>.IgnoreParameters IMockVerifyForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpClient.MemberId_SendAsync, "global::System.Net.Http.HttpMessageInvoker.SendAsync", __i => 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Net.Http.HttpRequestMessage>.Default.Equals(request, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"SendAsync({request}, {cancellationToken})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForHttpClient, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>(this, global::Mockolate.Mock.HttpClient.MemberId_SendAsync, "global::System.Net.Http.HttpMessageInvoker.SendAsync", request, cancellationToken, () => $"SendAsync({request}, {cancellationToken})");
 		#endregion IMockVerifyForHttpClient
 	}
 
@@ -677,7 +668,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -717,7 +708,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -745,7 +736,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(bool disposing)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", disposing);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -1562,7 +1553,7 @@ internal static partial class MockExtensionsForHttpClient
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Send", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Send, methodSetup);
 			return methodSetup;
 		}
@@ -1602,7 +1593,7 @@ internal static partial class MockExtensionsForHttpClient
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockSetupForHttpClient.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.SendAsync", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_SendAsync, methodSetup);
 			return methodSetup;
 		}
@@ -1630,7 +1621,7 @@ internal static partial class MockExtensionsForHttpClient
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpClient.Dispose(bool disposing)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageInvoker.Dispose", disposing);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpClient.MemberId_Dispose, methodSetup);
 			return methodSetup;
 		}

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpMessageHandler.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/HttpClient_CanBeCreated/Mock.HttpMessageHandler.g.cs
@@ -345,7 +345,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
 			return methodSetup;
 		}
@@ -385,7 +385,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
 			return methodSetup;
 		}
@@ -409,7 +409,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(bool disposing)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", disposing);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
 			return methodSetup;
 		}
@@ -445,9 +445,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"Send({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler>.IgnoreParameters IMockProtectedVerifyForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, "global::System.Net.Http.HttpMessageHandler.Send", __i => 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Net.Http.HttpRequestMessage>.Default.Equals(request, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"Send({request}, {cancellationToken})");
+			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, "global::System.Net.Http.HttpMessageHandler.Send", request, cancellationToken, () => $"Send({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> IMockProtectedVerifyForHttpMessageHandler.SendAsync(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, "global::System.Net.Http.HttpMessageHandler.SendAsync", __i => parameters switch
@@ -471,9 +469,7 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"SendAsync({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler>.IgnoreParameters IMockProtectedVerifyForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
-			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, global::Mockolate.Interactions.MethodInvocation<global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, "global::System.Net.Http.HttpMessageHandler.SendAsync", __i => 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Net.Http.HttpRequestMessage>.Default.Equals(request, __i.Parameter1)) && 
-				(global::System.Collections.Generic.EqualityComparer<global::System.Threading.CancellationToken>.Default.Equals(cancellationToken, __i.Parameter2)), () => $"SendAsync({request}, {cancellationToken})");
+			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, "global::System.Net.Http.HttpMessageHandler.SendAsync", request, cancellationToken, () => $"SendAsync({request}, {cancellationToken})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler> IMockProtectedVerifyForHttpMessageHandler.Dispose(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, global::Mockolate.Interactions.MethodInvocation<bool>>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, "global::System.Net.Http.HttpMessageHandler.Dispose", __i => parameters switch
@@ -487,8 +483,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, bool>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, "global::System.Net.Http.HttpMessageHandler.Dispose", disposing is null ? (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.Is<bool>(default!) : CovariantParameterAdapter<bool>.Wrap(disposing), () => $"Dispose({disposing})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockProtectedVerifyForHttpMessageHandler>.IgnoreParameters IMockProtectedVerifyForHttpMessageHandler.Dispose(bool disposing)
-			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, global::Mockolate.Interactions.MethodInvocation<bool>>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, "global::System.Net.Http.HttpMessageHandler.Dispose", __i => 
-				(global::System.Collections.Generic.EqualityComparer<bool>.Default.Equals(disposing, __i.Parameter1)), () => $"Dispose({disposing})");
+			=> this.MockRegistry.VerifyMethod<IMockProtectedVerifyForHttpMessageHandler, bool>(this, global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, "global::System.Net.Http.HttpMessageHandler.Dispose", disposing, () => $"Dispose({disposing})");
 		#endregion IMockProtectedVerifyForHttpMessageHandler
 	}
 
@@ -563,7 +558,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -603,7 +598,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -627,7 +622,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(bool disposing)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", disposing);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -1280,7 +1275,7 @@ internal static partial class MockExtensionsForHttpMessageHandler
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Send(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Net.Http.HttpResponseMessage, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Send", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Send, methodSetup);
 			return methodSetup;
 		}
@@ -1320,7 +1315,7 @@ internal static partial class MockExtensionsForHttpMessageHandler
 		/// <inheritdoc />
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.SendAsync(global::System.Net.Http.HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken)
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", (global::Mockolate.Parameters.IParameterMatch<global::System.Net.Http.HttpRequestMessage>)global::Mockolate.It.IsValue<global::System.Net.Http.HttpRequestMessage>(request), (global::Mockolate.Parameters.IParameterMatch<global::System.Threading.CancellationToken>)global::Mockolate.It.IsValue<global::System.Threading.CancellationToken>(cancellationToken));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>, global::System.Net.Http.HttpRequestMessage, global::System.Threading.CancellationToken>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.SendAsync", request, cancellationToken);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_SendAsync, methodSetup);
 			return methodSetup;
 		}
@@ -1344,7 +1339,7 @@ internal static partial class MockExtensionsForHttpMessageHandler
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<bool> global::Mockolate.Mock.IMockProtectedSetupForHttpMessageHandler.Dispose(bool disposing)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithParameterCollection(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", (global::Mockolate.Parameters.IParameterMatch<bool>)global::Mockolate.It.IsValue<bool>(disposing));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<bool>.WithLiteralValues(MockRegistry, "global::System.Net.Http.HttpMessageHandler.Dispose", disposing);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.HttpMessageHandler.MemberId_Dispose, methodSetup);
 			return methodSetup;
 		}

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
@@ -512,7 +512,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@if(int @params)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(@params));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", @params);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, methodSetup);
 			return methodSetup;
 		}
@@ -539,7 +539,7 @@ internal static partial class Mock
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@void<@class>(int @ref)
 			where @class : default
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int>.WithParameterCollection(MockRegistry, $"global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@void<{typeof(@class)}>", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(@ref));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int>.WithLiteralValues(MockRegistry, $"global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@void<{typeof(@class)}>", @ref);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IKeywordEdgeCases.MemberId__void__class_, methodSetup);
 			return methodSetup;
 		}
@@ -643,8 +643,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIKeywordEdgeCases, int>(this, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", @params is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(@params), () => $"@if({@params})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases>.IgnoreParameters IMockVerifyForIKeywordEdgeCases.@if(int @params)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIKeywordEdgeCases, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(@params, __i.Parameter1)), () => $"@if({@params})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIKeywordEdgeCases, int>(this, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", @params, () => $"@if({@params})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases> IMockVerifyForIKeywordEdgeCases.@void<@class>(global::Mockolate.Parameters.IParameters parameters)
 			where @class : default
@@ -764,8 +763,7 @@ internal static partial class Mock
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIKeywordEdgeCases, int>(this, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", @params is null ? (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.Is<int>(default!) : CovariantParameterAdapter<int>.Wrap(@params), () => $"@if({@params})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases>.IgnoreParameters IMockVerifyForIKeywordEdgeCases.@if(int @params)
-			=> this.MockRegistry.VerifyMethod<IMockVerifyForIKeywordEdgeCases, global::Mockolate.Interactions.MethodInvocation<int>>(this, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", __i => 
-				(global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(@params, __i.Parameter1)), () => $"@if({@params})");
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIKeywordEdgeCases, int>(this, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", @params, () => $"@if({@params})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIKeywordEdgeCases> IMockVerifyForIKeywordEdgeCases.@void<@class>(global::Mockolate.Parameters.IParameters parameters)
 			where @class : default
@@ -917,7 +915,7 @@ internal static partial class Mock
 		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupParameterIgnorer<int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@if(int @params)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(@params));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int>.WithLiteralValues(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@if", @params);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IKeywordEdgeCases.MemberId__if, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -944,7 +942,7 @@ internal static partial class Mock
 		global::Mockolate.Setup.IReturnMethodSetupParameterIgnorer<int, int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@void<@class>(int @ref)
 			where @class : default
 		{
-			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int>.WithParameterCollection(MockRegistry, $"global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@void<{typeof(@class)}>", (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(@ref));
+			var methodSetup = new global::Mockolate.Setup.ReturnMethodSetup<int, int>.WithLiteralValues(MockRegistry, $"global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@void<{typeof(@class)}>", @ref);
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IKeywordEdgeCases.MemberId__void__class_, _scenarioName, methodSetup);
 			return methodSetup;
 		}

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.LiteralValuesTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.LiteralValuesTests.cs
@@ -1,0 +1,176 @@
+namespace Mockolate.Tests.MockMethods;
+
+public sealed partial class SetupMethodTests
+{
+	/// <summary>
+	///     Behavioral coverage for the fused <c>WithLiteralValues</c> setup path and the literal-value
+	///     <c>VerifyMethod</c> overloads (arities 1..4, return + void). The bare-value setup overload
+	///     used to construct an <see cref="It.IsValue{T}" /> matcher per call; these tests pin the
+	///     equivalence between the literal-value path and the explicit-matcher path so the
+	///     allocation-saving rewrite cannot regress matching semantics.
+	/// </summary>
+	public sealed class LiteralValuesTests
+	{
+		[Fact]
+		public async Task LiteralValues_Arity1_Return_MatchesValue()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			sut.Mock.Setup.Get1(1).Returns("one");
+
+			string match = sut.Get1(1);
+			string miss = sut.Get1(2);
+
+			await That(match).IsEqualTo("one");
+			await That(miss).IsEqualTo(string.Empty);
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity1_Void_MatchesAndCounts()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			int hits = 0;
+			sut.Mock.Setup.Touch1(1).Do(() => hits++);
+
+			sut.Touch1(1);
+			sut.Touch1(2);
+
+			await That(hits).IsEqualTo(1);
+			await That(sut.Mock.Verify.Touch1(1)).Once();
+			await That(sut.Mock.Verify.Touch1(2)).Once();
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity1_AnyParameters_MatchesEverything()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			sut.Mock.Setup.Get1(1).AnyParameters().Returns("any");
+
+			await That(sut.Get1(1)).IsEqualTo("any");
+			await That(sut.Get1(99)).IsEqualTo("any");
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity1_EquivalentToItIs()
+		{
+			ILiteralFusedService literal = ILiteralFusedService.CreateMock();
+			ILiteralFusedService matcher = ILiteralFusedService.CreateMock();
+			literal.Mock.Setup.Get1(7).Returns("seven");
+			matcher.Mock.Setup.Get1(It.Is(7)).Returns("seven");
+
+			await That(literal.Get1(7)).IsEqualTo(matcher.Get1(7));
+			await That(literal.Get1(8)).IsEqualTo(matcher.Get1(8));
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity2_Return_MatchesAllParameters()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			sut.Mock.Setup.Get2(1, "a").Returns(11);
+
+			await That(sut.Get2(1, "a")).IsEqualTo(11);
+			await That(sut.Get2(1, "b")).IsEqualTo(0);
+			await That(sut.Get2(2, "a")).IsEqualTo(0);
+			await That(sut.Mock.Verify.Get2(1, "a")).Once();
+			await That(sut.Mock.Verify.Get2(2, "a")).Once();
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity2_Void_VerifiesByLiteralValues()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			sut.Touch2(1, true);
+			sut.Touch2(1, false);
+			sut.Touch2(2, true);
+
+			await That(sut.Mock.Verify.Touch2(1, true)).Once();
+			await That(sut.Mock.Verify.Touch2(1, false)).Once();
+			await That(sut.Mock.Verify.Touch2(3, true)).Never();
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity3_Return_MatchesAllParameters()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			sut.Mock.Setup.Get3(1, "a", true).Returns(33);
+
+			await That(sut.Get3(1, "a", true)).IsEqualTo(33);
+			await That(sut.Get3(1, "a", false)).IsEqualTo(0);
+			await That(sut.Mock.Verify.Get3(1, "a", true)).Once();
+			await That(sut.Mock.Verify.Get3(1, "a", false)).Once();
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity3_Void_AnyParameters()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			int hits = 0;
+			sut.Mock.Setup.Touch3(0, "x", false).AnyParameters().Do(() => hits++);
+
+			sut.Touch3(0, "x", false);
+			sut.Touch3(99, "y", true);
+
+			await That(hits).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity4_Return_MatchesAllParameters()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			sut.Mock.Setup.Get4(1, "a", true, 0.5).Returns(44);
+
+			await That(sut.Get4(1, "a", true, 0.5)).IsEqualTo(44);
+			await That(sut.Get4(1, "a", true, 0.6)).IsEqualTo(0);
+			await That(sut.Mock.Verify.Get4(1, "a", true, 0.5)).Once();
+			await That(sut.Mock.Verify.Get4(1, "a", true, 0.6)).Once();
+		}
+
+		[Fact]
+		public async Task LiteralValues_Arity4_Void_EquivalentToMatcherSetup()
+		{
+			ILiteralFusedService literal = ILiteralFusedService.CreateMock();
+			ILiteralFusedService matcher = ILiteralFusedService.CreateMock();
+			int literalHits = 0;
+			int matcherHits = 0;
+			literal.Mock.Setup.Touch4(1, "a", true, 1.5).Do(() => literalHits++);
+			matcher.Mock.Setup.Touch4(It.Is(1), It.Is("a"), It.Is(true), It.Is(1.5)).Do(() => matcherHits++);
+
+			literal.Touch4(1, "a", true, 1.5);
+			matcher.Touch4(1, "a", true, 1.5);
+			literal.Touch4(2, "a", true, 1.5);
+			matcher.Touch4(2, "a", true, 1.5);
+
+			await That(literalHits).IsEqualTo(matcherHits);
+		}
+
+		[Fact]
+		public async Task LiteralValues_ToString_UsesInvariantCulture()
+		{
+			ILiteralFusedService sut = ILiteralFusedService.CreateMock();
+			sut.Mock.Setup.Get4(1, "a", true, 0.5).Returns(44);
+			Mockolate.MockRegistry registry = ((Mockolate.IMock)sut).MockRegistry;
+
+			System.Collections.Generic.IReadOnlyCollection<Mockolate.Setup.ISetup> unused =
+				registry.GetUnusedSetups(new Mockolate.Interactions.FastMockInteractions(0));
+			Mockolate.Setup.ISetup setup = await That(unused).HasSingle();
+
+			// 0.5 must be formatted with InvariantCulture; on a German-locale host the host default
+			// would render it as "0,5" — this assertion would fail if FormatLiteralValue regressed.
+			await That(setup.ToString()!).Contains("0.5");
+		}
+	}
+
+	public interface ILiteralFusedService
+	{
+		string Get1(int p1);
+		void Touch1(int p1);
+
+		int Get2(int p1, string p2);
+		void Touch2(int p1, bool p2);
+
+		int Get3(int p1, string p2, bool p3);
+		void Touch3(int p1, string p2, bool p3);
+
+		int Get4(int p1, string p2, bool p3, double p4);
+		void Touch4(int p1, string p2, bool p3, double p4);
+	}
+}


### PR DESCRIPTION
For the bare-value Setup and Verify overloads (e.g. `Setup.GetById(1)` / `Verify.GetById(1)`), the generator previously routed through `WithParameterCollection(... It.IsValue<int>(1))` and a closure-based `VerifyMethod<T, MethodInvocation<T1>>` predicate. Each call site allocated a `ParameterEqualsMatch<T>` matcher (and, on verify, a closure) just to wrap a literal value.

Add `WithLiteralValues` nested setup classes (arities 1..4 on both `ReturnMethodSetup<...>` and `VoidMethodSetup<...>`) that store the expected values directly and compare with `EqualityComparer<T>.Default`, plus matching `ConsumeMatchingLiteral` overloads on `FastMethod{1..4}Buffer`, `Method{1..4}LiteralCountSource` count sources, and bare-value `VerifyMethod` overloads on `MockRegistry`. The generator now emits these for the all-literal overloads only (1..4 parameters, no ref/out/ref-readonly). The `WithParameterCollection` / matcher path is unchanged for explicit-matcher and mixed call sites.