### PR TITLE
fix: refuse to mock types with an inaccessible required member

### DIFF
--- a/Docs/pages/08-analyzers.md
+++ b/Docs/pages/08-analyzers.md
@@ -32,6 +32,12 @@ Mocked types must be mockable. This rule will prevent you from using unsupported
 - `Implementing<T>()`  
   Type must be an interface
 
+It also fires when the type has a member that the mock would have to implement (an abstract member,
+or an interface member without a default implementation) but that is not accessible from your
+assembly: for example an `internal abstract` member, or a `{ get; internal set; }` property, on a
+type from a referenced assembly that does not grant `InternalsVisibleTo`. There is no valid code a
+mock could emit for such a member, so the type cannot be mocked at all.
+
 ## Mockolate0003
 
 A mocked member's signature routes through the ref-struct pipeline in a way Mockolate can't

--- a/Docs/pages/08-analyzers.md
+++ b/Docs/pages/08-analyzers.md
@@ -34,9 +34,10 @@ Mocked types must be mockable. This rule will prevent you from using unsupported
 
 It also fires when the type has a member that the mock would have to implement (an abstract member,
 or an interface member without a default implementation) but that is not accessible from your
-assembly: for example an `internal abstract` member, or a `{ get; internal set; }` property, on a
-type from a referenced assembly that does not grant `InternalsVisibleTo`. There is no valid code a
-mock could emit for such a member, so the type cannot be mocked at all.
+assembly: for example an `internal abstract` or `private protected abstract` member, or a
+`{ get; internal set; }` property, on a type from a referenced assembly that does not grant
+`InternalsVisibleTo`. There is no valid code a mock could emit for such a member, so the type cannot
+be mocked at all.
 
 ## Mockolate0003
 

--- a/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
+++ b/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
@@ -87,7 +87,7 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 			return;
 		}
 
