### PR TITLE
fix: keep types mockable when an inaccessible member is already implemented

### DIFF
--- a/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
+++ b/Source/Mockolate.Analyzers/MockabilityAnalyzer.cs
@@ -478,10 +478,86 @@ public sealed class MockabilityAnalyzer : DiagnosticAnalyzer
 	}
 
 	private static ISymbol? FindInaccessibleRequiredMember(ITypeSymbol type, IAssemblySymbol sourceAssembly)
-		=> EnumerateImplementedTypes(type)
-			.SelectMany(implementedType => implementedType.GetMembers())
-			.Select(member => FindInaccessibleMember(member, sourceAssembly))
-			.FirstOrDefault(inaccessibleMember => inaccessibleMember is not null);
+	{
+		HashSet<string> filledSlots = new(StringComparer.Ordinal);
+
+		foreach (ITypeSymbol implementedType in EnumerateImplementedTypes(type))
+		{
+			foreach (ISymbol member in implementedType.GetMembers())
+			{
+				foreach (ISymbol slot in EnumerateFilledSlots(member))
+				{
+					filledSlots.Add(GetSignatureKey(slot));
+				}
+			}
+		}
+
+		foreach (ITypeSymbol implementedType in EnumerateImplementedTypes(type))
+		{
+			foreach (ISymbol member in implementedType.GetMembers())
+			{
+				if (filledSlots.Contains(GetSignatureKey(member)))
+				{
+					continue;
+				}
+
+				if (FindInaccessibleMember(member, sourceAssembly) is { } inaccessibleMember)
+				{
+					return inaccessibleMember;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static IEnumerable<ISymbol> EnumerateFilledSlots(ISymbol member)
+	{
+		if (member.IsAbstract)
+		{
+			yield break;
+		}
+
+		switch (member)
+		{
+			case IMethodSymbol method:
+				if (method.OverriddenMethod is { } overriddenMethod)
+				{
+					yield return overriddenMethod;
+				}
+
+				foreach (IMethodSymbol implemented in method.ExplicitInterfaceImplementations)
+				{
+					yield return implemented;
+				}
+
+				break;
+			case IPropertySymbol property:
+				if (property.OverriddenProperty is { } overriddenProperty)
+				{
+					yield return overriddenProperty;
+				}
+
+				foreach (IPropertySymbol implemented in property.ExplicitInterfaceImplementations)
+				{
+					yield return implemented;
+				}
+
+				break;
+			case IEventSymbol @event:
+				if (@event.OverriddenEvent is { } overriddenEvent)
+				{
+					yield return overriddenEvent;
+				}
+
+				foreach (IEventSymbol implemented in @event.ExplicitInterfaceImplementations)
+				{
+					yield return implemented;
+				}
+
+				break;
+		}
+	}
 
 	private static ISymbol? FindInaccessibleMember(ISymbol member, IAssemblySymbol sourceAssembly)
 		=> member switch

--- a/Source/Mockolate.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Class.cs
@@ -64,6 +64,27 @@ internal class Class : IEquatable<Class>
 
 		foreach (ISymbol member in members)
 		{
+			if (!FillsInaccessibleBaseSlot(member, sourceAssembly))
+			{
+				continue;
+			}
+
+			switch (member)
+			{
+				case IMethodSymbol methodSymbol:
+					methodExceptCandidates.Add(new Method(methodSymbol, null, sourceAssembly));
+					break;
+				case IPropertySymbol propertySymbol:
+					propertyExceptCandidates.Add(new Property(propertySymbol, null, sourceAssembly));
+					break;
+				case IEventSymbol { Type: INamedTypeSymbol { DelegateInvokeMethod: { } eventInvoke, }, } eventSymbol:
+					eventExceptCandidates.Add(new Event(eventSymbol, eventInvoke, null, sourceAssembly));
+					break;
+			}
+		}
+
+		foreach (ISymbol member in members)
+		{
 			switch (member)
 			{
 				case IMethodSymbol methodSymbol when methodSymbol.MethodKind is MethodKind.Ordinary:
@@ -148,13 +169,18 @@ internal class Class : IEquatable<Class>
 
 		ReservedNames = ComputeReservedNames(type);
 
-		HasInaccessibleRequiredMember = ComputeHasInaccessibleRequiredMember(members, sourceAssembly) ||
+		HasInaccessibleRequiredMember = ComputeHasInaccessibleRequiredMember() ||
 		                                InheritedTypes.Any(inherited => inherited.HasInaccessibleRequiredMember);
 
 		_surfaceHash = ComputeSurfaceHash();
 
 		bool ShouldIncludeMember(ISymbol member)
 		{
+			if (FillsInaccessibleBaseSlot(member, _sourceAssembly))
+			{
+				return false;
+			}
+
 			if (IsInterface || member.IsAbstract)
 			{
 				return true;
@@ -220,43 +246,92 @@ internal class Class : IEquatable<Class>
 	}
 
 	/// <summary>
-	///     True when one of <paramref name="members" /> is abstract (so the mock must implement it) but
-	///     invisible to <paramref name="sourceAssembly" />, leaving no valid code the generator could
-	///     emit for it.
+	///     True when a member the mock is still obliged to implement is invisible to the mock's
+	///     assembly, leaving no valid code the generator could emit for it.
 	/// </summary>
 	/// <remarks>
+	///     Deliberately reads the filtered <see cref="Methods" />/<see cref="Properties" />/
+	///     <see cref="Events" /> rather than <c>type.GetMembers()</c>: an abstract member that a
+	///     more-derived type already overrides has been dropped from those sets by
+	///     <see cref="FillsInaccessibleBaseSlot" />, and it is no longer the mock's obligation. Judging
+	///     the raw symbols instead would reject types that mock perfectly well.
+	///     <para />
 	///     Mirrored by <c>MockabilityAnalyzer.FindInaccessibleRequiredMember</c>, which reports
 	///     Mockolate0002 for the same condition so the user gets a diagnostic instead of a silently
 	///     missing mock. Keep both in sync.
 	/// </remarks>
-	private static bool ComputeHasInaccessibleRequiredMember(ImmutableArray<ISymbol> members,
-		IAssemblySymbol sourceAssembly)
-	{
-		foreach (ISymbol member in members)
-		{
-			bool isInaccessible = member switch
-			{
-				IMethodSymbol { MethodKind: MethodKind.Ordinary, IsAbstract: true, } method
-					=> !Helpers.IsOverridableFrom(method, sourceAssembly),
-				IPropertySymbol { IsAbstract: true, } property
-					=> IsInaccessibleAccessor(property.GetMethod, sourceAssembly) ||
-					   IsInaccessibleAccessor(property.SetMethod, sourceAssembly),
-				IEventSymbol { IsAbstract: true, } @event
-					=> !Helpers.IsOverridableFrom(@event, sourceAssembly),
-				_ => false,
-			};
+	private bool ComputeHasInaccessibleRequiredMember()
+		=> Methods.Any(method => method is { IsAbstract: true, IsOverridableFromMock: false, }) ||
+		   Properties.Any(property => property is { IsAbstract: true, IsOverridableFromMock: false, }) ||
+		   Events.Any(@event => @event is { IsAbstract: true, IsOverridableFromMock: false, });
 
-			if (isInaccessible)
-			{
-				return true;
-			}
+	/// <summary>
+	///     True when <paramref name="member" /> fills a base slot (by <see langword="override" /> or by
+	///     explicit interface implementation) whose base declaration is invisible to
+	///     <paramref name="sourceAssembly" />.
+	/// </summary>
+	private static bool FillsInaccessibleBaseSlot(ISymbol member, IAssemblySymbol? sourceAssembly)
+		=> EnumerateFilledSlots(member).Any(slot => !IsSlotReachable(slot, sourceAssembly));
+
+	private static IEnumerable<ISymbol> EnumerateFilledSlots(ISymbol member)
+	{
+		if (member.IsAbstract)
+		{
+			yield break;
 		}
 
-		return false;
+		switch (member)
+		{
+			case IMethodSymbol method:
+				if (method.OverriddenMethod is { } overriddenMethod)
+				{
+					yield return overriddenMethod;
+				}
+
+				foreach (IMethodSymbol implemented in method.ExplicitInterfaceImplementations)
+				{
+					yield return implemented;
+				}
+
+				break;
+			case IPropertySymbol property:
+				if (property.OverriddenProperty is { } overriddenProperty)
+				{
+					yield return overriddenProperty;
+				}
+
+				foreach (IPropertySymbol implemented in property.ExplicitInterfaceImplementations)
+				{
+					yield return implemented;
+				}
+
+				break;
+			case IEventSymbol @event:
+				if (@event.OverriddenEvent is { } overriddenEvent)
+				{
+					yield return overriddenEvent;
+				}
+
+				foreach (IEventSymbol implemented in @event.ExplicitInterfaceImplementations)
+				{
+					yield return implemented;
+				}
+
+				break;
+		}
 	}
 
-	private static bool IsInaccessibleAccessor(IMethodSymbol? accessor, IAssemblySymbol sourceAssembly)
-		=> accessor is not null && !Helpers.IsOverridableFrom(accessor, sourceAssembly);
+	private static bool IsSlotReachable(ISymbol slot, IAssemblySymbol? sourceAssembly)
+		=> slot switch
+		{
+			IPropertySymbol property => Helpers.IsOverridableFrom(property, sourceAssembly) &&
+			                            IsAccessorReachable(property.GetMethod, sourceAssembly) &&
+			                            IsAccessorReachable(property.SetMethod, sourceAssembly),
+			_ => Helpers.IsOverridableFrom(slot, sourceAssembly),
+		};
+
+	private static bool IsAccessorReachable(IMethodSymbol? accessor, IAssemblySymbol? sourceAssembly)
+		=> accessor is null || Helpers.IsOverridableFrom(accessor, sourceAssembly);
 
 	/// <summary>
 	///     Identifiers that the mock class shares its scope with but that aren't surfaced through

--- a/Source/Mockolate.SourceGenerators/Entities/Event.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Event.cs
@@ -12,6 +12,7 @@ internal record Event
 		OverrideAccessibility = Helpers.ResolveOverrideVisibility(
 			Accessibility, eventSymbol.ContainingAssembly, sourceAssembly);
 		UseOverride = eventSymbol.IsVirtual || eventSymbol.IsAbstract;
+		IsOverridableFromMock = Helpers.IsOverridableFrom(eventSymbol, sourceAssembly);
 		IsAbstract = eventSymbol.IsAbstract;
 		Name = Helpers.EscapeIfKeyword(eventSymbol.ExplicitInterfaceImplementations.Length > 0 ? eventSymbol.ExplicitInterfaceImplementations[0].Name : eventSymbol.Name);
 		Type = Type.From(eventSymbol.Type);
@@ -43,6 +44,7 @@ internal record Event
 	public Type Type { get; }
 	public string ContainingType { get; }
 	public bool UseOverride { get; }
+	public bool IsOverridableFromMock { get; }
 	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
 	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal

--- a/Source/Mockolate.SourceGenerators/Entities/Method.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Method.cs
@@ -12,6 +12,7 @@ internal record Method
 		OverrideAccessibility = Helpers.ResolveOverrideVisibility(
 			Accessibility, methodSymbol.ContainingAssembly, sourceAssembly);
 		UseOverride = methodSymbol.IsVirtual || methodSymbol.IsAbstract;
+		IsOverridableFromMock = Helpers.IsOverridableFrom(methodSymbol, sourceAssembly);
 		IsAbstract = methodSymbol.IsAbstract;
 		IsStatic = methodSymbol.IsStatic;
 		IsInitOnly = methodSymbol.IsInitOnly;
@@ -54,6 +55,7 @@ internal record Method
 	public EquatableArray<GenericParameter>? GenericParameters { get; }
 
 	public bool UseOverride { get; }
+	public bool IsOverridableFromMock { get; }
 	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
 	public bool IsInitOnly { get; }

--- a/Source/Mockolate.SourceGenerators/Entities/Property.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/Property.cs
@@ -37,10 +37,17 @@ internal record Property
 			alreadyDefinedProperties.Add(this);
 		}
 
-		Getter = propertySymbol.GetMethod is { } getter && Helpers.IsOverridableFrom(getter, sourceAssembly)
+		bool getterOverridable = propertySymbol.GetMethod is not { } getterSymbol ||
+		                         Helpers.IsOverridableFrom(getterSymbol, sourceAssembly);
+		bool setterOverridable = propertySymbol.SetMethod is not { } setterSymbol ||
+		                         Helpers.IsOverridableFrom(setterSymbol, sourceAssembly);
+		IsOverridableFromMock = getterOverridable && setterOverridable &&
+		                        Helpers.IsOverridableFrom(propertySymbol, sourceAssembly);
+
+		Getter = propertySymbol.GetMethod is { } getter && getterOverridable
 			? new Method(getter, null, sourceAssembly)
 			: null;
-		Setter = propertySymbol.SetMethod is { } setter && Helpers.IsOverridableFrom(setter, sourceAssembly)
+		Setter = propertySymbol.SetMethod is { } setter && setterOverridable
 			? new Method(setter, null, sourceAssembly)
 			: null;
 	}
@@ -51,6 +58,7 @@ internal record Property
 		new ContainingTypeIndependentPropertyEqualityComparer();
 
 	public bool IsIndexer { get; }
+	public bool IsOverridableFromMock { get; }
 	public bool IsAbstract { get; }
 	public bool IsStatic { get; }
 	public bool IsProtected => Accessibility is Accessibility.Protected or Accessibility.ProtectedOrInternal

--- a/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerAccessibilityTests.cs
+++ b/Tests/Mockolate.Analyzers.Tests/MockabilityAnalyzerAccessibilityTests.cs
@@ -57,6 +57,75 @@ public class MockabilityAnalyzerAccessibilityTests
 		);
 
 	[Theory]
+	[InlineData("internal abstract void MyMember();", "internal override void MyMember() { }")]
+	[InlineData("internal abstract int MyMember { get; set; }", "internal override int MyMember { get; set; }")]
+	[InlineData("internal abstract event System.EventHandler MyMember;",
+		"internal override event System.EventHandler MyMember;")]
+	[InlineData("public abstract string MyMember { get; internal set; }",
+		"public override string MyMember { get => null!; internal set { } }")]
+	public async Task WhenInaccessibleAbstractMemberIsAlreadyOverridden_ShouldNotBeFlagged(
+		string baseMember, string derivedOverride) => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			$$"""
+			  namespace Ext
+			  {
+			  	public abstract class MyBaseType
+			  	{
+			  		{{baseMember}}
+			  	}
+
+			  	public abstract class MyExternalType : MyBaseType
+			  	{
+			  		{{derivedOverride}}
+			  	}
+			  }
+			  """);
+
+	[Fact]
+	public async Task WhenInaccessibleInterfaceMemberHasADefaultImplementation_ShouldNotBeFlagged() => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			"""
+			namespace Ext
+			{
+				public interface IMyBaseType
+				{
+					internal void MyMember();
+				}
+
+				public interface MyExternalType : IMyBaseType
+				{
+					void IMyBaseType.MyMember() { }
+				}
+			}
+			""");
+
+	[Fact]
+	public async Task WhenInaccessibleAbstractMemberIsReDeclaredAsAbstract_ShouldBeFlagged() => await Verifier
+		.VerifyAnalyzerWithReferencedProjectAsync(
+			MockCreation,
+			"""
+			namespace Ext
+			{
+				public abstract class MyBaseType
+				{
+					internal abstract void MyMember();
+				}
+
+				public abstract class MyExternalType : MyBaseType
+				{
+					internal abstract override void MyMember();
+				}
+			}
+			""",
+			Verifier.Diagnostic(Rules.MockabilityRule)
+				.WithLocation(0)
+				.WithArguments("Ext.MyExternalType",
+					"the member 'Ext.MyExternalType.MyMember()' must be implemented, but it is not accessible from this assembly")
+		);
+
+	[Theory]
 	[InlineData("internal abstract void MyMember();")]
 	[InlineData("public abstract string MyMember { get; internal set; }")]
 	public async Task WhenInternalsAreVisibleToTheMockAssembly_ShouldNotBeFlagged(string member) => await Verifier
@@ -78,9 +147,6 @@ public class MockabilityAnalyzerAccessibilityTests
 			MockCreation,
 			ExternalType("abstract class", "protected internal abstract void MyMember();"));
 
-	// `private protected` (= protected AND internal) is unreachable across an assembly boundary
-	// without InternalsVisibleTo, so it must be flagged just like plain `internal`. This mirrors
-	// Helpers.IsOverridableFrom in the generator, which refuses to emit the mock for the same input.
 	[Theory]
 	[InlineData("private protected abstract void MyMember();", "Ext.MyExternalType.MyMember()")]
 	[InlineData("private protected abstract int MyMember { get; set; }", "Ext.MyExternalType.MyMember.get")]
@@ -107,8 +173,6 @@ public class MockabilityAnalyzerAccessibilityTests
 				MockCreation,
 				ExternalType("abstract class", member, internalsVisibleToTestProject: true));
 
-	// The same check guards the Implementing<T>() call site, which reaches IsMockable through a
-	// different code path (type argument rather than invocation receiver).
 	[Fact]
 	public async Task WhenAdditionalInterfaceHasAnInaccessibleMember_ShouldBeFlagged() => await Verifier
 		.VerifyAnalyzerWithReferencedProjectAsync(

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
@@ -134,9 +134,6 @@ public sealed partial class MockTests
 				.Contains("public override int Compute()");
 		}
 
-		// The emitted override must repeat the base member's declared accessibility, so assert the
-		// full signature rather than just the member name: the name alone also appears in the
-		// setup/verify surfaces and would match even if no override were emitted at all.
 		[Theory]
 		[InlineData("public abstract string MyProperty { get; internal set; }", "public override string MyProperty")]
 		[InlineData("internal abstract void MyMethod();", "internal override void MyMethod()")]
@@ -160,12 +157,11 @@ public sealed partial class MockTests
 
 			await That(result.Diagnostics).IsEmpty();
 			await That(result.Sources).ContainsKey("Mock.MyExternalType.g.cs");
-			await That(result.Sources["Mock.MyExternalType.g.cs"]).Contains(expectedOverride);
+			await That(result.Sources["Mock.MyExternalType.g.cs"]).Contains(expectedOverride)
+				.Because(
+					"the override must repeat the base member's declared accessibility, and the member name alone would also match the setup and verify surfaces");
 		}
 
-		// A `private protected` member cannot be reached through a base-typed qualifier from the
-		// derived mock, so it must not take part in the `Wraps` forwarding (CS1540). Non-mixed
-		// accessors additionally route to the protected setup surface rather than the public one.
 		[Theory]
 		[InlineData("private protected abstract void MyMethod();")]
 		[InlineData("private protected abstract event System.EventHandler MyEvent;")]
@@ -177,15 +173,11 @@ public sealed partial class MockTests
 			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
 
 			await That(result.Diagnostics).IsEmpty();
-			await That(result.Sources["Mock.MyExternalType.g.cs"]).DoesNotContain(".Wraps is global::Ext.MyExternalType");
+			await That(result.Sources["Mock.MyExternalType.g.cs"]).DoesNotContain(".Wraps is global::Ext.MyExternalType")
+				.Because(
+					"a `private protected` member cannot be reached through a base-typed qualifier from the derived mock (CS1540)");
 		}
 
