### PR TITLE
feat: add per-element matchers and values for params array parameters

### DIFF
--- a/Source/Mockolate.SourceGenerators/Entities/Type.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Type.cs
@@ -31,6 +31,11 @@ internal record Type
 				.ToArray());
 		}
 
+		if (typeSymbol is IArrayTypeSymbol arrayTypeSymbol)
+		{
+			ElementType = From(arrayTypeSymbol.ElementType);
+		}
+
 		SpecialGenericType = typeSymbol.GetSpecialType();
 		SpecialType = typeSymbol.SpecialType;
 		CanBeNullable = typeSymbol.NullableAnnotation == NullableAnnotation.Annotated ||
@@ -53,6 +58,11 @@ internal record Type
 	public SpecialGenericType SpecialGenericType { get; }
 	public EquatableArray<Type>? TupleTypes { get; }
 	public EquatableArray<Type>? GenericTypeParameters { get; }
+
+	/// <summary>
+	///     The element type when this type is an array (e.g. <c>bool</c> for <c>bool[]</c>); otherwise <see langword="null" />.
+	/// </summary>
+	public Type? ElementType { get; }
 	public string? Namespace { get; }
 
 	internal static Type Void { get; } = new("void");

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3235,7 +3235,7 @@ internal static partial class Sources
 				{
 					AppendMethodSetupDefinition(sb, @class, method, false,
 						hasOverloadResolutionPriority: hasOverloadResolutionPriority);
-					if (TryGetPerElementParamsParameter(method, out _))
+					if (TryGetPerElementParamsParameter(method))
 					{
 						AppendMethodSetupDefinition(sb, @class, method, false,
 							hasOverloadResolutionPriority: hasOverloadResolutionPriority, perElementParams: true);
@@ -3321,11 +3321,11 @@ internal static partial class Sources
 	/// <summary>
 	///     Detects whether <paramref name="method" /> ends in a <c>params T[]</c> parameter that can carry a
 	///     per-element matcher overload. The element type must flow through the regular <c>IParameter&lt;T&gt;</c>
-	///     pipeline (ref-struct element types are excluded for this prototype).
+	///     pipeline; ref-struct element types are intentionally not supported, as they cannot satisfy
+	///     <c>IParameter&lt;T&gt;</c>.
 	/// </summary>
-	private static bool TryGetPerElementParamsParameter(Method method, out string elementType)
+	private static bool TryGetPerElementParamsParameter(Method method)
 	{
-		elementType = "";
 		if (method.Parameters.Count == 0)
 		{
 			return false;
@@ -3337,7 +3337,6 @@ internal static partial class Sources
 			return false;
 		}
 
-		elementType = last.Type.ElementType.Fullname;
 		return true;
 	}
 
@@ -3703,7 +3702,7 @@ internal static partial class Sources
 				{
 					AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
 						memberIds, memberIdPrefix, scopeExpression: scopeExpression);
-					if (TryGetPerElementParamsParameter(method, out _))
+					if (TryGetPerElementParamsParameter(method))
 					{
 						AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
 							memberIds, memberIdPrefix, scopeExpression: scopeExpression, perElementParams: true);
@@ -5083,7 +5082,7 @@ internal static partial class Sources
 				{
 					AppendMethodVerifyDefinition(sb, method, verifyName, false,
 						hasOverloadResolutionPriority: hasOverloadResolutionPriority);
-					if (TryGetPerElementParamsParameter(method, out _))
+					if (TryGetPerElementParamsParameter(method))
 					{
 						AppendMethodVerifyDefinition(sb, method, verifyName, false,
 							hasOverloadResolutionPriority: hasOverloadResolutionPriority, perElementParams: true);
@@ -5368,7 +5367,7 @@ internal static partial class Sources
 				{
 					AppendMethodVerifyImplementation(sb, method, mockRegistryName, verifyName, false,
 						memberIds, memberIdPrefix, useFastBuffers);
-					if (TryGetPerElementParamsParameter(method, out _))
+					if (TryGetPerElementParamsParameter(method))
 					{
 						AppendMethodVerifyImplementation(sb, method, mockRegistryName, verifyName, false,
 							memberIds, memberIdPrefix, useFastBuffers, perElementParams: true);

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3235,6 +3235,12 @@ internal static partial class Sources
 				{
 					AppendMethodSetupDefinition(sb, @class, method, false,
 						hasOverloadResolutionPriority: hasOverloadResolutionPriority);
+					if (TryGetPerElementParamsParameter(method, out _))
+					{
+						AppendMethodSetupDefinition(sb, @class, method, false,
+							hasOverloadResolutionPriority: hasOverloadResolutionPriority, perElementParams: true);
+					}
+
 					if (method.Parameters.Count <= MaxExplicitParameters)
 					{
 						foreach (bool[] valueFlags in GenerateValueFlagCombinations(method.Parameters))
@@ -3312,9 +3318,50 @@ internal static partial class Sources
 		sb.AppendXmlRemarks(text);
 	}
 
+	/// <summary>
+	///     Detects whether <paramref name="method" /> ends in a <c>params T[]</c> parameter that can carry a
+	///     per-element matcher overload. The element type must flow through the regular <c>IParameter&lt;T&gt;</c>
+	///     pipeline (ref-struct element types are excluded for this prototype).
+	/// </summary>
+	private static bool TryGetPerElementParamsParameter(Method method, out string elementType)
+	{
+		elementType = "";
+		if (method.Parameters.Count == 0)
+		{
+			return false;
+		}
+
+		MethodParameter last = method.Parameters.AsArray()[method.Parameters.Count - 1];
+		if (!last.IsParams || last.Type.ElementType is null || last.NeedsRefStructPipeline())
+		{
+			return false;
+		}
+
+		elementType = last.Type.ElementType.Fullname;
+		return true;
+	}
+
+	/// <summary>
+	///     True when <paramref name="valueFlags" /> marks the trailing <c>params T[]</c> parameter as a
+	///     literal value. Such overloads render the parameter as <c>params T[]</c> and match it element-wise
+	///     by value (via <c>It.SequenceEquals</c>) rather than by whole-array reference equality.
+	/// </summary>
+	private static bool HasParamsValueParameter(Method method, bool[]? valueFlags)
+	{
+		if (valueFlags is null || method.Parameters.Count == 0)
+		{
+			return false;
+		}
+
+		int last = method.Parameters.Count - 1;
+		MethodParameter parameter = method.Parameters.AsArray()[last];
+		return valueFlags[last] && parameter.IsParams && parameter.Type.ElementType is not null &&
+		       !parameter.NeedsRefStructPipeline();
+	}
+
 	private static void AppendMethodSetupDefinition(StringBuilder sb, Class @class, Method method,
 		bool useParameters, string? methodNameOverride = null, bool[]? valueFlags = null,
-		bool hasOverloadResolutionPriority = false)
+		bool hasOverloadResolutionPriority = false, bool perElementParams = false)
 	{
 		// Methods using a generic type parameter that declares `allows ref struct` cannot expose
 		// a setup surface: IReturnMethodSetup<T> / IVoidMethodSetup<T> do not carry the same
@@ -3478,8 +3525,19 @@ internal static partial class Sources
 				}
 
 				bool isValueParam = valueFlags?[i] == true;
-				if (isValueParam)
+				if (perElementParams && parameter.IsParams &&
+				    parameter.Type.ElementType is not null)
 				{
+					sb.Append("params global::Mockolate.Parameters.IParameter<")
+						.Append(parameter.Type.ElementType.Fullname).Append(">[] ").Append(parameter.Name);
+				}
+				else if (isValueParam)
+				{
+					if (parameter.IsParams && parameter.Type.ElementType is not null)
+					{
+						sb.Append("params ");
+					}
+
 					sb.Append(parameter.ToNullableType()).Append(' ').Append(parameter.Name);
 				}
 				else
@@ -3645,6 +3703,12 @@ internal static partial class Sources
 				{
 					AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
 						memberIds, memberIdPrefix, scopeExpression: scopeExpression);
+					if (TryGetPerElementParamsParameter(method, out _))
+					{
+						AppendMethodSetupImplementation(sb, method, mockRegistryName, setupName, false,
+							memberIds, memberIdPrefix, scopeExpression: scopeExpression, perElementParams: true);
+					}
+
 					if (method.Parameters.Count <= MaxExplicitParameters)
 					{
 						foreach (bool[] valueFlags in GenerateValueFlagCombinations(method.Parameters))
@@ -3674,7 +3738,7 @@ internal static partial class Sources
 		string setupName,
 		bool useParameters, MemberIdTable memberIds, string memberIdPrefix,
 		string? methodNameOverride = null, bool[]? valueFlags = null,
-		string? scopeExpression = null)
+		string? scopeExpression = null, bool perElementParams = false)
 	{
 		// Setup-side carve-out: methods using a generic type parameter that declares
 		// `allows ref struct` have no setup interface declaration (see
@@ -3773,8 +3837,19 @@ internal static partial class Sources
 				}
 
 				bool isValueParam = valueFlags?[i] == true;
-				if (isValueParam)
+				if (perElementParams && parameter.IsParams &&
+				    parameter.Type.ElementType is not null)
 				{
+					sb.Append("params global::Mockolate.Parameters.IParameter<")
+						.Append(parameter.Type.ElementType.Fullname).Append(">[] ").Append(parameter.Name);
+				}
+				else if (isValueParam)
+				{
+					if (parameter.IsParams && parameter.Type.ElementType is not null)
+					{
+						sb.Append("params ");
+					}
+
 					sb.Append(parameter.ToNullableType()).Append(' ').Append(parameter.Name);
 				}
 				else
@@ -3863,8 +3938,11 @@ internal static partial class Sources
 			// skip the per-parameter IParameterMatch<T> allocations that WithParameterCollection
 			// would otherwise force via It.IsValue<T>(...). Gated to 1..4 parameters because that is
 			// the arity range covered by the WithLiteralValues nested types.
+			// A params value parameter matches element-wise by value (It.SequenceEquals), which the
+			// reference-equality WithLiteralValues fast path cannot express — force the collection path.
 			bool useLiteralValues = valueFlags is { Length: > 0 and <= MaxExplicitParameters, } &&
 			                        valueFlags.All(x => x) &&
+			                        !HasParamsValueParameter(method, valueFlags) &&
 			                        !method.Parameters.Any(p => p.RefKind == RefKind.Out ||
 			                                                    p.RefKind == RefKind.Ref ||
 			                                                    p.RefKind == RefKind.RefReadOnlyParameter);
@@ -3887,9 +3965,27 @@ internal static partial class Sources
 				foreach (MethodParameter parameter in method.Parameters)
 				{
 					sb.Append(", ");
-					if (valueFlags?[j] == true)
+					if (perElementParams && parameter.IsParams &&
+					    parameter.Type.ElementType is not null)
 					{
-						AppendNamedValueParameter(sb, parameter);
+						sb.Append("new global::Mockolate.Parameters.ParamsArrayParameterMatch<")
+							.Append(parameter.Type.ElementType.Fullname).Append(">(").Append(parameter.Name)
+							.Append(")");
+					}
+					else if (valueFlags?[j] == true)
+					{
+						if (parameter.IsParams && parameter.Type.ElementType is not null)
+						{
+							// params value parameter: match element-wise by value via It.SequenceEquals.
+							sb.Append("CovariantParameterAdapter<").Append(parameter.Type.Fullname)
+								.Append(">.Wrap(global::Mockolate.It.SequenceEquals<")
+								.Append(parameter.Type.ElementType.Fullname).Append(">(").Append(parameter.Name)
+								.Append("))");
+						}
+						else
+						{
+							AppendNamedValueParameter(sb, parameter);
+						}
 					}
 					else
 					{
@@ -4987,6 +5083,12 @@ internal static partial class Sources
 				{
 					AppendMethodVerifyDefinition(sb, method, verifyName, false,
 						hasOverloadResolutionPriority: hasOverloadResolutionPriority);
+					if (TryGetPerElementParamsParameter(method, out _))
+					{
+						AppendMethodVerifyDefinition(sb, method, verifyName, false,
+							hasOverloadResolutionPriority: hasOverloadResolutionPriority, perElementParams: true);
+					}
+
 					if (method.Parameters.Count <= MaxExplicitParameters)
 					{
 						foreach (bool[] valueFlags in GenerateValueFlagCombinations(method.Parameters))
@@ -5029,7 +5131,7 @@ internal static partial class Sources
 
 	private static void AppendMethodVerifyDefinition(StringBuilder sb, Method method, string verifyName,
 		bool useParameters, string? methodNameOverride = null, bool[]? valueFlags = null,
-		bool hasOverloadResolutionPriority = false)
+		bool hasOverloadResolutionPriority = false, bool perElementParams = false)
 	{
 		// For methods with ref-struct parameters, skip Verify emission entirely. The
 		// VerificationResult pipeline takes IParameter<T>? matchers that then feed into
@@ -5115,8 +5217,19 @@ internal static partial class Sources
 				}
 
 				bool isValueParam = valueFlags?[i] == true;
-				if (isValueParam)
+				if (perElementParams && parameter.IsParams &&
+				    parameter.Type.ElementType is not null)
 				{
+					sb.Append("params global::Mockolate.Parameters.IParameter<")
+						.Append(parameter.Type.ElementType.Fullname).Append(">[] ").Append(parameter.Name);
+				}
+				else if (isValueParam)
+				{
+					if (parameter.IsParams && parameter.Type.ElementType is not null)
+					{
+						sb.Append("params ");
+					}
+
 					sb.Append(parameter.ToNullableType()).Append(' ').Append(parameter.Name);
 				}
 				else
@@ -5255,6 +5368,12 @@ internal static partial class Sources
 				{
 					AppendMethodVerifyImplementation(sb, method, mockRegistryName, verifyName, false,
 						memberIds, memberIdPrefix, useFastBuffers);
+					if (TryGetPerElementParamsParameter(method, out _))
+					{
+						AppendMethodVerifyImplementation(sb, method, mockRegistryName, verifyName, false,
+							memberIds, memberIdPrefix, useFastBuffers, perElementParams: true);
+					}
+
 					if (method.Parameters.Count <= MaxExplicitParameters)
 					{
 						foreach (bool[] valueFlags in GenerateValueFlagCombinations(method.Parameters))
@@ -5317,7 +5436,7 @@ internal static partial class Sources
 	private static void AppendMethodVerifyImplementation(StringBuilder sb, Method method, string mockRegistryName,
 		string verifyName,
 		bool useParameters, MemberIdTable memberIds, string memberIdPrefix, bool useFastBuffers,
-		string? methodNameOverride = null, bool[]? valueFlags = null)
+		string? methodNameOverride = null, bool[]? valueFlags = null, bool perElementParams = false)
 #pragma warning restore S107
 	{
 		// Mirror the AppendMethodVerifyDefinition short-circuit for ref-struct signatures.
@@ -5355,8 +5474,19 @@ internal static partial class Sources
 				}
 
 				bool isValueParam = valueFlags?[i] == true;
-				if (isValueParam)
+				if (perElementParams && parameter.IsParams &&
+				    parameter.Type.ElementType is not null)
 				{
+					sb.Append("params global::Mockolate.Parameters.IParameter<")
+						.Append(parameter.Type.ElementType.Fullname).Append(">[] ").Append(parameter.Name);
+				}
+				else if (isValueParam)
+				{
+					if (parameter.IsParams && parameter.Type.ElementType is not null)
+					{
+						sb.Append("params ");
+					}
+
 					sb.Append(parameter.ToNullableType()).Append(' ').Append(parameter.Name);
 				}
 				else
@@ -5395,8 +5525,13 @@ internal static partial class Sources
 
 		bool canUseLiteralVerify = baseEligible &&
 		                           valueFlags is { Length: > 0 and <= 4, } &&
-		                           valueFlags.All(x => x);
-		bool canUseTypedVerify = useFastForMethod
+		                           valueFlags.All(x => x) &&
+		                           !HasParamsValueParameter(method, valueFlags);
+		// The per-element params overload passes a `params IParameter<TElement>[]` argument, which neither the
+		// literal nor the typed fast path can render (both assume a whole-array IParameter<TElement[]>). Route it
+		// through the slow predicate path, where the composite matcher is built explicitly.
+		bool canUseTypedVerify = !perElementParams
+		                         && useFastForMethod
 		                         && !useParameters
 		                         && method.Parameters.Count <= 4
 		                         && (method.GenericParameters is null || method.GenericParameters.Value.Count == 0)
@@ -5491,10 +5626,19 @@ internal static partial class Sources
 				sb.AppendLine().Append("\t\t\t\t");
 
 				bool isValueParam = valueFlags?[i] == true;
-				if (isValueParam)
+				if (perElementParams && parameter.IsParams &&
+				    parameter.Type.ElementType is not null)
+				{
+					sb.Append("(new global::Mockolate.Parameters.ParamsArrayParameterMatch<")
+						.Append(parameter.Type.ElementType.Fullname).Append(">(").Append(parameter.Name)
+						.Append(").Matches(__i.Parameter").Append(i + 1).Append("))");
+				}
+				else if (isValueParam)
 				{
 					sb.Append(
-						$"(global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals({parameter.Name}, __i.Parameter{i + 1}))");
+						parameter.IsParams && parameter.Type.ElementType is not null
+							? $"(CovariantParameterAdapter<{parameter.Type.Fullname}>.Wrap(global::Mockolate.It.SequenceEquals<{parameter.Type.ElementType.Fullname}>({parameter.Name})).Matches(__i.Parameter{i + 1}))"
+							: $"(global::System.Collections.Generic.EqualityComparer<{parameter.ToTypeOrWrapper()}>.Default.Equals({parameter.Name}, __i.Parameter{i + 1}))");
 				}
 				else if (parameter.RefKind == RefKind.Out || parameter.RefKind == RefKind.Ref ||
 				         parameter.RefKind == RefKind.RefReadOnlyParameter)

--- a/Source/Mockolate/It.Contains.cs
+++ b/Source/Mockolate/It.Contains.cs
@@ -75,6 +75,11 @@ public partial class It
 		/// <inheritdoc cref="CollectionMatchCore{T}.MatchesCollection(IEnumerable{T})" />
 		protected override bool MatchesCollection(IEnumerable<T> value)
 		{
+			if (value is null)
+			{
+				return false;
+			}
+
 			IEqualityComparer<T> comparer = _comparer ?? EqualityComparer<T>.Default;
 			return value.Contains(item, comparer);
 		}

--- a/Source/Mockolate/It.SequenceEquals.cs
+++ b/Source/Mockolate/It.SequenceEquals.cs
@@ -72,6 +72,11 @@ public partial class It
 		/// <inheritdoc cref="CollectionMatchCore{T}.MatchesCollection(IEnumerable{T})" />
 		protected override bool MatchesCollection(IEnumerable<T> value)
 		{
+			if (value is null)
+			{
+				return false;
+			}
+
 			IEqualityComparer<T> comparer = _comparer ?? EqualityComparer<T>.Default;
 			return value.SequenceEqual(expected, comparer);
 		}

--- a/Source/Mockolate/Parameters/ParamsArrayParameterMatch.cs
+++ b/Source/Mockolate/Parameters/ParamsArrayParameterMatch.cs
@@ -37,7 +37,7 @@ public sealed class ParamsArrayParameterMatch<TElement> : IParameterMatch<TEleme
 
 		for (int i = 0; i < _matchers.Length; i++)
 		{
-			if (!_matchers[i].Matches(value[i]))
+			if (_matchers[i] is null || !_matchers[i].Matches(value[i]))
 			{
 				return false;
 			}
@@ -56,7 +56,7 @@ public sealed class ParamsArrayParameterMatch<TElement> : IParameterMatch<TEleme
 
 		for (int i = 0; i < _matchers.Length; i++)
 		{
-			_matchers[i].InvokeCallbacks(value[i]);
+			_matchers[i]?.InvokeCallbacks(value[i]);
 		}
 	}
 

--- a/Source/Mockolate/Parameters/ParamsArrayParameterMatch.cs
+++ b/Source/Mockolate/Parameters/ParamsArrayParameterMatch.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+
+namespace Mockolate.Parameters;
+
+/// <summary>
+///     Matches a <c>params</c> array argument element-by-element against a set of per-element matchers.
+///     The recorded array matches when its length equals the number of matchers and each element
+///     satisfies the matcher at the same position.
+/// </summary>
+/// <remarks>
+///     Generated <c>Setup</c>/<c>Verify</c> overloads for <c>params T[]</c> methods wrap the per-element
+///     matchers into a single instance of this type, which then flows through the regular whole-array
+///     <see cref="IParameterMatch{T}" /> pipeline (where <c>T</c> is <typeparamref name="TElement" /> array).
+/// </remarks>
+/// <typeparam name="TElement">The element type of the <c>params</c> array.</typeparam>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public sealed class ParamsArrayParameterMatch<TElement> : IParameterMatch<TElement[]>
+{
+	private readonly IParameter<TElement>[] _matchers;
+
+	/// <summary>
+	///     Initializes a new <see cref="ParamsArrayParameterMatch{TElement}" /> from the per-element
+	///     <paramref name="matchers" />.
+	/// </summary>
+	public ParamsArrayParameterMatch(params IParameter<TElement>[] matchers)
+		=> _matchers = matchers;
+
+	/// <inheritdoc cref="IParameterMatch{T}.Matches(T)" />
+	public bool Matches(TElement[] value)
+	{
+		if (value is null || value.Length != _matchers.Length)
+		{
+			return false;
+		}
+
+		for (int i = 0; i < _matchers.Length; i++)
+		{
+			if (!_matchers[i].Matches(value[i]))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <inheritdoc cref="IParameterMatch{T}.InvokeCallbacks(T)" />
+	public void InvokeCallbacks(TElement[] value)
+	{
+		if (value is null || value.Length != _matchers.Length)
+		{
+			return;
+		}
+
+		for (int i = 0; i < _matchers.Length; i++)
+		{
+			_matchers[i].InvokeCallbacks(value[i]);
+		}
+	}
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+		=> $"[{string.Join(", ", _matchers.Select(m => m?.ToString() ?? "null"))}]";
+}

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -1042,6 +1042,13 @@ namespace Mockolate.Parameters
     public interface IVerifyReadOnlySpanParameter<T> : Mockolate.Parameters.IParameter, Mockolate.Parameters.IParameterWithCallback<Mockolate.Setup.ReadOnlySpanWrapper<T>>, Mockolate.Parameters.IParameter<Mockolate.Setup.ReadOnlySpanWrapper<T>>, Mockolate.Parameters.IReadOnlySpanParameter<T> { }
     public interface IVerifyRefParameter<T> { }
     public interface IVerifySpanParameter<T> : Mockolate.Parameters.IParameter, Mockolate.Parameters.IParameterWithCallback<Mockolate.Setup.SpanWrapper<T>>, Mockolate.Parameters.IParameter<Mockolate.Setup.SpanWrapper<T>>, Mockolate.Parameters.ISpanParameter<T> { }
+    public sealed class ParamsArrayParameterMatch<TElement> : Mockolate.Parameters.IParameterMatch<TElement[]>
+    {
+        public ParamsArrayParameterMatch(params Mockolate.Parameters.IParameter<TElement>[] matchers) { }
+        public void InvokeCallbacks(TElement[] value) { }
+        public bool Matches(TElement[] value) { }
+        public override string ToString() { }
+    }
 }
 namespace Mockolate.Setup
 {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -1000,6 +1000,13 @@ namespace Mockolate.Parameters
     public interface IVerifyReadOnlySpanParameter<T> : Mockolate.Parameters.IParameter, Mockolate.Parameters.IParameterWithCallback<Mockolate.Setup.ReadOnlySpanWrapper<T>>, Mockolate.Parameters.IParameter<Mockolate.Setup.ReadOnlySpanWrapper<T>>, Mockolate.Parameters.IReadOnlySpanParameter<T> { }
     public interface IVerifyRefParameter<T> { }
     public interface IVerifySpanParameter<T> : Mockolate.Parameters.IParameter, Mockolate.Parameters.IParameterWithCallback<Mockolate.Setup.SpanWrapper<T>>, Mockolate.Parameters.IParameter<Mockolate.Setup.SpanWrapper<T>>, Mockolate.Parameters.ISpanParameter<T> { }
+    public sealed class ParamsArrayParameterMatch<TElement> : Mockolate.Parameters.IParameterMatch<TElement[]>
+    {
+        public ParamsArrayParameterMatch(params Mockolate.Parameters.IParameter<TElement>[] matchers) { }
+        public void InvokeCallbacks(TElement[] value) { }
+        public bool Matches(TElement[] value) { }
+        public override string ToString() { }
+    }
 }
 namespace Mockolate.Setup
 {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -943,6 +943,13 @@ namespace Mockolate.Parameters
     }
     public interface IVerifyOutParameter<out T> { }
     public interface IVerifyRefParameter<T> { }
+    public sealed class ParamsArrayParameterMatch<TElement> : Mockolate.Parameters.IParameterMatch<TElement[]>
+    {
+        public ParamsArrayParameterMatch(params Mockolate.Parameters.IParameter<TElement>[] matchers) { }
+        public void InvokeCallbacks(TElement[] value) { }
+        public bool Matches(TElement[] value) { }
+        public override string ToString() { }
+    }
 }
 namespace Mockolate.Setup
 {

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -2351,6 +2351,14 @@ internal static partial class Mock
 		}
 
 		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params global::Mockolate.Parameters.IParameter<int>[] tail)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)(c ?? global::Mockolate.It.IsNull<long>("null")), new global::Mockolate.Parameters.ParamsArrayParameterMatch<int>(tail));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, global::Mockolate.Parameters.IParameter<int[]>? tail)
 		{
 			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)global::Mockolate.It.IsValue<long>(c), CovariantParameterAdapter<int[]>.Wrap(tail ?? global::Mockolate.It.IsNull<int[]>("null")));
@@ -2359,17 +2367,17 @@ internal static partial class Mock
 		}
 
 		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, int[] tail)
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params int[] tail)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)(c ?? global::Mockolate.It.IsNull<long>("null")), (global::Mockolate.Parameters.IParameterMatch<int[]>)global::Mockolate.It.IsValue<int[]>(tail));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)(c ?? global::Mockolate.It.IsNull<long>("null")), CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)));
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, methodSetup);
 			return methodSetup;
 		}
 
 		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, int[] tail)
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, params int[] tail)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)global::Mockolate.It.IsValue<long>(c), (global::Mockolate.Parameters.IParameterMatch<int[]>)global::Mockolate.It.IsValue<int[]>(tail));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)global::Mockolate.It.IsValue<long>(c), CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)));
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, methodSetup);
 			return methodSetup;
 		}