-		if (!IsMockable(receiverType, out string? reason))
+		if (!IsMockable(receiverType, context.Compilation.Assembly, out string? reason))
 		{
 			context.ReportDiagnostic(Diagnostic.Create(
 				Rules.MockabilityRule,
@@ -376,7 +376,7 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 		Location typeArgumentLocation = AnalyzerHelpers.GetTypeArgumentLocation(invocation, typeArgument) ??
 		                                invocation.GetLocation();
 
-		if (!IsMockable(typeArgument, out string? reason))
+		if (!IsMockable(typeArgument, context.Compilation.Assembly, out string? reason))
 		{
 			context.ReportDiagnostic(Diagnostic.Create(
 				Rules.MockabilityRule,
@@ -426,7 +426,7 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 	private static bool IsInMockolateNamespace(ISymbol symbol)
 		=> symbol.ContainingNamespace is { Name: "Mockolate", ContainingNamespace.IsGlobalNamespace: true, };
 
-	private static bool IsMockable(ITypeSymbol typeSymbol, out string? reason)
+	private static bool IsMockable(ITypeSymbol typeSymbol, IAssemblySymbol sourceAssembly, out string? reason)
 	{
 		if (typeSymbol.TypeKind == TypeKind.Struct)
 		{
@@ -466,7 +466,90 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 			return false;
 		}
 
+		if (FindInaccessibleRequiredMember(typeSymbol, sourceAssembly) is { } inaccessibleMember)
+		{
+			reason =
+				$"the member '{inaccessibleMember.ToDisplayString()}' must be implemented, but it is not accessible from this assembly";
+			return false;
+		}
+
 		reason = null;
 		return true;
+	}
+
+	private static ISymbol? FindInaccessibleRequiredMember(ITypeSymbol type, IAssemblySymbol sourceAssembly)
+	{
+		foreach (ITypeSymbol implementedType in EnumerateImplementedTypes(type))
+		{
+			foreach (ISymbol member in implementedType.GetMembers())
+			{
+				ISymbol? inaccessibleMember = member switch
+				{
+					IMethodSymbol { MethodKind: MethodKind.Ordinary, IsAbstract: true, } method
+						=> IsAccessibleFrom(method, sourceAssembly) ? null : method,
+					IPropertySymbol { IsAbstract: true, } property
+						=> FindInaccessibleAccessor(property, sourceAssembly),
+					IEventSymbol { IsAbstract: true, } @event
+						=> IsAccessibleFrom(@event, sourceAssembly) ? null : @event,
+					_ => null,
+				};
+
+				if (inaccessibleMember is not null)
+				{
+					return inaccessibleMember;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static ISymbol? FindInaccessibleAccessor(IPropertySymbol property, IAssemblySymbol sourceAssembly)
+	{
+		if (property.GetMethod is { } getter && !IsAccessibleFrom(getter, sourceAssembly))
+		{
+			return getter;
+		}
+
+		if (property.SetMethod is { } setter && !IsAccessibleFrom(setter, sourceAssembly))
+		{
+			return setter;
+		}
+
+		return null;
+	}
+
+	private static IEnumerable<ITypeSymbol> EnumerateImplementedTypes(ITypeSymbol type)
+	{
+		yield return type;
+
+		if (type.TypeKind == TypeKind.Interface)
+		{
+			foreach (INamedTypeSymbol @interface in type.AllInterfaces)
+			{
+				yield return @interface;
+			}
+
+			yield break;
+		}
+
+		for (ITypeSymbol? baseType = type.BaseType;
+		     baseType is not null && baseType.SpecialType != SpecialType.System_Object;
+		     baseType = baseType.BaseType)
+		{
+			yield return baseType;
+		}
+	}
+
+	private static bool IsAccessibleFrom(ISymbol member, IAssemblySymbol sourceAssembly)
+	{
+		if (member.DeclaredAccessibility is not (Accessibility.Internal or Accessibility.ProtectedAndInternal))
+		{
+			return true;
+		}
+
+		IAssemblySymbol containingAssembly = member.ContainingAssembly;
+		return SymbolEqualityComparer.Default.Equals(containingAssembly, sourceAssembly) ||
+		       containingAssembly.GivesAccessTo(sourceAssembly);
 	}
 }

--- a/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
+++ b/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
@@ -478,31 +478,22 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 	}
 
 	private static ISymbol? FindInaccessibleRequiredMember(ITypeSymbol type, IAssemblySymbol sourceAssembly)
-	{
-		foreach (ITypeSymbol implementedType in EnumerateImplementedTypes(type))
+		=> EnumerateImplementedTypes(type)
+			.SelectMany(implementedType => implementedType.GetMembers())
+			.Select(member => FindInaccessibleMember(member, sourceAssembly))
+			.FirstOrDefault(inaccessibleMember => inaccessibleMember is not null);
+
+	private static ISymbol? FindInaccessibleMember(ISymbol member, IAssemblySymbol sourceAssembly)
+		=> member switch
 		{
-			foreach (ISymbol member in implementedType.GetMembers())
-			{
-				ISymbol? inaccessibleMember = member switch
-				{
-					IMethodSymbol { MethodKind: MethodKind.Ordinary, IsAbstract: true, } method
-						=> IsAccessibleFrom(method, sourceAssembly) ? null : method,
-					IPropertySymbol { IsAbstract: true, } property
-						=> FindInaccessibleAccessor(property, sourceAssembly),
-					IEventSymbol { IsAbstract: true, } @event
-						=> IsAccessibleFrom(@event, sourceAssembly) ? null : @event,
-					_ => null,
-				};
-
-				if (inaccessibleMember is not null)
-				{
-					return inaccessibleMember;
-				}
-			}
-		}
-
-		return null;
-	}
+			IMethodSymbol { MethodKind: MethodKind.Ordinary, IsAbstract: true, } method
+				=> IsAccessibleFrom(method, sourceAssembly) ? null : method,
+			IPropertySymbol { IsAbstract: true, } property
+				=> FindInaccessibleAccessor(property, sourceAssembly),
+			IEventSymbol { IsAbstract: true, } @event
+				=> IsAccessibleFrom(@event, sourceAssembly) ? null : @event,
+			_ => null,
+		};
 
 	private static ISymbol? FindInaccessibleAccessor(IPropertySymbol property, IAssemblySymbol sourceAssembly)
 	{

--- a/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
+++ b/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
@@ -510,6 +510,18 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 		return null;
 	}
 
+	/// <summary>
+	///     Yields the types that declare the members a mock of <paramref name="type" /> is obliged to
+	///     implement: the type itself, plus its base interfaces (for an interface) or its base class
+	///     chain (for a class).
+	/// </summary>
+	/// <remarks>
+	///     Deliberately narrower than <see cref="GetCandidateMembers" />, which also walks
+	///     <see cref="ITypeSymbol.AllInterfaces" /> for classes. A class must already implement every
+	///     interface member it inherits (CS0535), so those members are not the mock's obligation and
+	///     folding them in here would reject types that mock perfectly well. The two walkers are not
+	///     interchangeable; keep them separate.
+	/// </remarks>
 	private static IEnumerable<ITypeSymbol> EnumerateImplementedTypes(ITypeSymbol type)
 	{
 		yield return type;
@@ -532,6 +544,20 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 		}
 	}
 
+	/// <summary>
+	///     A member (or accessor) declared in another assembly is overridable only if the overriding
+	///     assembly can actually see it. <c>internal</c> and <c>private protected</c> are invisible
+	///     across assembly boundaries unless the declaring assembly grants InternalsVisibleTo.
+	///     <c>protected internal</c> (= protected OR internal) is always reachable via the protected
+	///     half from a derived class.
+	/// </summary>
+	/// <remarks>
+	///     Must stay in sync with <c>Helpers.IsOverridableFrom</c> in
+	///     <c>Source/Mockolate.SourceGenerators/Helpers.cs</c>, which gates the generator on the same
+	///     rule. The two projects share no sources, so the logic is duplicated by necessity: if this
+	///     check and the generator's disagree, the analyzer either reports a type the generator mocks
+	///     fine or stays silent on one it refuses to emit.
+	/// </remarks>
 	private static bool IsAccessibleFrom(ISymbol member, IAssemblySymbol sourceAssembly)
 	{
 		if (member.DeclaredAccessibility is not (Accessibility.Internal or Accessibility.ProtectedAndInternal))

--- a/Source/Mockolate.Analyzers/Resources.resx
+++ b/Source/Mockolate.Analyzers/Resources.resx
@@ -137,7 +137,7 @@
 		<comment>The title of the code fix.</comment>
   </data>
 	<data name="Mockolate0002Description" xml:space="preserve">
-		<value>Types that are sealed, structs, records, enums, or in the global namespace cannot be mocked.</value>
+		<value>Types that are sealed, structs, records, enums, or in the global namespace cannot be mocked. Neither can types with a member that must be implemented but is not accessible from the current assembly.</value>
 	</data>
 	<data name="Mockolate0002MessageFormat" xml:space="preserve">
 		<value>Type '{0}' cannot be mocked: {1}</value>

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -148,6 +148,9 @@ internal class Class : IEquatable<Class>
 
 		ReservedNames = ComputeReservedNames(type);
 
+		HasInaccessibleRequiredMember = ComputeHasInaccessibleRequiredMember(members, sourceAssembly) ||
+		                                InheritedTypes.Any(inherited => inherited.HasInaccessibleRequiredMember);
+
 		_surfaceHash = ComputeSurfaceHash();
 
 		bool ShouldIncludeMember(ISymbol member)
@@ -169,6 +172,7 @@ internal class Class : IEquatable<Class>
 
 	public bool IsInterface { get; }
 	public bool HasRequiredMembers { get; }
+	public bool HasInaccessibleRequiredMember { get; }
 	public string ClassFullName { get; }
 	public string ClassName { get; }
 	public string DisplayString { get; }
@@ -211,8 +215,38 @@ internal class Class : IEquatable<Class>
 		hash = unchecked((hash * 17) + ReservedNames.GetHashCode());
 		hash = unchecked((hash * 17) + (IsInterface ? 1 : 0));
 		hash = unchecked((hash * 17) + (HasRequiredMembers ? 1 : 0));
+		hash = unchecked((hash * 17) + (HasInaccessibleRequiredMember ? 1 : 0));
 		return hash;
 	}
+
+	private static bool ComputeHasInaccessibleRequiredMember(ImmutableArray<ISymbol> members,
+		IAssemblySymbol sourceAssembly)
+	{
+		foreach (ISymbol member in members)
+		{
+			bool isInaccessible = member switch
+			{
+				IMethodSymbol { MethodKind: MethodKind.Ordinary, IsAbstract: true, } method
+					=> !Helpers.IsOverridableFrom(method, sourceAssembly),
+				IPropertySymbol { IsAbstract: true, } property
+					=> IsInaccessibleAccessor(property.GetMethod, sourceAssembly) ||
+					   IsInaccessibleAccessor(property.SetMethod, sourceAssembly),
+				IEventSymbol { IsAbstract: true, } @event
+					=> !Helpers.IsOverridableFrom(@event, sourceAssembly),
+				_ => false,
+			};
+
+			if (isInaccessible)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool IsInaccessibleAccessor(IMethodSymbol? accessor, IAssemblySymbol sourceAssembly)
+		=> accessor is not null && !Helpers.IsOverridableFrom(accessor, sourceAssembly);
 
 	/// <summary>
 	///     Identifiers that the mock class shares its scope with but that aren't surfaced through

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -219,6 +219,16 @@ internal class Class : IEquatable<Class>
 		return hash;
 	}
 
+	/// <summary>
+	///     True when one of <paramref name="members" /> is abstract (so the mock must implement it) but
+	///     invisible to <paramref name="sourceAssembly" />, leaving no valid code the generator could
+	///     emit for it.
+	/// </summary>
+	/// <remarks>
+	///     Mirrored by <c>MockabilityAnalyzer.FindInaccessibleRequiredMember</c>, which reports
+	///     Mockolate0002 for the same condition so the user gets a diagnostic instead of a silently
+	///     missing mock. Keep both in sync.
+	/// </remarks>
 	private static bool ComputeHasInaccessibleRequiredMember(ImmutableArray<ISymbol> members,
 		IAssemblySymbol sourceAssembly)
 	{

--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -45,7 +45,8 @@ internal record Event
 	public bool UseOverride { get; }
 	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
-	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal;
+	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal
+		or Accessibility.ProtectedAndInternal;
 
 	public MemberType MemberType => (IsStatic, IsProtected) switch
 	{

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -59,7 +59,8 @@ internal record Method
 	public bool IsInitOnly { get; }
 	public bool IsRefReturn { get; }
 	public bool IsRefReadonlyReturn { get; }
-	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal;
+	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal
+		or Accessibility.ProtectedAndInternal;
 
 	public MemberType MemberType => (IsStatic, IsProtected) switch
 	{

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -53,7 +53,8 @@ internal record Property
 	public bool IsIndexer { get; }
 	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
-	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal;
+	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal
+		or Accessibility.ProtectedAndInternal;
 
 	public MemberType MemberType => (IsStatic, IsProtected) switch
 	{

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -536,7 +536,8 @@ public class MockGenerator : IIncrementalGenerator
 
 	private static bool IsValidMockDeclaration(MockClass mockClass)
 		=> (mockClass.IsInterface || mockClass.Constructors is { Count: > 0, }) &&
-		   mockClass.AdditionalImplementations.All(x => x.IsInterface);
+		   mockClass.AdditionalImplementations.All(x => x.IsInterface) &&
+		   mockClass.AllImplementations().All(x => !x.HasInaccessibleRequiredMember);
 }
 
 internal readonly record struct MethodSetupKey(int Arity, bool IsVoid);

--- a/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerAccessibilityTests.cs
+++ b/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerAccessibilityTests.cs
@@ -1,0 +1,122 @@
+using System.Threading.Tasks;
+using Xunit;
+using Verifier = Mockolate.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<Mockolate.Analyzers.MockabilityAnalyzer>;
+
+namespace Mockolate.Analyzers.Tests;
+
+public class MockabilityAnalyzerAccessibilityTests
+{
+	[Theory]
+	[InlineData("internal abstract void MyMember();", "Ext.MyExternalType.MyMember()")]
+	[InlineData("internal abstract int MyMember { get; set; }", "Ext.MyExternalType.MyMember.get")]
+	[InlineData("internal abstract event System.EventHandler MyMember;", "Ext.MyExternalType.MyMember")]
+	[InlineData("public abstract string MyMember { get; internal set; }", "Ext.MyExternalType.MyMember.set")]
+	public async Task WhenAbstractMemberOfReferencedAssemblyIsNotAccessible_ShouldBeFlagged(
+		string member, string reportedMember) => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			ExternalType("abstract class", member),
+			Verifier.Diagnostic(Rules.MockabilityRule)
+				.WithLocation(0)
+				.WithArguments("Ext.MyExternalType",
+					$"the member '{reportedMember}' must be implemented, but it is not accessible from this assembly")
+		);
+
+	[Fact]
+	public async Task WhenInterfaceAccessorOfReferencedAssemblyIsNotAccessible_ShouldBeFlagged() => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			ExternalType("interface", "string MyMember { get; internal set; }"),
+			Verifier.Diagnostic(Rules.MockabilityRule)
+				.WithLocation(0)
+				.WithArguments("Ext.MyExternalType",
+					"the member 'Ext.MyExternalType.MyMember.set' must be implemented, but it is not accessible from this assembly")
+		);
+
+	[Fact]
+	public async Task WhenInaccessibleAbstractMemberIsInheritedFromABaseType_ShouldBeFlagged() => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			"""
+			namespace Ext
+			{
+				public abstract class MyBaseType
+				{
+					internal abstract void MyMember();
+				}
+
+				public abstract class MyExternalType : MyBaseType
+				{
+				}
+			}
+			""",
+			Verifier.Diagnostic(Rules.MockabilityRule)
+				.WithLocation(0)
+				.WithArguments("Ext.MyExternalType",
+					"the member 'Ext.MyBaseType.MyMember()' must be implemented, but it is not accessible from this assembly")
+		);
+
+	[Theory]
+	[InlineData("internal abstract void MyMember();")]
+	[InlineData("public abstract string MyMember { get; internal set; }")]
+	public async Task WhenInternalsAreVisibleToTheMockAssembly_ShouldNotBeFlagged(string member) => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			ExternalType("abstract class", member, internalsVisibleToTestProject: true));
+
+	[Theory]
+	[InlineData("internal virtual void MyMember() { }")]
+	[InlineData("internal virtual int MyMember { get; set; }")]
+	public async Task WhenInaccessibleMemberIsOnlyVirtual_ShouldNotBeFlagged(string member) => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			ExternalType("class", member));
+
+	[Fact]
+	public async Task WhenProtectedInternalAbstractMember_ShouldNotBeFlagged() => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			ExternalType("abstract class", "protected internal abstract void MyMember();"));
+
+	private const string MockCreation = """
+	                                    namespace Mockolate
+	                                    {
+	                                    	internal static partial class MockExtensionsForMyExternalType
+	                                    	{
+	                                    		extension(Ext.MyExternalType mock)
+	                                    		{
+	                                    			public static Ext.MyExternalType CreateMock() => default!;
+	                                    		}
+	                                    	}
+	                                    }
+
+	                                    namespace MyNamespace
+	                                    {
+	                                    	public class MyClass
+	                                    	{
+	                                    		public void MyTest()
+	                                    		{
+	                                    			_ = {|#0:Ext.MyExternalType|}.CreateMock();
+	                                    		}
+	                                    	}
+	                                    }
+	                                    """;
+
+	private static string ExternalType(string typeKeyword, string member,
+		bool internalsVisibleToTestProject = false)
+	{
+		string internalsVisibleTo = internalsVisibleToTestProject
+			? """[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("TestProject")]"""
+			: "";
+		return $$"""
+		         {{internalsVisibleTo}}
+		         namespace Ext
+		         {
+		         	public {{typeKeyword}} MyExternalType
+		         	{
+		         		{{member}}
+		         	}
+		         }
+		         """;
+	}
+}

--- a/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerAccessibilityTests.cs
+++ b/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerAccessibilityTests.cs
@@ -78,6 +78,54 @@ public class MockabilityAnalyzerAccessibilityTests
 			MockCreation,
 			ExternalType("abstract class", "protected internal abstract void MyMember();"));
 
+	// `private protected` (= protected AND internal) is unreachable across an assembly boundary
+	// without InternalsVisibleTo, so it must be flagged just like plain `internal`. This mirrors
+	// Helpers.IsOverridableFrom in the generator, which refuses to emit the mock for the same input.
+	[Theory]
+	[InlineData("private protected abstract void MyMember();", "Ext.MyExternalType.MyMember()")]
+	[InlineData("private protected abstract int MyMember { get; set; }", "Ext.MyExternalType.MyMember.get")]
+	[InlineData("private protected abstract event System.EventHandler MyMember;", "Ext.MyExternalType.MyMember")]
+	[InlineData("public abstract string MyMember { get; private protected set; }", "Ext.MyExternalType.MyMember.set")]
+	public async Task WhenPrivateProtectedAbstractMemberIsNotAccessible_ShouldBeFlagged(
+		string member, string reportedMember) => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			ExternalType("abstract class", member),
+			Verifier.Diagnostic(Rules.MockabilityRule)
+				.WithLocation(0)
+				.WithArguments("Ext.MyExternalType",
+					$"the member '{reportedMember}' must be implemented, but it is not accessible from this assembly")
+		);
+
+	[Theory]
+	[InlineData("private protected abstract void MyMember();")]
+	[InlineData("private protected abstract event System.EventHandler MyMember;")]
+	[InlineData("public abstract string MyMember { get; private protected set; }")]
+	public async Task WhenPrivateProtectedAbstractMemberIsVisibleToTheMockAssembly_ShouldNotBeFlagged(string member)
+		=> await Verifier
+			.VerifyAnalyzerWithReferencedProjectAsync(
+				MockCreation,
+				ExternalType("abstract class", member, internalsVisibleToTestProject: true));
+
+	// The same check guards the Implementing<T>() call site, which reaches IsMockable through a
+	// different code path (type argument rather than invocation receiver).
+	[Fact]
+	public async Task WhenAdditionalInterfaceHasAnInaccessibleMember_ShouldBeFlagged() => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			ImplementingMockCreation,
+			ExternalType("interface", "internal void MyMember();"),
+			Verifier.Diagnostic(Rules.MockabilityRule)
+				.WithLocation(0)
+				.WithArguments("Ext.MyExternalType",
+					"the member 'Ext.MyExternalType.MyMember()' must be implemented, but it is not accessible from this assembly")
+		);
+
+	[Fact]
+	public async Task WhenAdditionalInterfaceMemberIsVisibleToTheMockAssembly_ShouldNotBeFlagged() => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			ImplementingMockCreation,
+			ExternalType("interface", "internal void MyMember();", internalsVisibleToTestProject: true));
+
 	private const string MockCreation = """
 	                                    namespace Mockolate
 	                                    {
@@ -101,6 +149,35 @@ public class MockabilityAnalyzerAccessibilityTests
 	                                    	}
 	                                    }
 	                                    """;
