### PR TITLE
chore: notify docs site after benchmark data is published

### DIFF
--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,15 +1,15 @@
 name: Notify Docs Site
 
 on:
-    push:
+    workflow_run:
+        workflows: [ "Build" ]
+        types: [ completed ]
         branches: [ main ]
-        paths:
-            - 'Docs/pages/**'
     workflow_dispatch:
 
 jobs:
     dispatch:
-        if: github.ref == 'refs/heads/main'
+        if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
         name: Trigger Site rebuild
         runs-on: ubuntu-latest
         steps:
@@ -19,4 +19,4 @@ jobs:
                     token: ${{ secrets.SITE_DISPATCH_TOKEN }}
                     repository: Testably/Testably.Site
                     event-type: extension-documentation-updated-event
-                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.sha }}"}'
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.event.workflow_run.head_sha || github.sha }}"}'


### PR DESCRIPTION
The previous push trigger was path-filtered on Docs/pages/**, so it never fired for benchmark data: that data is published to the 'benchmarks' branch via the GitHub API using GITHUB_TOKEN, which cannot trigger push-based workflows.

Switch to a workflow_run trigger on the Build workflow completing on main (mirroring aweXpect). This notifies the site after every successful main Build, covering docs edits and benchmark updates alike, without depending on which files or branches changed.