@@ -2982,6 +2990,13 @@ internal static partial class Mock
 				(c is not null ? CovariantParameterAdapter<long>.Wrap(c).Matches(__i.Parameter3) : global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(__i.Parameter3, default(long))) && 
 				(tail is not null ? CovariantParameterAdapter<int[]>.Wrap(tail).Matches(__i.Parameter4) : global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(__i.Parameter4, default(int[]))), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params global::Mockolate.Parameters.IParameter<int>[] tail)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
+				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
+				(b is global::Mockolate.Parameters.IParameterMatch<string> bMatch ? bMatch.Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(__i.Parameter2, default(string))) && 
+				(c is not null ? CovariantParameterAdapter<long>.Wrap(c).Matches(__i.Parameter3) : global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(__i.Parameter3, default(long))) && 
+				(new global::Mockolate.Parameters.ParamsArrayParameterMatch<int>(tail).Matches(__i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
+		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, global::Mockolate.Parameters.IParameter<int[]>? tail)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
 				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
@@ -2989,19 +3004,19 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(c, __i.Parameter3)) && 
 				(tail is not null ? CovariantParameterAdapter<int[]>.Wrap(tail).Matches(__i.Parameter4) : global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(__i.Parameter4, default(int[]))), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
-		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, int[] tail)
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params int[] tail)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
 				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
 				(b is global::Mockolate.Parameters.IParameterMatch<string> bMatch ? bMatch.Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(__i.Parameter2, default(string))) && 
 				(c is not null ? CovariantParameterAdapter<long>.Wrap(c).Matches(__i.Parameter3) : global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(__i.Parameter3, default(long))) && 
