### PR TITLE
refactor: move assertion rationale from comments into .Because(...)

### DIFF
--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferBoxingAndUnverifiedTests.cs
@@ -129,10 +129,6 @@ public class FastBufferBoxingAndUnverifiedTests
 	[Fact]
 	public async Task FastEventBuffer_Unsubscribe_AppendBoxedUnverified_ShouldBoxAsEventUnsubscription()
 	{
-		// Pins the `_kind == FastEventBufferKind.Subscribe ? new EventSubscription(...) :
-		// new EventUnsubscription(...)` ternary in AppendBoxedUnverified. With the conditional
-		// flipped to `(true ? Subscription : Unsubscription)`, an unsubscribe buffer would
-		// surface its records as EventSubscription.
 		FastMockInteractions store = new(1);
 		FastEventBuffer buffer = InstallEventUnsubscribe(store, 0);
 		buffer.Append("E", this, SampleMethod);
@@ -141,7 +137,9 @@ public class FastBufferBoxingAndUnverifiedTests
 		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
 
 		await That(dest).HasCount(1);
-		await That(dest[0].Interaction).IsExactly<EventUnsubscription>();
+		await That(dest[0].Interaction).IsExactly<EventUnsubscription>()
+			.Because(
+				"the `_kind == FastEventBufferKind.Subscribe` ternary in AppendBoxedUnverified must pick the record type from the buffer kind, so an unsubscribe buffer never surfaces EventSubscription");
 	}
 
 	[Fact]
