### PR TITLE
feat!: only expose indexer accessors the mock intercepts

### DIFF
--- a/Docs/pages/08-analyzers.md
+++ b/Docs/pages/08-analyzers.md
@@ -68,8 +68,9 @@ The same applies per accessor. For a property whose accessors differ in accessib
 inaccessible half. The mock then overrides the accessor it can see and leaves the other one to the
 referenced assembly's implementation. Because writes never reach the mock, `Setup` and `Verify` expose
 only the getter for such a property, so a write that could never be recorded is not offered for
-configuration or verification. See
-[properties with only one accessor](setup/properties#properties-with-only-one-accessor) for details.
+configuration or verification. The same narrowing applies to indexers. See
+[properties with only one accessor](setup/properties#properties-with-only-one-accessor) and
+[indexers with only one accessor](setup/indexers#indexers-with-only-one-accessor) for details.
 
 ## Mockolate0003
 

--- a/Docs/pages/setup/03-indexers.md
+++ b/Docs/pages/setup/03-indexers.md
@@ -73,6 +73,54 @@ sut.Mock.Setup[It.IsAny<string>()].OnGet
     .Do(() => Console.WriteLine("Execute on all odd read interactions"));
 ```
 
+## Indexers with only one accessor
+
+The setup and verify surfaces only offer the accessors the mock actually intercepts.
+`SkippingBaseClass(…)` stays available on both, but the accessor-specific members do not: a get-only
+indexer has no `OnSet`, and a set-only indexer has neither `OnGet` nor the `Returns`/`Throws`
+read-sequence nor `InitializeWith`, since there is no getter to read the value back.
+
+```csharp
+public interface IChocolateStorage
+{
+    int this[string shelf] { get; }    // no setter
+    string this[int box] { set; }      // no getter
+}
+
+IChocolateStorage sut = IChocolateStorage.CreateMock();
+
+sut.Mock.Setup[It.IsAny<string>()].Returns(3);
+sut.Mock.Setup[It.IsAny<string>()].OnSet…                 // does not compile
+sut.Mock.Setup[It.IsAny<string>()].Returns(3).OnSet…      // does not compile
+
+sut.Mock.Setup[It.IsAny<int>()].OnSet.Do(value => { });
+sut.Mock.Setup[It.IsAny<int>()].Returns("Ada")…           // does not compile
+sut.Mock.Setup[It.IsAny<int>()].InitializeWith("Ada")…    // does not compile
+sut.Mock.Setup[It.IsAny<int>()].OnSet.Do(value => { }).OnGet… // does not compile
+```
+
+The verify facade likewise offers the intercepted accessor only:
+
+```csharp
+_ = sut["top"];
+sut[7] = "Ada";
+
+await That(sut.Mock.Verify[It.Is("top")].Got()).Once();
+await That(sut.Mock.Verify[It.Is(7)].Set("Ada")).Once();
+
+sut.Mock.Verify[It.Is("top")].Set(3)…                     // does not compile
+sut.Mock.Verify[It.Is(7)].Got()…                          // does not compile
+```
+
+This also applies when the indexer declares an accessor the mock cannot see, such as
+`{ get; internal set; }` on a type from an assembly that does not grant `InternalsVisibleTo`. Writes
+never reach the mock in that case, so configuring or verifying one could only ever report zero
+interactions.
+
+Both facades are fully restricted: the fluent builders returned by `Returns`, `Throws`, `Do` and
+`TransitionTo` stay on the narrowed surface, so no amount of chaining reaches the accessor the mock
+does not intercept. Indexers with more than four keys keep the full surface.
+
 **Notes:**
 
 - All callbacks support more advanced features like conditional execution, frequency control, parallel execution, and

--- a/Docs/pages/setup/03-indexers.md
+++ b/Docs/pages/setup/03-indexers.md
@@ -115,7 +115,7 @@ sut.Mock.Verify[It.Is(7)].Got()…                          // does not compile
 This also applies when the indexer declares an accessor the mock cannot see, such as
 `{ get; internal set; }` on a type from an assembly that does not grant `InternalsVisibleTo`. Writes
 never reach the mock in that case, so configuring or verifying one could only ever report zero
-interactions.
+interactions. See [Mockolate0002](../analyzers#mockolate0002) for when such a type is mockable at all.
 
 Both facades are fully restricted: the fluent builders returned by `Returns`, `Throws`, `Do` and
 `TransitionTo` stay on the narrowed surface, so no amount of chaining reaches the accessor the mock

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3190,6 +3190,63 @@ internal static partial class Sources
 			_ => $"global::Mockolate.Verify.VerificationPropertyResult<{verifyName}, {property.Type.Fullname}>",
 		};
 
+	/// <summary>
+	///     Which accessors of the <paramref name="indexer" /> the narrowed setup/verify facades follow. The
+	///     narrowed indexer types only exist for up to <see cref="MaxExplicitParameters" /> keys, so indexers
+	///     with more keys keep the full surface regardless of <see cref="GetInterceptedAccessors" />.
+	/// </summary>
+	private static PropertyAccessors GetIndexerInterceptedAccessors(Property indexer)
+		=> indexer.IndexerParameters!.Value.Count <= MaxExplicitParameters
+			? GetInterceptedAccessors(indexer)
+			: PropertyAccessors.Both;
+
+	/// <summary>
+	///     The open-generic setup facade emitted for the <paramref name="indexer" />, narrowed to the accessors
+	///     classified by <see cref="GetIndexerInterceptedAccessors" />. The caller appends the value and key type
+	///     arguments and the closing angle bracket.
+	/// </summary>
+	private static string GetIndexerSetupType(Property indexer)
+		=> GetIndexerInterceptedAccessors(indexer) switch
+		{
+			PropertyAccessors.GetOnly => "global::Mockolate.Setup.IIndexerGetterOnlySetup<",
+			PropertyAccessors.SetOnly => "global::Mockolate.Setup.IIndexerSetterOnlySetup<",
+			_ => "global::Mockolate.Setup.IndexerSetup<",
+		};
+
+	/// <summary>
+	///     Appends the verify facade emitted for the <paramref name="indexer" />, narrowed to the accessors
+	///     classified by <see cref="GetIndexerInterceptedAccessors" />. The narrowed results are keyed by the
+	///     indexer parameters, the full <c>VerificationIndexerResult</c> only by the value type.
+	/// </summary>
+	private static void AppendIndexerVerifyType(StringBuilder sb, Property indexer, string verifyName)
+	{
+		switch (GetIndexerInterceptedAccessors(indexer))
+		{
+			case PropertyAccessors.GetOnly:
+				sb.Append("global::Mockolate.Verify.VerificationIndexerGetterResult<").Append(verifyName);
+				foreach (MethodParameter parameter in indexer.IndexerParameters!.Value)
+				{
+					sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
+				}
+
+				sb.Append('>');
+				break;
+			case PropertyAccessors.SetOnly:
+				sb.Append("global::Mockolate.Verify.VerificationIndexerSetterResult<").Append(verifyName);
+				foreach (MethodParameter parameter in indexer.IndexerParameters!.Value)
+				{
+					sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
+				}
+
+				sb.Append(", ").AppendTypeOrWrapper(indexer.Type).Append('>');
+				break;
+			default:
+				sb.Append("global::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName).Append(", ")
+					.AppendTypeOrWrapper(indexer.Type).Append('>');
+				break;
+		}
+	}
+
 	private static void DefineSetupInterface(StringBuilder sb, Class @class, MemberType memberType,
 		bool hasOverloadResolutionPriority)
 	{
@@ -4222,7 +4279,7 @@ internal static partial class Sources
 				.Append(valueFlags?.Count(x => !x).ToString() ?? "int.MaxValue").Append(")]").AppendLine();
 		}
 
-		sb.Append("\t\tglobal::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(indexer.Type);
+		sb.Append("\t\t").Append(GetIndexerSetupType(indexer)).AppendTypeOrWrapper(indexer.Type);
 		foreach (MethodParameter parameter in indexer.IndexerParameters!)
 		{
 			sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
@@ -4299,7 +4356,7 @@ internal static partial class Sources
 		sb.Append(
 				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
 			.AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Setup.IndexerSetup<").AppendTypeOrWrapper(indexer.Type);
+		sb.Append("\t\t").Append(GetIndexerSetupType(indexer)).AppendTypeOrWrapper(indexer.Type);
 		foreach (MethodParameter parameter in indexer.IndexerParameters!)
 		{
 			sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
@@ -4675,8 +4732,9 @@ internal static partial class Sources
 				.Append(valueFlags?.Count(x => !x).ToString() ?? "int.MaxValue").Append(")]").AppendLine();
 		}
 
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName).Append(", ")
-			.AppendTypeOrWrapper(indexer.Type).Append("> this[");
+		sb.Append("\t\t");
+		AppendIndexerVerifyType(sb, indexer, verifyName);
+		sb.Append(" this[");
 		int i = 0;
 		foreach (MethodParameter parameter in indexer.IndexerParameters!.Value)
 		{
@@ -4731,8 +4789,9 @@ internal static partial class Sources
 		sb.Append(
 				"\t\t[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]")
 			.AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName).Append(", ")
-			.AppendTypeOrWrapper(indexer.Type).Append("> ").Append(verifyName).Append(".this[");
+		sb.Append("\t\t");
+		AppendIndexerVerifyType(sb, indexer, verifyName);
+		sb.Append(' ').Append(verifyName).Append(".this[");
 		int i = 0;
 		foreach (MethodParameter parameter in indexer.IndexerParameters!.Value)
 		{
@@ -4767,14 +4826,35 @@ internal static partial class Sources
 		bool useTypedVerify = indexer.IndexerParameters.Value.Count is >= 1 and <= 4;
 		if (useTypedVerify)
 		{
-			sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName);
+			PropertyAccessors interceptedAccessors = GetIndexerInterceptedAccessors(indexer);
+			string typedVerifyType = interceptedAccessors switch
+			{
+				PropertyAccessors.GetOnly => "VerificationIndexerGetterResult",
+				PropertyAccessors.SetOnly => "VerificationIndexerSetterResult",
+				_ => "VerificationIndexerResult",
+			};
+			// The narrow views take only the member id of the accessor they expose.
+			string verifyMemberIds = interceptedAccessors switch
+			{
+				PropertyAccessors.GetOnly => indexerGetMemberId,
+				PropertyAccessors.SetOnly => indexerSetMemberId,
+				_ => $"{indexerGetMemberId}, {indexerSetMemberId}",
+			};
+			sb.Append("\t\t\t\treturn new global::Mockolate.Verify.").Append(typedVerifyType).Append('<')
+				.Append(verifyName);
 			foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
 			{
 				sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
 			}
 
-			sb.Append(", ").AppendTypeOrWrapper(indexer.Type).Append(">(this, this.").Append(mockRegistryName)
-				.Append(", ").Append(indexerGetMemberId).Append(", ").Append(indexerSetMemberId).Append(",").AppendLine();
+			// Only Set(...) needs the value type, so the getter-only result is keyed by the parameters alone.
+			if (interceptedAccessors != PropertyAccessors.GetOnly)
+			{
+				sb.Append(", ").AppendTypeOrWrapper(indexer.Type);
+			}
+
+			sb.Append(">(this, this.").Append(mockRegistryName)
+				.Append(", ").Append(verifyMemberIds).Append(",").AppendLine();
 
 			AppendIndexerVerifyTypedMatches(sb, indexer.IndexerParameters.Value, valueFlags);
 		}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3216,7 +3216,8 @@ internal static partial class Sources
 	/// <summary>
 	///     Appends the verify facade emitted for the <paramref name="indexer" />, narrowed to the accessors
 	///     classified by <see cref="GetIndexerInterceptedAccessors" />. The narrowed results are keyed by the
-	///     indexer parameters, the full <c>VerificationIndexerResult</c> only by the value type.
+	///     indexer parameters (the setter result additionally by the value type), the full
+	///     <c>VerificationIndexerResult</c> only by the value type.
 	/// </summary>
 	private static void AppendIndexerVerifyType(StringBuilder sb, Property indexer, string verifyName)
 	{

--- a/Source/Mockolate/Setup/IndexerSetup.cs
+++ b/Source/Mockolate/Setup/IndexerSetup.cs
@@ -133,7 +133,11 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 		IIndexerSetupWithCallback<TValue, T1>,
 		IIndexerGetterSetupCallbackBuilder<TValue, T1>, IIndexerSetterSetupCallbackBuilder<TValue, T1>,
 		IIndexerSetupReturnBuilder<TValue, T1>,
-		IIndexerGetterSetupWithCallback<TValue, T1>, IIndexerSetterSetupWithCallback<TValue, T1>
+		IIndexerGetterSetupWithCallback<TValue, T1>, IIndexerSetterSetupWithCallback<TValue, T1>,
+		IIndexerGetterOnlySetup<TValue, T1>, IIndexerSetterOnlySetup<TValue, T1>,
+		IIndexerGetterOnlyGetterSetup<TValue, T1>, IIndexerSetterOnlySetterSetup<TValue, T1>,
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1>, IIndexerSetterOnlySetupCallbackBuilder<TValue, T1>,
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1>
 {
 	private Callbacks<Action<int, T1, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, TValue, TValue>>? _returnCallbacks;
@@ -716,6 +720,272 @@ public class IndexerSetup<TValue, T1>(MockRegistry mockRegistry, IParameterMatch
 		p1 = default!;
 		return false;
 	}
+
+	#region Accessor-restricted views
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.InitializeWith(TValue)" />
+	IIndexerGetterOnlySetup<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.InitializeWith(TValue value)
+	{
+		InitializeWith(value);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.InitializeWith(Func{T1, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.InitializeWith(Func<T1, TValue> valueGenerator)
+	{
+		InitializeWith(valueGenerator);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.OnGet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> IIndexerGetterOnlyGetterSetup<TValue, T1>.Do(Action callback)
+	{
+		((IIndexerGetterSetup<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1}.Do(Action{T1})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> IIndexerGetterOnlyGetterSetup<TValue, T1>.Do(Action<T1> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1}.Do(Action{T1, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> IIndexerGetterOnlyGetterSetup<TValue, T1>.Do(
+		Action<T1, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1}.Do(Action{int, T1, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> IIndexerGetterOnlyGetterSetup<TValue, T1>.Do(
+		Action<int, T1, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> IIndexerGetterOnlyGetterSetup<TValue, T1>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerGetterSetup<TValue, T1>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackBuilder{TValue, T1}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> IIndexerGetterOnlySetupCallbackBuilder<TValue, T1>.InParallel()
+	{
+		((IIndexerGetterSetupCallbackBuilder<TValue, T1>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>.For(
+		int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>.Only(int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Returns(TValue returnValue)
+	{
+		Returns(returnValue);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Returns(Func<TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Returns(Func{T1, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Returns(Func<T1, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Returns(Func{T1, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Returns(
+		Func<T1, TValue, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Throws<TException>()
+	{
+		Throws<TException>();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Throws(Exception exception)
+	{
+		Throws(exception);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Throws(Func<Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Throws(Func{T1, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Throws(
+		Func<T1, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1}.Throws(Func{T1, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> IIndexerGetterOnlySetup<TValue, T1>.Throws(
+		Func<T1, TValue, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> IIndexerGetterOnlySetupReturnBuilder<TValue, T1>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetupReturnBuilder<TValue, T1>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>.For(
+		int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>.Only(int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1> IIndexerSetterOnlySetup<TValue, T1>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1> IIndexerSetterOnlySetup<TValue, T1>.OnSet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> IIndexerSetterOnlySetterSetup<TValue, T1>.Do(Action callback)
+	{
+		((IIndexerSetterSetup<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> IIndexerSetterOnlySetterSetup<TValue, T1>.Do(
+		Action<TValue> callback)
+	{
+		((IIndexerSetterSetup<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1}.Do(Action{T1, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> IIndexerSetterOnlySetterSetup<TValue, T1>.Do(
+		Action<T1, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1}.Do(Action{int, T1, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> IIndexerSetterOnlySetterSetup<TValue, T1>.Do(
+		Action<int, T1, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> IIndexerSetterOnlySetterSetup<TValue, T1>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerSetterSetup<TValue, T1>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackBuilder{TValue, T1}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> IIndexerSetterOnlySetupCallbackBuilder<TValue, T1>.InParallel()
+	{
+		((IIndexerSetterSetupCallbackBuilder<TValue, T1>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>.For(
+		int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>.Only(int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>)this).Only(times);
+		return this;
+	}
+
+	#endregion Accessor-restricted views
 }
 
 /// <summary>
@@ -731,7 +1001,11 @@ public class IndexerSetup<TValue, T1, T2>(
 	IIndexerSetupWithCallback<TValue, T1, T2>,
 	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>,
 	IIndexerSetupReturnBuilder<TValue, T1, T2>,
-	IIndexerGetterSetupWithCallback<TValue, T1, T2>, IIndexerSetterSetupWithCallback<TValue, T1, T2>
+	IIndexerGetterSetupWithCallback<TValue, T1, T2>, IIndexerSetterSetupWithCallback<TValue, T1, T2>,
+	IIndexerGetterOnlySetup<TValue, T1, T2>, IIndexerSetterOnlySetup<TValue, T1, T2>,
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2>, IIndexerSetterOnlySetterSetup<TValue, T1, T2>,
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2>, IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2>,
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2>
 {
 	private Callbacks<Action<int, T1, T2, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, T2, TValue, TValue>>? _returnCallbacks;
@@ -1321,6 +1595,272 @@ public class IndexerSetup<TValue, T1, T2>(
 		p2 = default!;
 		return false;
 	}
+
+	#region Accessor-restricted views
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.InitializeWith(TValue)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.InitializeWith(TValue value)
+	{
+		InitializeWith(value);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.InitializeWith(Func{T1, T2, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.InitializeWith(Func<T1, T2, TValue> valueGenerator)
+	{
+		InitializeWith(valueGenerator);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.OnGet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerGetterOnlyGetterSetup<TValue, T1, T2>.Do(Action callback)
+	{
+		((IIndexerGetterSetup<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2}.Do(Action{T1, T2})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerGetterOnlyGetterSetup<TValue, T1, T2>.Do(Action<T1, T2> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerGetterOnlyGetterSetup<TValue, T1, T2>.Do(
+		Action<T1, T2, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerGetterOnlyGetterSetup<TValue, T1, T2>.Do(
+		Action<int, T1, T2, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> IIndexerGetterOnlyGetterSetup<TValue, T1, T2>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerGetterSetup<TValue, T1, T2>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2>.InParallel()
+	{
+		((IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>.For(
+		int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>.Only(int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Returns(TValue returnValue)
+	{
+		Returns(returnValue);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Returns(Func<TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Returns(Func{T1, T2, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Returns(Func<T1, T2, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Returns(Func{T1, T2, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Returns(
+		Func<T1, T2, TValue, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Throws<TException>()
+	{
+		Throws<TException>();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Throws(Exception exception)
+	{
+		Throws(exception);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Throws(Func<Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Throws(Func{T1, T2, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Throws(
+		Func<T1, T2, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2}.Throws(Func{T1, T2, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> IIndexerGetterOnlySetup<TValue, T1, T2>.Throws(
+		Func<T1, T2, TValue, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetupReturnBuilder<TValue, T1, T2>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>.For(
+		int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1, T2>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>.Only(int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1, T2>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2> IIndexerSetterOnlySetup<TValue, T1, T2>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1, T2> IIndexerSetterOnlySetup<TValue, T1, T2>.OnSet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerSetterOnlySetterSetup<TValue, T1, T2>.Do(Action callback)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerSetterOnlySetterSetup<TValue, T1, T2>.Do(
+		Action<TValue> callback)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerSetterOnlySetterSetup<TValue, T1, T2>.Do(
+		Action<T1, T2, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> IIndexerSetterOnlySetterSetup<TValue, T1, T2>.Do(
+		Action<int, T1, T2, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1, T2>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> IIndexerSetterOnlySetterSetup<TValue, T1, T2>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2>.InParallel()
+	{
+		((IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>.For(
+		int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>.Only(int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>)this).Only(times);
+		return this;
+	}
+
+	#endregion Accessor-restricted views
 }
 
 /// <summary>
@@ -1338,7 +1878,11 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 	IIndexerSetupWithCallback<TValue, T1, T2, T3>,
 	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>,
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3>,
-	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>
+	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>,
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3>, IIndexerSetterOnlySetup<TValue, T1, T2, T3>,
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>, IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>,
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>, IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>,
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3>
 {
 	private Callbacks<Action<int, T1, T2, T3, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, T2, T3, TValue, TValue>>? _returnCallbacks;
@@ -1943,6 +2487,272 @@ public class IndexerSetup<TValue, T1, T2, T3>(
 		p3 = default!;
 		return false;
 	}
+
+	#region Accessor-restricted views
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.InitializeWith(TValue)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.InitializeWith(TValue value)
+	{
+		InitializeWith(value);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.InitializeWith(Func{T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.InitializeWith(Func<T1, T2, T3, TValue> valueGenerator)
+	{
+		InitializeWith(valueGenerator);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.OnGet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>.Do(Action callback)
+	{
+		((IIndexerGetterSetup<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>.Do(Action<T1, T2, T3> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>.Do(
+		Action<T1, T2, T3, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>.Do(
+		Action<int, T1, T2, T3, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerGetterSetup<TValue, T1, T2, T3>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>.InParallel()
+	{
+		((IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>.For(
+		int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>.Only(int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Returns(TValue returnValue)
+	{
+		Returns(returnValue);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Returns(Func<TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Returns(Func{T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Returns(Func<T1, T2, T3, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Returns(Func{T1, T2, T3, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Returns(
+		Func<T1, T2, T3, TValue, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Throws<TException>()
+	{
+		Throws<TException>();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Throws(Exception exception)
+	{
+		Throws(exception);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Throws(Func<Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Throws(Func{T1, T2, T3, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Throws(
+		Func<T1, T2, T3, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}.Throws(Func{T1, T2, T3, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetup<TValue, T1, T2, T3>.Throws(
+		Func<T1, T2, T3, TValue, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetupReturnBuilder<TValue, T1, T2, T3>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2, T3}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>.For(
+		int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2, T3}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>.Only(int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3> IIndexerSetterOnlySetup<TValue, T1, T2, T3>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3> IIndexerSetterOnlySetup<TValue, T1, T2, T3>.OnSet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>.Do(Action callback)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>.Do(
+		Action<TValue> callback)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>.Do(
+		Action<T1, T2, T3, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>.Do(
+		Action<int, T1, T2, T3, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2, T3>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>.InParallel()
+	{
+		((IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>.For(
+		int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>.Only(int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>)this).Only(times);
+		return this;
+	}
+
+	#endregion Accessor-restricted views
 }
 
 /// <summary>
@@ -1961,7 +2771,12 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 	IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>,
 	IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>,
 	IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>,
-	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>
+	IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>,
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>, IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>,
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>, IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>,
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>,
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>,
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4>
 {
 	private Callbacks<Action<int, T1, T2, T3, T4, TValue>>? _getterCallbacks;
 	private Callbacks<Func<int, T1, T2, T3, T4, TValue, TValue>>? _returnCallbacks;
@@ -2575,4 +3390,270 @@ public class IndexerSetup<TValue, T1, T2, T3, T4>(
 		p4 = default!;
 		return false;
 	}
+
+	#region Accessor-restricted views
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.InitializeWith(TValue)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.InitializeWith(TValue value)
+	{
+		InitializeWith(value);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.InitializeWith(Func{T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.InitializeWith(Func<T1, T2, T3, T4, TValue> valueGenerator)
+	{
+		InitializeWith(valueGenerator);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.OnGet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
+	{
+		((IIndexerGetterSetup<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>.Do(Action<T1, T2, T3, T4> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<T1, T2, T3, T4, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<int, T1, T2, T3, T4, TValue> callback)
+	{
+		((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerGetterSetup<TValue, T1, T2, T3, T4>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackBuilder{TValue, T1, T2, T3, T4}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>.InParallel()
+	{
+		((IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.For(
+		int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
+	{
+		((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Returns(TValue returnValue)
+	{
+		Returns(returnValue);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Returns(Func<TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Returns(Func{T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Returns(Func<T1, T2, T3, T4, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Returns(Func{T1, T2, T3, T4, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Returns(
+		Func<T1, T2, T3, T4, TValue, TValue> callback)
+	{
+		Returns(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Throws<TException>()
+	{
+		Throws<TException>();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Throws(Exception exception)
+	{
+		Throws(exception);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Throws(Func<Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Throws(Func{T1, T2, T3, T4, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Throws(
+		Func<T1, T2, T3, T4, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}.Throws(Func{T1, T2, T3, T4, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>.Throws(
+		Func<T1, T2, T3, T4, TValue, Exception> callback)
+	{
+		Throws(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2, T3, T4}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>.For(
+		int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2, T3, T4}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
+	{
+		((IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>)this).Only(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3, T4}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>.SkippingBaseClass(bool skipBaseClass)
+	{
+		SkippingBaseClass(skipBaseClass);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3, T4}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>.OnSet
+		=> this;
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>.Do(Action callback)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<TValue> callback)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<T1, T2, T3, T4, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>.Do(
+		Action<int, T1, T2, T3, T4, TValue> callback)
+	{
+		((IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>)this).Do(callback);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>.TransitionTo(
+		string scenario)
+	{
+		((IIndexerSetterSetup<TValue, T1, T2, T3, T4>)this).TransitionTo(scenario);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackBuilder{TValue, T1, T2, T3, T4}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>.InParallel()
+	{
+		((IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>)this).InParallel();
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>.When(
+		Func<int, bool> predicate)
+	{
+		((IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>)this).When(predicate);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.For(
+		int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>)this).For(times);
+		return this;
+	}
+
+	/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>.Only(int times)
+	{
+		((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>)this).Only(times);
+		return this;
+	}
+
+	#endregion Accessor-restricted views
 }

--- a/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
+++ b/Source/Mockolate/Setup/Interfaces.IndexerSetup.cs
@@ -1456,3 +1456,917 @@ public interface IIndexerSetupReturnWhenBuilder<TValue, out T1, out T2, out T3, 
 	IIndexerSetup<TValue, T1, T2, T3, T4> Only(int times);
 }
 #pragma warning restore S2436 // Types and methods should not have too many generic parameters
+
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> that the mock only
+///     reads.
+/// </summary>
+/// <remarks>
+///     Used instead of <see cref="IIndexerSetup{TValue, T1}" /> when the mock has no setter to intercept, either
+///     because the indexer is declared without one or because its setter is not accessible from the mock's assembly.
+///     Writes then never reach the mock, so <see cref="IIndexerSetup{TValue, T1}.OnSet" /> is not offered.
+/// </remarks>
+public interface IIndexerGetterOnlySetup<TValue, out T1>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1> OnGet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.InitializeWith(TValue)" />
+	/// <remarks>
+	///     Seeds the value that reads return. Unlike a read-write indexer there is no setter to update the
+	///     slot afterwards, so it stays at <paramref name="value" /> unless a <c>Returns</c> entry applies.
+	/// </remarks>
+	IIndexerGetterOnlySetup<TValue, T1> InitializeWith(TValue value);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1}.InitializeWith(Func{T1, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1> InitializeWith(Func<T1, TValue> valueGenerator);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(Func<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1}.Returns(Func{T1, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1}.Returns(Func{T1, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(Func<T1, TValue, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws<TException>()
+		where TException : Exception, new();
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(Exception exception);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(Func<Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1}.Throws(Func{T1, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(Func<T1, Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1}.Throws(Func{T1, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(Func<T1, TValue, Exception> callback);
+}
+
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> that the mock only
+///     writes.
+/// </summary>
+/// <remarks>
+///     The write-only counterpart of <see cref="IIndexerGetterOnlySetup{TValue, T1}" />: the mock has no getter to
+///     intercept, so <see cref="IIndexerSetup{TValue, T1}.OnGet" />, <c>InitializeWith</c> and the
+///     <c>Returns</c>/<c>Throws</c> read-sequence are not offered.
+/// </remarks>
+public interface IIndexerSetterOnlySetup<TValue, out T1>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1> OnSet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the getter of a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerGetterSetupWithCallback{TValue, T1}" /> for
+///     <see cref="IIndexerGetterOnlySetup{TValue, T1}" />: the returned builders stay on the getter-only surface,
+///     so chaining can never reach <see cref="IIndexerSetup{TValue, T1}.OnSet" />.
+/// </remarks>
+public interface IIndexerGetterOnlyGetterSetup<TValue, out T1>
+{
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1}.Do(Action{T1})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(Action<T1> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1}.Do(Action{T1, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1}.Do(Action{int, T1, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1>
+	: IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel callback for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1>
+	: IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1>
+	: IIndexerGetterOnlySetup<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+}
+
+/// <summary>
+///     Sets up a return/throw builder for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1>
+	: IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when builder for returns/throws for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1>
+	: IIndexerGetterOnlySetup<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the setter of a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerSetterSetupWithCallback{TValue, T1}" /> for
+///     <see cref="IIndexerSetterOnlySetup{TValue, T1}" />: the returned builders stay on the setter-only surface,
+///     so chaining can never reach <see cref="IIndexerSetup{TValue, T1}.OnGet" /> or the
+///     <c>Returns</c>/<c>Throws</c> read-sequence.
+/// </remarks>
+public interface IIndexerSetterOnlySetterSetup<TValue, out T1>
+{
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(Action<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1}.Do(Action{T1, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(Action<T1, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1}.Do(Action{int, T1, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(Action<int, T1, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a setter callback for a set-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1>
+	: IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1>
+	: IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1>
+	: IIndexerSetterOnlySetup<TValue, T1>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1> Only(int times);
+}
+
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
+///     <typeparamref name="T2" /> that the mock only reads.
+/// </summary>
+/// <remarks>
+///     Used instead of <see cref="IIndexerSetup{TValue, T1, T2}" /> when the mock has no setter to intercept, either
+///     because the indexer is declared without one or because its setter is not accessible from the mock's assembly.
+///     Writes then never reach the mock, so <see cref="IIndexerSetup{TValue, T1, T2}.OnSet" /> is not offered.
+/// </remarks>
+public interface IIndexerGetterOnlySetup<TValue, out T1, out T2>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2> OnGet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.InitializeWith(TValue)" />
+	/// <remarks>
+	///     Seeds the value that reads return. Unlike a read-write indexer there is no setter to update the
+	///     slot afterwards, so it stays at <paramref name="value" /> unless a <c>Returns</c> entry applies.
+	/// </remarks>
+	IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(TValue value);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2}.InitializeWith(Func{T1, T2, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(Func<T1, T2, TValue> valueGenerator);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(Func<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2}.Returns(Func{T1, T2, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2}.Returns(Func{T1, T2, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(Func<T1, T2, TValue, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws<TException>()
+		where TException : Exception, new();
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(Exception exception);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(Func<Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2}.Throws(Func{T1, T2, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2}.Throws(Func{T1, T2, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(Func<T1, T2, TValue, Exception> callback);
+}
+
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
+///     <typeparamref name="T2" /> that the mock only writes.
+/// </summary>
+/// <remarks>
+///     The write-only counterpart of <see cref="IIndexerGetterOnlySetup{TValue, T1, T2}" />: the mock has no getter
+///     to intercept, so <see cref="IIndexerSetup{TValue, T1, T2}.OnGet" />, <c>InitializeWith</c> and the
+///     <c>Returns</c>/<c>Throws</c> read-sequence are not offered.
+/// </remarks>
+public interface IIndexerSetterOnlySetup<TValue, out T1, out T2>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1, T2> OnSet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the getter of a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerGetterSetupWithCallback{TValue, T1, T2}" /> for
+///     <see cref="IIndexerGetterOnlySetup{TValue, T1, T2}" />: the returned builders stay on the getter-only surface,
+///     so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2}.OnSet" />.
+/// </remarks>
+public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2>
+{
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2}.Do(Action{T1, T2})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" /> and
+///     <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel callback for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />
+///     and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2>
+	: IIndexerGetterOnlySetup<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+}
+
+/// <summary>
+///     Sets up a return/throw builder for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2>
+	: IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when builder for returns/throws for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2>
+	: IIndexerGetterOnlySetup<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the setter of a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerSetterSetupWithCallback{TValue, T1, T2}" /> for
+///     <see cref="IIndexerSetterOnlySetup{TValue, T1, T2}" />: the returned builders stay on the setter-only surface,
+///     so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2}.OnGet" /> or the
+///     <c>Returns</c>/<c>Throws</c> read-sequence.
+/// </remarks>
+public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2>
+{
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2}.Do(Action{T1, T2, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action<T1, T2, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2}.Do(Action{int, T1, T2, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(Action<int, T1, T2, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a setter callback for a set-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />
+///     and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1, T2}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2>
+	: IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" /> and <typeparamref name="T2" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2>
+	: IIndexerSetterOnlySetup<TValue, T1, T2>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2> Only(int times);
+}
+
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" /> that the mock only reads.
+/// </summary>
+/// <remarks>
+///     Used instead of <see cref="IIndexerSetup{TValue, T1, T2, T3}" /> when the mock has no setter to intercept,
+///     either because the indexer is declared without one or because its setter is not accessible from the mock's
+///     assembly. Writes then never reach the mock, so <see cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet" /> is not
+///     offered.
+/// </remarks>
+public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.InitializeWith(TValue)" />
+	/// <remarks>
+	///     Seeds the value that reads return. Unlike a read-write indexer there is no setter to update the
+	///     slot afterwards, so it stays at <paramref name="value" /> unless a <c>Returns</c> entry applies.
+	/// </remarks>
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(TValue value);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3}.InitializeWith(Func{T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(Func<T1, T2, T3, TValue> valueGenerator);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3}.Returns(Func{T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3}.Returns(Func{T1, T2, T3, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(Func<T1, T2, T3, TValue, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
+		where TException : Exception, new();
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(Exception exception);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3}.Throws(Func{T1, T2, T3, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3}.Throws(Func{T1, T2, T3, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(Func<T1, T2, T3, TValue, Exception> callback);
+}
+
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" /> that the mock only writes.
+/// </summary>
+/// <remarks>
+///     The write-only counterpart of <see cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}" />: the mock has no
+///     getter to intercept, so <see cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet" />, <c>InitializeWith</c> and the
+///     <c>Returns</c>/<c>Throws</c> read-sequence are not offered.
+/// </remarks>
+public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3> OnSet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the getter of a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3}" /> for
+///     <see cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3}" />: the returned builders stay on the getter-only
+///     surface, so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2, T3}.OnSet" />.
+/// </remarks>
+public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3>
+{
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3}.Do(Action{T1, T2, T3})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel callback for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2, T3}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2, T3}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+}
+
+/// <summary>
+///     Sets up a return/throw builder for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when builder for returns/throws for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2, T3}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2, T3}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the setter of a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3}" /> for
+///     <see cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3}" />: the returned builders stay on the setter-only
+///     surface, so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2, T3}.OnGet" /> or the
+///     <c>Returns</c>/<c>Throws</c> read-sequence.
+/// </remarks>
+public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3>
+{
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3}.Do(Action{T1, T2, T3, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<T1, T2, T3, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3}.Do(Action{int, T1, T2, T3, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(Action<int, T1, T2, T3, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a setter callback for a set-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1, T2, T3}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" /> and <typeparamref name="T3" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3>
+	: IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2, T3}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2, T3}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+}
+
+#pragma warning disable S2436 // Types and methods should not have too many generic parameters
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" /> that the mock only
+///     reads.
+/// </summary>
+/// <remarks>
+///     Used instead of <see cref="IIndexerSetup{TValue, T1, T2, T3, T4}" /> when the mock has no setter to intercept,
+///     either because the indexer is declared without one or because its setter is not accessible from the mock's
+///     assembly. Writes then never reach the mock, so <see cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet" /> is
+///     not offered.
+/// </remarks>
+public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet" />
+	IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.SkippingBaseClass(bool)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.InitializeWith(TValue)" />
+	/// <remarks>
+	///     Seeds the value that reads return. Unlike a read-write indexer there is no setter to update the
+	///     slot afterwards, so it stays at <paramref name="value" /> unless a <c>Returns</c> entry applies.
+	/// </remarks>
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4}.InitializeWith(Func{T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(Func<T1, T2, T3, T4, TValue> valueGenerator);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Returns(TValue)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Returns(Func{TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4}.Returns(Func{T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4}.Returns(Func{T1, T2, T3, T4, TValue, TValue})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(Func<T1, T2, T3, T4, TValue, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws{TException}()" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
+		where TException : Exception, new();
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws(Exception)" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Exception exception);
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.Throws(Func{Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4}.Throws(Func{T1, T2, T3, T4, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, Exception> callback);
+
+	/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4}.Throws(Func{T1, T2, T3, T4, TValue, Exception})" />
+	IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(Func<T1, T2, T3, T4, TValue, Exception> callback);
+}
+
+/// <summary>
+///     Setup for a mocked <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" /> that the mock only
+///     writes.
+/// </summary>
+/// <remarks>
+///     The write-only counterpart of <see cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}" />: the mock has no
+///     getter to intercept, so <see cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet" />, <c>InitializeWith</c> and
+///     the <c>Returns</c>/<c>Throws</c> read-sequence are not offered.
+/// </remarks>
+public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+{
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet" />
+	IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+
+	/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4}.SkippingBaseClass(bool)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the getter of a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" /> and
+///     <typeparamref name="T4" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4}" /> for
+///     <see cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4}" />: the returned builders stay on the getter-only
+///     surface, so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnSet" />.
+/// </remarks>
+public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3, out T4>
+{
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
+	IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4}.TransitionTo(string)" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1, T2, T3, T4}.InParallel()" />
+	IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel callback for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" /> and
+///     <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when callback for a get-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.For(int)" />
+	IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+
+	/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+}
+
+/// <summary>
+///     Sets up a return/throw builder for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" /> and
+///     <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when builder for returns/throws for a get-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" /> and
+///     <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2, T3, T4}.For(int)" />
+	IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2, T3, T4}.Only(int)" />
+	IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+}
+
+/// <summary>
+///     Setup for attaching side-effects to the setter of a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" /> and
+///     <typeparamref name="T4" />.
+/// </summary>
+/// <remarks>
+///     The counterpart of <see cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3, T4}" /> for
+///     <see cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3, T4}" />: the returned builders stay on the setter-only
+///     surface, so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2, T3, T4}.OnGet" /> or the
+///     <c>Returns</c>/<c>Throws</c> read-sequence.
+/// </remarks>
+public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3, out T4>
+{
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action)" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.Do(Action{TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3, T4}.Do(Action{T1, T2, T3, T4, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<T1, T2, T3, T4, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3, T4}.Do(Action{int, T1, T2, T3, T4, TValue})" />
+	IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(Action<int, T1, T2, T3, T4, TValue> callback);
+
+	/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4}.TransitionTo(string)" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+}
+
+/// <summary>
+///     Sets up a setter callback for a set-only <typeparamref name="TValue" /> indexer for <typeparamref name="T1" />,
+///     <typeparamref name="T2" />, <typeparamref name="T3" /> and <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1, T2, T3, T4}.InParallel()" />
+	IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+}
+
+/// <summary>
+///     Sets up a parallel setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" /> and
+///     <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4}.When(Func{int, bool})" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(Func<int, bool> predicate);
+}
+
+/// <summary>
+///     Sets up a when setter callback for a set-only <typeparamref name="TValue" /> indexer for
+///     <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" /> and
+///     <typeparamref name="T4" />.
+/// </summary>
+public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4>
+	: IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+{
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.For(int)" />
+	IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+
+	/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4}.Only(int)" />
+	IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+}
+#pragma warning restore S2436 // Types and methods should not have too many generic parameters

--- a/Source/Mockolate/SetupExtensions.cs
+++ b/Source/Mockolate/SetupExtensions.cs
@@ -417,6 +417,242 @@ public static class SetupExtensions
 	}
 
 	/// <summary>
+	///     Extensions for setups of get-only indexers with one parameter.
+	/// </summary>
+	extension<TValue, T1>(IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> setup)
+	{
+		/// <summary>
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
+		public void Forever()
+			=> setup.For(int.MaxValue);
+
+		/// <summary>
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for getter callback setups of get-only indexers with one parameter.
+	/// </summary>
+	extension<TValue, T1>(IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setter callback setups of set-only indexers with one parameter.
+	/// </summary>
+	extension<TValue, T1>(IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerSetterOnlySetup<TValue, T1> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setups of get-only indexers with two parameters.
+	/// </summary>
+	extension<TValue, T1, T2>(IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> setup)
+	{
+		/// <summary>
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
+		public void Forever()
+			=> setup.For(int.MaxValue);
+
+		/// <summary>
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for getter callback setups of get-only indexers with two parameters.
+	/// </summary>
+	extension<TValue, T1, T2>(IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setter callback setups of set-only indexers with two parameters.
+	/// </summary>
+	extension<TValue, T1, T2>(IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerSetterOnlySetup<TValue, T1, T2> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setups of get-only indexers with three parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3>(IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> setup)
+	{
+		/// <summary>
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
+		public void Forever()
+			=> setup.For(int.MaxValue);
+
+		/// <summary>
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for getter callback setups of get-only indexers with three parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3>(IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setter callback setups of set-only indexers with three parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3>(IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerSetterOnlySetup<TValue, T1, T2, T3> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setups of get-only indexers with four parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3, T4>(IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> setup)
+	{
+		/// <summary>
+		///     Terminates the return/throw sequence by repeating the preceding entry forever instead of cycling
+		///     back to the first entry once the end is reached.
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.For(int.MaxValue)</c>. Applies only to the preceding <c>Returns(...)</c>/<c>Throws(...)</c>
+		///     entry; earlier entries in the sequence still run once each in order.
+		/// </remarks>
+		public void Forever()
+			=> setup.For(int.MaxValue);
+
+		/// <summary>
+		///     Deactivates the preceding <c>Returns(...)</c>/<c>Throws(...)</c> entry after a single invocation,
+		///     so subsequent invocations fall through to the next sequence entry (or to the mock's default behaviour).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for getter callback setups of get-only indexers with four parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3, T4>(IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
+	///     Extensions for setter callback setups of set-only indexers with four parameters.
+	/// </summary>
+	extension<TValue, T1, T2, T3, T4>(IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> setup)
+	{
+		/// <summary>
+		///     Deactivates the preceding <c>Do(...)</c> callback after a single invocation, so subsequent invocations
+		///     fall through to the next callback in the sequence (or are skipped).
+		/// </summary>
+		/// <remarks>
+		///     Equivalent to <c>.Only(1)</c>.
+		/// </remarks>
+		public IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce()
+			=> setup.Only(1);
+	}
+
+	/// <summary>
 	///     Extensions for method setup returning <typeparamref name="TReturn" /> without parameters.
 	/// </summary>
 	extension<TReturn>(IReturnMethodSetupReturnWhenBuilder<TReturn> setup)

--- a/Source/Mockolate/Verify/VerificationIndexerResult.cs
+++ b/Source/Mockolate/Verify/VerificationIndexerResult.cs
@@ -288,3 +288,377 @@ public sealed class VerificationIndexerResult<TSubject, T1, T2, T3, T4, TParamet
 			_match1, _match2, _match3, _match4,
 			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), ParametersDescription);
 }
+
+/// <summary>
+///     Verifications on a 1-key indexer that the mock only reads.
+/// </summary>
+/// <remarks>
+///     Used instead of <see cref="VerificationIndexerResult{TSubject, T1, TParameter}" /> when the mock has no
+///     setter to intercept, either because the indexer is declared without one or because its setter is not
+///     accessible from the mock's assembly. Writes then never reach the mock, so offering <c>Set(...)</c> here
+///     would always report zero interactions. The value type is not a type parameter because only <c>Set(...)</c>
+///     needs it.
+/// </remarks>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerGetterResult<TSubject, T1>
+{
+	private readonly int _getMemberId;
+	private readonly IParameterMatch<T1> _match1;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerGetterResult{TSubject, T1}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="getMemberId">Member id of the indexer getter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerGetterResult(TSubject subject, MockRegistry mockRegistry, int getMemberId,
+		IParameterMatch<T1> match1, Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_getMemberId = getMemberId;
+		_match1 = match1;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Got()" />
+	public VerificationResult<TSubject> Got()
+		=> _mockRegistry.IndexerGotTyped(_subject, _getMemberId, _match1, _parametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 1-key indexer of type <typeparamref name="TParameter" /> that the mock only writes.
+/// </summary>
+/// <remarks>
+///     The write-only counterpart of <see cref="VerificationIndexerGetterResult{TSubject, T1}" />: the mock has
+///     no getter to intercept, so <c>Got()</c> is not offered.
+/// </remarks>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerSetterResult<TSubject, T1, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly int _setMemberId;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerSetterResult{TSubject, T1, TParameter}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="setMemberId">Member id of the indexer setter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerSetterResult(TSubject subject, MockRegistry mockRegistry, int setMemberId,
+		IParameterMatch<T1> match1, Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_setMemberId = setMemberId;
+		_match1 = match1;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(IParameter{TParameter})" />
+	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1,
+			(IParameterMatch<TParameter>)value, _parametersDescription);
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(TParameter, string)" />
+	[OverloadResolutionPriority(1)]
+	public VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1,
+			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), _parametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 2-key indexer that the mock only reads. See
+///     <see cref="VerificationIndexerGetterResult{TSubject, T1}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerGetterResult<TSubject, T1, T2>
+{
+	private readonly int _getMemberId;
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerGetterResult{TSubject, T1, T2}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="getMemberId">Member id of the indexer getter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="match2">The matcher for the second indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerGetterResult(TSubject subject, MockRegistry mockRegistry, int getMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2, Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_getMemberId = getMemberId;
+		_match1 = match1;
+		_match2 = match2;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Got()" />
+	public VerificationResult<TSubject> Got()
+		=> _mockRegistry.IndexerGotTyped(_subject, _getMemberId, _match1, _match2, _parametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 2-key indexer of type <typeparamref name="TParameter" /> that the mock only writes. See
+///     <see cref="VerificationIndexerSetterResult{TSubject, T1, TParameter}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerSetterResult<TSubject, T1, T2, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly int _setMemberId;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerSetterResult{TSubject, T1, T2, TParameter}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="setMemberId">Member id of the indexer setter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="match2">The matcher for the second indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerSetterResult(TSubject subject, MockRegistry mockRegistry, int setMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2, Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_setMemberId = setMemberId;
+		_match1 = match1;
+		_match2 = match2;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(IParameter{TParameter})" />
+	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1, _match2,
+			(IParameterMatch<TParameter>)value, _parametersDescription);
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(TParameter, string)" />
+	[OverloadResolutionPriority(1)]
+	public VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1, _match2,
+			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), _parametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 3-key indexer that the mock only reads. See
+///     <see cref="VerificationIndexerGetterResult{TSubject, T1}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerGetterResult<TSubject, T1, T2, T3>
+{
+	private readonly int _getMemberId;
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly IParameterMatch<T3> _match3;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerGetterResult{TSubject, T1, T2, T3}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="getMemberId">Member id of the indexer getter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="match2">The matcher for the second indexer parameter.</param>
+	/// <param name="match3">The matcher for the third indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerGetterResult(TSubject subject, MockRegistry mockRegistry, int getMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2, IParameterMatch<T3> match3,
+		Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_getMemberId = getMemberId;
+		_match1 = match1;
+		_match2 = match2;
+		_match3 = match3;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Got()" />
+	public VerificationResult<TSubject> Got()
+		=> _mockRegistry.IndexerGotTyped(_subject, _getMemberId, _match1, _match2, _match3, _parametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 3-key indexer of type <typeparamref name="TParameter" /> that the mock only writes. See
+///     <see cref="VerificationIndexerSetterResult{TSubject, T1, TParameter}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly IParameterMatch<T3> _match3;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly int _setMemberId;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerSetterResult{TSubject, T1, T2, T3, TParameter}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="setMemberId">Member id of the indexer setter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="match2">The matcher for the second indexer parameter.</param>
+	/// <param name="match3">The matcher for the third indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerSetterResult(TSubject subject, MockRegistry mockRegistry, int setMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2, IParameterMatch<T3> match3,
+		Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_setMemberId = setMemberId;
+		_match1 = match1;
+		_match2 = match2;
+		_match3 = match3;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(IParameter{TParameter})" />
+	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1, _match2, _match3,
+			(IParameterMatch<TParameter>)value, _parametersDescription);
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(TParameter, string)" />
+	[OverloadResolutionPriority(1)]
+	public VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1, _match2, _match3,
+			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), _parametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 4-key indexer that the mock only reads. See
+///     <see cref="VerificationIndexerGetterResult{TSubject, T1}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerGetterResult<TSubject, T1, T2, T3, T4>
+{
+	private readonly int _getMemberId;
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly IParameterMatch<T3> _match3;
+	private readonly IParameterMatch<T4> _match4;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerGetterResult{TSubject, T1, T2, T3, T4}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="getMemberId">Member id of the indexer getter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="match2">The matcher for the second indexer parameter.</param>
+	/// <param name="match3">The matcher for the third indexer parameter.</param>
+	/// <param name="match4">The matcher for the fourth indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerGetterResult(TSubject subject, MockRegistry mockRegistry, int getMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2, IParameterMatch<T3> match3, IParameterMatch<T4> match4,
+		Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_getMemberId = getMemberId;
+		_match1 = match1;
+		_match2 = match2;
+		_match3 = match3;
+		_match4 = match4;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Got()" />
+	public VerificationResult<TSubject> Got()
+		=> _mockRegistry.IndexerGotTyped(_subject, _getMemberId, _match1, _match2, _match3, _match4,
+			_parametersDescription);
+}
+
+/// <summary>
+///     Verifications on a 4-key indexer of type <typeparamref name="TParameter" /> that the mock only writes. See
+///     <see cref="VerificationIndexerSetterResult{TSubject, T1, TParameter}" /> for rationale.
+/// </summary>
+#if !DEBUG
+[System.Diagnostics.DebuggerNonUserCode]
+#endif
+public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, T4, TParameter>
+{
+	private readonly IParameterMatch<T1> _match1;
+	private readonly IParameterMatch<T2> _match2;
+	private readonly IParameterMatch<T3> _match3;
+	private readonly IParameterMatch<T4> _match4;
+	private readonly MockRegistry _mockRegistry;
+	private readonly Func<string> _parametersDescription;
+	private readonly int _setMemberId;
+	private readonly TSubject _subject;
+
+	/// <inheritdoc cref="VerificationIndexerSetterResult{TSubject, T1, T2, T3, T4, TParameter}" />
+	/// <param name="subject">The verification facade the result is bound to.</param>
+	/// <param name="mockRegistry">The mock registry holding the recorded interactions.</param>
+	/// <param name="setMemberId">Member id of the indexer setter, or <c>-1</c> when unknown.</param>
+	/// <param name="match1">The matcher for the first indexer parameter.</param>
+	/// <param name="match2">The matcher for the second indexer parameter.</param>
+	/// <param name="match3">The matcher for the third indexer parameter.</param>
+	/// <param name="match4">The matcher for the fourth indexer parameter.</param>
+	/// <param name="parametersDescription">Factory producing the indexer-argument description used in failure messages.</param>
+	public VerificationIndexerSetterResult(TSubject subject, MockRegistry mockRegistry, int setMemberId,
+		IParameterMatch<T1> match1, IParameterMatch<T2> match2, IParameterMatch<T3> match3, IParameterMatch<T4> match4,
+		Func<string> parametersDescription)
+	{
+		_subject = subject;
+		_mockRegistry = mockRegistry;
+		_setMemberId = setMemberId;
+		_match1 = match1;
+		_match2 = match2;
+		_match3 = match3;
+		_match4 = match4;
+		_parametersDescription = parametersDescription;
+	}
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(IParameter{TParameter})" />
+	public VerificationResult<TSubject> Set(IParameter<TParameter> value)
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1, _match2, _match3, _match4,
+			(IParameterMatch<TParameter>)value, _parametersDescription);
+
+	/// <inheritdoc cref="VerificationIndexerResult{TSubject, TParameter}.Set(TParameter, string)" />
+	[OverloadResolutionPriority(1)]
+	public VerificationResult<TSubject> Set(TParameter value,
+		[CallerArgumentExpression(nameof(value))]
+		string doNotPopulateThisValue = "")
+		=> _mockRegistry.IndexerSetTyped(_subject, _setMemberId, _match1, _match2, _match3, _match4,
+			(IParameterMatch<TParameter>)It.Is(value, doNotPopulateThisValue), _parametersDescription);
+}

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net10.0.txt
@@ -457,6 +457,58 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
         extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?>? setup)
         {
             public void Forever() { }
@@ -1151,6 +1203,194 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
     public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
@@ -1246,6 +1486,110 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
     }
     public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -2255,7 +2599,7 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1> OnGet { get; }
@@ -2283,7 +2627,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2> OnGet { get; }
@@ -2311,7 +2655,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3> OnGet { get; }
@@ -2339,7 +2683,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4> OnGet { get; }
@@ -2936,6 +3280,26 @@ namespace Mockolate.Verify
         public Mockolate.Verify.VerificationResult<TSubject> Subscribed() { }
         public Mockolate.Verify.VerificationResult<TSubject> Unsubscribed() { }
     }
+    public class VerificationIndexerGetterResult<TSubject, T1>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2, T3>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2, T3, T4>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
     public class VerificationIndexerResult<TSubject, TParameter>
     {
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
@@ -2971,6 +3335,30 @@ namespace Mockolate.Verify
         public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, T4, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
     public class VerificationPropertyGetterResult<TSubject>
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_net8.0.txt
@@ -440,6 +440,58 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
         extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?>? setup)
         {
             public void Forever() { }
@@ -1109,6 +1161,194 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
     public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
@@ -1204,6 +1444,110 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
     }
     public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -2017,7 +2361,7 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1> OnGet { get; }
@@ -2045,7 +2389,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2> OnGet { get; }
@@ -2073,7 +2417,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3> OnGet { get; }
@@ -2101,7 +2445,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4> OnGet { get; }
@@ -2490,6 +2834,26 @@ namespace Mockolate.Verify
         public Mockolate.Verify.VerificationResult<TSubject> Subscribed() { }
         public Mockolate.Verify.VerificationResult<TSubject> Unsubscribed() { }
     }
+    public class VerificationIndexerGetterResult<TSubject, T1>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2, T3>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2, T3, T4>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
     public class VerificationIndexerResult<TSubject, TParameter>
     {
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
@@ -2525,6 +2889,30 @@ namespace Mockolate.Verify
         public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, T4, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
     public class VerificationPropertyGetterResult<TSubject>
     {

--- a/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
+++ b/Tests/Mockolate.Api.Tests/Expected/Mockolate_netstandard2.0.txt
@@ -387,6 +387,58 @@ namespace Mockolate
         {
             public Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
         }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public void Forever() { }
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
+        extension<TValue, T1, T2, T3, T4>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue?, T1?, T2?, T3?, T4?>? setup)
+        {
+            public Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> OnlyOnce() { }
+        }
         extension<TReturn>(Mockolate.Setup.IReturnMethodSetupReturnWhenBuilder<TReturn?>? setup)
         {
             public void Forever() { }
@@ -1052,6 +1104,194 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IEventUnsubscriptionSetupCallbackWhenBuilder When(System.Func<int, bool> predicate);
     }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> InitializeWith(System.Func<T1, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(System.Func<T1, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<T1, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws(System.Func<T1, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(System.Func<T1, T2, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(System.Func<T1, T2, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws(System.Func<T1, T2, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(System.Func<T1, T2, T3, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(System.Func<T1, T2, T3, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws(System.Func<T1, T2, T3, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
+    public interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4> OnGet { get; }
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(System.Func<T1, T2, T3, T4, TValue> valueGenerator);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> InitializeWith(TValue value);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(System.Func<T1, T2, T3, T4, TValue, TValue> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Returns(TValue returnValue);
+        Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Exception exception);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws(System.Func<T1, T2, T3, T4, TValue, System.Exception> callback);
+        Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4> Throws<TException>()
+            where TException : System.Exception, new ();
+    }
     public interface IIndexerGetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1> InParallel();
@@ -1147,6 +1387,110 @@ namespace Mockolate.Setup
     {
         Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
         Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1> Do(System.Action<int, T1, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2> Do(System.Action<int, T1, T2, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3> Do(System.Action<int, T1, T2, T3, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4> Do(System.Action<int, T1, T2, T3, T4, TValue> callback);
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> TransitionTo(string scenario);
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4> InParallel();
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> For(int times);
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> Only(int times);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4> : Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4> When(System.Func<int, bool> predicate);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3> SkippingBaseClass(bool skipBaseClass = true);
+    }
+    public interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3, out T4>
+    {
+        Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4> OnSet { get; }
+        Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4> SkippingBaseClass(bool skipBaseClass = true);
     }
     public interface IIndexerSetterSetupCallbackBuilder<TValue, out T1> : Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
@@ -1960,7 +2304,7 @@ namespace Mockolate.Setup
         protected static string FormatType(System.Type type) { }
         protected static bool TryCast<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(false)] object? value, out T result, Mockolate.MockBehavior behavior) { }
     }
-    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
+    public class IndexerSetup<TValue, T1> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1>, Mockolate.Setup.IIndexerSetup<TValue, T1>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1> OnGet { get; }
@@ -1988,7 +2332,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
+    public class IndexerSetup<TValue, T1, T2> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2> OnGet { get; }
@@ -2016,7 +2360,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
+    public class IndexerSetup<TValue, T1, T2, T3> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3> OnGet { get; }
@@ -2044,7 +2388,7 @@ namespace Mockolate.Setup
             where TException : System.Exception, new () { }
         public override string ToString() { }
     }
-    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
+    public class IndexerSetup<TValue, T1, T2, T3, T4> : Mockolate.Setup.IndexerSetup, Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerGetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetterSetup<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetupWithCallback<TValue, T1, T2, T3, T4>, Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4>
     {
         public IndexerSetup(Mockolate.MockRegistry mockRegistry, Mockolate.Parameters.IParameterMatch<T1> parameter1, Mockolate.Parameters.IParameterMatch<T2> parameter2, Mockolate.Parameters.IParameterMatch<T3> parameter3, Mockolate.Parameters.IParameterMatch<T4> parameter4) { }
         public Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4> OnGet { get; }
@@ -2419,6 +2763,26 @@ namespace Mockolate.Verify
         public Mockolate.Verify.VerificationResult<TSubject> Subscribed() { }
         public Mockolate.Verify.VerificationResult<TSubject> Unsubscribed() { }
     }
+    public class VerificationIndexerGetterResult<TSubject, T1>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2, T3>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
+    public class VerificationIndexerGetterResult<TSubject, T1, T2, T3, T4>
+    {
+        public VerificationIndexerGetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int getMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Got() { }
+    }
     public class VerificationIndexerResult<TSubject, TParameter>
     {
         public VerificationIndexerResult(TSubject subject, Mockolate.MockRegistry mockRegistry, System.Func<Mockolate.Interactions.IInteraction, bool> gotPredicate, System.Func<Mockolate.Interactions.IInteraction, Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate, System.Func<string> parametersDescription) { }
@@ -2454,6 +2818,30 @@ namespace Mockolate.Verify
         public override Mockolate.Verify.VerificationResult<TSubject> Got() { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
         public override Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
+    }
+    public class VerificationIndexerSetterResult<TSubject, T1, T2, T3, T4, TParameter>
+    {
+        public VerificationIndexerSetterResult(TSubject subject, Mockolate.MockRegistry mockRegistry, int setMemberId, Mockolate.Parameters.IParameterMatch<T1> match1, Mockolate.Parameters.IParameterMatch<T2> match2, Mockolate.Parameters.IParameterMatch<T3> match3, Mockolate.Parameters.IParameterMatch<T4> match4, System.Func<string> parametersDescription) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(Mockolate.Parameters.IParameter<TParameter> value) { }
+        public Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value, [System.Runtime.CompilerServices.CallerArgumentExpression("value")] string doNotPopulateThisValue = "") { }
     }
     public class VerificationPropertyGetterResult<TSubject>
     {

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -64,6 +64,41 @@ public sealed partial class MockTests
 					.Because("a widened facade would silently re-expose an accessor the mock never intercepts");
 			}
 
+			[Theory]
+			[InlineData("string this[int a, int b, int c, int d, int e] { get; }")]
+			[InlineData("string this[int a, int b, int c, int d, int e] { set; }")]
+			public async Task IndexerWithMoreThanFourKeys_ShouldKeepTheFullSurface(string indexer)
+			{
+				GeneratorResult result = Generator
+					.Run($$"""
+					       using Mockolate;
+
+					       namespace MyCode;
+					       public class Program
+					       {
+					           public static void Main(string[] args)
+					           {
+					       		_ = IMyService.CreateMock();
+					           }
+					       }
+
+					       public interface IMyService
+					       {
+					           {{indexer}}
+					       }
+					       """);
+
+				await That(result.Diagnostics).IsEmpty();
+				await That(result.Sources["Mock.IMyService.g.cs"])
+					.Contains("global::Mockolate.Setup.IndexerSetup<string, int, int, int, int, int> this[").And
+					.Contains("global::Mockolate.Verify.VerificationIndexerResult<IMockVerifyForIMyService, string> this[").And
+					.DoesNotContain("IIndexerGetterOnlySetup").And
+					.DoesNotContain("IIndexerSetterOnlySetup").And
+					.DoesNotContain("VerificationIndexerGetterResult").And
+					.DoesNotContain("VerificationIndexerSetterResult")
+					.Because("the narrowed indexer types only exist for up to four keys, so a wider indexer keeps the full surface");
+			}
+
 			[Fact]
 			public async Task InterfaceIndexerWithParameterNamedLikeLocal_ShouldGenerateUniqueLocalVariableName()
 			{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -6,6 +6,64 @@ public sealed partial class MockTests
 	{
 		public sealed class IndexerTests
 		{
+			[Theory]
+			[InlineData("string this[int key] { get; }",
+				"Setup.IIndexerGetterOnlySetup<string, int>",
+				"Verify.VerificationIndexerGetterResult<IMockVerifyForIMyService, int>",
+				"Setup.IndexerSetup<string, int>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string this[int key] { set; }",
+				"Setup.IIndexerSetterOnlySetup<string, int>",
+				"Verify.VerificationIndexerSetterResult<IMockVerifyForIMyService, int, string>",
+				"Setup.IndexerSetup<string, int>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string this[int key] { get; set; }",
+				"Setup.IndexerSetup<string, int>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>",
+				"Setup.IIndexerGetterOnlySetup<string, int>",
+				"Verify.VerificationIndexerGetterResult<IMockVerifyForIMyService, int>")]
+			[InlineData("string this[int key, bool flag] { get; }",
+				"Setup.IIndexerGetterOnlySetup<string, int, bool>",
+				"Verify.VerificationIndexerGetterResult<IMockVerifyForIMyService, int, bool>",
+				"Setup.IndexerSetup<string, int, bool>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string this[int key, bool flag] { set; }",
+				"Setup.IIndexerSetterOnlySetup<string, int, bool>",
+				"Verify.VerificationIndexerSetterResult<IMockVerifyForIMyService, int, bool, string>",
+				"Setup.IndexerSetup<string, int, bool>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>")]
+			public async Task IndexerSurface_ShouldOnlyExposeTheAccessorsTheMockIntercepts(
+				string indexer, string expectedSetupType, string expectedVerifyType,
+				string unexpectedSetupType, string unexpectedVerifyType)
+			{
+				GeneratorResult result = Generator
+					.Run($$"""
+					       using Mockolate;
+
+					       namespace MyCode;
+					       public class Program
+					       {
+					           public static void Main(string[] args)
+					           {
+					       		_ = IMyService.CreateMock();
+					           }
+					       }
+
+					       public interface IMyService
+					       {
+					           {{indexer}}
+					       }
+					       """);
+
+				await That(result.Diagnostics).IsEmpty();
+				await That(result.Sources["Mock.IMyService.g.cs"])
+					.Contains($"global::Mockolate.{expectedSetupType} this[").And
+					.Contains($"global::Mockolate.{expectedVerifyType} this[").And
+					.DoesNotContain($"global::Mockolate.{unexpectedSetupType} this[").And
+					.DoesNotContain($"global::Mockolate.{unexpectedVerifyType} this[")
+					.Because("a widened facade would silently re-expose an accessor the mock never intercepts");
+			}
+
 			[Fact]
 			public async Task InterfaceIndexerWithParameterNamedLikeLocal_ShouldGenerateUniqueLocalVariableName()
 			{

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
@@ -364,6 +364,9 @@ public sealed partial class MockTests
 			await That(result.Diagnostics).IsEmpty();
 			await That(result.Sources["Mock.MyExternalType.g.cs"])
 				.Contains("public override int this[int index]").And
+				.Contains("global::Mockolate.Setup.IIndexerGetterOnlySetup<int, int> this[").And
+				.Contains("global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForMyExternalType, int> this[").And
+				.DoesNotContain("global::Mockolate.Setup.IndexerSetup<int, int> this[").And
 				.DoesNotContain("internal set")
 				.Because("the setter is invisible to the mock's assembly, so only the getter may be overridden");
 		}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.CrossAssemblyTests.cs
@@ -372,6 +372,35 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task MixedAccessorIndexerSlotAlreadyOverridden_WithOnlyTheSetterReachable_ShouldBeMockedWithTheSetter()
+		{
+			MetadataReference external = ExternalAssembly.Compile("""
+			                                                      namespace Ext;
+
+			                                                      public abstract class MyBaseType
+			                                                      {
+			                                                      	public abstract int this[int index] { internal get; set; }
+			                                                      }
+
+			                                                      public abstract class MyExternalType : MyBaseType
+			                                                      {
+			                                                      	public override int this[int index] { internal get => 0; set { } }
+			                                                      }
+			                                                      """);
+
+			GeneratorResult result = Generator.RunWithReferences(CreateMockForMyExternalType, [external,]);
+
+			await That(result.Diagnostics).IsEmpty();
+			await That(result.Sources["Mock.MyExternalType.g.cs"])
+				.Contains("public override int this[int index]").And
+				.Contains("global::Mockolate.Setup.IIndexerSetterOnlySetup<int, int> this[").And
+				.Contains("global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForMyExternalType, int, int> this[").And
+				.DoesNotContain("global::Mockolate.Setup.IndexerSetup<int, int> this[").And
+				.DoesNotContain("internal get")
+				.Because("the getter is invisible to the mock's assembly, so only the setter may be overridden");
+		}
+
+		[Fact]
 		public async Task MixedAccessorSlotFilledByAnIntermediateType_ShouldBeMockedWithTheAccessibleAccessorOnly()
 		{
 			MetadataReference external = ExternalAssembly.Compile("""

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -43,36 +43,40 @@ internal static partial class Mock
 		internal const int MemberId_Indexer_int_Set = 19;
 		internal const int MemberId_Indexer_int_int_int_int_int_Get = 20;
 		internal const int MemberId_Indexer_int_int_int_int_int_Set = 21;
-		internal const int MemberId_StaticAbstractMethod = 22;
-		internal const int MemberId_WithModifiers = 23;
-		internal const int MemberId_WithDefaults = 24;
-		internal const int MemberId_WithCollidingNames = 25;
-		internal const int MemberId_GetMaybeNull = 26;
-		internal const int MemberId_TakeObject = 27;
-		internal const int MemberId_TakeTwoObjects = 28;
-		internal const int MemberId_TakeIntAndObject = 29;
-		internal const int MemberId_DoTask = 30;
-		internal const int MemberId_DoTaskOf = 31;
-		internal const int MemberId_DoVT = 32;
-		internal const int MemberId_DoVTOf = 33;
-		internal const int MemberId_GetTuple = 34;
-		internal const int MemberId_GetNullable = 35;
-		internal const int MemberId_GetSpan = 36;
-		internal const int MemberId_GetROSpan = 37;
-		internal const int MemberId_GetByRef = 38;
-		internal const int MemberId_GetByRefReadonly = 39;
-		internal const int MemberId_G1_T_ = 40;
-		internal const int MemberId_G2_T_ = 41;
-		internal const int MemberId_G3_T_ = 42;
-		internal const int MemberId_G4_T_ = 43;
-		internal const int MemberId_G5_T_ = 44;
-		internal const int MemberId_G6_T_ = 45;
-		internal const int MemberId_G7_T_ = 46;
-		internal const int MemberId_G8_T_ = 47;
-		internal const int MemberId_Five = 48;
-		internal const int MemberId_Seventeen = 49;
-		internal const int MemberId_SeventeenVoid = 50;
-		internal const int MemberCount = 51;
+		internal const int MemberId_Indexer_double_Get = 22;
+		internal const int MemberId_Indexer_double_Set = 23;
+		internal const int MemberId_Indexer_char_Get = 24;
+		internal const int MemberId_Indexer_char_Set = 25;
+		internal const int MemberId_StaticAbstractMethod = 26;
+		internal const int MemberId_WithModifiers = 27;
+		internal const int MemberId_WithDefaults = 28;
+		internal const int MemberId_WithCollidingNames = 29;
+		internal const int MemberId_GetMaybeNull = 30;
+		internal const int MemberId_TakeObject = 31;
+		internal const int MemberId_TakeTwoObjects = 32;
+		internal const int MemberId_TakeIntAndObject = 33;
+		internal const int MemberId_DoTask = 34;
+		internal const int MemberId_DoTaskOf = 35;
+		internal const int MemberId_DoVT = 36;
+		internal const int MemberId_DoVTOf = 37;
+		internal const int MemberId_GetTuple = 38;
+		internal const int MemberId_GetNullable = 39;
+		internal const int MemberId_GetSpan = 40;
+		internal const int MemberId_GetROSpan = 41;
+		internal const int MemberId_GetByRef = 42;
+		internal const int MemberId_GetByRefReadonly = 43;
+		internal const int MemberId_G1_T_ = 44;
+		internal const int MemberId_G2_T_ = 45;
+		internal const int MemberId_G3_T_ = 46;
+		internal const int MemberId_G4_T_ = 47;
+		internal const int MemberId_G5_T_ = 48;
+		internal const int MemberId_G6_T_ = 49;
+		internal const int MemberId_G7_T_ = 50;
+		internal const int MemberId_G8_T_ = 51;
+		internal const int MemberId_Five = 52;
+		internal const int MemberId_Seventeen = 53;
+		internal const int MemberId_SeventeenVoid = 54;
+		internal const int MemberCount = 55;
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_GetSet_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSet");
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_GetOnly_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly");
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_SetOnly_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly");
@@ -110,6 +114,18 @@ internal static partial class Mock
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		private global::Mockolate.Interactions.FastIndexerSetterBuffer<int, string> MockolateBuffer_Indexer_int_Set
 			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastIndexerSetterBuffer<int, string>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_int_Set, static fast => new global::Mockolate.Interactions.FastIndexerSetterBuffer<int, string>(fast)));
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		private global::Mockolate.Interactions.FastIndexerGetterBuffer<double> MockolateBuffer_Indexer_double_Get
+			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastIndexerGetterBuffer<double>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get, static fast => new global::Mockolate.Interactions.FastIndexerGetterBuffer<double>(fast)));
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		private global::Mockolate.Interactions.FastIndexerSetterBuffer<double, string> MockolateBuffer_Indexer_double_Set
+			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastIndexerSetterBuffer<double, string>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Set, static fast => new global::Mockolate.Interactions.FastIndexerSetterBuffer<double, string>(fast)));
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		private global::Mockolate.Interactions.FastIndexerGetterBuffer<char> MockolateBuffer_Indexer_char_Get
+			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastIndexerGetterBuffer<char>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Get, static fast => new global::Mockolate.Interactions.FastIndexerGetterBuffer<char>(fast)));
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		private global::Mockolate.Interactions.FastIndexerSetterBuffer<char, string> MockolateBuffer_Indexer_char_Set
+			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastIndexerSetterBuffer<char, string>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Set, static fast => new global::Mockolate.Interactions.FastIndexerSetterBuffer<char, string>(fast)));
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		private global::Mockolate.Interactions.FastMethod4Buffer<int, string, long, int[]> MockolateBuffer_WithModifiers
 			=> field ?? (field = ((global::Mockolate.Interactions.FastMockInteractions)this.MockRegistry.Interactions).GetOrCreateBuffer<global::Mockolate.Interactions.FastMethod4Buffer<int, string, long, int[]>>(global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, static fast => new global::Mockolate.Interactions.FastMethod4Buffer<int, string, long, int[]>(fast)));
@@ -502,6 +518,79 @@ internal static partial class Mock
 				if (this.MockRegistry.Wraps is global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
 				{
 					wraps[a, b, c, d, e] = value;
+				}
+			}
+		}
+
+		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]" />
+		public string this[double key]
+		{
+			get
+			{
+				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+				{
+					this.MockolateBuffer_Indexer_double_Get.Append(key);
+				}
+				global::Mockolate.Setup.IndexerSetup<string, double>? setup = null;
+				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
+				{
+					global::Mockolate.Setup.IndexerSetup[]? snapshot_setup = this.MockRegistry.GetIndexerSetupSnapshot(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get);
+					if (snapshot_setup is not null)
+					{
+						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
+						{
+							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<string, double> s_setup && s_setup.Matches(key))
+							{
+								setup = s_setup;
+								break;
+							}
+						}
+					}
+				}
+				global::Mockolate.Interactions.IndexerGetterAccess<double> access = new(key);
+				setup ??= this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<string, double>>(access);
+				if (this.MockRegistry.Wraps is not global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
+				{
+					return setup is null
+						? this.MockRegistry.GetIndexerFallback<string>(access, 2)
+						: this.MockRegistry.ApplyIndexerSetup<string>(access, setup, 2);
+				}
+				string baseResult = wraps[key];
+				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 2);
+			}
+		}
+
+		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[char]" />
+		public string this[char key]
+		{
+			set
+			{
+				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+				{
+					this.MockolateBuffer_Indexer_char_Set.Append(key, value);
+				}
+				global::Mockolate.Setup.IndexerSetup<string, char>? setup = null;
+				if (string.IsNullOrEmpty(this.MockRegistry.Scenario))
+				{
+					global::Mockolate.Setup.IndexerSetup[]? snapshot_setup = this.MockRegistry.GetIndexerSetupSnapshot(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Get);
+					if (snapshot_setup is not null)
+					{
+						for (int i_setup = snapshot_setup.Length - 1; i_setup >= 0; i_setup--)
+						{
+							if (snapshot_setup[i_setup] is global::Mockolate.Setup.IndexerSetup<string, char> s_setup && s_setup.Matches(key, value))
+							{
+								setup = s_setup;
+								break;
+							}
+						}
+					}
+				}
+				global::Mockolate.Interactions.IndexerSetterAccess<char, string> access = new(key, value);
+				setup ??= this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<string, char>>(access);
+				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 3);
+				if (this.MockRegistry.Wraps is global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
+				{
+					wraps[key] = value;
 				}
 			}
 		}
@@ -2335,6 +2424,54 @@ internal static partial class Mock
 		}
 
 		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<string, double> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<double>? parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, double>(MockRegistry, CovariantParameterAdapter<double>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<double>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<string, double> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[double parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, double>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<double>)global::Mockolate.It.IsValue<double>(parameter1));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<string, char> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<char>? parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, char>(MockRegistry, CovariantParameterAdapter<char>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<char>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<string, char> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[char parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, char>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<char>)global::Mockolate.It.IsValue<char>(parameter1));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
 		global::Mockolate.Setup.IVoidMethodSetupWithCallback<int, string, long, int[]> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IParameters parameters)
 		{
 			var methodSetup = new global::Mockolate.Setup.VoidMethodSetup<int, string, long, int[]>.WithParameters(MockRegistry, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", parameters, "a", "b", "c", "tail");
@@ -2975,6 +3112,54 @@ internal static partial class Mock
 		}
 
 		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<double>? key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get,
+					CovariantParameterAdapter<double>.Wrap(key ?? global::Mockolate.It.IsNull<double>("null")),
+					() => global::System.String.Format("[{0}]", (object?)key ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double> IMockVerifyForIComprehensiveInterface.this[double key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get,
+					(global::Mockolate.Parameters.IParameterMatch<double>)global::Mockolate.It.Is<double>(key, "key"),
+					() => global::System.String.Format("[{0}]", (object?)key));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<char>? key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Set,
+					CovariantParameterAdapter<char>.Wrap(key ?? global::Mockolate.It.IsNull<char>("null")),
+					() => global::System.String.Format("[{0}]", (object?)key ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string> IMockVerifyForIComprehensiveInterface.this[char key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Set,
+					(global::Mockolate.Parameters.IParameterMatch<char>)global::Mockolate.It.Is<char>(key, "key"),
+					() => global::System.String.Format("[{0}]", (object?)key));
+			}
+		}
+
+		/// <inheritdoc />
 		global::Mockolate.Verify.VerificationResult<IMockVerifyForIComprehensiveInterface> IMockVerifyForIComprehensiveInterface.WithModifiers(global::Mockolate.Parameters.IParameters parameters)
 			=> this.MockRegistry.VerifyMethod<IMockVerifyForIComprehensiveInterface, global::Mockolate.Interactions.MethodInvocation<int, string, long, int[]>>(this, global::Mockolate.Mock.IComprehensiveInterface.MemberId_WithModifiers, "global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers", __i => parameters switch
 				{
@@ -3501,6 +3686,54 @@ internal static partial class Mock
 					interaction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<int, int, int, int, int> g && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(a, g.Parameter1) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(b, g.Parameter2) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(c, g.Parameter3) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(d, g.Parameter4) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(e, g.Parameter5),
 					(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<int, int, int, int, int, string> s && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(a, s.Parameter1) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(b, s.Parameter2) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(c, s.Parameter3) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(d, s.Parameter4) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(e, s.Parameter5) && value.Matches(s.TypedValue),
 					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a, (object?)b, (object?)c, (object?)d, (object?)e));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<double>? key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get,
+					CovariantParameterAdapter<double>.Wrap(key ?? global::Mockolate.It.IsNull<double>("null")),
+					() => global::System.String.Format("[{0}]", (object?)key ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double> IMockVerifyForIComprehensiveInterface.this[double key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get,
+					(global::Mockolate.Parameters.IParameterMatch<double>)global::Mockolate.It.Is<double>(key, "key"),
+					() => global::System.String.Format("[{0}]", (object?)key));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<char>? key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Set,
+					CovariantParameterAdapter<char>.Wrap(key ?? global::Mockolate.It.IsNull<char>("null")),
+					() => global::System.String.Format("[{0}]", (object?)key ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string> IMockVerifyForIComprehensiveInterface.this[char key]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string>(this, this.MockRegistry, global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Set,
+					(global::Mockolate.Parameters.IParameterMatch<char>)global::Mockolate.It.Is<char>(key, "key"),
+					() => global::System.String.Format("[{0}]", (object?)key));
 			}
 		}
 
@@ -4068,6 +4301,54 @@ internal static partial class Mock
 			{
 				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, int, int, int, int, int>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter1), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter2), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter3), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter4), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter5));
 				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_int_int_int_int_int_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<string, double> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<double>? parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, double>(MockRegistry, CovariantParameterAdapter<double>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<double>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<string, double> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[double parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, double>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<double>)global::Mockolate.It.IsValue<double>(parameter1));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_double_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<string, char> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<char>? parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, char>(MockRegistry, CovariantParameterAdapter<char>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<char>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<string, char> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[char parameter1]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, char>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<char>)global::Mockolate.It.IsValue<char>(parameter1));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_char_Get, _scenarioName, indexerSetup);
 				return indexerSetup;
 			}
 		}
@@ -4760,6 +5041,42 @@ internal static partial class Mock
 		global::Mockolate.Setup.IndexerSetup<string, int, int, int, int, int> this[int parameter1, int parameter2, int parameter3, int parameter4, int parameter5] { get; }
 
 		/// <summary>
+		///     Setup for the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]">this[double]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<string, double> this[global::Mockolate.Parameters.IParameter<double>? parameter1] { get; }
+
+		/// <summary>
+		///     Setup for the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]">this[double]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<string, double> this[double parameter1] { get; }
+
+		/// <summary>
+		///     Setup for the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[char]">this[char]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<string, char> this[global::Mockolate.Parameters.IParameter<char>? parameter1] { get; }
+
+		/// <summary>
+		///     Setup for the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[char]">this[char]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<string, char> this[char parameter1] { get; }
+
+		/// <summary>
 		///     Setup for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="parameters" />.
 		/// </summary>
 		/// <remarks>
@@ -5362,6 +5679,42 @@ internal static partial class Mock
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
 		global::Mockolate.Verify.VerificationIndexerResult<IMockVerifyForIComprehensiveInterface, string> this[int a, int b, int c, int d, int e] { get; }
+
+		/// <summary>
+		///     Verify interactions with the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]">this[double]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double> this[global::Mockolate.Parameters.IParameter<double>? key] { get; }
+
+		/// <summary>
+		///     Verify interactions with the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]">this[double]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double> this[double key] { get; }
+
+		/// <summary>
+		///     Verify interactions with the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[char]">this[char]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string> this[global::Mockolate.Parameters.IParameter<char>? key] { get; }
+
+		/// <summary>
+		///     Verify interactions with the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[char]">this[char]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, char, string> this[char key] { get; }
 
 		/// <summary>
 		///     Verify invocations for the method <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.WithModifiers(ref int, out string, in long, int[])">WithModifiers(ref int, out string, in long, int[])</see> with the given <paramref name="parameters"/>.

--- a/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
+++ b/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
@@ -6,7 +6,7 @@ namespace Mockolate.Tests.GeneratorCoverage;
 
 /// <summary>
 ///     Squeezes every interface-shaped generator branch we can fit into a single type:
-///     property accessor combinations, indexers (single + arity-5), all three event flavors,
+///     property accessor combinations, indexers (single + arity-5, get-only + set-only), all three event flavors,
 ///     static abstract members, every parameter modifier, every default-value kind,
 ///     every "reserved" parameter name, nullable annotations, async returns, special return
 ///     shapes (Span/ReadOnlySpan/ref/ref-readonly/tuple/Nullable&lt;T&gt;),
@@ -23,6 +23,8 @@ public interface IComprehensiveInterface
 
 	string this[int i] { get; set; }
 	string this[int a, int b, int c, int d, int e] { get; set; }
+	string this[double key] { get; }
+	string this[char key] { set; }
 
 	static abstract int StaticAbstractValue { get; }
 

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.AccessorRestrictedTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.AccessorRestrictedTests.cs
@@ -1,0 +1,400 @@
+using System.Collections.Generic;
+using Mockolate.Setup;
+
+namespace Mockolate.Tests.MockIndexers;
+
+public sealed partial class SetupIndexerTests
+{
+	public sealed class AccessorRestrictedTests
+	{
+		[Fact]
+		public async Task SetOnlyIndexer_OnSet_ShouldFireAndRecordTheWrite()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			List<string> written = new();
+			sut.Mock.Setup[It.IsAny<string>()].OnSet.Do(value => written.Add(value));
+
+			sut["name"] = "Ada";
+
+			await That(written).IsEqualTo(["Ada",]);
+			await That(sut.Mock.Verify[It.Is("name")].Set("Ada")).Once()
+				.Because("the setter facade must be keyed on the setter member id, not the getter's");
+		}
+
+		[Fact]
+		public async Task SetOnlyIndexer_VerifyOtherValue_ShouldNotMatch()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+
+			sut["name"] = "Ada";
+
+			await That(sut.Mock.Verify[It.Is("name")].Set("Grace")).Never();
+		}
+
+		[Fact]
+		public async Task SetOnlyIndexer_VerifyWithParameterMatcher_ShouldMatch()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+
+			sut["name"] = "Ada";
+
+			await That(sut.Mock.Verify[It.IsAny<string>()].Set(It.IsAny<string>())).Once();
+		}
+
+		[Theory]
+		[InlineData(false, 1)]
+		[InlineData(true, 0)]
+		public async Task SetOnlyClassIndexer_ShouldSkipCallingBaseWhenRequested(bool skipBaseClass,
+			int expectedCallCount)
+		{
+			AccessorService sut = AccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()].SkippingBaseClass(skipBaseClass);
+
+			sut[4] = 1;
+
+			await That(sut.SetterCallCount).IsEqualTo(expectedCallCount);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_ChainedReturns_ShouldStayOnGetterOnlySurface()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			IIndexerGetterOnlySetup<int, int> chained = sut.Mock.Setup[It.IsAny<int>()]
+				.Returns(1).OnlyOnce();
+			chained.Returns(() => 2);
+
+			await That(sut[1]).IsEqualTo(1);
+			await That(sut[1]).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_ReturnsForever_ShouldUseTheLastValueForever()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.Returns(2)
+				.Returns(4).Forever();
+
+			int[] result = new int[4];
+			for (int i = 0; i < 4; i++)
+			{
+				result[i] = sut[i];
+			}
+
+			await That(result).IsEqualTo([2, 4, 4, 4,]);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_ReturnsWhen_ShouldOnlyUseValueWhenPredicateIsTrue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.Returns(() => 4).When(i => i > 0);
+
+			int result1 = sut[1];
+			int result2 = sut[1];
+
+			await That(result1).IsEqualTo(0);
+			await That(result2).IsEqualTo(4);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_ReturnsCallbackWithValue_ShouldReturnExpectedValue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.InitializeWith(3)
+				.Returns((_, v) => 4 * v);
+
+			int result = sut[7];
+
+			await That(result).IsEqualTo(12);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_InitializeWithGenerator_ShouldSeedTheReadValue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.InitializeWith(key => 10 * key);
+
+			await That(sut[3]).IsEqualTo(30);
+			await That(sut[5]).IsEqualTo(50);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_Throws_ShouldIterateThroughAllRegisteredExceptions()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.Throws<InvalidOperationException>()
+				.Throws(new Exception("foo"))
+				.Throws(() => new Exception("bar"))
+				.Throws(k => new Exception($"baz-{k}"))
+				.Throws((k, v) => new Exception($"qux-{k}-{v}"));
+
+			void Act() => _ = sut[6];
+
+			await That(Act).Throws<InvalidOperationException>();
+			Exception? result2 = Record.Exception(Act);
+			Exception? result3 = Record.Exception(Act);
+			Exception? result4 = Record.Exception(Act);
+			Exception? result5 = Record.Exception(Act);
+			await That(result2).HasMessage("foo");
+			await That(result3).HasMessage("bar");
+			await That(result4).HasMessage("baz-6");
+			await That(result5).HasMessage("qux-6-0");
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_OnGetChain_ShouldStayOnGetterOnlySurface()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			IIndexerGetterOnlySetup<int, int> chained = sut.Mock.Setup[It.IsAny<int>()]
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(k => { callCount2++; }).OnlyOnce();
+			chained.Returns(9);
+
+			int result = sut[1];
+			_ = sut[2];
+			_ = sut[3];
+			_ = sut[4];
+
+			await That(result).IsEqualTo(9);
+			await That(callCount1).IsEqualTo(3);
+			await That(callCount2).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_OnGetWhen_ShouldOnlyInvokeCallbackWhenPredicateIsTrue()
+		{
+			int callCount = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.OnGet.Do(() => { callCount++; }).When(i => i > 0);
+
+			_ = sut[1];
+			_ = sut[1];
+			_ = sut[1];
+
+			await That(callCount).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_OnGetInParallel_ShouldInvokeParallelCallbacksAlways()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			int callCount3 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do(k => { callCount2++; }).InParallel()
+				.OnGet.Do((k, v) => { callCount3++; });
+
+			_ = sut[1];
+			_ = sut[2];
+			_ = sut[3];
+			_ = sut[4];
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(4);
+			await That(callCount3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_OnGetFor_ShouldRepeatCallbackTheGivenNumberOfTimes()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>()]
+				.OnGet.Do(() => { callCount1++; }).For(2)
+				.OnGet.Do(() => { callCount2++; });
+
+			for (int i = 0; i < 6; i++)
+			{
+				_ = sut[1];
+			}
+
+			await That(callCount1).IsEqualTo(4);
+			await That(callCount2).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_OnGetTransitionTo_ShouldSwitchScenario()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.InScenario("a").Setup[It.IsAny<int>()]
+				.OnGet.Do(() => { })
+				.OnGet.TransitionTo("b");
+			sut.Mock.TransitionTo("a");
+
+			_ = sut[1];
+
+			await That(((IMock)sut).MockRegistry.Scenario).IsEqualTo("b");
+		}
+
+		[Fact]
+		public async Task SetOnlyIndexer_OnSetChain_ShouldStayOnSetterOnlySurface()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			IIndexerSetterOnlySetup<string, string> chained = sut.Mock.Setup[It.IsAny<string>()]
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do(v => { callCount2++; }).OnlyOnce();
+			chained.SkippingBaseClass();
+
+			sut["k"] = "a";
+			sut["k"] = "b";
+			sut["k"] = "c";
+			sut["k"] = "d";
+
+			await That(callCount1).IsEqualTo(3);
+			await That(callCount2).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task SetOnlyIndexer_OnSetWhen_ShouldOnlyInvokeCallbackWhenPredicateIsTrue()
+		{
+			int callCount = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<string>()]
+				.OnSet.Do(() => { callCount++; }).When(i => i > 0);
+
+			sut["k"] = "a";
+			sut["k"] = "b";
+			sut["k"] = "c";
+
+			await That(callCount).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyIndexer_OnSetInParallel_ShouldInvokeParallelCallbacksAlways()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			int callCount3 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<string>()]
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((k, v) => { callCount2++; }).InParallel()
+				.OnSet.Do(() => { callCount3++; });
+
+			sut["k"] = "a";
+			sut["k"] = "b";
+			sut["k"] = "c";
+			sut["k"] = "d";
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(4);
+			await That(callCount3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyIndexer_OnSetFor_ShouldRepeatCallbackTheGivenNumberOfTimes()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<string>()]
+				.OnSet.Do(() => { callCount1++; }).For(2)
+				.OnSet.Do(() => { callCount2++; });
+
+			for (int i = 0; i < 6; i++)
+			{
+				sut["k"] = "a";
+			}
+
+			await That(callCount1).IsEqualTo(4);
+			await That(callCount2).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyIndexer_OnSetTransitionTo_ShouldSwitchScenario()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.InScenario("a").Setup[It.IsAny<string>()]
+				.OnSet.Do(() => { })
+				.OnSet.TransitionTo("b");
+			sut.Mock.TransitionTo("a");
+
+			sut["k"] = "x";
+
+			await That(((IMock)sut).MockRegistry.Scenario).IsEqualTo("b");
+		}
+
+		[Fact]
+		public async Task GetOnlyIndexer_Got_ShouldMatchOnlyMatchingKeys()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+
+			_ = sut[1];
+
+			await That(sut.Mock.Verify[It.Is(1)].Got()).Once();
+			await That(sut.Mock.Verify[It.Is(2)].Got()).Never();
+		}
+
+		[Fact]
+		public async Task GetOnlyTwoKeyIndexer_ReturnsAndGot_ShouldUseTheNarrowedSurface()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>()]
+				.Returns((k1, k2) => k1 + k2);
+
+			int result = sut[20, 22];
+
+			await That(result).IsEqualTo(42);
+			await That(sut.Mock.Verify[It.Is(20), It.Is(22)].Got()).Once();
+			await That(sut.Mock.Verify[It.Is(20), It.Is(23)].Got()).Never();
+		}
+
+		[Fact]
+		public async Task SetOnlyTwoKeyIndexer_OnSetAndVerify_ShouldUseTheNarrowedSurface()
+		{
+			List<string> written = new();
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<string>(), It.IsAny<string>()]
+				.OnSet.Do((k1, k2, v) => written.Add($"{k1}-{k2}-{v}"));
+
+			sut["a", "b"] = "c";
+
+			await That(written).IsEqualTo(["a-b-c",]);
+			await That(sut.Mock.Verify[It.Is("a"), It.Is("b")].Set("c")).Once();
+			await That(sut.Mock.Verify[It.Is("a"), It.Is("b")].Set("d")).Never();
+		}
+
+		[Fact]
+		public async Task SetOnlyFourKeyIndexer_Set_ShouldVerifyTheWrite()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+
+			sut[1, 2, 3, 4] = "x";
+
+			await That(sut.Mock.Verify[It.Is(1), It.Is(2), It.Is(3), It.Is(4)].Set("x")).Once();
+			await That(sut.Mock.Verify[It.Is(1), It.Is(2), It.Is(3), It.Is(5)].Set(It.IsAny<string>())).Never();
+		}
+
+		public interface IAccessorService
+		{
+			int this[int key] { get; }
+			string this[string key] { set; }
+			int this[int key1, int key2] { get; }
+			string this[string key1, string key2] { set; }
+			string this[int key1, int key2, int key3, int key4] { set; }
+		}
+
+		public class AccessorService
+		{
+			public int SetterCallCount { get; private set; }
+
+			public virtual int this[int key]
+			{
+				set => SetterCallCount += value;
+			}
+		}
+	}
+}


### PR DESCRIPTION
A generated mock advertised setup and verification for both accessors of every indexer, even when it intercepted only one. For a get-only indexer

```csharp
    int this[string shelf] { get; }
```

Setup[...].OnSet and Verify[...].Set(3) compiled and silently did nothing: no setter body is emitted, so a write can never be recorded and the verification could only ever report zero.

The generator now picks the facade from the accessors it actually emits a body for, mirroring the property narrowing:

- IIndexerGetterOnlySetup<TValue, T1..Tn> / IIndexerSetterOnlySetup< TValue, T1..Tn> (arities 1-4) replace IndexerSetup<TValue, T1..Tn> on the setup surface, with parallel getter-only and setter-only builder hierarchies so chaining through Returns/Throws/Do/TransitionTo stays on the narrowed surface, plus Forever/OnlyOnce extensions for the narrowed when-builders.
- VerificationIndexerGetterResult<TSubject, T1..Tn> and VerificationIndexerSetterResult<TSubject, T1..Tn, TParameter> replace VerificationIndexerResult<TSubject, TParameter> on the verify surface, each taking only the member id of the accessor it exposes.

GetIndexerInterceptedAccessors reuses the property classification keyed on the same Getter/Setter nullity that guards body emission, so the surface cannot drift from what the proxy intercepts. This also covers the cross-assembly case: an indexer such as { get; internal set; } whose setter is invisible to the mock's assembly narrows to the getter.

BREAKING CHANGE: on an indexer the mock reads or writes but not both, Setup[...].OnSet/OnGet, Setup[...].Returns/Throws/InitializeWith and Verify[...].Set(...)/Got() no longer compile for the absent accessor. Each previously compiled and silently had no effect. The library API is additive; only generated mock surfaces narrow. Indexers with more than four keys keep the full surface, as their setup types are generated per-compilation.