-				(global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(tail, __i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
+				(CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)).Matches(__i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
-		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, int[] tail)
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, params int[] tail)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
 				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
 				(b is global::Mockolate.Parameters.IParameterMatch<string> bMatch ? bMatch.Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(__i.Parameter2, default(string))) && 
 				(global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(c, __i.Parameter3)) && 
-				(global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(tail, __i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
+				(CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)).Matches(__i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithDefaults(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, global::Mockolate.Tests.GeneratorCoverage.MyEnum, decimal, float, char, string?, global::Mockolate.Tests.GeneratorCoverage.MyStruct>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithDefaults, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithDefaults", __i => parameters switch
@@ -3505,6 +3520,13 @@ internal static partial class Mock
 				(c is not null ? CovariantParameterAdapter<long>.Wrap(c).Matches(__i.Parameter3) : global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(__i.Parameter3, default(long))) && 
 				(tail is not null ? CovariantParameterAdapter<int[]>.Wrap(tail).Matches(__i.Parameter4) : global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(__i.Parameter4, default(int[]))), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params global::Mockolate.Parameters.IParameter<int>[] tail)
+			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
+				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
+				(b is global::Mockolate.Parameters.IParameterMatch<string> bMatch ? bMatch.Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(__i.Parameter2, default(string))) && 
+				(c is not null ? CovariantParameterAdapter<long>.Wrap(c).Matches(__i.Parameter3) : global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(__i.Parameter3, default(long))) && 
+				(new global::Mockolate.Parameters.ParamsArrayParameterMatch<int>(tail).Matches(__i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
+		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, global::Mockolate.Parameters.IParameter<int[]>? tail)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
 				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
@@ -3512,19 +3534,19 @@ internal static partial class Mock
 				(global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(c, __i.Parameter3)) && 
 				(tail is not null ? CovariantParameterAdapter<int[]>.Wrap(tail).Matches(__i.Parameter4) : global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(__i.Parameter4, default(int[]))), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
-		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, int[] tail)
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params int[] tail)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
 				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
 				(b is global::Mockolate.Parameters.IParameterMatch<string> bMatch ? bMatch.Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(__i.Parameter2, default(string))) && 
 				(c is not null ? CovariantParameterAdapter<long>.Wrap(c).Matches(__i.Parameter3) : global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(__i.Parameter3, default(long))) && 
-				(global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(tail, __i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
+				(CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)).Matches(__i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
-		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, int[] tail)
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, params int[] tail)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => 
 				(a is global::Mockolate.Parameters.IParameterMatch<int> aMatch ? aMatch.Matches(__i.Parameter1) : global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(__i.Parameter1, default(int))) && 
 				(b is global::Mockolate.Parameters.IParameterMatch<string> bMatch ? bMatch.Matches(__i.Parameter2) : global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(__i.Parameter2, default(string))) && 
 				(global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(c, __i.Parameter3)) && 
-				(global::System.Collections.Generic.EqualityComparer<int[]>.Default.Equals(tail, __i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
+				(CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)).Matches(__i.Parameter4)), () => $"WithModifiers({a}, {b}, {c}, {tail})");
 		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithDefaults(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, global::Mockolate.Tests.GeneratorCoverage.MyEnum, decimal, float, char, string?, global::Mockolate.Tests.GeneratorCoverage.MyStruct>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithDefaults, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithDefaults", __i => parameters switch
@@ -4067,6 +4089,14 @@ internal static partial class Mock
 		}
 
 		/// <inheritdoc />
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params global::Mockolate.Parameters.IParameter<int>[] tail)
+		{
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)(c ?? global::Mockolate.It.IsNull<long>("null")), new global::Mockolate.Parameters.ParamsArrayParameterMatch<int>(tail));
+			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, _scenarioName, methodSetup);
+			return methodSetup;
+		}
+
+		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, global::Mockolate.Parameters.IParameter<int[]>? tail)
 		{
 			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)global::Mockolate.It.IsValue<long>(c), CovariantParameterAdapter<int[]>.Wrap(tail ?? global::Mockolate.It.IsNull<int[]>("null")));