+
+	private const string ImplementingMockCreation = """
+	                                                namespace Mockolate
+	                                                {
+	                                                	internal static partial class MockExtensionsForIMyInterface
+	                                                	{
+	                                                		extension(MyNamespace.IMyInterface mock)
+	                                                		{
+	                                                			public static MyNamespace.IMyInterface CreateMock() => default!;
+	                                                			public MyNamespace.IMyInterface Implementing<TInterface>() => default!;
+	                                                		}
+	                                                	}
+	                                                }
+
+	                                                namespace MyNamespace
+	                                                {
+	                                                	public interface IMyInterface
+	                                                	{
+	                                                	}
+
+	                                                	public class MyClass
+	                                                	{
+	                                                		public void MyTest()
+	                                                		{
+	                                                			IMyInterface.CreateMock().Implementing<{|#0:Ext.MyExternalType|}>();
+	                                                		}
+	                                                	}
+	                                                }
+	                                                """;
 
 	private static string ExternalType(string typeKeyword, string member,
 		bool internalsVisibleToTestProject = false)

--- a/Tests/Mockolate.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/Tests/Mockolate.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -46,6 +46,36 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 		await test.RunAsync(CancellationToken.None);
 	}
 
+	public static async Task VerifyAnalyzerWithReferencedProjectAsync([StringSyntax("c#-test")] string source,
+		[StringSyntax("c#-test")] string externalSource,
+		params DiagnosticResult[] expected)
+	{
+		Test test = new()
+		{
+			TestCode = source,
+			TestState =
+			{
+				AdditionalReferences =
+				{
+					typeof(MockBehavior).Assembly.Location,
+				},
+				AdditionalProjects =
+				{
+					["ExternalProject"] =
+					{
+						Sources = { ("/ExternalProject/External.cs", externalSource), },
+					},
+				},
+				AdditionalProjectReferences = { "ExternalProject", },
+			},
+		};
+
+		// TODO: Remove once CS1705 no longer occurs
+		test.CompilerDiagnostics = CompilerDiagnostics.None;
+		test.ExpectedDiagnostics.AddRange(expected);
+		await test.RunAsync(CancellationToken.None);
+	}
+
 	/// <summary>
 	///     Overload that pins the compilation's <see cref="LanguageVersion" /> to a specific
 	///     value, overriding the default <see cref="LanguageVersion.Preview" /> selection in

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
@@ -134,13 +134,24 @@ public sealed partial class MockTests
 				.Contains("public override int Compute()");
 		}
 