@@ -931,9 +929,6 @@ public class FastBufferBoxingAndUnverifiedTests
 	[Fact]
 	public async Task FastPropertySetterBuffer_ConsumeMatching_ShouldMarkSlotsVerified()
 	{
-		// Pins the `_storage.VerifiedUnderLock(slot) = true` write. With the mutation flipped
-		// to `false`, ConsumeMatching would still report matches but the slots would never be
-		// marked verified — so a second ConsumeMatching call would re-count the same records.
 		FastMockInteractions store = new(1);
 		FastPropertySetterBuffer<int> buffer = InstallPropertySetter<int>(store, 0);
 		buffer.Append("P", 1);
@@ -945,7 +940,9 @@ public class FastBufferBoxingAndUnverifiedTests
 		List<(long Seq, IInteraction Interaction)> dest = [];
 		((IFastMemberBuffer)buffer).AppendBoxedUnverified(dest);
 
-		await That(dest).IsEmpty();
+		await That(dest).IsEmpty()
+			.Because(
+				"ConsumeMatching must write `_storage.VerifiedUnderLock(slot) = true`, otherwise the matched slots stay unverified and a second call would re-count the same records");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastBufferConsumeMatchingTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastBufferConsumeMatchingTests.cs
@@ -241,16 +241,15 @@ public class FastBufferConsumeMatchingTests
 	[Fact]
 	public async Task FastMethod1Buffer_ConsumeAll_OnEmptyBuffer_ShouldReturnZeroWithoutThrowing()
 	{
-		// Pins the `slot < n` loop bound in Method1 ConsumeAll. Mutated to `slot <= n`, an empty
-		// buffer (n == 0) would still enter the loop at slot=0 and call VerifiedUnderLock(0),
-		// which dereferences the not-yet-allocated VerifiedChunks[0] → NRE.
 		FastMockInteractions store = new(1);
 		FastMethod1Buffer<int> buffer = store.GetOrCreateBuffer<FastMethod1Buffer<int>>(0,
 			static f => new FastMethod1Buffer<int>(f));
 
 		int consumed = buffer.ConsumeAll();
 
-		await That(consumed).IsEqualTo(0);
+		await That(consumed).IsEqualTo(0)
+			.Because(
+				"the `slot < n` loop bound in Method1 ConsumeAll must keep an empty buffer out of the loop; entering it at slot 0 would dereference the not-yet-allocated VerifiedChunks[0]");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/FastMockInteractionsTests.cs
@@ -460,15 +460,14 @@ public class FastMockInteractionsTests
 	[Fact]
 	public async Task GetUnverifiedInteractions_WhenNothingRecorded_ShouldReturnArrayEmptySingleton()
 	{
-		// Pins the `return Array.Empty<IInteraction>();` early-return on the empty path. With
-		// the block removed, the method falls through to `new IInteraction[unverified.Count]`
-		// and returns a freshly-allocated zero-length array instead of the shared singleton.
 		FastMockInteractions sut = new(1);
 		InstallMethod(sut, 0);
 
 		IReadOnlyCollection<IInteraction> result = sut.GetUnverifiedInteractions();
 
-		await That(result).IsSameAs(Array.Empty<IInteraction>());
+		await That(result).IsSameAs(Array.Empty<IInteraction>())
+			.Because(
+				"the empty path must take the `return Array.Empty<IInteraction>();` early-return rather than fall through and allocate a fresh zero-length array");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/Interactions/IndexerAccessTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Interactions/IndexerAccessTests.cs
@@ -125,12 +125,11 @@ public sealed class IndexerAccessTests
 	[Fact]
 	public async Task ToString_OnIndexerGetterAccess3_FormatsEachNullParameterAsNullLiteral()
 	{
-		// Pins the `?? "null"` literals in IndexerGetterAccess<T1, T2, T3>.ToString. With any of
-		// the three "null" → "" mutations applied, a null parameter would render as an empty
-		// slot like "[, ...]" instead of "[null, ...]".
 		IndexerGetterAccess<string?, string?, string?> access = new(null, null, null);
 
-		await That(access.ToString()).IsEqualTo("get indexer [null, null, null]");
+		await That(access.ToString()).IsEqualTo("get indexer [null, null, null]")
+			.Because(
+				"each `?? \"null\"` literal in IndexerGetterAccess<T1, T2, T3>.ToString must render a null parameter as `null` rather than as an empty slot like \"[, ...]\"");
 	}
 
 	[Fact]
@@ -176,14 +175,13 @@ public sealed class IndexerAccessTests
 	[Fact]
 	public async Task TryFindStoredValue_OnIndexerGetterAccess1_WithoutStorage_ShouldReturnFalse()
 	{
-		// Pins the `if (s is null) { return null; }` first guard in
-		// IndexerGetterAccess<T1>.TraverseStorage. With the body removed, the next line would
-		// dereference null `s` to call GetChildDispatch and throw NRE.
 		IndexerGetterAccess<int> access = new(42);
 
 		bool found = access.TryFindStoredValue(out string _);
 
-		await That(found).IsFalse();
+		await That(found).IsFalse()
+			.Because(
+				"the first `if (s is null) { return null; }` guard in IndexerGetterAccess<T1>.TraverseStorage must short-circuit instead of dereferencing null to call GetChildDispatch");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Internal.Tests/RefStructProjectionStorageTests.cs
+++ b/Tests/Mockolate.Internal.Tests/RefStructProjectionStorageTests.cs
@@ -116,13 +116,13 @@ public sealed class RefStructProjectionStorageTests
 	[Fact]
 	public async Task GetterSetup_WithProjection_HasReturnValue_IsTrueEvenWithoutReturnFactory()
 	{
-		// Activation of the storage dictionary flips HasReturnValue to true so that the
-		// generator's emitted getter body takes the return path and serves stored values.
 		RefStructIndexerGetterSetup<string, Key> getter = new(
 			"get_Item",
 			(IParameterMatch<Key>)It.IsRefStructBy<Key, int>(k => k.Id));
 
-		await That(getter.HasReturnValue).IsTrue();
+		await That(getter.HasReturnValue).IsTrue()
+			.Because(
+				"activating the storage dictionary must flip HasReturnValue, so that the generator's emitted getter body takes the return path and serves stored values");
 	}
 
 	[Fact]
@@ -184,14 +184,14 @@ public sealed class RefStructProjectionStorageTests
 		RefStructIndexerSetup<string, Key> setup = new(
 			"get_Item", "set_Item", (IParameterMatch<Key>)matcher);
 
-		// BoundGetter is still wired (the combined setup always wires it), but the getter's
-		// storage is not active — writes cannot be stored.
-		await That(setup.Setter.BoundGetter).IsSameAs(setup.Getter);
+		await That(setup.Setter.BoundGetter).IsSameAs(setup.Getter)
+			.Because("the combined setup always wires the bound getter, projection or not");
 
 		setup.Setter.Invoke(new Key(7), "seven");
 		bool found = setup.Getter.TryGetStoredValue(new Key(7), out _);
 
-		await That(found).IsFalse();
+		await That(found).IsFalse()
+			.Because("without a projection the getter's storage is never activated, so writes cannot be stored");
 	}
 
 	public sealed class Arity2Tests

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryScenarioTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryScenarioTests.cs
@@ -18,8 +18,8 @@ public sealed class MockRegistryScenarioTests
 		int callCount = 0;
 		int result = registry.ApplyIndexerGetter(access, setup, () => ++callCount, 0);
 
-		// FakeIndexerSetup.GetResult<TResult>(access, behavior, defaultValueGenerator) returns the generator's value.
-		await That(result).IsEqualTo(1);
+		await That(result).IsEqualTo(1)
+			.Because("FakeIndexerSetup.GetResult hands back the value produced by the default value generator");
 		await That(callCount).IsEqualTo(1);
 	}
 

--- a/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Registry/MockRegistryTests.cs
@@ -586,9 +586,6 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task WithNullSnapshotAtMemberIdSlot_ShouldFallBackToColdPathWithoutThrowing()
 		{
-			// The member-id table is allocated to length 6 by registering at index 5, leaving indices
-			// 0..4 holding null entries. Reading from such a null slot must fall through to the cold
-			// path rather than dereferencing the null PropertySetup reference.
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> unrelatedSetup = new(registry, "Q");
 			unrelatedSetup.InitializeWith(99);
@@ -596,7 +593,9 @@ public sealed class MockRegistryTests
 
 			int result = registry.GetPropertyFast(0, new PropertyGetterAccess("P"), _ => 7);
 
-			await That(result).IsEqualTo(7);
+			await That(result).IsEqualTo(7)
+				.Because(
+					"registering at index 5 sizes the member-id table to 6 and leaves indices 0..4 null, and reading such a slot must fall through to the cold path rather than dereference the null PropertySetup");
 		}
 
 		[Fact]
@@ -903,10 +902,6 @@ public sealed class MockRegistryTests
 		[Fact]
 		public async Task GetPropertyFast_WhenSnapshotTableHasNullEntryAtMemberId_ShouldFallToColdPath()
 		{
-			// Pins the `if (snapshot is not null)` guard inside ResolvePropertyFast. With the
-			// guard inverted to `is null`, the body would dereference a null `snapshot` and
-			// throw NullReferenceException. Forces the snapshot table to be non-null with
-			// length > queried memberId, but with `table[memberId]` itself null.
 			MockRegistry registry = new(MockBehavior.Default, new FastMockInteractions(0));
 			PropertySetup<int> snapshotAtFive = new(registry, "P5");
 			snapshotAtFive.InitializeWith(50);
@@ -914,7 +909,9 @@ public sealed class MockRegistryTests
 
 			int result = registry.GetPropertyFast(2, new PropertyGetterAccess("P"), _ => 7);
 
-			await That(result).IsEqualTo(7);
+			await That(result).IsEqualTo(7)
+				.Because(
+					"the snapshot table is long enough for the queried memberId but holds null there, so the `if (snapshot is not null)` guard inside ResolvePropertyFast must skip the body instead of dereferencing it");
 		}
 	}
 

--- a/Tests/Mockolate.Internal.Tests/Setup/PropertySetupTests.cs
+++ b/Tests/Mockolate.Internal.Tests/Setup/PropertySetupTests.cs
@@ -23,14 +23,14 @@ public sealed class PropertySetupTests
 	[Fact]
 	public async Task DefaultInvokeGetter_WhenRequestedTypeDiffersFromBackingType_ShouldFallBackToGenerator()
 	{
-		// 0x40400000 reinterpreted via Unsafe.As<int, float> would yield 3.0f; the correct path
-		// must take the typeof-equality branch and fall through to the defaultValueGenerator.
 		PropertySetup.Default<int> setup = new("p", 0x40400000);
 		IInteractivePropertySetup interactive = setup;
 
 		float value = interactive.InvokeGetter(null, MockBehavior.Default, () => 99f);
 
-		await That(value).IsEqualTo(99f);
+		await That(value).IsEqualTo(99f)
+			.Because(
+				"the typeof-equality branch must fall through to the defaultValueGenerator; reinterpreting 0x40400000 via Unsafe.As<int, float> would yield 3.0f instead");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/GeneralTests.cs
@@ -608,14 +608,14 @@ public class GeneralTests
 			     }
 			     """);
 
-		// A mock subclass declaring a property `MockRegistry` would hide the inherited field
-		// (CS0108). The dedup pipeline must skip past the conflicting member name.
 		await That(result.Sources).ContainsKey("Mock.MyService.g.cs");
 		await That(result.Sources["Mock.MyService.g.cs"])
 			.Contains("MockolateMockRegistry")
 			.IgnoringNewlineStyle().And
 			.DoesNotContain("private global::Mockolate.MockRegistry MockRegistry { get; }")
-			.IgnoringNewlineStyle();
+			.IgnoringNewlineStyle()
+			.Because(
+				"a mock subclass declaring a property `MockRegistry` would hide the inherited field (CS0108), so the dedup pipeline must skip past the conflicting member name");
 	}
 
 	[Fact]
@@ -673,12 +673,12 @@ public class GeneralTests
 			     }
 			     """);
 