@@ -4075,17 +4105,17 @@ internal static partial class Mock
 		}
 
 		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, int[] tail)
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params int[] tail)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)(c ?? global::Mockolate.It.IsNull<long>("null")), (global::Mockolate.Parameters.IParameterMatch<int[]>)global::Mockolate.It.IsValue<int[]>(tail));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)(c ?? global::Mockolate.It.IsNull<long>("null")), CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)));
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, _scenarioName, methodSetup);
 			return methodSetup;
 		}
 
 		/// <inheritdoc />
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, int[] tail)
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, params int[] tail)
 		{
-			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)global::Mockolate.It.IsValue<long>(c), (global::Mockolate.Parameters.IParameterMatch<int[]>)global::Mockolate.It.IsValue<int[]>(tail));
+			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameterCollection(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", (global::Mockolate.Parameters.IParameterMatch<int>)(a), (global::Mockolate.Parameters.IParameterMatch<string>)(b), (global::Mockolate.Parameters.IParameterMatch<long>)global::Mockolate.It.IsValue<long>(c), CovariantParameterAdapter<int[]>.Wrap(global::Mockolate.It.SequenceEquals<int>(tail)));
 			this.MockRegistry.SetupMethod(global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, _scenarioName, methodSetup);
 			return methodSetup;
 		}