+		// The emitted override must repeat the base member's declared accessibility, so assert the
+		// full signature rather than just the member name: the name alone also appears in the
+		// setup/verify surfaces and would match even if no override were emitted at all.
 		[Theory]
-		[InlineData("public abstract string MyProperty { get; internal set; }", "MyProperty")]
-		[InlineData("internal abstract void MyMethod();", "MyMethod")]
-		[InlineData("internal abstract int MyProperty { get; set; }", "MyProperty")]
-		[InlineData("internal abstract event System.EventHandler MyEvent;", "MyEvent")]
+		[InlineData("public abstract string MyProperty { get; internal set; }", "public override string MyProperty")]
+		[InlineData("internal abstract void MyMethod();", "internal override void MyMethod()")]
+		[InlineData("internal abstract int MyProperty { get; set; }", "internal override int MyProperty")]
+		[InlineData("internal abstract event System.EventHandler MyEvent;",
+			"internal override event global::System.EventHandler MyEvent")]
+		[InlineData("private protected abstract void MyMethod();", "private protected override void MyMethod()")]
+		[InlineData("private protected abstract int MyProperty { get; set; }",
+			"private protected override int MyProperty")]
+		[InlineData("private protected abstract event System.EventHandler MyEvent;",
+			"private protected override event global::System.EventHandler MyEvent")]
+		[InlineData("public abstract string MyProperty { get; private protected set; }",
+			"public override string MyProperty")]
 		public async Task InaccessibleAbstractClassMember_WithInternalsVisibleTo_ShouldBeMocked(
-			string member, string memberName)
+			string member, string expectedOverride)
 		{
 			MetadataReference external = CompileMyExternalTypeAssembly("abstract class", member,
 				grantsInternalsVisibleTo: true);
@@ -149,9 +160,32 @@ public sealed partial class MockTests
 
 			await That(result.Diagnostics).IsEmpty();
 			await That(result.Sources).ContainsKey("Mock.MyExternalType.g.cs");
-			await That(result.Sources["Mock.MyExternalType.g.cs"]).Contains(memberName);
+			await That(result.Sources["Mock.MyExternalType.g.cs"]).Contains(expectedOverride);
 		}
 