-		// `Mock` is a method on the type, so the extension `Mock` property would shadow access.
-		// CreateUniquePropertyName must now skip past it to a Mockolate_-prefixed alternative.
 		await That(result.Sources).ContainsKey("Mock.IMyInterface.g.cs");
 		await That(result.Sources["Mock.IMyInterface.g.cs"])
 			.Contains("Mockolate_Mock")
-			.IgnoringNewlineStyle();
+			.IgnoringNewlineStyle()
+			.Because(
+				"`Mock` is a method on the type, so the extension `Mock` property would shadow access and CreateUniquePropertyName must skip past it to a Mockolate_-prefixed alternative");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGenerator.EqualityTests.cs
@@ -178,11 +178,11 @@ public sealed class MockGeneratorEqualityTests
 				new EquatableArray<NamedClass>([new NamedClass("X", mc),]));
 			NamedMock withNull = new("F", "P", mc, null);
 
-			// Different additionalClasses should produce different hash codes — can't guarantee
-			// strict inequality, but the field is part of the hash so at minimum it must run.
 			_ = withAdditional.GetHashCode();
 			_ = withNull.GetHashCode();
-			await That(true).IsTrue();
+			await That(true).IsTrue()
+				.Because(
+					"strict inequality of the two hash codes cannot be guaranteed, so this only pins that additionalClasses takes part in the hash at all");
 		}
 
 		private static MockClass CreateMockClass(string source = "public interface IFoo { void M(); }",

--- a/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockGeneratorTests.cs
@@ -168,12 +168,12 @@ public partial class MockGeneratorTests
 			     """);
 
 		await That(result.Diagnostics).IsEmpty();
-		// No typed overloads beyond the existing hand-written ones; the existing parameterless
-		// CreateMock() overload is still there and no typed overload is emitted for it.
 		await That(result.Sources).ContainsKey("Mock.MyService.g.cs");
 		await That(result.Sources["Mock.MyService.g.cs"])
 			.Contains("public static global::MyCode.MyService CreateMock()")
-			.IgnoringNewlineStyle();
+			.IgnoringNewlineStyle()
+			.Because(
+				"the hand-written parameterless CreateMock() overload is still emitted, and no typed overload is added beyond it");
 	}
 
 	[Fact]
@@ -541,11 +541,10 @@ public partial class MockGeneratorTests
 			     """);
 
 		await That(result.Diagnostics).IsEmpty();
