### PR TITLE
feat!: only expose property accessors the mock intercepts

### DIFF
--- a/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
+++ b/Benchmarks/Mockolate.Benchmarks/CompleteEventBenchmarks.cs
@@ -89,7 +89,7 @@ public class CompleteEventBenchmarks : BenchmarksBase
 		EventHandler handler = (_, _) => { };
 
 		mock.SomeEvent += handler;
-		mock.SomeEvent += Raise.EventWith(null, EventArgs.Empty);
+		mock.SomeEvent += Raise.EventWith(null!, EventArgs.Empty);
 
 		mock.Received(1).SomeEvent += Arg.Any<EventHandler>();
 	}

--- a/Docs/pages/08-analyzers.md
+++ b/Docs/pages/08-analyzers.md
@@ -66,7 +66,10 @@ implementing it, so the rule still fires.
 The same applies per accessor. For a property whose accessors differ in accessibility, such as
 `public abstract string Flavour { get; internal set; }`, an override further down discharges only the
 inaccessible half. The mock then overrides the accessor it can see and leaves the other one to the
-referenced assembly's implementation, so writes through the mock are not intercepted or recorded.
+referenced assembly's implementation. Because writes never reach the mock, `Setup` and `Verify` expose
+only the getter for such a property, so a write that could never be recorded is not offered for
+configuration or verification. See
+[properties with only one accessor](setup/properties#properties-with-only-one-accessor) for details.
 
 ## Mockolate0003
 

--- a/Docs/pages/setup/01-properties.md
+++ b/Docs/pages/setup/01-properties.md
@@ -92,11 +92,13 @@ IChocolateInventory sut = IChocolateInventory.CreateMock();
 sut.Mock.Setup.RemainingBars.Returns(3);
 sut.Mock.Setup.RemainingBars.Register();
 sut.Mock.Setup.RemainingBars.OnSet…                 // does not compile
+sut.Mock.Setup.RemainingBars.Returns(3).OnSet…      // does not compile
 
 sut.Mock.Setup.LastCountedBy.OnSet.Do(value => { });
 sut.Mock.Setup.LastCountedBy.Register();
 sut.Mock.Setup.LastCountedBy.Returns("Ada")…        // does not compile
 sut.Mock.Setup.LastCountedBy.InitializeWith("Ada")… // does not compile
+sut.Mock.Setup.LastCountedBy.OnSet.Do(value => { }).OnGet… // does not compile
 ```
 
 The verify facade likewise offers the intercepted accessor only:
@@ -117,9 +119,9 @@ This also applies when the property declares an accessor the mock cannot see, su
 never reach the mock in that case, so configuring or verifying one could only ever report zero
 interactions. See [Mockolate0002](../analyzers#mockolate0002) for when such a type is mockable at all.
 
-The verify facade is fully restricted. On the setup side the restriction covers the property's own
-surface: the fluent builders returned by `Returns`, `Throws`, `Do` and `TransitionTo` are shared with
-read-write properties, so chaining on past one of them reaches the full setup again.
+Both facades are fully restricted: the fluent builders returned by `Returns`, `Throws`, `Do` and
+`TransitionTo` stay on the narrowed surface, so no amount of chaining reaches the accessor the mock
+does not intercept.
 
 **Notes:**
 

--- a/Docs/pages/setup/01-properties.md
+++ b/Docs/pages/setup/01-properties.md
@@ -72,6 +72,55 @@ sut.Mock.Setup.TotalDispensed.OnGet
     .Do(() => Console.WriteLine("Execute on all odd read interactions"));
 ```
 
+## Properties with only one accessor
+
+The setup and verify surfaces only offer the accessors the mock actually intercepts.
+`Register()` and `SkippingBaseClass(…)` stay available on both, but the accessor-specific members do
+not: a get-only property has no `OnSet`, and a set-only property has neither `OnGet` nor the
+`Returns`/`Throws` read-sequence nor `InitializeWith`, since there is no getter to read the value
+back.
+
+```csharp
+public interface IChocolateInventory
+{
+    int RemainingBars { get; }        // no setter
+    string LastCountedBy { set; }     // no getter
+}
+
+IChocolateInventory sut = IChocolateInventory.CreateMock();
+
+sut.Mock.Setup.RemainingBars.Returns(3);
+sut.Mock.Setup.RemainingBars.Register();
+sut.Mock.Setup.RemainingBars.OnSet…                 // does not compile
+
+sut.Mock.Setup.LastCountedBy.OnSet.Do(value => { });
+sut.Mock.Setup.LastCountedBy.Register();
+sut.Mock.Setup.LastCountedBy.Returns("Ada")…        // does not compile
+sut.Mock.Setup.LastCountedBy.InitializeWith("Ada")… // does not compile
+```
+
+The verify facade likewise offers the intercepted accessor only:
+
+```csharp
+_ = sut.RemainingBars;
+sut.LastCountedBy = "Ada";
+
+await That(sut.Mock.Verify.RemainingBars.Got()).Once();
+await That(sut.Mock.Verify.LastCountedBy.Set("Ada")).Once();
+
+sut.Mock.Verify.RemainingBars.Set(3)…               // does not compile
+sut.Mock.Verify.LastCountedBy.Got()…                // does not compile
+```
+
+This also applies when the property declares an accessor the mock cannot see, such as
+`{ get; internal set; }` on a type from an assembly that does not grant `InternalsVisibleTo`. Writes
+never reach the mock in that case, so configuring or verifying one could only ever report zero
+interactions. See [Mockolate0002](../analyzers#mockolate0002) for when such a type is mockable at all.
+
+The verify facade is fully restricted. On the setup side the restriction covers the property's own
+surface: the fluent builders returned by `Returns`, `Throws`, `Do` and `TransitionTo` are shared with
+read-write properties, so chaining on past one of them reaches the full setup again.
+
 **Notes:**
 
 - Use `.SkippingBaseClass(…)` to override the base class behavior for a specific property (only for class mocks).

--- a/Source/Mockolate.SourceGenerators/Entities/PropertyAccessors.cs
+++ b/Source/Mockolate.SourceGenerators/Entities/PropertyAccessors.cs
@@ -1,0 +1,8 @@
+namespace Mockolate.SourceGenerators.Entities;
+
+internal enum PropertyAccessors
+{
+	Both,
+	GetOnly,
+	SetOnly,
+}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3142,6 +3142,54 @@ internal static partial class Sources
 		return false;
 	}
 
+	/// <summary>
+	///     Which accessors of <paramref name="property" /> the mock actually intercepts, and therefore
+	///     which setup/verify facade the generated surface exposes. The setup type, the verify type and the
+	///     verify constructor arguments all derive from this one classification so they cannot disagree.
+	/// </summary>
+	/// <remarks>
+	///     The classification follows the accessors the mock emits a body for, which is exactly what
+	///     <see cref="Property.Getter" />/<see cref="Property.Setter" /> being non-null means: the property
+	///     declares the accessor, and it is not an <c>internal</c>/<c>private protected</c> one hidden from
+	///     the mock's assembly. Other accessibilities are not considered here, so a
+	///     <c>{ get; private set; }</c> property still classifies as <see cref="PropertyAccessors.Both" />.
+	///     The <see cref="PropertyAccessors.Both" /> arm therefore also absorbs degenerate shapes that
+	///     cannot produce compiling output regardless of the facade chosen.
+	/// </remarks>
+	private static PropertyAccessors GetInterceptedAccessors(Property property)
+		=> (property.Getter, property.Setter) switch
+		{
+			(not null, null) => PropertyAccessors.GetOnly,
+			(null, not null) => PropertyAccessors.SetOnly,
+			_ => PropertyAccessors.Both,
+		};
+
+	/// <summary>
+	///     The setup facade emitted for <paramref name="property" />, narrowed to the accessors classified
+	///     by <see cref="GetInterceptedAccessors" />.
+	/// </summary>
+	private static string GetPropertySetupType(Property property)
+		=> GetInterceptedAccessors(property) switch
+		{
+			PropertyAccessors.GetOnly => $"global::Mockolate.Setup.IPropertyGetterOnlySetup<{property.Type.Fullname}>",
+			PropertyAccessors.SetOnly => $"global::Mockolate.Setup.IPropertySetterOnlySetup<{property.Type.Fullname}>",
+			_ => $"global::Mockolate.Setup.PropertySetup<{property.Type.Fullname}>",
+		};
+
+	/// <summary>
+	///     The verify facade emitted for <paramref name="property" />, narrowed to the accessors classified
+	///     by <see cref="GetInterceptedAccessors" />.
+	/// </summary>
+	private static string GetPropertyVerifyType(Property property, string verifyName)
+		=> GetInterceptedAccessors(property) switch
+		{
+			PropertyAccessors.GetOnly =>
+				$"global::Mockolate.Verify.VerificationPropertyGetterResult<{verifyName}>",
+			PropertyAccessors.SetOnly =>
+				$"global::Mockolate.Verify.VerificationPropertySetterResult<{verifyName}, {property.Type.Fullname}>",
+			_ => $"global::Mockolate.Verify.VerificationPropertyResult<{verifyName}, {property.Type.Fullname}>",
+		};
+
 	private static void DefineSetupInterface(StringBuilder sb, Class @class, MemberType memberType,
 		bool hasOverloadResolutionPriority)
 	{
@@ -3154,7 +3202,7 @@ internal static partial class Sources
 		{
 			sb.AppendXmlSummary(
 				$"Setup for the {property.Type.Fullname.EscapeForXmlDoc()} property <see cref=\"{property.ContainingType.EscapeForXmlDoc()}.{property.Name}\" />.");
-			sb.Append("\t\tglobal::Mockolate.Setup.PropertySetup<").Append(property.Type.Fullname).Append("> ")
+			sb.Append("\t\t").Append(GetPropertySetupType(property)).Append(' ')
 				.Append(property.Name).Append(" { get; }").AppendLine();
 			sb.AppendLine();
 		}
@@ -3591,8 +3639,8 @@ internal static partial class Sources
 			sb.Append(
 					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
 				.AppendLine();
-			sb.Append("\t\tglobal::Mockolate.Setup.PropertySetup<").Append(property.Type.Fullname)
-				.Append("> global::Mockolate.Mock.").Append(setupName).Append('.').Append(property.Name).AppendLine();
+			sb.Append("\t\t").Append(GetPropertySetupType(property))
+				.Append(" global::Mockolate.Mock.").Append(setupName).Append('.').Append(property.Name).AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tget").AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
@@ -5013,8 +5061,8 @@ internal static partial class Sources
 		{
 			sb.AppendXmlSummary(
 				$"Verify interactions with the {property.Type.Fullname.EscapeForXmlDoc()} property <see cref=\"{property.ContainingType.EscapeForXmlDoc()}.{property.Name}\" />.");
-			sb.Append("\t\tglobal::Mockolate.Verify.VerificationPropertyResult<").Append(verifyName).Append(", ")
-				.Append(property.Type.Fullname).Append("> ").Append(property.Name).Append(" { get; }").AppendLine();
+			sb.Append("\t\t").Append(GetPropertyVerifyType(property, verifyName)).Append(' ')
+				.Append(property.Name).Append(" { get; }").AppendLine();
 			sb.AppendLine();
 		}
 
@@ -5287,15 +5335,21 @@ internal static partial class Sources
 			sb.Append(
 					"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
 				.AppendLine();
-			sb.Append("\t\tglobal::Mockolate.Verify.VerificationPropertyResult<").Append(verifyName).Append(", ")
-				.Append(property.Type.Fullname).Append("> ").Append(verifyName).Append('.').Append(property.Name)
+			string verifyType = GetPropertyVerifyType(property, verifyName);
+			// The narrow views take only the member id of the accessor they expose.
+			string verifyMemberIds = GetInterceptedAccessors(property) switch
+			{
+				PropertyAccessors.GetOnly => propertyGetMemberId,
+				PropertyAccessors.SetOnly => propertySetMemberId,
+				_ => $"{propertyGetMemberId}, {propertySetMemberId}",
+			};
+			sb.Append("\t\t").Append(verifyType).Append(' ').Append(verifyName).Append('.').Append(property.Name)
 				.AppendLine();
 			sb.Append("\t\t{").AppendLine();
 			sb.Append("\t\t\tget").AppendLine();
 			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationPropertyResult<").Append(verifyName)
-				.Append(", ").Append(property.Type.Fullname).Append(">(this, this.").Append(mockRegistryName)
-				.Append(", ").Append(propertyGetMemberId).Append(", ").Append(propertySetMemberId).Append(", ")
+			sb.Append("\t\t\t\treturn new ").Append(verifyType).Append("(this, this.").Append(mockRegistryName)
+				.Append(", ").Append(verifyMemberIds).Append(", ")
 				.Append(property.GetUniqueNameString()).Append(");").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
 			sb.Append("\t\t}").AppendLine();

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -286,7 +286,7 @@ public interface IPropertySetup<T>
 public interface IPropertyGetterOnlySetup<T>
 {
 	/// <inheritdoc cref="IPropertySetup{T}.OnGet" />
-	IPropertyGetterSetup<T> OnGet { get; }
+	IPropertyGetterOnlyGetterSetup<T> OnGet { get; }
 
 	/// <inheritdoc cref="IPropertySetup{T}.SkippingBaseClass(bool)" />
 	IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
@@ -302,26 +302,26 @@ public interface IPropertyGetterOnlySetup<T>
 	IPropertyGetterOnlySetup<T> InitializeWith(T value);
 
 	/// <inheritdoc cref="IPropertySetup{T}.Returns(T)" />
-	IPropertySetupReturnBuilder<T> Returns(T returnValue);
+	IPropertyGetterOnlySetupReturnBuilder<T> Returns(T returnValue);
 
 	/// <inheritdoc cref="IPropertySetup{T}.Returns(Func{T})" />
-	IPropertySetupReturnBuilder<T> Returns(Func<T> callback);
+	IPropertyGetterOnlySetupReturnBuilder<T> Returns(Func<T> callback);
 
 	/// <inheritdoc cref="IPropertySetup{T}.Returns(Func{T, T})" />
-	IPropertySetupReturnBuilder<T> Returns(Func<T, T> callback);
+	IPropertyGetterOnlySetupReturnBuilder<T> Returns(Func<T, T> callback);
 
 	/// <inheritdoc cref="IPropertySetup{T}.Throws{TException}()" />
-	IPropertySetupReturnBuilder<T> Throws<TException>()
+	IPropertyGetterOnlySetupReturnBuilder<T> Throws<TException>()
 		where TException : Exception, new();
 
 	/// <inheritdoc cref="IPropertySetup{T}.Throws(Exception)" />
-	IPropertySetupReturnBuilder<T> Throws(Exception exception);
+	IPropertyGetterOnlySetupReturnBuilder<T> Throws(Exception exception);
 
 	/// <inheritdoc cref="IPropertySetup{T}.Throws(Func{Exception})" />
-	IPropertySetupReturnBuilder<T> Throws(Func<Exception> callback);
+	IPropertyGetterOnlySetupReturnBuilder<T> Throws(Func<Exception> callback);
 
 	/// <inheritdoc cref="IPropertySetup{T}.Throws(Func{T, Exception})" />
-	IPropertySetupReturnBuilder<T> Throws(Func<T, Exception> callback);
+	IPropertyGetterOnlySetupReturnBuilder<T> Throws(Func<T, Exception> callback);
 }
 
 /// <summary>
@@ -335,7 +335,7 @@ public interface IPropertyGetterOnlySetup<T>
 public interface IPropertySetterOnlySetup<T>
 {
 	/// <inheritdoc cref="IPropertySetup{T}.OnSet" />
-	IPropertySetterSetup<T> OnSet { get; }
+	IPropertySetterOnlySetterSetup<T> OnSet { get; }
 
 	/// <inheritdoc cref="IPropertySetup{T}.SkippingBaseClass(bool)" />
 	IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
@@ -498,4 +498,131 @@ public interface IPropertySetupReturnWhenBuilder<T> : IPropertySetup<T>
 	/// <param name="times">The number of executions after which the callback stops firing.</param>
 	/// <returns>The outer setup for chaining additional returns/throws.</returns>
 	IPropertySetup<T> Only(int times);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the getter of a property the mock only reads.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IPropertyGetterSetup{T}" /> for <see cref="IPropertyGetterOnlySetup{T}" />:
+///     the returned builders stay on the getter-only surface, so chaining can never reach
+///     <see cref="IPropertySetup{T}.OnSet" />.
+/// </remarks>
+public interface IPropertyGetterOnlyGetterSetup<T>
+{
+	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action)" />
+	IPropertyGetterOnlySetupCallbackBuilder<T> Do(Action callback);
+
+	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action{T})" />
+	IPropertyGetterOnlySetupCallbackBuilder<T> Do(Action<T> callback);
+
+	/// <inheritdoc cref="IPropertyGetterSetup{T}.Do(Action{int, T})" />
+	IPropertyGetterOnlySetupCallbackBuilder<T> Do(Action<int, T> callback);
+
+	/// <inheritdoc cref="IPropertyGetterSetup{T}.TransitionTo(string)" />
+	IPropertyGetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Interface for setting up the getter of a get-only property with fluent syntax.
+/// </summary>
+public interface IPropertyGetterOnlySetupParallelCallbackBuilder<T> : IPropertyGetterOnlySetupCallbackWhenBuilder<T>
+{
+	/// <inheritdoc cref="IPropertyGetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
+	IPropertyGetterOnlySetupCallbackWhenBuilder<T> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Interface for setting up the getter of a get-only property with fluent syntax.
+/// </summary>
+public interface IPropertyGetterOnlySetupCallbackBuilder<T> : IPropertyGetterOnlySetupParallelCallbackBuilder<T>
+{
+	/// <inheritdoc cref="IPropertyGetterSetupCallbackBuilder{T}.InParallel()" />
+	IPropertyGetterOnlySetupParallelCallbackBuilder<T> InParallel();
+}
+
+/// <summary>
+///     Interface for setting up the getter of a get-only property with fluent syntax.
+/// </summary>
+public interface IPropertyGetterOnlySetupCallbackWhenBuilder<T> : IPropertyGetterOnlySetup<T>
+{
+	/// <inheritdoc cref="IPropertyGetterSetupCallbackWhenBuilder{T}.For(int)" />
+	IPropertyGetterOnlySetupCallbackWhenBuilder<T> For(int times);
+
+	/// <inheritdoc cref="IPropertyGetterSetupCallbackWhenBuilder{T}.Only(int)" />
+	IPropertyGetterOnlySetup<T> Only(int times);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the setter of a property the mock only writes.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IPropertySetterSetup{T}" /> for <see cref="IPropertySetterOnlySetup{T}" />:
+///     the returned builders stay on the setter-only surface, so chaining can never reach
+///     <see cref="IPropertySetup{T}.OnGet" /> or the <c>Returns</c>/<c>Throws</c> read-sequence.
+/// </remarks>
+public interface IPropertySetterOnlySetterSetup<T>
+{
+	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action)" />
+	IPropertySetterOnlySetupCallbackBuilder<T> Do(Action callback);
+
+	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action{T})" />
+	IPropertySetterOnlySetupCallbackBuilder<T> Do(Action<T> callback);
+
+	/// <inheritdoc cref="IPropertySetterSetup{T}.Do(Action{int, T})" />
+	IPropertySetterOnlySetupCallbackBuilder<T> Do(Action<int, T> callback);
+
+	/// <inheritdoc cref="IPropertySetterSetup{T}.TransitionTo(string)" />
+	IPropertySetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Interface for setting up the setter of a set-only property with fluent syntax.
+/// </summary>
+public interface IPropertySetterOnlySetupParallelCallbackBuilder<T> : IPropertySetterOnlySetupCallbackWhenBuilder<T>
+{
+	/// <inheritdoc cref="IPropertySetterSetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
+	IPropertySetterOnlySetupCallbackWhenBuilder<T> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Interface for setting up the setter of a set-only property with fluent syntax.
+/// </summary>
+public interface IPropertySetterOnlySetupCallbackBuilder<T> : IPropertySetterOnlySetupParallelCallbackBuilder<T>
+{
+	/// <inheritdoc cref="IPropertySetterSetupCallbackBuilder{T}.InParallel()" />
+	IPropertySetterOnlySetupParallelCallbackBuilder<T> InParallel();
+}
+
+/// <summary>
+///     Interface for setting up the setter of a set-only property with fluent syntax.
+/// </summary>
+public interface IPropertySetterOnlySetupCallbackWhenBuilder<T> : IPropertySetterOnlySetup<T>
+{
+	/// <inheritdoc cref="IPropertySetterSetupCallbackWhenBuilder{T}.For(int)" />
+	IPropertySetterOnlySetupCallbackWhenBuilder<T> For(int times);
+
+	/// <inheritdoc cref="IPropertySetterSetupCallbackWhenBuilder{T}.Only(int)" />
+	IPropertySetterOnlySetup<T> Only(int times);
+}
+
+/// <summary>
+///     Interface for setting up a return/throw builder for a get-only property with fluent syntax.
+/// </summary>
+public interface IPropertyGetterOnlySetupReturnBuilder<T> : IPropertyGetterOnlySetupReturnWhenBuilder<T>
+{
+	/// <inheritdoc cref="IPropertySetupReturnBuilder{T}.When(Func{int, bool})" />
+	IPropertyGetterOnlySetupReturnWhenBuilder<T> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Interface for setting up a when builder for returns/throws for a get-only property with fluent syntax.
+/// </summary>
+public interface IPropertyGetterOnlySetupReturnWhenBuilder<T> : IPropertyGetterOnlySetup<T>
+{
+	/// <inheritdoc cref="IPropertySetupReturnWhenBuilder{T}.For(int)" />
+	IPropertyGetterOnlySetupReturnWhenBuilder<T> For(int times);
+
+	/// <inheritdoc cref="IPropertySetupReturnWhenBuilder{T}.Only(int)" />
+	IPropertyGetterOnlySetup<T> Only(int times);
 }

--- a/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.PropertySetup.cs
@@ -275,6 +275,76 @@ public interface IPropertySetup<T>
 }
 
 /// <summary>
+///     Setup for a mocked property of type <typeparamref name="T" /> that the mock only reads.
+/// </summary>
+/// <remarks>
+///     Used instead of <see cref="IPropertySetup{T}" /> when the mock has no setter to intercept, either
+///     because the property is declared without one or because its setter is not accessible from the
+///     mock's assembly. Writes then never reach the mock, so <see cref="IPropertySetup{T}.OnSet" /> is not
+///     offered.
+/// </remarks>
+public interface IPropertyGetterOnlySetup<T>
+{
+	/// <inheritdoc cref="IPropertySetup{T}.OnGet" />
+	IPropertyGetterSetup<T> OnGet { get; }
+
+	/// <inheritdoc cref="IPropertySetup{T}.SkippingBaseClass(bool)" />
+	IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Register()" />
+	IPropertyGetterOnlySetup<T> Register();
+
+	/// <inheritdoc cref="IPropertySetup{T}.InitializeWith(T)" />
+	/// <remarks>
+	///     Seeds the value that reads return. Unlike a read-write property there is no setter to update the
+	///     slot afterwards, so it stays at <paramref name="value" /> unless a <c>Returns</c> entry applies.
+	/// </remarks>
+	IPropertyGetterOnlySetup<T> InitializeWith(T value);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Returns(T)" />
+	IPropertySetupReturnBuilder<T> Returns(T returnValue);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Returns(Func{T})" />
+	IPropertySetupReturnBuilder<T> Returns(Func<T> callback);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Returns(Func{T, T})" />
+	IPropertySetupReturnBuilder<T> Returns(Func<T, T> callback);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Throws{TException}()" />
+	IPropertySetupReturnBuilder<T> Throws<TException>()
+		where TException : Exception, new();
+
+	/// <inheritdoc cref="IPropertySetup{T}.Throws(Exception)" />
+	IPropertySetupReturnBuilder<T> Throws(Exception exception);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Throws(Func{Exception})" />
+	IPropertySetupReturnBuilder<T> Throws(Func<Exception> callback);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Throws(Func{T, Exception})" />
+	IPropertySetupReturnBuilder<T> Throws(Func<T, Exception> callback);
+}
+
+/// <summary>
+///     Setup for a mocked property of type <typeparamref name="T" /> that the mock only writes.
+/// </summary>
+/// <remarks>
+///     The write-only counterpart of <see cref="IPropertyGetterOnlySetup{T}" />: the mock has no getter to
+///     intercept, so <see cref="IPropertySetup{T}.OnGet" /> and the <c>Returns</c>/<c>Throws</c>
+///     read-sequence are not offered.
+/// </remarks>
+public interface IPropertySetterOnlySetup<T>
+{
+	/// <inheritdoc cref="IPropertySetup{T}.OnSet" />
+	IPropertySetterSetup<T> OnSet { get; }
+
+	/// <inheritdoc cref="IPropertySetup{T}.SkippingBaseClass(bool)" />
+	IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
+
+	/// <inheritdoc cref="IPropertySetup{T}.Register()" />
+	IPropertySetterOnlySetup<T> Register();
+}
+
+/// <summary>
 ///     Interface for setting up a property getter with fluent syntax.
 /// </summary>
 public interface IPropertyGetterSetupParallelCallbackBuilder<T> : IPropertyGetterSetupCallbackWhenBuilder<T>

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -189,7 +189,8 @@ public abstract class PropertySetup : IInteractivePropertySetup
 public class PropertySetup<T> : PropertySetup,
 	IPropertyGetterSetupCallbackBuilder<T>, IPropertySetterSetupCallbackBuilder<T>,
 	IPropertySetupReturnBuilder<T>,
-	IPropertyGetterSetup<T>, IPropertySetterSetup<T>
+	IPropertyGetterSetup<T>, IPropertySetterSetup<T>,
+	IPropertyGetterOnlySetup<T>, IPropertySetterOnlySetup<T>
 {
 	private readonly MockRegistry _mockRegistry;
 	private readonly string _name;
@@ -668,4 +669,46 @@ public class PropertySetup<T> : PropertySetup,
 	}
 
 	#endregion IPropertySetup<T>
+
+	#region Accessor-restricted views
+
+	// The narrow views reuse the full implementation and only re-type the chaining return value, so a
+	// get-only property cannot reach OnSet and a set-only one cannot reach OnGet or the read-sequence.
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.SkippingBaseClass(bool)" />
+	IPropertyGetterOnlySetup<T> IPropertyGetterOnlySetup<T>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Register()" />
+	IPropertyGetterOnlySetup<T> IPropertyGetterOnlySetup<T>.Register()
+	{
+		Register();
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.InitializeWith(T)" />
+	IPropertyGetterOnlySetup<T> IPropertyGetterOnlySetup<T>.InitializeWith(T value)
+	{
+		InitializeWith(value);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetup{T}.SkippingBaseClass(bool)" />
+	IPropertySetterOnlySetup<T> IPropertySetterOnlySetup<T>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetup{T}.Register()" />
+	IPropertySetterOnlySetup<T> IPropertySetterOnlySetup<T>.Register()
+	{
+		Register();
+		return this;
+	}
+
+	#endregion Accessor-restricted views
 }

--- a/Source/Mockolate/Setup/PropertySetup.cs
+++ b/Source/Mockolate/Setup/PropertySetup.cs
@@ -190,7 +190,10 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertyGetterSetupCallbackBuilder<T>, IPropertySetterSetupCallbackBuilder<T>,
 	IPropertySetupReturnBuilder<T>,
 	IPropertyGetterSetup<T>, IPropertySetterSetup<T>,
-	IPropertyGetterOnlySetup<T>, IPropertySetterOnlySetup<T>
+	IPropertyGetterOnlySetup<T>, IPropertySetterOnlySetup<T>,
+	IPropertyGetterOnlyGetterSetup<T>, IPropertySetterOnlySetterSetup<T>,
+	IPropertyGetterOnlySetupCallbackBuilder<T>, IPropertySetterOnlySetupCallbackBuilder<T>,
+	IPropertyGetterOnlySetupReturnBuilder<T>
 {
 	private readonly MockRegistry _mockRegistry;
 	private readonly string _name;
@@ -672,9 +675,6 @@ public class PropertySetup<T> : PropertySetup,
 
 	#region Accessor-restricted views
 
-	// The narrow views reuse the full implementation and only re-type the chaining return value, so a
-	// get-only property cannot reach OnSet and a set-only one cannot reach OnGet or the read-sequence.
-
 	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.SkippingBaseClass(bool)" />
 	IPropertyGetterOnlySetup<T> IPropertyGetterOnlySetup<T>.SkippingBaseClass(bool skipBaseClass)
 	{
@@ -696,6 +696,137 @@ public class PropertySetup<T> : PropertySetup,
 		return this;
 	}
 
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.OnGet" />
+	IPropertyGetterOnlyGetterSetup<T> IPropertyGetterOnlySetup<T>.OnGet
+		=> this;
+
+	/// <inheritdoc cref="IPropertyGetterOnlyGetterSetup{T}.Do(Action)" />
+	IPropertyGetterOnlySetupCallbackBuilder<T> IPropertyGetterOnlyGetterSetup<T>.Do(Action callback)
+	{
+		((IPropertyGetterSetup<T>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlyGetterSetup{T}.Do(Action{T})" />
+	IPropertyGetterOnlySetupCallbackBuilder<T> IPropertyGetterOnlyGetterSetup<T>.Do(Action<T> callback)
+	{
+		((IPropertyGetterSetup<T>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlyGetterSetup{T}.Do(Action{int, T})" />
+	IPropertyGetterOnlySetupCallbackBuilder<T> IPropertyGetterOnlyGetterSetup<T>.Do(Action<int, T> callback)
+	{
+		((IPropertyGetterSetup<T>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlyGetterSetup{T}.TransitionTo(string)" />
+	IPropertyGetterOnlySetupParallelCallbackBuilder<T> IPropertyGetterOnlyGetterSetup<T>.TransitionTo(string scenario)
+	{
+		((IPropertyGetterSetup<T>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetupCallbackBuilder{T}.InParallel()" />
+	IPropertyGetterOnlySetupParallelCallbackBuilder<T> IPropertyGetterOnlySetupCallbackBuilder<T>.InParallel()
+	{
+		((IPropertyGetterSetupCallbackBuilder<T>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
+	IPropertyGetterOnlySetupCallbackWhenBuilder<T> IPropertyGetterOnlySetupParallelCallbackBuilder<T>.When(
+		Func<int, bool> predicate)
+	{
+		((IPropertyGetterSetupParallelCallbackBuilder<T>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetupCallbackWhenBuilder{T}.For(int)" />
+	IPropertyGetterOnlySetupCallbackWhenBuilder<T> IPropertyGetterOnlySetupCallbackWhenBuilder<T>.For(int times)
+	{
+		((IPropertyGetterSetupCallbackWhenBuilder<T>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetupCallbackWhenBuilder{T}.Only(int)" />
+	IPropertyGetterOnlySetup<T> IPropertyGetterOnlySetupCallbackWhenBuilder<T>.Only(int times)
+	{
+		((IPropertyGetterSetupCallbackWhenBuilder<T>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Returns(T)" />
+	IPropertyGetterOnlySetupReturnBuilder<T> IPropertyGetterOnlySetup<T>.Returns(T returnValue)
+	{
+		Returns(returnValue);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Returns(Func{T})" />
+	IPropertyGetterOnlySetupReturnBuilder<T> IPropertyGetterOnlySetup<T>.Returns(Func<T> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Returns(Func{T, T})" />
+	IPropertyGetterOnlySetupReturnBuilder<T> IPropertyGetterOnlySetup<T>.Returns(Func<T, T> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Throws{TException}()" />
+	IPropertyGetterOnlySetupReturnBuilder<T> IPropertyGetterOnlySetup<T>.Throws<TException>()
+	{
+		Throws<TException>();
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Throws(Exception)" />
+	IPropertyGetterOnlySetupReturnBuilder<T> IPropertyGetterOnlySetup<T>.Throws(Exception exception)
+	{
+		Throws(exception);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Throws(Func{Exception})" />
+	IPropertyGetterOnlySetupReturnBuilder<T> IPropertyGetterOnlySetup<T>.Throws(Func<Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetup{T}.Throws(Func{T, Exception})" />
+	IPropertyGetterOnlySetupReturnBuilder<T> IPropertyGetterOnlySetup<T>.Throws(Func<T, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetupReturnBuilder{T}.When(Func{int, bool})" />
+	IPropertyGetterOnlySetupReturnWhenBuilder<T> IPropertyGetterOnlySetupReturnBuilder<T>.When(Func<int, bool> predicate)
+	{
+		((IPropertySetupReturnBuilder<T>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetupReturnWhenBuilder{T}.For(int)" />
+	IPropertyGetterOnlySetupReturnWhenBuilder<T> IPropertyGetterOnlySetupReturnWhenBuilder<T>.For(int times)
+	{
+		((IPropertySetupReturnWhenBuilder<T>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertyGetterOnlySetupReturnWhenBuilder{T}.Only(int)" />
+	IPropertyGetterOnlySetup<T> IPropertyGetterOnlySetupReturnWhenBuilder<T>.Only(int times)
+	{
+		((IPropertySetupReturnWhenBuilder<T>)this).Only(times);
+		return this;
+	}
+
 	/// <inheritdoc cref="IPropertySetterOnlySetup{T}.SkippingBaseClass(bool)" />
 	IPropertySetterOnlySetup<T> IPropertySetterOnlySetup<T>.SkippingBaseClass(bool skipBaseClass)
 	{
@@ -707,6 +838,67 @@ public class PropertySetup<T> : PropertySetup,
 	IPropertySetterOnlySetup<T> IPropertySetterOnlySetup<T>.Register()
 	{
 		Register();
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetup{T}.OnSet" />
+	IPropertySetterOnlySetterSetup<T> IPropertySetterOnlySetup<T>.OnSet
+		=> this;
+
+	/// <inheritdoc cref="IPropertySetterOnlySetterSetup{T}.Do(Action)" />
+	IPropertySetterOnlySetupCallbackBuilder<T> IPropertySetterOnlySetterSetup<T>.Do(Action callback)
+	{
+		((IPropertySetterSetup<T>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetterSetup{T}.Do(Action{T})" />
+	IPropertySetterOnlySetupCallbackBuilder<T> IPropertySetterOnlySetterSetup<T>.Do(Action<T> callback)
+	{
+		((IPropertySetterSetup<T>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetterSetup{T}.Do(Action{int, T})" />
+	IPropertySetterOnlySetupCallbackBuilder<T> IPropertySetterOnlySetterSetup<T>.Do(Action<int, T> callback)
+	{
+		((IPropertySetterSetup<T>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetterSetup{T}.TransitionTo(string)" />
+	IPropertySetterOnlySetupParallelCallbackBuilder<T> IPropertySetterOnlySetterSetup<T>.TransitionTo(string scenario)
+	{
+		((IPropertySetterSetup<T>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetupCallbackBuilder{T}.InParallel()" />
+	IPropertySetterOnlySetupParallelCallbackBuilder<T> IPropertySetterOnlySetupCallbackBuilder<T>.InParallel()
+	{
+		((IPropertySetterSetupCallbackBuilder<T>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetupParallelCallbackBuilder{T}.When(Func{int, bool})" />
+	IPropertySetterOnlySetupCallbackWhenBuilder<T> IPropertySetterOnlySetupParallelCallbackBuilder<T>.When(
+		Func<int, bool> predicate)
+	{
+		((IPropertySetterSetupParallelCallbackBuilder<T>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetupCallbackWhenBuilder{T}.For(int)" />
+	IPropertySetterOnlySetupCallbackWhenBuilder<T> IPropertySetterOnlySetupCallbackWhenBuilder<T>.For(int times)
+	{
+		((IPropertySetterSetupCallbackWhenBuilder<T>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IPropertySetterOnlySetupCallbackWhenBuilder{T}.Only(int)" />
+	IPropertySetterOnlySetup<T> IPropertySetterOnlySetupCallbackWhenBuilder<T>.Only(int times)
+	{
+		((IPropertySetterSetupCallbackWhenBuilder<T>)this).Only(times);
 		return this;
 	}
 

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -70,6 +70,65 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
+	///     Extensions for setups of get-only properties.
+	/// </summary>
+	extension<T>(IPropertyGetterOnlySetupReturnWhenBuilder<T> setup)
+	{
+		/// <summary>
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
+		public void Forever()
+			=> setup.For(int.MaxValue);
+
+		/// <summary>
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IPropertyGetterOnlySetup<T> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for getter callback setups of get-only properties.
+	/// </summary>
+	extension<T>(IPropertyGetterOnlySetupCallbackWhenBuilder<T> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IPropertyGetterOnlySetup<T> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setter callback setups of set-only properties.
+	/// </summary>
+	extension<T>(IPropertySetterOnlySetupCallbackWhenBuilder<T> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IPropertySetterOnlySetup<T> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
 	///     Extensions for event subscription callback setups.
 	/// </summary>
 	extension(IEventSubscriptionSetupCallbackWhenBuilder setup)

--- a/Source/Mockolate/Verify/VerificationPropertyResult.cs
+++ b/Source/Mockolate/Verify/VerificationPropertyResult.cs
@@ -65,3 +65,86 @@ public class VerificationPropertyResult<TSubject, TParameter>
 		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName,
 			It.Is(value, doNotPopulateThisValue).AsParameterMatch());
 }
+
+/// <summary>
+///     Verifications on a property that the mock only reads.
+/// </summary>
+/// <remarks>
+///     Used instead of <see cref="VerificationPropertyResult{TSubject, TParameter}" /> when the mock has no
+///     setter to intercept, either because the property is declared without one or because its setter is
+///     not accessible from the mock's assembly. Writes then never reach the mock, so offering
+///     <c>Set(...)</c> here would always report zero interactions. The property type is not a type
+///     parameter because only <c>Set(...)</c> needs it.
+/// </remarks>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationPropertyGetterResult<TSubject>
+{
+	private readonly int _getMemberId;
+	private readonly MockRegistry _mockRegistry;
+	private readonly string _propertyName;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationPropertyGetterResult{TSubject}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="getMemberId">Member id of the property getter, or <c>-1</c> when unknown.</param>
+	/// <param name="propertyName">The simple property name.</param>
+	public VerificationPropertyGetterResult(TSubject subject, MockRegistry mockRegistry, int getMemberId,
+		string propertyName)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_getMemberId = getMemberId;
+		_propertyName = propertyName;
+	}
+
+	/// <inheritdoc cref="VerificationPropertyResult{TSubject, TParameter}.Got()" />
+	public VerificationResult<TSubject> Got()
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _getMemberId, _propertyName);
+}
+
+/// <summary>
+///     Verifications on a property of type <typeparamref name="TParameter" /> that the mock only writes.
+/// </summary>
+/// <remarks>
+///     The write-only counterpart of <see cref="VerificationPropertyGetterResult{TSubject}" />: the mock
+///     has no getter to intercept, so <c>Got()</c> is not offered.
+/// </remarks>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationPropertySetterResult<TSubject, TParameter>
+{
+	private readonly MockRegistry _mockRegistry;
+	private readonly string _propertyName;
+	private readonly int _setMemberId;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationPropertySetterResult{TSubject, TParameter}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="setMemberId">Member id of the property setter, or <c>-1</c> when unknown.</param>
+	/// <param name="propertyName">The simple property name.</param>
+	public VerificationPropertySetterResult(TSubject subject, MockRegistry mockRegistry, int setMemberId,
+		string propertyName)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_setMemberId = setMemberId;
+		_propertyName = propertyName;
+	}
+
+	/// <inheritdoc cref="VerificationPropertyResult{TSubject, TParameter}.Set(IParameter{TParameter})" />
+	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName, value.AsParameterMatch());
+
+	/// <inheritdoc cref="VerificationPropertyResult{TSubject, TParameter}.Set(TParameter, string)" />
+	[OverloadResolutionPriority(1)]
+	public VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> _mockRegistry.VerifyPropertyTyped(_subject, _setMemberId, _propertyName,
+			It.Is(value, doNotPopulateThisValue).AsParameterMatch());
+}

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -382,6 +382,19 @@ namespace Mockolate
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
+        extension<T>(Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IPropertyGetterOnlySetup<T> OnlyOnce() { }
+        }
+        extension<T>(Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T?>? setup)
+        {
+            public Mockolate.Setup.IPropertyGetterOnlySetup<T> OnlyOnce() { }
+        }
+        extension<T>(Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T?>? setup)
+        {
+            public Mockolate.Setup.IPropertySetterOnlySetup<T> OnlyOnce() { }
+        }
         extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
@@ -1472,19 +1485,48 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterOnlyGetterSetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertyGetterOnlySetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertyGetterOnlySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Only(int times);
+    }
+    public interface IPropertyGetterOnlySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
+    public interface IPropertyGetterOnlySetupReturnBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
+    public interface IPropertyGetterOnlySetupReturnWhenBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Only(int times);
+    }
     public interface IPropertyGetterOnlySetup<T>
     {
-        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertyGetterOnlyGetterSetup<T> OnGet { get; }
         Mockolate.Setup.IPropertyGetterOnlySetup<T> InitializeWith(T value);
         Mockolate.Setup.IPropertyGetterOnlySetup<T> Register();
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(System.Func<T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(T returnValue);
         Mockolate.Setup.IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Exception exception);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws<TException>()
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Exception exception);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws<TException>()
             where TException : System.Exception, new ();
     }
     public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
@@ -1507,9 +1549,29 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
     }
+    public interface IPropertySetterOnlySetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterOnlySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertySetterOnlySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetterOnlySetup<T> Only(int times);
+    }
+    public interface IPropertySetterOnlySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
     public interface IPropertySetterOnlySetup<T>
     {
-        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
+        Mockolate.Setup.IPropertySetterOnlySetterSetup<T> OnSet { get; }
         Mockolate.Setup.IPropertySetterOnlySetup<T> Register();
         Mockolate.Setup.IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
     }
@@ -2329,7 +2391,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlyGetterSetup<T>, Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -1472,6 +1472,21 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> InitializeWith(T value);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Register();
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Exception exception);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
     public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
@@ -1491,6 +1506,12 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
+        Mockolate.Setup.IPropertySetterOnlySetup<T> Register();
+        Mockolate.Setup.IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
     }
     public interface IPropertySetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -2308,7 +2329,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }
@@ -2889,11 +2910,22 @@ namespace Mockolate.Verify
         public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
+    public class VerificationPropertyGetterResult<TSubject>
+    {
+        public VerificationPropertyGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, string propertyName) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
     public class VerificationPropertyResult<TSubject, TParameter>
     {
         public VerificationPropertyResult(TSubject subject, Mockolate.MockRegistry mockRegistry, string propertyName) { }
         public VerificationPropertyResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationPropertySetterResult<TSubject, TParameter>
+    {
+        public VerificationPropertySetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -1430,6 +1430,21 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> InitializeWith(T value);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Register();
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Exception exception);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
     public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
@@ -1449,6 +1464,12 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
+        Mockolate.Setup.IPropertySetterOnlySetup<T> Register();
+        Mockolate.Setup.IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
     }
     public interface IPropertySetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -2070,7 +2091,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }
@@ -2443,11 +2464,22 @@ namespace Mockolate.Verify
         public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
+    public class VerificationPropertyGetterResult<TSubject>
+    {
+        public VerificationPropertyGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, string propertyName) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
     public class VerificationPropertyResult<TSubject, TParameter>
     {
         public VerificationPropertyResult(TSubject subject, Mockolate.MockRegistry mockRegistry, string propertyName) { }
         public VerificationPropertyResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationPropertySetterResult<TSubject, TParameter>
+    {
+        public VerificationPropertySetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -365,6 +365,19 @@ namespace Mockolate
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
+        extension<T>(Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IPropertyGetterOnlySetup<T> OnlyOnce() { }
+        }
+        extension<T>(Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T?>? setup)
+        {
+            public Mockolate.Setup.IPropertyGetterOnlySetup<T> OnlyOnce() { }
+        }
+        extension<T>(Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T?>? setup)
+        {
+            public Mockolate.Setup.IPropertySetterOnlySetup<T> OnlyOnce() { }
+        }
         extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
@@ -1430,19 +1443,48 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterOnlyGetterSetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertyGetterOnlySetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertyGetterOnlySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Only(int times);
+    }
+    public interface IPropertyGetterOnlySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
+    public interface IPropertyGetterOnlySetupReturnBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
+    public interface IPropertyGetterOnlySetupReturnWhenBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Only(int times);
+    }
     public interface IPropertyGetterOnlySetup<T>
     {
-        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertyGetterOnlyGetterSetup<T> OnGet { get; }
         Mockolate.Setup.IPropertyGetterOnlySetup<T> InitializeWith(T value);
         Mockolate.Setup.IPropertyGetterOnlySetup<T> Register();
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(System.Func<T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(T returnValue);
         Mockolate.Setup.IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Exception exception);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws<TException>()
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Exception exception);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws<TException>()
             where TException : System.Exception, new ();
     }
     public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
@@ -1465,9 +1507,29 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
     }
+    public interface IPropertySetterOnlySetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterOnlySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertySetterOnlySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetterOnlySetup<T> Only(int times);
+    }
+    public interface IPropertySetterOnlySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
     public interface IPropertySetterOnlySetup<T>
     {
-        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
+        Mockolate.Setup.IPropertySetterOnlySetterSetup<T> OnSet { get; }
         Mockolate.Setup.IPropertySetterOnlySetup<T> Register();
         Mockolate.Setup.IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
     }
@@ -2091,7 +2153,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlyGetterSetup<T>, Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -312,6 +312,19 @@ namespace Mockolate
         {
             public Mockolate.Setup.IPropertySetup<T> OnlyOnce() { }
         }
+        extension<T>(Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IPropertyGetterOnlySetup<T> OnlyOnce() { }
+        }
+        extension<T>(Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T?>? setup)
+        {
+            public Mockolate.Setup.IPropertyGetterOnlySetup<T> OnlyOnce() { }
+        }
+        extension<T>(Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T?>? setup)
+        {
+            public Mockolate.Setup.IPropertySetterOnlySetup<T> OnlyOnce() { }
+        }
         extension(Mockolate.Setup.IEventSubscriptionSetupCallbackWhenBuilder? setup)
         {
             public void Forever() { }
@@ -1373,19 +1386,48 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterOnlyGetterSetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertyGetterOnlySetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertyGetterOnlySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Only(int times);
+    }
+    public interface IPropertyGetterOnlySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
+    public interface IPropertyGetterOnlySetupReturnBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
+    public interface IPropertyGetterOnlySetupReturnWhenBuilder<T> : Mockolate.Setup.IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Only(int times);
+    }
     public interface IPropertyGetterOnlySetup<T>
     {
-        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertyGetterOnlyGetterSetup<T> OnGet { get; }
         Mockolate.Setup.IPropertyGetterOnlySetup<T> InitializeWith(T value);
         Mockolate.Setup.IPropertyGetterOnlySetup<T> Register();
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(System.Func<T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Returns(T returnValue);
         Mockolate.Setup.IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Exception exception);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
-        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws<TException>()
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Exception exception);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
+        Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T> Throws<TException>()
             where TException : System.Exception, new ();
     }
     public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
@@ -1408,9 +1450,29 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
     }
+    public interface IPropertySetterOnlySetterSetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action callback);
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action<T> callback);
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T> Do(System.Action<int, T> callback);
+        Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterOnlySetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T> InParallel();
+    }
+    public interface IPropertySetterOnlySetupCallbackWhenBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T> For(int times);
+        Mockolate.Setup.IPropertySetterOnlySetup<T> Only(int times);
+    }
+    public interface IPropertySetterOnlySetupParallelCallbackBuilder<T> : Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T> When(System.Func<int, bool> predicate);
+    }
     public interface IPropertySetterOnlySetup<T>
     {
-        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
+        Mockolate.Setup.IPropertySetterOnlySetterSetup<T> OnSet { get; }
         Mockolate.Setup.IPropertySetterOnlySetup<T> Register();
         Mockolate.Setup.IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
     }
@@ -2034,7 +2096,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlyGetterSetup<T>, Mockolate.Setup.IPropertyGetterOnlySetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupReturnBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -1373,6 +1373,21 @@ namespace Mockolate.Setup
         string Name { get; }
     }
     public interface IMockSetup<out T> : Mockolate.IInteractiveMock<T> { }
+    public interface IPropertyGetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertyGetterSetup<T> OnGet { get; }
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> InitializeWith(T value);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> Register();
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(System.Func<T, T> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Returns(T returnValue);
+        Mockolate.Setup.IPropertyGetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Exception exception);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws(System.Func<T, System.Exception> callback);
+        Mockolate.Setup.IPropertySetupReturnBuilder<T> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
     public interface IPropertyGetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> InParallel();
@@ -1392,6 +1407,12 @@ namespace Mockolate.Setup
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<T> callback);
         Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T> Do(System.Action<int, T> callback);
         Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T> TransitionTo(string scenario);
+    }
+    public interface IPropertySetterOnlySetup<T>
+    {
+        Mockolate.Setup.IPropertySetterSetup<T> OnSet { get; }
+        Mockolate.Setup.IPropertySetterOnlySetup<T> Register();
+        Mockolate.Setup.IPropertySetterOnlySetup<T> SkippingBaseClass(bool skipBaseClass = true);
     }
     public interface IPropertySetterSetupCallbackBuilder<T> : Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
@@ -2013,7 +2034,7 @@ namespace Mockolate.Setup
         protected abstract void InvokeSetter<TValue>(TValue value, Mockolate.MockBehavior behavior);
         protected abstract bool Matches(Mockolate.Interactions.PropertyAccess propertyAccess);
     }
-    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
+    public class PropertySetup<T> : Mockolate.Setup.PropertySetup, Mockolate.Setup.IPropertyGetterOnlySetup<T>, Mockolate.Setup.IPropertyGetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertyGetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertyGetterSetup<T>, Mockolate.Setup.IPropertySetterOnlySetup<T>, Mockolate.Setup.IPropertySetterSetupCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetupCallbackWhenBuilder<T>, Mockolate.Setup.IPropertySetterSetupParallelCallbackBuilder<T>, Mockolate.Setup.IPropertySetterSetup<T>, Mockolate.Setup.IPropertySetupReturnBuilder<T>, Mockolate.Setup.IPropertySetupReturnWhenBuilder<T>, Mockolate.Setup.IPropertySetup<T>
     {
         public PropertySetup(Mockolate.MockRegistry mockRegistry, string name) { }
         public override string Name { get; }
@@ -2372,11 +2393,22 @@ namespace Mockolate.Verify
         public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
+    public class VerificationPropertyGetterResult<TSubject>
+    {
+        public VerificationPropertyGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, string propertyName) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
     public class VerificationPropertyResult<TSubject, TParameter>
     {
         public VerificationPropertyResult(TSubject subject, Mockolate.MockRegistry mockRegistry, string propertyName) { }
         public VerificationPropertyResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, int setMemberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationPropertySetterResult<TSubject, TParameter>
+    {
+        public VerificationPropertySetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, string propertyName) { }
         public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -6,6 +6,48 @@ public sealed partial class MockTests
 	{
 		public sealed class PropertiesTests
 		{
+			[Theory]
+			[InlineData("string Name { get; }", "Setup.IPropertyGetterOnlySetup<string>",
+				"Verify.VerificationPropertyGetterResult<IMockVerifyForIMyService>",
+				"Setup.PropertySetup<string>", "Verify.VerificationPropertyResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string Name { set; }", "Setup.IPropertySetterOnlySetup<string>",
+				"Verify.VerificationPropertySetterResult<IMockVerifyForIMyService, string>",
+				"Setup.PropertySetup<string>", "Verify.VerificationPropertyResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string Name { get; set; }", "Setup.PropertySetup<string>",
+				"Verify.VerificationPropertyResult<IMockVerifyForIMyService, string>",
+				"Setup.IPropertyGetterOnlySetup<string>", "Verify.VerificationPropertyGetterResult<IMockVerifyForIMyService>")]
+			public async Task PropertySurface_ShouldOnlyExposeTheAccessorsTheMockIntercepts(
+				string property, string expectedSetupType, string expectedVerifyType,
+				string unexpectedSetupType, string unexpectedVerifyType)
+			{
+				GeneratorResult result = Generator
+					.Run($$"""
+					       using Mockolate;
+
+					       namespace MyCode;
+					       public class Program
+					       {
+					           public static void Main(string[] args)
+					           {
+					       		_ = IMyService.CreateMock();
+					           }
+					       }
+
+					       public interface IMyService
+					       {
+					           {{property}}
+					       }
+					       """);
+
+				await That(result.Diagnostics).IsEmpty();
+				await That(result.Sources["Mock.IMyService.g.cs"])
+					.Contains($"global::Mockolate.{expectedSetupType} Name {{ get; }}").And
+					.Contains($"global::Mockolate.{expectedVerifyType} Name {{ get; }}").And
+					.DoesNotContain($"global::Mockolate.{unexpectedSetupType} Name {{ get; }}").And
+					.DoesNotContain($"global::Mockolate.{unexpectedVerifyType} Name {{ get; }}")
+					.Because("a widened facade would silently re-expose an accessor the mock never intercepts");
+			}
+
 			[Fact]
 			public async Task InitOnlyProperty_ShouldEmitInitAccessorAndCompile()
 			{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
@@ -299,6 +299,9 @@ public sealed partial class MockTests
 
 			await That(result.Diagnostics).IsEmpty();
 			await That(result.Sources["Mock.MyExternalType.g.cs"])
+				.Contains("global::Mockolate.Setup.IPropertyGetterOnlySetup<string> Mixed { get; }").And
+				.Contains("global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForMyExternalType> Mixed { get; }")
+				.Because("the mock does not intercept the inaccessible setter, so neither surface may offer it").And
 				.Contains("public override string Mixed").And
 				.Contains(".GetProperty").And
 				.DoesNotContain(inaccessibleAccessor)
@@ -329,6 +332,10 @@ public sealed partial class MockTests
 
 			await That(result.Diagnostics).IsEmpty();
 			await That(result.Sources["Mock.MyExternalType.g.cs"])
+				.Contains("global::Mockolate.Setup.IPropertySetterOnlySetup<string> Mixed { get; }").And
+				.Contains(
+					"global::Mockolate.Verify.VerificationPropertySetterResult<IMockVerifyForMyExternalType, string> Mixed { get; }")
+				.Because("the mock does not intercept the inaccessible getter, so neither surface may offer it").And
 				.Contains("public override string Mixed").And
 				.Contains(".SetProperty").And
 				.DoesNotContain(inaccessibleAccessor)

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -67,11 +67,11 @@ public sealed partial class MockTests
 
 		await That(result.Sources).ContainsKey("Mock.OuterClass.g.cs");
 		await That(result.Sources["Mock.OuterClass.g.cs"])
-			.Contains("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.OuterValue").And
-			.Contains("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.BaseClassValue").And
-			.DoesNotContain("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.DirectValue").And
-			.DoesNotContain("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.ParentValue").And
-			.DoesNotContain("global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.NestedValue").And
+			.Contains("global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.OuterValue").And
+			.Contains("global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.BaseClassValue").And
+			.DoesNotContain("IMockSetupForOuterClass.DirectValue").And
+			.DoesNotContain("IMockSetupForOuterClass.ParentValue").And
+			.DoesNotContain("IMockSetupForOuterClass.NestedValue").And
 			.Contains("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.OuterMethod()").And
 			.Contains("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.BaseClassMethod()").And
 			.DoesNotContain("global::Mockolate.Setup.IReturnMethodSetup<int> global::Mockolate.Mock.IMockSetupForOuterClass.DirectMethod()").And
@@ -82,11 +82,11 @@ public sealed partial class MockTests
 			.DoesNotContain("void IMockRaiseOnOuterClass.DirectEvent(object? sender, global::System.EventArgs e)").And
 			.DoesNotContain("void IMockRaiseOnOuterClass.ParentEvent(object? sender, global::System.EventArgs e)").And
 			.DoesNotContain("void IMockRaiseOnOuterClass.NestedEvent(object? sender, global::System.EventArgs e)").And
-			.Contains("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.OuterValue").And
-			.Contains("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.BaseClassValue").And
-			.DoesNotContain("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.DirectValue").And
-			.DoesNotContain("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.ParentValue").And
-			.DoesNotContain("global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForOuterClass, int> IMockVerifyForOuterClass.NestedValue").And
+			.Contains("global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.OuterValue").And
+			.Contains("global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForOuterClass> IMockVerifyForOuterClass.BaseClassValue").And
+			.DoesNotContain("IMockVerifyForOuterClass.DirectValue").And
+			.DoesNotContain("IMockVerifyForOuterClass.ParentValue").And
+			.DoesNotContain("IMockVerifyForOuterClass.NestedValue").And
 			.Contains("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass>.IgnoreParameters IMockVerifyForOuterClass.OuterMethod()").And
 			.Contains("global::Mockolate.Verify.VerificationResult<IMockVerifyForOuterClass>.IgnoreParameters IMockVerifyForOuterClass.BaseClassMethod()").And
 			.DoesNotContain("IMockVerifyForOuterClass.DirectMethod()").And

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA.g.cs
@@ -415,7 +415,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
 		{
 			get
 			{
@@ -463,11 +463,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int> IMockVerifyForICombinationMockA.Value
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA> IMockVerifyForICombinationMockA.Value
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int>(this, this.MockRegistry, -1, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA>(this, this.MockRegistry, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
 			}
 		}
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ComprehensiveAbstractClass__ICombinationMockA__ICombinationMockB.g.cs
@@ -523,7 +523,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
 		{
 			get
 			{
@@ -547,7 +547,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockB.Value
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockB.Value
 		{
 			get
 			{
@@ -595,11 +595,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int> IMockVerifyForICombinationMockA.Value
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA> IMockVerifyForICombinationMockA.Value
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int>(this, this.MockRegistry, -1, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA>(this, this.MockRegistry, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
 			}
 		}
 
@@ -612,11 +612,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockB, int> IMockVerifyForICombinationMockB.Value
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockB> IMockVerifyForICombinationMockB.Value
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockB, int>(this, this.MockRegistry, -1, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockB>(this, this.MockRegistry, -1, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value");
 			}
 		}
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockA.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockA.g.cs
@@ -179,7 +179,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
 		{
 			get
 			{
@@ -203,11 +203,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int> IMockVerifyForICombinationMockA.Value
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA> IMockVerifyForICombinationMockA.Value
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockA.MemberId_Value_Get, global::Mockolate.Mock.ICombinationMockA.MemberId_Value_Set, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockA.MemberId_Value_Get, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
 			}
 		}
 
@@ -226,11 +226,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int> IMockVerifyForICombinationMockA.Value
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA> IMockVerifyForICombinationMockA.Value
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockA.MemberId_Value_Get, global::Mockolate.Mock.ICombinationMockA.MemberId_Value_Set, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockA.MemberId_Value_Get, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value");
 			}
 		}
 
@@ -260,7 +260,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockA.Value
 		{
 			get
 			{
@@ -404,7 +404,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Setup for the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value">Value</see>.
 		/// </summary>
-		global::Mockolate.Setup.PropertySetup<int> Value { get; }
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> Value { get; }
 
 		/// <summary>
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Run()">Run()</see>.
@@ -422,7 +422,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Verify interactions with the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Value">Value</see>.
 		/// </summary>
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockA, int> Value { get; }
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockA> Value { get; }
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockA.Run()">Run()</see>.

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockB.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/BaseClass_WithMultipleAdditionalInterfaces_CanBeCreated/Mock.ICombinationMockB.g.cs
@@ -179,7 +179,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockB.Value
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockB.Value
 		{
 			get
 			{
@@ -203,11 +203,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockB, int> IMockVerifyForICombinationMockB.Value
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockB> IMockVerifyForICombinationMockB.Value
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockB, int>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockB.MemberId_Value_Get, global::Mockolate.Mock.ICombinationMockB.MemberId_Value_Set, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockB>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockB.MemberId_Value_Get, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value");
 			}
 		}
 
@@ -226,11 +226,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockB, int> IMockVerifyForICombinationMockB.Value
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockB> IMockVerifyForICombinationMockB.Value
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockB, int>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockB.MemberId_Value_Get, global::Mockolate.Mock.ICombinationMockB.MemberId_Value_Set, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockB>(this, this.MockRegistry, global::Mockolate.Mock.ICombinationMockB.MemberId_Value_Get, "global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value");
 			}
 		}
 
@@ -260,7 +260,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockB.Value
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForICombinationMockB.Value
 		{
 			get
 			{
@@ -404,7 +404,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Setup for the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value">Value</see>.
 		/// </summary>
-		global::Mockolate.Setup.PropertySetup<int> Value { get; }
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> Value { get; }
 
 		/// <summary>
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Run()">Run()</see>.
@@ -422,7 +422,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Verify interactions with the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Value">Value</see>.
 		/// </summary>
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForICombinationMockB, int> Value { get; }
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForICombinationMockB> Value { get; }
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.ICombinationMockB.Run()">Run()</see>.

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -2204,7 +2204,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetOnly
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetOnly
 		{
 			get
 			{
@@ -2216,7 +2216,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.SetOnly
+		global::Mockolate.Setup.IPropertySetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.SetOnly
 		{
 			get
 			{
@@ -2804,7 +2804,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockStaticSetupForIComprehensiveInterface.StaticAbstractValue
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockStaticSetupForIComprehensiveInterface.StaticAbstractValue
 		{
 			get
 			{
@@ -2886,21 +2886,21 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int> IMockVerifyForIComprehensiveInterface.GetOnly
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.GetOnly
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetOnly_Get, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetOnly_Set, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIComprehensiveInterface>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetOnly_Get, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly");
 			}
 		}
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int> IMockVerifyForIComprehensiveInterface.SetOnly
+		global::Mockolate.Verify.VerificationPropertySetterResult<IMockVerifyForIComprehensiveInterface, int> IMockVerifyForIComprehensiveInterface.SetOnly
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_SetOnly_Get, global::Mockolate.Mock.IComprehensiveInterface.MemberId_SetOnly_Set, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly");
+				return new global::Mockolate.Verify.VerificationPropertySetterResult<IMockVerifyForIComprehensiveInterface, int>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_SetOnly_Set, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly");
 			}
 		}
 
@@ -3383,11 +3383,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockStaticVerifyForIComprehensiveInterface, int> IMockStaticVerifyForIComprehensiveInterface.StaticAbstractValue
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockStaticVerifyForIComprehensiveInterface> IMockStaticVerifyForIComprehensiveInterface.StaticAbstractValue
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockStaticVerifyForIComprehensiveInterface, int>(this, this.MockRegistry, -1, -1, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.StaticAbstractValue");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockStaticVerifyForIComprehensiveInterface>(this, this.MockRegistry, -1, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.StaticAbstractValue");
 			}
 		}
 
@@ -3416,21 +3416,21 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int> IMockVerifyForIComprehensiveInterface.GetOnly
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.GetOnly
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetOnly_Get, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetOnly_Set, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIComprehensiveInterface>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_GetOnly_Get, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly");
 			}
 		}
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int> IMockVerifyForIComprehensiveInterface.SetOnly
+		global::Mockolate.Verify.VerificationPropertySetterResult<IMockVerifyForIComprehensiveInterface, int> IMockVerifyForIComprehensiveInterface.SetOnly
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_SetOnly_Get, global::Mockolate.Mock.IComprehensiveInterface.MemberId_SetOnly_Set, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly");
+				return new global::Mockolate.Verify.VerificationPropertySetterResult<IMockVerifyForIComprehensiveInterface, int>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_SetOnly_Set, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly");
 			}
 		}
 
@@ -3942,7 +3942,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetOnly
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.GetOnly
 		{
 			get
 			{
@@ -3954,7 +3954,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.SetOnly
+		global::Mockolate.Setup.IPropertySetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.SetOnly
 		{
 			get
 			{
@@ -4691,12 +4691,12 @@ internal static partial class Mock
 		/// <summary>
 		///     Setup for the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly">GetOnly</see>.
 		/// </summary>
-		global::Mockolate.Setup.PropertySetup<int> GetOnly { get; }
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> GetOnly { get; }
 
 		/// <summary>
 		///     Setup for the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly">SetOnly</see>.
 		/// </summary>
-		global::Mockolate.Setup.PropertySetup<int> SetOnly { get; }
+		global::Mockolate.Setup.IPropertySetterOnlySetup<int> SetOnly { get; }
 
 		/// <summary>
 		///     Setup for the string? property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.NullableProp">NullableProp</see>.
@@ -5250,7 +5250,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Setup for the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.StaticAbstractValue">StaticAbstractValue</see>.
 		/// </summary>
-		global::Mockolate.Setup.PropertySetup<int> StaticAbstractValue { get; }
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> StaticAbstractValue { get; }
 
 		/// <summary>
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.StaticAbstractMethod()">StaticAbstractMethod()</see>.
@@ -5310,12 +5310,12 @@ internal static partial class Mock
 		/// <summary>
 		///     Verify interactions with the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly">GetOnly</see>.
 		/// </summary>
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int> GetOnly { get; }
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIComprehensiveInterface> GetOnly { get; }
 
 		/// <summary>
 		///     Verify interactions with the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly">SetOnly</see>.
 		/// </summary>
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIComprehensiveInterface, int> SetOnly { get; }
+		global::Mockolate.Verify.VerificationPropertySetterResult<IMockVerifyForIComprehensiveInterface, int> SetOnly { get; }
 
 		/// <summary>
 		///     Verify interactions with the string? property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.NullableProp">NullableProp</see>.
@@ -5860,7 +5860,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Verify interactions with the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.StaticAbstractValue">StaticAbstractValue</see>.
 		/// </summary>
-		global::Mockolate.Verify.VerificationPropertyResult<IMockStaticVerifyForIComprehensiveInterface, int> StaticAbstractValue { get; }
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockStaticVerifyForIComprehensiveInterface> StaticAbstractValue { get; }
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.StaticAbstractMethod()">StaticAbstractMethod()</see>.

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/KeywordEdgeCases_CanBeCreated/Mock.IKeywordEdgeCases.g.cs
@@ -415,7 +415,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@class
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@class
 		{
 			get
 			{
@@ -567,11 +567,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIKeywordEdgeCases, int> IMockVerifyForIKeywordEdgeCases.@class
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIKeywordEdgeCases> IMockVerifyForIKeywordEdgeCases.@class
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIKeywordEdgeCases, int>(this, this.MockRegistry, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__class_Get, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__class_Set, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@class");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIKeywordEdgeCases>(this, this.MockRegistry, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__class_Get, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@class");
 			}
 		}
 
@@ -687,11 +687,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIKeywordEdgeCases, int> IMockVerifyForIKeywordEdgeCases.@class
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIKeywordEdgeCases> IMockVerifyForIKeywordEdgeCases.@class
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIKeywordEdgeCases, int>(this, this.MockRegistry, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__class_Get, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__class_Set, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@class");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIKeywordEdgeCases>(this, this.MockRegistry, global::Mockolate.Mock.IKeywordEdgeCases.MemberId__class_Get, "global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@class");
 			}
 		}
 
@@ -818,7 +818,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@class
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockSetupForIKeywordEdgeCases.@class
 		{
 			get
 			{
@@ -1081,7 +1081,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Setup for the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@class">@class</see>.
 		/// </summary>
-		global::Mockolate.Setup.PropertySetup<int> @class { get; }
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> @class { get; }
 
 		/// <summary>
 		///     Setup for the event <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@event">@event</see>.
@@ -1211,7 +1211,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Verify interactions with the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.@class">@class</see>.
 		/// </summary>
-		global::Mockolate.Verify.VerificationPropertyResult<IMockVerifyForIKeywordEdgeCases, int> @class { get; }
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockVerifyForIKeywordEdgeCases> @class { get; }
 
 		/// <summary>
 		///     Verify interactions with the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IKeywordEdgeCases.this[int, string]">this[int, string]</see>.

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/StaticAbstractMembers_CanBeCreated/Mock.IStaticAbstractMembers.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/StaticAbstractMembers_CanBeCreated/Mock.IStaticAbstractMembers.g.cs
@@ -304,7 +304,7 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Setup.PropertySetup<int> global::Mockolate.Mock.IMockStaticSetupForIStaticAbstractMembers.VirtualStaticProperty
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> global::Mockolate.Mock.IMockStaticSetupForIStaticAbstractMembers.VirtualStaticProperty
 		{
 			get
 			{
@@ -379,11 +379,11 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-		global::Mockolate.Verify.VerificationPropertyResult<IMockStaticVerifyForIStaticAbstractMembers, int> IMockStaticVerifyForIStaticAbstractMembers.VirtualStaticProperty
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockStaticVerifyForIStaticAbstractMembers> IMockStaticVerifyForIStaticAbstractMembers.VirtualStaticProperty
 		{
 			get
 			{
-				return new global::Mockolate.Verify.VerificationPropertyResult<IMockStaticVerifyForIStaticAbstractMembers, int>(this, this.MockRegistry, -1, -1, "global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers.VirtualStaticProperty");
+				return new global::Mockolate.Verify.VerificationPropertyGetterResult<IMockStaticVerifyForIStaticAbstractMembers>(this, this.MockRegistry, -1, "global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers.VirtualStaticProperty");
 			}
 		}
 
@@ -598,7 +598,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Setup for the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers.VirtualStaticProperty">VirtualStaticProperty</see>.
 		/// </summary>
-		global::Mockolate.Setup.PropertySetup<int> VirtualStaticProperty { get; }
+		global::Mockolate.Setup.IPropertyGetterOnlySetup<int> VirtualStaticProperty { get; }
 
 		/// <summary>
 		///     Setup for the event <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers.AbstractStaticEvent">AbstractStaticEvent</see>.
@@ -656,7 +656,7 @@ internal static partial class Mock
 		/// <summary>
 		///     Verify interactions with the int property <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers.VirtualStaticProperty">VirtualStaticProperty</see>.
 		/// </summary>
-		global::Mockolate.Verify.VerificationPropertyResult<IMockStaticVerifyForIStaticAbstractMembers, int> VirtualStaticProperty { get; }
+		global::Mockolate.Verify.VerificationPropertyGetterResult<IMockStaticVerifyForIStaticAbstractMembers> VirtualStaticProperty { get; }
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IStaticAbstractMembers.AbstractStaticMethod()">AbstractStaticMethod()</see>.

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.AccessorRestrictedTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.AccessorRestrictedTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Mockolate.Setup;
 
 namespace Mockolate.Tests.MockProperties;
 
@@ -75,6 +76,263 @@ public sealed partial class SetupPropertyTests
 			sut.WriteOnly = 1;
 
 			await That(sut.WriteOnlySetterCallCount).IsEqualTo(expectedCallCount);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_ChainedReturns_ShouldStayOnGetterOnlySurface()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			IPropertyGetterOnlySetup<int> chained = sut.Mock.Setup.ReadOnly
+				.Returns(1).OnlyOnce();
+			chained.Returns(() => 2);
+
+			await That(sut.ReadOnly).IsEqualTo(1);
+			await That(sut.ReadOnly).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_ReturnsForever_ShouldUseTheLastValueForever()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.ReadOnly
+				.Returns(2)
+				.Returns(4).Forever();
+
+			int[] result = new int[4];
+			for (int i = 0; i < 4; i++)
+			{
+				result[i] = sut.ReadOnly;
+			}
+
+			await That(result).IsEqualTo([2, 4, 4, 4,]);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_ReturnsWhen_ShouldOnlyUseValueWhenPredicateIsTrue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.ReadOnly
+				.Returns(() => 4).When(i => i > 0);
+
+			int result1 = sut.ReadOnly;
+			int result2 = sut.ReadOnly;
+
+			await That(result1).IsEqualTo(0);
+			await That(result2).IsEqualTo(4);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_ReturnsCallbackWithValue_ShouldReturnExpectedValue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.ReadOnly
+				.InitializeWith(3)
+				.Returns(x => 4 * x);
+
+			int result = sut.ReadOnly;
+
+			await That(result).IsEqualTo(12);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_Throws_ShouldIterateThroughAllRegisteredExceptions()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.ReadOnly
+				.Throws<InvalidOperationException>()
+				.Throws(new Exception("foo"))
+				.Throws(() => new Exception("bar"))
+				.Throws(v => new Exception($"baz-{v}"));
+
+			void Act() => _ = sut.ReadOnly;
+
+			await That(Act).Throws<InvalidOperationException>();
+			Exception? result2 = Record.Exception(Act);
+			Exception? result3 = Record.Exception(Act);
+			Exception? result4 = Record.Exception(Act);
+			await That(result2).HasMessage("foo");
+			await That(result3).HasMessage("bar");
+			await That(result4).HasMessage("baz-0");
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_OnGetChain_ShouldStayOnGetterOnlySurface()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			IPropertyGetterOnlySetup<int> chained = sut.Mock.Setup.ReadOnly
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2 += 1 + v; }).OnlyOnce();
+			chained.Register();
+
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+
+			await That(callCount1).IsEqualTo(3);
+			await That(callCount2).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_OnGetWhen_ShouldOnlyInvokeCallbackWhenPredicateIsTrue()
+		{
+			int callCount = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.ReadOnly
+				.OnGet.Do(() => { callCount++; }).When(i => i > 0);
+
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+
+			await That(callCount).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_OnGetInParallel_ShouldInvokeParallelCallbacksAlways()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			int callCount3 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.ReadOnly
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(v => { callCount2++; }).InParallel()
+				.OnGet.Do((i, v) => { callCount3++; });
+
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+			_ = sut.ReadOnly;
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(4);
+			await That(callCount3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_OnGetFor_ShouldRepeatCallbackTheGivenNumberOfTimes()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.ReadOnly
+				.OnGet.Do(() => { callCount1++; }).For(2)
+				.OnGet.Do(() => { callCount2++; });
+
+			for (int i = 0; i < 6; i++)
+			{
+				_ = sut.ReadOnly;
+			}
+
+			await That(callCount1).IsEqualTo(4);
+			await That(callCount2).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_OnGetTransitionTo_ShouldSwitchScenario()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.InScenario("a").Setup.ReadOnly
+				.OnGet.Do(() => { })
+				.OnGet.TransitionTo("b");
+			sut.Mock.TransitionTo("a");
+
+			_ = sut.ReadOnly;
+
+			await That(((IMock)sut).MockRegistry.Scenario).IsEqualTo("b");
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_OnSetChain_ShouldStayOnSetterOnlySurface()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			IPropertySetterOnlySetup<string> chained = sut.Mock.Setup.WriteOnly
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do(v => { callCount2++; }).OnlyOnce();
+			chained.Register();
+
+			sut.WriteOnly = "a";
+			sut.WriteOnly = "b";
+			sut.WriteOnly = "c";
+			sut.WriteOnly = "d";
+
+			await That(callCount1).IsEqualTo(3);
+			await That(callCount2).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_OnSetWhen_ShouldOnlyInvokeCallbackWhenPredicateIsTrue()
+		{
+			int callCount = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.WriteOnly
+				.OnSet.Do(() => { callCount++; }).When(i => i > 0);
+
+			sut.WriteOnly = "a";
+			sut.WriteOnly = "b";
+			sut.WriteOnly = "c";
+
+			await That(callCount).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_OnSetInParallel_ShouldInvokeParallelCallbacksAlways()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			int callCount3 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.WriteOnly
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((i, v) => { callCount2++; }).InParallel()
+				.OnSet.Do(() => { callCount3++; });
+
+			sut.WriteOnly = "a";
+			sut.WriteOnly = "b";
+			sut.WriteOnly = "c";
+			sut.WriteOnly = "d";
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(4);
+			await That(callCount3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_OnSetFor_ShouldRepeatCallbackTheGivenNumberOfTimes()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup.WriteOnly
+				.OnSet.Do(() => { callCount1++; }).For(2)
+				.OnSet.Do(() => { callCount2++; });
+
+			for (int i = 0; i < 6; i++)
+			{
+				sut.WriteOnly = "a";
+			}
+
+			await That(callCount1).IsEqualTo(4);
+			await That(callCount2).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_OnSetTransitionTo_ShouldSwitchScenario()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.InScenario("a").Setup.WriteOnly
+				.OnSet.Do(() => { })
+				.OnSet.TransitionTo("b");
+			sut.Mock.TransitionTo("a");
+
+			sut.WriteOnly = "x";
+
+			await That(((IMock)sut).MockRegistry.Scenario).IsEqualTo("b");
 		}
 
 		public interface IAccessorService

--- a/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.AccessorRestrictedTests.cs
+++ b/Tests/Mockolate.Tests/MockProperties/SetupPropertyTests.AccessorRestrictedTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+
+namespace Mockolate.Tests.MockProperties;
+
+public sealed partial class SetupPropertyTests
+{
+	public sealed class AccessorRestrictedTests
+	{
+		[Fact]
+		public async Task SetOnlyProperty_OnSet_ShouldFireAndRecordTheWrite()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			List<string> written = new();
+			sut.Mock.Setup.WriteOnly.OnSet.Do(value => written.Add(value));
+
+			sut.WriteOnly = "Ada";
+
+			await That(written).IsEqualTo(["Ada",]);
+			await That(sut.Mock.Verify.WriteOnly.Set("Ada")).Once()
+				.Because("the setter facade must be keyed on the setter member id, not the getter's");
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_VerifyOtherValue_ShouldNotMatch()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+
+			sut.WriteOnly = "Ada";
+
+			await That(sut.Mock.Verify.WriteOnly.Set("Grace")).Never();
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_VerifyWithParameterMatcher_ShouldMatch()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+
+			sut.WriteOnly = "Ada";
+
+			await That(sut.Mock.Verify.WriteOnly.Set(It.IsAny<string>())).Once();
+		}
+
+		[Fact]
+		public async Task SetOnlyProperty_Register_ShouldAllowWriteWithoutSetup()
+		{
+			IAccessorService sut = IAccessorService.CreateMock(MockBehavior.Default.ThrowingWhenNotSetup());
+			sut.Mock.Setup.WriteOnly.Register();
+
+			void Act() => sut.WriteOnly = "Ada";
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task GetOnlyProperty_Register_ShouldAllowReadWithoutSetup()
+		{
+			IAccessorService sut = IAccessorService.CreateMock(MockBehavior.Default.ThrowingWhenNotSetup());
+			sut.Mock.Setup.ReadOnly.Register();
+
+			int result = sut.ReadOnly;
+
+			await That(result).IsEqualTo(0);
+			await That(sut.Mock.Verify.ReadOnly.Got()).Once();
+		}
+
+		[Theory]
+		[InlineData(false, 1)]
+		[InlineData(true, 0)]
+		public async Task SetOnlyClassProperty_ShouldSkipCallingBaseWhenRequested(bool skipBaseClass,
+			int expectedCallCount)
+		{
+			AccessorService sut = AccessorService.CreateMock();
+			sut.Mock.Setup.WriteOnly.SkippingBaseClass(skipBaseClass);
+
+			sut.WriteOnly = 1;
+
+			await That(sut.WriteOnlySetterCallCount).IsEqualTo(expectedCallCount);
+		}
+
+		public interface IAccessorService
+		{
+			int ReadOnly { get; }
+			string WriteOnly { set; }
+		}
+
+		public class AccessorService
+		{
+			public int WriteOnlySetterCallCount { get; private set; }
+
+			public virtual int WriteOnly
+			{
+				set => WriteOnlySetterCallCount += value;
+			}
+		}
+	}
+}


### PR DESCRIPTION
A generated mock advertised setup and verification for both accessors of every property, even when it intercepted only one. For a get-only property

```csharp
    int RemainingBars { get; }
```

`Setup.RemainingBars.OnSet` and `Verify.RemainingBars.Set(3)` compiled and silently did nothing: no setter body is emitted, so a write can never be recorded and the verification could only ever report zero.

The generator now picks the facade from the accessors it actually emits a body for:

- IPropertyGetterOnlySetup<T> / IPropertySetterOnlySetup<T> replace PropertySetup<T> on the setup surface.
- VerificationPropertyGetterResult<TSubject> and VerificationPropertySetterResult<TSubject, TParameter> replace VerificationPropertyResult<TSubject, TParameter> on the verify surface, each taking only the member id of the accessor it exposes.

GetInterceptedAccessors is the single classification behind all three decisions, keyed on the same Getter/Setter nullity that guards body emission, so the surface cannot drift from what the proxy intercepts.

This also completes the cross-assembly case from #828: a property such as `{ get; internal set; }` whose setter is invisible to the mock's assembly now narrows to the getter instead of offering a write that never arrives.

BREAKING CHANGE: on a property the mock reads or writes but not both, `Setup.X.OnSet`/`OnGet`, `Setup.X.Returns`/`Throws`/`InitializeWith` and `Verify.X.Set(...)`/`Got()` no longer compile for the absent accessor. Each previously compiled and silently had no effect. The library API is additive; only generated mock surfaces narrow.

The restriction survives chaining: the narrowed setup facades have their own fluent builder hierarchies (`IPropertyGetterOnlySetupReturnBuilder<T>`, `IPropertyGetterOnlySetupCallbackBuilder<T>`, `IPropertySetterOnlySetupCallbackBuilder<T>` and their When/Parallel stages, including Forever/OnlyOnce), so chaining past Returns/Throws/Do/TransitionTo can never reach the accessor the mock does not intercept. The verify facades have no continuation and are likewise fully restricted. Indexers and init-only properties keep the full surface.