+		// A `private protected` member cannot be reached through a base-typed qualifier from the
+		// derived mock, so it must not take part in the `Wraps` forwarding (CS1540). Non-mixed
+		// accessors additionally route to the protected setup surface rather than the public one.
+		[Theory]
+		[InlineData("private protected abstract void MyMethod();")]
+		[InlineData("private protected abstract event System.EventHandler MyEvent;")]
+		public async Task PrivateProtectedMember_WithInternalsVisibleTo_ShouldNotBeWrapped(string member)
+		{
+			MetadataReference external = CompileMyExternalTypeAssembly("abstract class", member,
+				grantsInternalsVisibleTo: true);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources["Mock.MyExternalType.g.cs"]).DoesNotContain(".Wraps is global::Ext.MyExternalType");
+		}
+
+		// Diagnostics being empty here is not evidence of a graceful outcome: `Mock.g.cs` emits a
+		// generic `CreateMock` fallback that the call binds to (and CS1061 is suppressed in
+		// Generator.NoWarn anyway), so the program compiles and throws MockException at runtime. The
+		// user-facing guarantee is the Mockolate0002 error from MockabilityAnalyzer, covered by
+		// MockabilityAnalyzerAccessibilityTests. What this test pins is only that the generator
+		// refuses to emit a mock whose overrides could not compile.
 		[Theory]
 		[InlineData("interface", "string MyProperty { get; internal set; }")]
 		[InlineData("interface", "internal void MyMethod();")]