-		// The hand-written CreateMock(MockBehavior) overload already covers this signature.
-		// A typed single-parameter overload with the same signature would produce a duplicate
-		// definition, so the generator must skip it.
 		int matches = CreateMockBehaviorSignatureRegex().Count(result.Sources["Mock.MyService.g.cs"]);
-		await That(matches).IsEqualTo(1);
+		await That(matches).IsEqualTo(1)
+			.Because(
+				"the hand-written CreateMock(MockBehavior) overload already covers this signature, so a typed single-parameter overload would produce a duplicate definition");
 	}
 
 	[Fact]
@@ -574,12 +573,12 @@ public partial class MockGeneratorTests
 			     """);
 
 		await That(result.Diagnostics).IsEmpty();
-		// Action<string> does not collide with the setup action type (Action<IMockSetupForMyService>),
-		// so the generator should emit the typed overload.
 		await That(result.Sources).ContainsKey("Mock.MyService.g.cs");
 		await That(result.Sources["Mock.MyService.g.cs"])
 			.Contains("CreateMock(global::System.Action<string> callback)")
-			.IgnoringNewlineStyle();
+			.IgnoringNewlineStyle()
+			.Because(
+				"Action<string> does not collide with the setup action type (Action<IMockSetupForMyService>)");
 	}
 
 	[Fact]
@@ -676,12 +675,12 @@ public partial class MockGeneratorTests
 			     """);
 
 		await That(result.Diagnostics).IsEmpty();