@@ -4751,6 +4781,15 @@ internal static partial class Mock
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="a"/>, <paramref name="b"/>, <paramref name="c"/>, <paramref name="tail"/>.
 		/// </summary>
 		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(4)]
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params global::Mockolate.Parameters.IParameter<int>[] tail);
+
+		/// <summary>
+		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="a"/>, <paramref name="b"/>, <paramref name="c"/>, <paramref name="tail"/>.
+		/// </summary>
+		/// <remarks>
 		///     This overload accepts a direct value for <paramref name="c" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="a" />, <paramref name="b" />, <paramref name="tail" />.
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(3)]
@@ -4763,7 +4802,7 @@ internal static partial class Mock
 		///     This overload accepts a direct value for <paramref name="tail" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="a" />, <paramref name="b" />, <paramref name="c" />.
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(3)]
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, int[] tail);
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params int[] tail);
 
 		/// <summary>
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="a"/>, <paramref name="b"/>, <paramref name="c"/>, <paramref name="tail"/>.
@@ -4772,7 +4811,7 @@ internal static partial class Mock
 		///     This overload accepts a direct value for <paramref name="c" />, <paramref name="tail" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="a" />, <paramref name="b" />.
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
-		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, int[] tail);
+		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> WithModifiers(global::Mockolate.Parameters.IRefParameter<int> a, global::Mockolate.Parameters.IOutParameter<string> b, long c, params int[] tail);
 
 		/// <summary>
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithDefaults(int, global::Mockolate.Tests.GeneratorCoverage.MyEnum, decimal, float, char, string?, global::Mockolate.Tests.GeneratorCoverage.MyStruct)">WithDefaults(int, MyEnum, decimal, float, char, string?, MyStruct)</see> with the given <paramref name="parameters" />.
@@ -5346,6 +5385,15 @@ internal static partial class Mock
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="a"/>, <paramref name="b"/>, <paramref name="c"/>, <paramref name="tail"/>.
 		/// </summary>
 		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(4)]
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params global::Mockolate.Parameters.IParameter<int>[] tail);
+
+		/// <summary>
+		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="a"/>, <paramref name="b"/>, <paramref name="c"/>, <paramref name="tail"/>.
+		/// </summary>
+		/// <remarks>
 		///     This overload accepts a direct value for <paramref name="c" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="a" />, <paramref name="b" />, <paramref name="tail" />.
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(3)]
@@ -5358,7 +5406,7 @@ internal static partial class Mock
 		///     This overload accepts a direct value for <paramref name="tail" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="a" />, <paramref name="b" />, <paramref name="c" />.
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(3)]
-		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, int[] tail);
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, global::Mockolate.Parameters.IParameter<long>? c, params int[] tail);
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="a"/>, <paramref name="b"/>, <paramref name="c"/>, <paramref name="tail"/>.
@@ -5367,7 +5415,7 @@ internal static partial class Mock
 		///     This overload accepts a direct value for <paramref name="c" />, <paramref name="tail" /> (equivalent to <c>It.Is&lt;T&gt;(value)</c>) and an <see cref="global::Mockolate.It">It</see> matcher for <paramref name="a" />, <paramref name="b" />.
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
-		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, int[] tail);
+		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> WithModifiers(global::Mockolate.Parameters.IVerifyRefParameter<int> a, global::Mockolate.Parameters.IVerifyOutParameter<string> b, long c, params int[] tail);
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithDefaults(int, global::Mockolate.Tests.GeneratorCoverage.MyEnum, decimal, float, char, string?, global::Mockolate.Tests.GeneratorCoverage.MyStruct)">WithDefaults(int, MyEnum, decimal, float, char, string?, MyStruct)</see> with the given <paramref name="parameters"/>.