@@ -159,6 +193,9 @@ public sealed partial class MockTests
 		[InlineData("abstract class", "internal abstract void MyMethod();")]
 		[InlineData("abstract class", "internal abstract int MyProperty { get; set; }")]
 		[InlineData("abstract class", "internal abstract event System.EventHandler MyEvent;")]
+		[InlineData("abstract class", "private protected abstract void MyMethod();")]
+		[InlineData("abstract class", "private protected abstract int MyProperty { get; set; }")]
+		[InlineData("abstract class", "private protected abstract event System.EventHandler MyEvent;")]
 		public async Task InaccessibleRequiredMember_WithoutInternalsVisibleTo_ShouldNotBeMocked(
 			string typeKeyword, string member)
 		{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
@@ -17,6 +17,17 @@ public sealed partial class MockTests
 		                                               }
 		                                               """;
 
+		private const string CreateMockForMyExternalType = """
+		                                                   using Mockolate;
+
+		                                                   namespace MyCode;
+
+		                                                   public class Program
+		                                                   {
+		                                                       public static void Main(string[] args) => _ = Ext.MyExternalType.CreateMock();
+		                                                   }
+		                                                   """;
+
 		[Fact]
 		public async Task InternalVirtualMember_WithInternalsVisibleTo_ShouldBeOverridden()
 		{
@@ -121,6 +132,60 @@ public sealed partial class MockTests
 			await That(result.Sources["Mock.MyAbstractService.g.cs"])
 				.Contains("public override string Name").And
 				.Contains("public override int Compute()");
+		}
+
+		[Theory]
+		[InlineData("public abstract string MyProperty { get; internal set; }", "MyProperty")]
+		[InlineData("internal abstract void MyMethod();", "MyMethod")]
+		[InlineData("internal abstract int MyProperty { get; set; }", "MyProperty")]
+		[InlineData("internal abstract event System.EventHandler MyEvent;", "MyEvent")]
+		public async Task InaccessibleAbstractClassMember_WithInternalsVisibleTo_ShouldBeMocked(
+			string member, string memberName)
+		{
+			MetadataReference external = CompileMyExternalTypeAssembly("abstract class", member,
+				grantsInternalsVisibleTo: true);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.MyExternalType.g.cs");
+			await That(result.Sources["Mock.MyExternalType.g.cs"]).Contains(memberName);
+		}
+
+		[Theory]
+		[InlineData("interface", "string MyProperty { get; internal set; }")]
+		[InlineData("interface", "internal void MyMethod();")]
+		[InlineData("abstract class", "public abstract string MyProperty { get; internal set; }")]
+		[InlineData("abstract class", "internal abstract void MyMethod();")]
+		[InlineData("abstract class", "internal abstract int MyProperty { get; set; }")]
+		[InlineData("abstract class", "internal abstract event System.EventHandler MyEvent;")]
+		public async Task InaccessibleRequiredMember_WithoutInternalsVisibleTo_ShouldNotBeMocked(
+			string typeKeyword, string member)
+		{
+			MetadataReference external = CompileMyExternalTypeAssembly(typeKeyword, member,
+				grantsInternalsVisibleTo: false);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).DoesNotContainKey("Mock.MyExternalType.g.cs");
+		}
+
+		private static MetadataReference CompileMyExternalTypeAssembly(string typeKeyword, string member,
+			bool grantsInternalsVisibleTo)
+		{
+			string internalsVisibleTo = grantsInternalsVisibleTo
+				? """[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("TestAssembly")]"""
+				: "";
+			return ExternalAssembly.Compile($$"""
+			                                 {{internalsVisibleTo}}
+			                                 namespace Ext;
+
+			                                 public {{typeKeyword}} MyExternalType
+			                                 {
+			                                 	{{member}}
+			                                 }
+			                                 """);
 		}
 
 		private static MetadataReference CompileMyBaseClassAssembly(bool grantsInternalsVisibleTo)


### PR DESCRIPTION
A type from a referenced assembly can declare a member the mock must implement but that the mock's assembly cannot see, for example an `internal abstract` member or a `{ get; internal set; }` property on a type from an assembly that does not grant `InternalsVisibleTo`. `Class.ShouldIncludeMember` short-circuited the accessibility check for abstract and interface members while `Property.Getter`/`Setter` did not, so the generator emitted a member with an accessor missing, or an override of something it cannot see. The result did not compile (CS0115, CS0122, CS0277, CS0534, CS0535, CS0548).

There is no valid code a mock could emit for such a member, so the type is not mockable at all. Let `IsValidMockDeclaration` skip it and have `MockabilityAnalyzer` report Mockolate0002 naming the offending member.

Members that are merely `virtual` are unaffected: they stay excluded from the mock without making the type unmockable.