### PR TITLE
test: cover cross-assembly accessibility in the source generator

### DIFF
--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.CodeAnalysis;
+
+namespace Mockolate.SourceGenerators.Tests;
+
+public sealed partial class MockTests
+{
+	public sealed class CrossAssemblyTests
+	{
+		private const string CreateMockForMyBaseClass = """
+		                                               using Mockolate;
+
+		                                               namespace MyCode;
+
+		                                               public class Program
+		                                               {
+		                                                   public static void Main(string[] args) => _ = Ext.MyBaseClass.CreateMock();
+		                                               }
+		                                               """;
+
+		[Fact]
+		public async Task InternalVirtualMember_WithInternalsVisibleTo_ShouldBeOverridden()
+		{
+			MetadataReference external = CompileMyBaseClassAssembly(grantsInternalsVisibleTo: true);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyBaseClass, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.MyBaseClass.g.cs");
+			await That(result.Sources["Mock.MyBaseClass.g.cs"])
+				.Contains("internal override void InternalVirtualMethod()").And
+				.Contains("internal override int InternalVirtualProperty");
+		}
+
+		[Fact]
+		public async Task InternalVirtualMember_WithoutInternalsVisibleTo_ShouldNotBeOverridden()
+		{
+			MetadataReference external = CompileMyBaseClassAssembly(grantsInternalsVisibleTo: false);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyBaseClass, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.MyBaseClass.g.cs");
+			await That(result.Sources["Mock.MyBaseClass.g.cs"])
+				.Contains("public override void PublicAbstractMethod()").And
+				.DoesNotContain("InternalVirtualMethod").And
+				.DoesNotContain("InternalVirtualProperty");
+		}
+
+		[Fact]
+		public async Task ProtectedInternalMember_WithInternalsVisibleTo_ShouldBeOverriddenAsProtectedInternal()
+		{
+			MetadataReference external = CompileMyBaseClassAssembly(grantsInternalsVisibleTo: true);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyBaseClass, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.MyBaseClass.g.cs");
+			await That(result.Sources["Mock.MyBaseClass.g.cs"])
+				.Contains("protected internal override void ProtectedInternalMethod()").And
+				.Contains("protected internal override int ProtectedInternalProperty").And
+				.Contains("protected internal override event global::System.EventHandler? ProtectedInternalEvent").And
+				.Contains("protected internal set");
+		}
+
+		[Fact]
+		public async Task ProtectedInternalMember_WithoutInternalsVisibleTo_ShouldBeOverriddenAsProtected()
+		{
+			MetadataReference external = CompileMyBaseClassAssembly(grantsInternalsVisibleTo: false);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyBaseClass, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.MyBaseClass.g.cs");
+			await That(result.Sources["Mock.MyBaseClass.g.cs"])
+				.Contains("protected override void ProtectedInternalMethod()").And
+				.Contains("protected override int ProtectedInternalProperty").And
+				.Contains("protected override event global::System.EventHandler? ProtectedInternalEvent").And
+				.Contains("protected set").And
+				.DoesNotContain("protected internal override").And
+				.DoesNotContain("protected internal set");
+		}
+
+		[Fact]
+		public async Task PublicMembers_ShouldBeMockedAcrossAssemblyBoundary()
+		{
+			MetadataReference external = ExternalAssembly.Compile("""
+			                                                      namespace Ext;
+
+			                                                      public interface IMyService
+			                                                      {
+			                                                      	int GetValue();
+			                                                      }
+
+			                                                      public abstract class MyAbstractService
+			                                                      {
+			                                                      	public abstract string Name { get; }
+			                                                      	public virtual int Compute() => 0;
+			                                                      }
+			                                                      """);
+
+			GeneratorResult result = Generator.RunWithReferences("""
+			                                                     using Mockolate;
+
+			                                                     namespace MyCode;
+
+			                                                     public class Program
+			                                                     {
+			                                                         public static void Main(string[] args)
+			                                                         {
+			                                                     		_ = Ext.IMyService.CreateMock();
+			                                                     		_ = Ext.MyAbstractService.CreateMock();
+			                                                         }
+			                                                     }
+			                                                     """, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.IMyService.g.cs").And
+				.ContainsKey("Mock.MyAbstractService.g.cs");
+			await That(result.Sources["Mock.IMyService.g.cs"])
+				.Contains("public int GetValue()");
+			await That(result.Sources["Mock.MyAbstractService.g.cs"])
+				.Contains("public override string Name").And
+				.Contains("public override int Compute()");
+		}
+
+		private static MetadataReference CompileMyBaseClassAssembly(bool grantsInternalsVisibleTo)
+		{
+			string internalsVisibleTo = grantsInternalsVisibleTo
+				? """[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("TestAssembly")]"""
+				: "";
+			return ExternalAssembly.Compile($$"""
+			                                 {{internalsVisibleTo}}
+			                                 namespace Ext;
+
+			                                 public abstract class MyBaseClass
+			                                 {
+			                                 	public abstract void PublicAbstractMethod();
+			                                 	internal virtual void InternalVirtualMethod() { }
+			                                 	internal virtual int InternalVirtualProperty { get; set; }
+			                                 	protected internal virtual void ProtectedInternalMethod() { }
+			                                 	protected internal virtual int ProtectedInternalProperty { get; set; }
+			                                 	protected internal virtual event System.EventHandler? ProtectedInternalEvent;
+			                                 	public virtual int MixedAccessorProperty { get; protected internal set; }
+			                                 }
+			                                 """);
+		}
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/ExternalAssembly.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/ExternalAssembly.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace Mockolate.SourceGenerators.Tests.TestHelpers;
+
+public static class ExternalAssembly
+{
+	/// <summary>
+	///     Compiles the <paramref name="source" /> into an in-memory library named
+	///     <paramref name="assemblyName" /> and returns a reference to it.
+	/// </summary>
+	public static MetadataReference Compile([StringSyntax("c#-test")] string source,
+		string assemblyName = "ExternalAssembly")
+	{
+		CSharpParseOptions parseOptions = new(LanguageVersion.Latest);
+		CSharpCompilation compilation = CSharpCompilation.Create(
+			assemblyName,
+			[CSharpSyntaxTree.ParseText(source, parseOptions),],
+			Generator.GetReferences([]),
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		using MemoryStream stream = new();
+		EmitResult emitResult = compilation.Emit(stream);
+		if (!emitResult.Success)
+		{
+			throw new InvalidOperationException(
+				$"Could not compile the external assembly '{assemblyName}':{Environment.NewLine}" +
+				string.Join(Environment.NewLine, emitResult.Diagnostics
+					.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+					.Select(diagnostic => diagnostic.ToString())));
+		}
+
+		stream.Position = 0;
+		return MetadataReference.CreateFromStream(stream);
+	}
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/Generator.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/TestHelpers/Generator.cs
@@ -54,6 +54,14 @@ public static class Generator
 
 	public static GeneratorResult Run(string[] sources, DocumentationMode documentationMode,
 		string[] preprocessorSymbols, params Type[] assemblyTypes)
+		=> RunCore(sources, documentationMode, preprocessorSymbols, [], assemblyTypes);
+
+	public static GeneratorResult RunWithReferences([StringSyntax("c#-test")] string source,
+		MetadataReference[] externalReferences, params Type[] assemblyTypes)
+		=> RunCore([source,], DocumentationMode.Parse, [], externalReferences, assemblyTypes);
+
+	private static GeneratorResult RunCore(string[] sources, DocumentationMode documentationMode,
+		string[] preprocessorSymbols, MetadataReference[] externalReferences, Type[] assemblyTypes)
 	{
 		MockGenerator generator = new();
 		CSharpParseOptions parseOptions = new CSharpParseOptions(LanguageVersion.Latest, documentationMode)
@@ -65,7 +73,7 @@ public static class Generator
 		CSharpCompilation compilation = CSharpCompilation.Create(
 			"TestAssembly",
 			syntaxTrees,
-			GetReferences(assemblyTypes),
+			[..GetReferences(assemblyTypes), ..externalReferences,],
 			new CSharpCompilationOptions(OutputKind.ConsoleApplication));
 
 		GeneratorDriver driver = CSharpGeneratorDriver.Create(
@@ -100,7 +108,7 @@ public static class Generator
 		return result;
 	}
 
-	private static List<PortableExecutableReference> GetReferences(Type[] types) =>
+	internal static List<PortableExecutableReference> GetReferences(Type[] types) =>
 		AppDomain.CurrentDomain.GetAssemblies()
 			.Where(x => !x.IsDynamic && !string.IsNullOrWhiteSpace(x.Location))
 			.Select(x => x.Location)


### PR DESCRIPTION
Generator tests so far compiled everything into a single "TestAssembly", so the cross-assembly branches of `Helpers.IsOverridableFrom` and `Helpers.ResolveOverrideVisibility` were never exercised.

Add an `ExternalAssembly` test helper that compiles source into a separate in-memory assembly, plus `Generator.RunWithReferences`, which adds such references to the generated compilation. Use it to verify that

- an `internal virtual` member from a referenced assembly is excluded,
- it is included when `InternalsVisibleTo` is granted,
- a `protected internal virtual` member is overridden as plain `protected` without `InternalsVisibleTo`, and as `protected internal` with it,
- public members are mocked across the assembly boundary.