--- a/Tests/Mockolate.Tests/ItTests.ContainsTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.ContainsTests.cs
@@ -158,6 +158,16 @@ public sealed partial class ItTests
 		}
 
 		[Fact]
+		public async Task TypedArrayMatch_WithNullValue_ShouldNotMatch()
+		{
+			IParameter<int[]> sut = It.Contains(5);
+
+			bool result = ((IParameterMatch<int[]>)sut).Matches(null!);
+
+			await That(result).IsFalse();
+		}
+
+		[Fact]
 		public async Task ShouldSupportVerify()
 		{
 			ICollectionConsumer sut = ICollectionConsumer.CreateMock();

--- a/Tests/Mockolate.Tests/ItTests.SequenceEqualsTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.SequenceEqualsTests.cs
@@ -193,6 +193,16 @@ public sealed partial class ItTests
 			await That(result).IsTrue();
 		}
 
+		[Fact]
+		public async Task TypedArrayMatch_WithNullValue_ShouldNotMatch()
+		{
+			IParameter<int[]> sut = It.SequenceEquals(1, 2, 3);
+
+			bool result = ((IParameterMatch<int[]>)sut).Matches(null!);
+
+			await That(result).IsFalse();
+		}
+
 		public sealed class DoTests
 		{
 			[Fact]

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.cs
@@ -484,7 +484,7 @@ public sealed partial class SetupMethodTests
 	}
 
 	[Fact]