-		// The generator emits a mock for the closed generic MyService<string>. Locate the generated
-		// file and assert the typed overload was emitted with the substituted type argument.
 		string generated = string.Concat(result.Sources.Values);
 		await That(generated)
 			.Contains("CreateMock(string value)")
-			.IgnoringNewlineStyle();
+			.IgnoringNewlineStyle()
+			.Because(
+				"the mock for the closed generic MyService<string> must carry the typed overload with the substituted type argument");
 	}
 
 	[Fact]
@@ -1191,12 +1190,12 @@ public partial class MockGeneratorTests
 			.Contains($"to invoke the <see cref=\"{expectedCref}\">MyService(int, string)</see> constructor.")
 			.IgnoringNewlineStyle();
 
-		// CS1574/CS1584/CS1658 messages embed the offending cref text; if the constructor cref
-		// resolved cleanly under DocumentationMode.Diagnose, no diagnostic mentions it.
 		string[] crefFailures = result.Diagnostics
 			.Where(d => d.Contains(expectedCref))
 			.ToArray();
-		await That(crefFailures).IsEmpty();
+		await That(crefFailures).IsEmpty()
+			.Because(
+				"CS1574/CS1584/CS1658 messages embed the offending cref text, so a cref that resolves cleanly under DocumentationMode.Diagnose is mentioned by no diagnostic");
 	}
 
 	[Fact]
@@ -1254,15 +1253,14 @@ public partial class MockGeneratorTests
 			     }
 			     """, DocumentationMode.Diagnose);
 
-		// Closed-generic constructor crefs (e.g. MyService{int}.MyService(int)) aren't valid C#
-		// cref syntax, so the generator falls back to the unlinked phrasing for generic classes
-		// rather than emit something that would surface CS1584 on the consumer side.
 		await That(result.Sources).ContainsKey("Mock.MyService_int.g.cs");
 		await That(result.Sources["Mock.MyService_int.g.cs"])
 			.Contains("to invoke the base-class constructor.")
 			.IgnoringNewlineStyle().And
 			.DoesNotContain("MyService.MyService(")
-			.IgnoringNewlineStyle();
+			.IgnoringNewlineStyle()
+			.Because(
+				"closed-generic constructor crefs (e.g. MyService{int}.MyService(int)) aren't valid C# cref syntax, so generic classes fall back to the unlinked phrasing rather than surface CS1584 on the consumer side");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.cs
@@ -71,12 +71,11 @@ public sealed partial class MockTests
 				     """);
 
 			await That(result.Diagnostics).IsEmpty();
-			// One occurrence per generator-emitted public ctor: the (MockRegistry, ...) overload and
-			// the typed (MockBehavior, ...) overload that subclasses use. The base ctor already carries
-			// the attribute, and the dedup check still suppresses an injected duplicate on each.
 			await That(result.Sources).ContainsKey("Mock.AnnotatedShape.g.cs");
 			await That(result.Sources["Mock.AnnotatedShape.g.cs"])
