### PR TITLE
refactor: update to .NET SDK version 10.0.300

### DIFF
--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -368,263 +368,168 @@ namespace Mockolate
     }
     public static class SetupExtensions
     {
-        extension<T>(Mockolate.Setup.IPropertySetupReturnWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertySetupReturnWhenBuilder<T?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T?>? setup)
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T?>? setup)
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
-            where TReturn :  notnull
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
-            where TReturn :  notnull
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1> setup)
-            where T1 :  notnull
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1> setup)
-            where T1 :  notnull
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
@@ -2986,8 +2891,7 @@ namespace Mockolate.Verify
     }
     public static class VerificationResultExtensions
     {
-        extension<TMock>(Mockolate.Verify.VerificationResult<TMock> verificationResult)
-            where TMock :  notnull
+        extension<TMock>(Mockolate.Verify.VerificationResult<TMock?>? verificationResult)
         {
             public void AtLeast(int times) { }
             public void AtLeastOnce() { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -351,263 +351,168 @@ namespace Mockolate
     }
     public static class SetupExtensions
     {
-        extension<T>(Mockolate.Setup.IPropertySetupReturnWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertySetupReturnWhenBuilder<T?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T?>? setup)
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T?>? setup)
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
-            where TReturn :  notnull
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
-            where TReturn :  notnull
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1> setup)
-            where T1 :  notnull
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1> setup)
-            where T1 :  notnull
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
@@ -2540,8 +2445,7 @@ namespace Mockolate.Verify
     }
     public static class VerificationResultExtensions
     {
-        extension<TMock>(Mockolate.Verify.VerificationResult<TMock> verificationResult)
-            where TMock :  notnull
+        extension<TMock>(Mockolate.Verify.VerificationResult<TMock?>? verificationResult)
         {
             public void AtLeast(int times) { }
             public void AtLeastOnce() { }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -298,263 +298,168 @@ namespace Mockolate
     }
     public static class SetupExtensions
     {
-        extension<T>(Mockolate.Setup.IPropertySetupReturnWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertySetupReturnWhenBuilder<T?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T?>? setup)
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T> setup)
-            where T :  notnull
+        extension<T>(Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T?>? setup)
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IEventSetup OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1> setup)
-            where TValue :  notnull
-            where T1 :  notnull
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
-            where TValue :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn> setup)
-            where TReturn :  notnull
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn> setup)
-            where TReturn :  notnull
+        extension<TReturn>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
+        extension<TReturn, T1>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<TReturn, T1, T2>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<TReturn, T1, T2, T3>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn, T1, T2, T3, T4> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?, T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn, T1, T2, T3, T4> setup)
-            where TReturn :  notnull
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<TReturn, T1, T2, T3, T4>(Mockolate.Setup.IReturnMethodSetupCallbackWhenBuilder<TReturn?, T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IReturnMethodSetup<TReturn, T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder setup)
+        extension(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1> setup)
-            where T1 :  notnull
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1> setup)
-            where T1 :  notnull
+        extension<T1>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2> setup)
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2> setup)
-            where T1 :  notnull
-            where T2 :  notnull
+        extension<T1, T2>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?, T3?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
+        extension<T1, T2, T3>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?, T3?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1, T2, T3, T4> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupReturnWhenBuilder<T1?, T2?, T3?, T4?>? setup)
         {
             public void Forever() { }
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
-        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1, T2, T3, T4> setup)
-            where T1 :  notnull
-            where T2 :  notnull
-            where T3 :  notnull
-            where T4 :  notnull
+        extension<T1, T2, T3, T4>(Mockolate.Setup.IVoidMethodSetupCallbackWhenBuilder<T1?, T2?, T3?, T4?>? setup)
         {
             public Mockolate.Setup.IVoidMethodSetup<T1, T2, T3, T4> OnlyOnce() { }
         }
@@ -2469,8 +2374,7 @@ namespace Mockolate.Verify
     }
     public static class VerificationResultExtensions
     {
-        extension<TMock>(Mockolate.Verify.VerificationResult<TMock> verificationResult)
-            where TMock :  notnull
+        extension<TMock>(Mockolate.Verify.VerificationResult<TMock?>? verificationResult)
         {
             public void AtLeast(int times) { }
             public void AtLeastOnce() { }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "10.0.201",
+		"version": "10.0.300",
 		"rollForward": "latestMinor"
 	}
 }


### PR DESCRIPTION
This pull request updates the extension method signatures in `Mockolate` to improve nullability handling and simplify type constraints. The changes make the extension methods more flexible by allowing nullable types and optional builder parameters, and by removing unnecessary `notnull` constraints.

### Nullability and Type Constraint Updates

* All extension methods in `Mockolate.Setup` and `Mockolate.Verify` now accept nullable generic type arguments (e.g., `T?`, `T1?`, etc.) and the builder parameters themselves are now nullable (e.g., `IPropertySetupReturnWhenBuilder<T?>?`). This change increases the flexibility of the API and improves compatibility with nullable reference types.
* The `where T : notnull` and similar type constraints have been removed from all relevant extension methods, further relaxing the requirements on generic parameters.