-		// Diagnostics being empty here is not evidence of a graceful outcome: `Mock.g.cs` emits a
-		// generic `CreateMock` fallback that the call binds to (and CS1061 is suppressed in
-		// Generator.NoWarn anyway), so the program compiles and throws MockException at runtime. The
-		// user-facing guarantee is the Mockolate0002 error from MockabilityAnalyzer, covered by
-		// MockabilityAnalyzerAccessibilityTests. What this test pins is only that the generator
-		// refuses to emit a mock whose overrides could not compile.
 		[Theory]
 		[InlineData("interface", "string MyProperty { get; internal set; }")]
 		[InlineData("interface", "internal void MyMethod();")]
@@ -204,8 +196,106 @@ public sealed partial class MockTests
 
 			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
 
+			await That(result.Diagnostics).IsEmpty()
+				.Because(
+					"the call binds to the generic `CreateMock` fallback in Mock.g.cs, so the program still compiles and throws MockException at runtime instead");
+			await That(result.Sources).DoesNotContainKey("Mock.MyExternalType.g.cs")
+				.Because(
+					"the generator must refuse to emit a mock whose overrides could not compile; the user-facing guarantee is the Mockolate0002 error");
+		}
+
+		[Theory]
+		[InlineData("internal abstract void Hidden();", "internal override void Hidden() { }")]
+		[InlineData("internal abstract int Hidden { get; set; }", "internal override int Hidden { get; set; }")]
+		[InlineData("internal abstract event System.EventHandler Hidden;",
+			"internal override event System.EventHandler Hidden;")]
+		[InlineData("public abstract string Hidden { get; internal set; }",
+			"public override string Hidden { get => null!; internal set { } }")]
+		public async Task InaccessibleAbstractMemberAlreadyOverridden_ShouldStillBeMocked(
+			string baseMember, string derivedOverride)
+		{
+			MetadataReference external = ExternalAssembly.Compile($$"""
+			                                                       namespace Ext;
+
+			                                                       public abstract class MyBaseType
+			                                                       {
+			                                                       	{{baseMember}}
+			                                                       	public abstract int Visible();
+			                                                       }
+
+			                                                       public abstract class MyExternalType : MyBaseType
+			                                                       {
+			                                                       	{{derivedOverride}}
+			                                                       }
+			                                                       """);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
+
 			await That(result.Diagnostics).IsEmpty();
-			await That(result.Sources).DoesNotContainKey("Mock.MyExternalType.g.cs");
+			await That(result.Sources).ContainsKey("Mock.MyExternalType.g.cs");
+			await That(result.Sources["Mock.MyExternalType.g.cs"])
+				.Contains("public override int Visible()").And
+				.DoesNotContain("Hidden")
+				.Because("the slot is already filled, so neither the unreachable override nor the base declaration may be restated");
+		}
+
+		[Theory]
+		[InlineData("internal void Hidden();", "void IMyBaseType.Hidden() { }")]
+		[InlineData("internal int Hidden { get; set; }",
+			"int IMyBaseType.Hidden { get => 0; set { } }")]
+		[InlineData("internal event System.EventHandler Hidden;",
+			"event System.EventHandler IMyBaseType.Hidden { add { } remove { } }")]
+		public async Task InaccessibleInterfaceMemberWithDefaultImplementation_ShouldStillBeMocked(
+			string baseMember, string defaultImplementation)
+		{
+			MetadataReference external = ExternalAssembly.Compile($$"""
+			                                                       namespace Ext;
+
+			                                                       public interface IMyBaseType
+			                                                       {
+			                                                       	{{baseMember}}
+			                                                       }
+
+			                                                       public interface MyExternalType : IMyBaseType
+			                                                       {
+			                                                       	{{defaultImplementation}}
+			                                                       	int Visible();
+			                                                       }
+			                                                       """);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).ContainsKey("Mock.MyExternalType.g.cs");
+			await That(result.Sources["Mock.MyExternalType.g.cs"])
+				.Contains("public int Visible()").And
+				.DoesNotContain("Hidden")
+				.Because("the default implementation fills the slot, so the mock inherits it rather than restating it");
+		}
+
+		[Fact]
+		public async Task InaccessibleAbstractMemberReDeclaredAsAbstract_ShouldNotBeMocked()
+		{
+			MetadataReference external = ExternalAssembly.Compile("""
+			                                                      namespace Ext;
+
+			                                                      public abstract class MyBaseType
+			                                                      {
+			                                                      	internal abstract void Hidden();
+			                                                      }
+
+			                                                      public abstract class MyExternalType : MyBaseType
+			                                                      {
+			                                                      	internal abstract override void Hidden();
+			                                                      }
+			                                                      """);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources).DoesNotContainKey("Mock.MyExternalType.g.cs")
+				.Because(
+					"an `abstract override` re-declaration continues the slot without filling it, so the member is still the mock's obligation");
 		}
 
 		private static MetadataReference CompileMyExternalTypeAssembly(string typeKeyword, string member,


### PR DESCRIPTION
The mockability check rejected a type if *any* abstract member anywhere in its hierarchy was inaccessible, rather than any member the mock is still obliged to implement. A type whose inaccessible abstract member is already overridden by a more-derived type in the referenced assembly was therefore reported as unmockable, with a message claiming the member must be implemented when it already had been:

    public abstract class MyBaseType { internal abstract void Hidden(); }
    public abstract class MyExternalType : MyBaseType
    {
        internal override void Hidden() { }
    }

Mockolate0002 is an error, so this broke the build for a type that mocks fine. The same applied to a base-interface member with a default implementation in a derived interface.

The root cause was upstream of the check: the generator collected every abstract member in the hierarchy regardless of whether a more-derived type had already filled the slot, so before the check existed these types produced generated code that failed with CS0115/CS0122 instead. Both symptoms share a fix:

- Class.FillsInaccessibleBaseSlot drops a member that fills an unreachable base slot (by override or explicit interface implementation) together with the base declaration itself. Detection runs in a pre-pass because an explicit interface implementation is MethodKind.ExplicitInterfaceImplementation and so never matched the member switch.
- HasInaccessibleRequiredMember now reads the filtered member surface instead of the raw symbols, so it automatically respects that exclusion. This adds IsOverridableFromMock to Method/Property/Event; on properties it also covers an inaccessible accessor of an otherwise public property.
- MockabilityAnalyzer.FindInaccessibleRequiredMember records filled slots while walking most-derived first, and skips base declarations already satisfied.

An `abstract override` re-declaration continues the slot without filling it, so it is deliberately not treated as satisfying the obligation and the diagnostic still fires.