-				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").Exactly(2);
+				.Contains("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]").Exactly(2)
+				.Because(
+					"one occurrence per generator-emitted public ctor, the (MockRegistry, ...) overload and the typed (MockBehavior, ...) overload that subclasses use; the base ctor already carries the attribute and the dedup check suppresses an injected duplicate on each");
 		}
 
 		[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -692,11 +692,11 @@ public sealed partial class MockTests
 			     }
 			     """);
 
-		// Even though MyMiddleClass.Equals has non-nullable parameter (object),
-		// it should still match and filter out object.Equals with nullable parameter (object?)
 		await That(result.Sources).ContainsKey("Mock.MyDerivedClass.g.cs");
 		await That(result.Sources["Mock.MyDerivedClass.g.cs"])
-			.DoesNotContain("override bool Equals");
+			.DoesNotContain("override bool Equals")
+			.Because(
+				"MyMiddleClass.Equals(object) must still match and filter out object.Equals(object?) despite the nullability difference");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/ItTests.IsNotOneOfTests.cs
+++ b/Tests/Mockolate.Tests/ItTests.IsNotOneOfTests.cs
@@ -52,10 +52,10 @@ public sealed partial class ItTests
 
 			sut.DoSomething(other);
 
-			// 'other' is not in [value1, value2], so the match is found once
-			await That(sut.Mock.Verify.DoSomething(It.IsNotOneOf(value1, value2))).Once();
-			// 'other' IS in [other], so no match
-			await That(sut.Mock.Verify.DoSomething(It.IsNotOneOf(other))).Never();
+			await That(sut.Mock.Verify.DoSomething(It.IsNotOneOf(value1, value2))).Once()
+				.Because("'other' is not in [value1, value2]");
+			await That(sut.Mock.Verify.DoSomething(It.IsNotOneOf(other))).Never()
+				.Because("'other' IS in [other]");
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/MockEvents/SetupEventTests.cs
+++ b/Tests/Mockolate.Tests/MockEvents/SetupEventTests.cs
@@ -201,8 +201,8 @@ public sealed partial class SetupEventTests
 			sut.ChocolateDispensed += Handler;
 		}
 
-		// subscriptions at index 0, 2, 4 pass the predicate
-		await That(callCount).IsEqualTo(3);
+		await That(callCount).IsEqualTo(3)
+			.Because("the subscriptions at index 0, 2 and 4 pass the predicate");
 
 		void Handler(string type, int amount) { }
 	}
@@ -387,8 +387,8 @@ public sealed partial class SetupEventTests
 			sut.ChocolateDispensed -= Handler;
 		}
 
-		// unsubscriptions at index 0, 2, 4 pass the predicate
-		await That(callCount).IsEqualTo(3);
+		await That(callCount).IsEqualTo(3)
+			.Because("the unsubscriptions at index 0, 2 and 4 pass the predicate");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.LiteralValuesTests.cs
+++ b/Tests/Mockolate.Tests/MockMethods/SetupMethodTests.LiteralValuesTests.cs
@@ -153,9 +153,9 @@ public sealed partial class SetupMethodTests
 				registry.GetUnusedSetups(new Mockolate.Interactions.FastMockInteractions(0));
 			Mockolate.Setup.ISetup setup = await That(unused).HasSingle();
 
-			// 0.5 must be formatted with InvariantCulture; on a German-locale host the host default
-			// would render it as "0,5" — this assertion would fail if FormatLiteralValue regressed.
-			await That(setup.ToString()!).Contains("0.5");
+			await That(setup.ToString()!).Contains("0.5")
+				.Because(
+					"FormatLiteralValue must use InvariantCulture; on a German-locale host the host default would render 0.5 as \"0,5\"");
 		}
 	}
 

--- a/Tests/Mockolate.Tests/MockTests.HiddenInterfaceMemberTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.HiddenInterfaceMemberTests.cs
@@ -22,9 +22,9 @@ public sealed partial class MockTests
 
 			_ = ((IBaseIndexer)mock)[5];
 
-			// Indexers are keyed by their parameter signature (not the declaring interface), so base and
-			// derived access share storage; As<TBase> still reaches the same recorded interaction.
-			await That(mock.Mock.As<IBaseIndexer>().Verify[It.IsAny<int>()].Got()).Once();
+			await That(mock.Mock.As<IBaseIndexer>().Verify[It.IsAny<int>()].Got()).Once()
+				.Because(
+					"indexers are keyed by their parameter signature rather than the declaring interface, so base and derived access share storage and As<TBase> reaches the same recorded interaction");
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.ThreadSafetyTests.cs
@@ -170,7 +170,6 @@ public sealed partial class MockTests
 				barrier.Set();
 				await Task.WhenAll(tasks);
 
-				// Verify all reads returned expected values (no corruption)
 				await That(valuesByKey).All().Satisfy(kvp =>
 				{
 					string expectedValue = $"key-{kvp.Key}";
@@ -332,13 +331,16 @@ public sealed partial class MockTests
 				barrier.Set();
 				await Task.WhenAll(tasks);
 
-				// Each read sees either the pre-setup default or the configured value.
-				await That(stringValues).All().Satisfy(v => v is "" or "hello");
-				await That(guidValues).All().Satisfy(v => v == Guid.Empty || v == expectedGuid);
-				// Both setup tasks have finished by now, so the configured value
-				// must win — a racing default insert must not have overwritten it.
-				await That(sut.MyStringProperty).IsEqualTo("hello");
-				await That(sut.MyGuidProperty).IsEqualTo(expectedGuid);
+				await That(stringValues).All().Satisfy(v => v is "" or "hello")
+					.Because("each read sees either the pre-setup default or the configured value");
+				await That(guidValues).All().Satisfy(v => v == Guid.Empty || v == expectedGuid)
+					.Because("each read sees either the pre-setup default or the configured value");
+				await That(sut.MyStringProperty).IsEqualTo("hello")
+					.Because(
+						"both setup tasks have finished by now, so a racing default insert must not have overwritten the configured value");
+				await That(sut.MyGuidProperty).IsEqualTo(expectedGuid)
+					.Because(
+						"both setup tasks have finished by now, so a racing default insert must not have overwritten the configured value");
 				await That(sut.Mock.Verify.MyStringProperty.Got()).Exactly((readerCount * iterationsPerReader) + 1);
 				await That(sut.Mock.Verify.MyGuidProperty.Got()).Exactly((readerCount * iterationsPerReader) + 1);
 			}

--- a/Tests/Mockolate.Tests/RefStruct/GeneratedPacketSinkTests.cs
+++ b/Tests/Mockolate.Tests/RefStruct/GeneratedPacketSinkTests.cs
@@ -346,8 +346,8 @@ public sealed class GeneratedPacketSinkTests
 
 			await That(high).IsEqualTo(100);
 			await That(low).IsEqualTo(1);
-			// Nothing matches → framework default.
-			await That(mid).IsEqualTo(0);
+			await That(mid).IsEqualTo(0)
+				.Because("nothing matches, so the framework default applies");
 		}
 
 		[Fact]
@@ -472,8 +472,8 @@ public sealed class GeneratedPacketSinkTests
 			}
 
 			await That(match).IsEqualTo("hit");
-			// Nothing matches -> Mockolate default string value "".
-			await That(miss).IsEqualTo("");
+			await That(miss).IsEqualTo("")
+				.Because("nothing matches, so Mockolate's default string value applies");
 			await That(ActWriteHit).Throws<InvalidOperationException>();
 		}
 
@@ -956,8 +956,8 @@ public sealed class GeneratedPacketSinkTests
 			string miss = sut[new Packet(2, missBytes)];
 
 			await That(hit).IsEqualTo("matched");
-			// Nothing matches -> framework default; Mockolate's default for string is "".
-			await That(miss).IsEqualTo("");
+			await That(miss).IsEqualTo("")
+				.Because("nothing matches, so the framework default applies and Mockolate's default for string is \"\"");
 		}
 
 		[Fact]

--- a/Tests/Mockolate.Tests/RefStruct/ProjectionIndexerTests.cs
+++ b/Tests/Mockolate.Tests/RefStruct/ProjectionIndexerTests.cs
@@ -75,8 +75,8 @@ public sealed class ProjectionIndexerTests
 			string small = sut[new Packet(5, [])];
 
 			await That(big).IsEqualTo("wrote-big");
-			// small does not match the setup → getter falls through to framework default.
-			await That(small).IsEqualTo("");
+			await That(small).IsEqualTo("")
+				.Because("small does not match the setup, so the getter falls through to the framework default");
 		}
 
 		[Fact]
@@ -236,11 +236,11 @@ public sealed class ProjectionIndexerTests
 
 			sut[new Packet(1, []), new Packet(2, [])] = "written";
 			byte[] bytes = [0xA];
-			// Same projected ids but different inline spans — still matches the stored bucket.
 			string hit = sut[new Packet(1, bytes), new Packet(2, [])];
 			string miss = sut[new Packet(1, []), new Packet(3, [])];
 
-			await That(hit).IsEqualTo("written");
+			await That(hit).IsEqualTo("written")
+				.Because("the projected ids are the same, so the differing inline spans still match the stored bucket");
 			await That(miss).IsEqualTo("fallback");
 		}
 	}
@@ -319,13 +319,14 @@ public sealed class ProjectionIndexerTests
 		[Fact]
 		public async Task IsRefStructBy_Matches_ObjectOverload_ReturnsFalse()
 		{
-			// The untyped IParameter.Matches(object?) overload is a fallback for covariance-safe
-			// dispatch; ref-struct matchers always return false from it (ref structs cannot be
-			// boxed into object in the first place).
 			IParameter<Packet> matcher = It.IsRefStructBy<Packet, int>(p => p.Id);
 
-			await That(matcher.Matches(null)).IsFalse();
-			await That(matcher.Matches(42)).IsFalse();
+			await That(matcher.Matches(null)).IsFalse()
+				.Because(
+					"the untyped IParameter.Matches(object?) overload is only a fallback for covariance-safe dispatch, and a ref struct can never be boxed into object");
+			await That(matcher.Matches(42)).IsFalse()
+				.Because(
+					"the untyped IParameter.Matches(object?) overload is only a fallback for covariance-safe dispatch, and a ref struct can never be boxed into object");
 		}
 	}
 }

--- a/Tests/Mockolate.Tests/RefStruct/RefStructPrimitivesTests.cs
+++ b/Tests/Mockolate.Tests/RefStruct/RefStructPrimitivesTests.cs
@@ -72,13 +72,13 @@ public sealed class RefStructPrimitivesTests
 		[Fact]
 		public async Task IsAnyRefStruct_NonGenericMatches_ReturnsFalseForBoxedSlot()
 		{
-			// The non-generic IParameter.Matches(object?) is the covariance-safe fallback and is
-			// deliberately inert for ref-struct matchers: the boxed path can never be a ref struct.
 			IParameter sut = It.IsAnyRefStruct<Packet>();
 
 			bool result = sut.Matches(null);
 
-			await That(result).IsFalse();
+			await That(result).IsFalse()
+				.Because(
+					"the non-generic IParameter.Matches(object?) is the covariance-safe fallback and is deliberately inert for ref-struct matchers, as the boxed path can never be a ref struct");
 		}
 	}
 

--- a/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithBytesTests.cs
+++ b/Tests/Mockolate.Tests/Web/ItExtensionsTests.IsHttpContentTests.WithBytesTests.cs
@@ -22,15 +22,14 @@ public sealed partial class ItExtensionsTests
 
 				await httpClient.PostAsync("https://testably.org", new ByteArrayContent(payload), CancellationToken.None);
 
-				// The first WithBytes predicate matches (length == 3) while the second does not.
-				// Original (??=): first wins, verification succeeds.
-				// Mutant (=): second wins, verification fails.
 				await That(httpClient.Mock.Verify.PostAsync(
 						It.IsAny<string?>(),
 						It.IsHttpContent()
 							.WithBytes(b => b.Length == 3)
 							.WithBytes(b => b.Length == 99)))
-					.Once();
+					.Once()
+					.Because(
+						"the first WithBytes predicate matches (length == 3) while the second does not, and the first one must win");
 			}
 
 			[Theory]


### PR DESCRIPTION
Comments that explained why a specific assertion holds now live in .Because(...) on that assertion, so the reason shows up in the failure message instead of only in the source. Pure narration that restated the assertion without adding a reason was dropped.

Left untouched: comments that explain arrange/act code rather than an assertion, method-level notes on why a test exists, and the two Assert.NotNull sites that have no That(...) chain to attach to.