### PR TITLE
refactor: re-enable disabled tests due to testhost crash

### DIFF
--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -2016,7 +2016,6 @@ public sealed partial class SetupMethodTests
 		void UniqueMethodWith5Parameters(int p1, int p2, int p3, int p4, int p5);
 	}
 
-#if DEBUG // TODO: re-enable after https://github.com/dotnet/sdk/issues/52579 is fixed
 	[Fact]
 	public async Task ReturnMethodWith17Parameters_ShouldStillAllowCallbackAndReturns()
 	{
@@ -2060,9 +2059,7 @@ public sealed partial class SetupMethodTests
 		await That(isCalled).IsEqualTo(1);
 		await That(result).IsEqualTo(171);
 	}
-#endif
 
-#if DEBUG // TODO: re-enable after https://github.com/dotnet/sdk/issues/52579 is fixed
 	[Fact]
 	public async Task VoidMethodWith17Parameters_ShouldStillAllowCallbackAndReturns()
 	{
@@ -2100,5 +2097,4 @@ public sealed partial class SetupMethodTests
 
 		await That(isCalled).IsEqualTo(1);
 	}
-#endif
 }


### PR DESCRIPTION
This PR re-enables previously disabled high-parameter-count setup tests in `Mockolate.Tests`, based on the premise that the underlying `dotnet test`/testhost crash (dotnet/sdk#52579) is resolved with SDK `10.0.201`.

**Changes:**
- Removed `#if DEBUG` / `#endif` guards that prevented several `[Fact]` tests (17/18 parameters) from compiling/running outside Debug builds.