-	public async Task WithParamsParameters_ExplicitArrayArgument_ShouldUseReferenceEquality()
+	public async Task WithParamsParameters_ExplicitArrayArgument_ShouldUseValueEquality()
 	{
 		IMyService sut = IMyService.CreateMock();
 		bool[] flags = [true, false,];
@@ -492,9 +492,39 @@ public sealed partial class SetupMethodTests
 
 		bool result1 = sut.MyMethodWithParams(1, flags);
 		bool result2 = sut.MyMethodWithParams(1, true, false);
+		bool result3 = sut.MyMethodWithParams(1, false, true);
+
+		await That(result1).IsTrue();
+		await That(result2).IsTrue();
+		await That(result3).IsFalse();
+	}
+
+	[Fact]
+	public async Task WithParamsParameters_PerElementValues_ShouldMatchElementByElement()
+	{
+		IMyService sut = IMyService.CreateMock();
+		sut.Mock.Setup.MyMethodWithParams(It.IsAny<int>(), true, false).Returns(true);
+
+		bool result1 = sut.MyMethodWithParams(5, true, false);
+		bool result2 = sut.MyMethodWithParams(5, true, true);
+		bool result3 = sut.MyMethodWithParams(5, true);
+		bool result4 = sut.MyMethodWithParams(5, true, false, true);
 
 		await That(result1).IsTrue();
 		await That(result2).IsFalse();
+		await That(result3).IsFalse();
+		await That(result4).IsFalse();
+	}
+
+	[Fact]
+	public async Task WithParamsParameters_PerElementValues_ShouldSupportVerify()
+	{
+		IMyService sut = IMyService.CreateMock();
+
+		_ = sut.MyMethodWithParams(5, true, false);
+
+		await That(sut.Mock.Verify.MyMethodWithParams(It.IsAny<int>(), true, false)).Once();
+		await That(sut.Mock.Verify.MyMethodWithParams(It.IsAny<int>(), true, true)).Never();
 	}
 
 	[Fact]
@@ -512,6 +542,40 @@ public sealed partial class SetupMethodTests
 		await That(result2).IsFalse();
 		await That(result3).IsTrue();
 		await That(result4).IsTrue();
+	}
+
+	[Fact]
+	public async Task WithParamsParameters_PerElementMatchers_ShouldMatchElementByElement()
+	{
+		IMyService sut = IMyService.CreateMock();
+		sut.Mock.Setup.MyMethodWithParams(It.IsAny<int>(), It.IsAny<bool>(), It.IsFalse()).Returns(true);
+
+		bool result1 = sut.MyMethodWithParams(5);
+		bool result2 = sut.MyMethodWithParams(5, true);
+		bool result3 = sut.MyMethodWithParams(5, true, false);
+		bool result4 = sut.MyMethodWithParams(5, true, true);
+		bool result5 = sut.MyMethodWithParams(5, true, false, true);
+
+		await That(result1).IsFalse();
+		await That(result2).IsFalse();
+		await That(result3).IsTrue();
+		await That(result4).IsFalse();
+		await That(result5).IsFalse();
+	}
+
+	[Fact]
+	public async Task WithParamsParameters_PerElementMatchers_ShouldSupportVerify()
+	{
+		IMyService sut = IMyService.CreateMock();
+
+		_ = sut.MyMethodWithParams(5);
+		_ = sut.MyMethodWithParams(5, true);
+		_ = sut.MyMethodWithParams(5, true, false);
+		_ = sut.MyMethodWithParams(5, true, true);
+		_ = sut.MyMethodWithParams(5, true, false, true);
+
+		await That(sut.Mock.Verify.MyMethodWithParams(
+			It.IsAny<int>(), It.IsAny<bool>(), It.IsFalse())).Once();
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/Parameters/ParamsArrayParameterMatchTests.cs
+++ b/Tests/Mockolate.Tests/Parameters/ParamsArrayParameterMatchTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using Mockolate.Parameters;
+
+namespace Mockolate.Tests.Parameters;
+
+public sealed class ParamsArrayParameterMatchTests
+{
+	[Fact]
+	public async Task Matches_WhenLengthMatchesAndAllElementsSatisfy_ShouldReturnTrue()
+	{
+		StubParameter first = new(true, "first");
+		StubParameter second = new(true, "second");
+		ParamsArrayParameterMatch<int> sut = new(first, second);
+
+		bool result = sut.Matches([1, 2,]);
+
+		await That(result).IsTrue();
+		await That(first.MatchedValues).IsEqualTo([1,]);
+		await That(second.MatchedValues).IsEqualTo([2,]);
+	}
+
+	[Fact]
+	public async Task Matches_WhenAnElementFails_ShouldReturnFalse()
+	{
+		ParamsArrayParameterMatch<int> sut = new(new StubParameter(true, "first"), new StubParameter(false, "second"));
+
+		bool result = sut.Matches([1, 2,]);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task Matches_WhenLengthDiffers_ShouldReturnFalseWithoutInvokingMatchers()
+	{
+		StubParameter only = new(true, "only");
+		ParamsArrayParameterMatch<int> sut = new(only);
+
+		bool result = sut.Matches([1, 2,]);
+
+		await That(result).IsFalse();
+		await That(only.MatchedValues).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Matches_WhenValueIsNull_ShouldReturnFalse()
+	{
+		ParamsArrayParameterMatch<int> sut = new(new StubParameter(true, "only"));
+
+		bool result = sut.Matches(null!);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task Matches_WhenMatcherElementIsNull_ShouldReturnFalseWithoutThrowing()
+	{
+		ParamsArrayParameterMatch<int> sut = new(new StubParameter(true, "first"), null!);
+
+		bool result = sut.Matches([1, 2,]);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task InvokeCallbacks_WhenLengthMatches_ShouldInvokeEachMatcher()
+	{
+		StubParameter first = new(true, "first");
+		StubParameter second = new(true, "second");
+		ParamsArrayParameterMatch<int> sut = new(first, second);
+
+		sut.InvokeCallbacks([1, 2,]);
+
+		await That(first.InvokedValues).IsEqualTo([1,]);
+		await That(second.InvokedValues).IsEqualTo([2,]);
+	}
+
+	[Fact]
+	public async Task InvokeCallbacks_WhenLengthDiffers_ShouldNotInvokeMatchers()
+	{
+		StubParameter only = new(true, "only");
+		ParamsArrayParameterMatch<int> sut = new(only);
+
+		sut.InvokeCallbacks([1, 2,]);
+
+		await That(only.InvokedValues).IsEmpty();
+	}
+
+	[Fact]
+	public async Task InvokeCallbacks_WhenValueIsNull_ShouldNotInvokeMatchers()
+	{
+		StubParameter only = new(true, "only");
+		ParamsArrayParameterMatch<int> sut = new(only);
+
+		sut.InvokeCallbacks(null!);
+
+		await That(only.InvokedValues).IsEmpty();
+	}
+
+	[Fact]
+	public async Task InvokeCallbacks_WhenMatcherElementIsNull_ShouldSkipItWithoutThrowing()
+	{
+		StubParameter first = new(true, "first");
+		ParamsArrayParameterMatch<int> sut = new(first, null!);
+
+		sut.InvokeCallbacks([1, 2,]);
+
+		await That(first.InvokedValues).IsEqualTo([1,]);
+	}
+
+	[Fact]
+	public async Task ToString_ShouldRenderMatchersInOrder()
+	{
+		ParamsArrayParameterMatch<int> sut = new(new StubParameter(true, "first"), new StubParameter(true, "second"));
+
+		await That(sut.ToString()).IsEqualTo("[first, second]");
+	}
+
+	[Fact]
+	public async Task ToString_WithNullMatcher_ShouldRenderNullToken()
+	{
+		ParamsArrayParameterMatch<int> sut = new(new StubParameter(true, "first"), null!);
+
+		await That(sut.ToString()).IsEqualTo("[first, null]");
+	}
+
+	private sealed class StubParameter(bool matches, string label) : IParameter<int>
+	{
+		public List<int> MatchedValues { get; } = [];
+		public List<int> InvokedValues { get; } = [];
+
+		public bool Matches(object? value)
+		{
+			MatchedValues.Add((int)value!);
+			return matches;
+		}
+
+		public void InvokeCallbacks(object? value) => InvokedValues.Add((int)value!);
+
+		public override string ToString() => label;
+	}
+}


### PR DESCRIPTION
Generate two additional Setup/Verify overloads for methods ending in a params T[] parameter: one accepting params IParameter<T>[] for per-element matchers (e.g. Setup.M(It.IsAny<int>(), It.IsAny<bool>(), It.IsFalse())) and one accepting params T[] for per-element values matched element-wise by value (e.g. Setup.M(It.IsAny<int>(), true, false)). The matcher overload wraps the elements in a new ParamsArrayParameterMatch<T> composite; the value overload routes through It.SequenceEquals so the whole array is compared element-wise rather than by reference.

This replaces the previous whole-array literal value overload for the params parameter, so an explicitly passed array argument is now matched by value equality instead of reference equality. Overload resolution between the matcher and value params overloads for the zero-element case is handled by the existing OverloadResolutionPriority mechanism.