### PR TITLE
fix: require Roslyn 5.0 instead of 5.6 for the generator and analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,4 +6,12 @@
 		<PublicKey>0024000004800000940000000602000000240000525341310004000001000100917b2e28a0dcd1de99a208f70383c300caa03729b1f9cdad97cb11a127f822aa36aad08225cc24312de1fadf3aeafc7ab6c2c4b588d5e88c2b61f0a56e02df1b6aa11d0c3e4ee6675f24b20dbd75ee4fc229f82b0eeeafe1a5bc376d5e5f9a5c4320267921d9a962cc5f58ccc94e7127db3119bafedfb76fd3a7b1f2d22155ac</PublicKey>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<!-- The oldest Roslyn the generator and analyzers must load in. A compiler host older than this
+		refuses to load them (CS9057), so IntelliSense silently loses all generated members. Cannot go below
+		5.0: the emitted `Mock.g.cs` declares `CreateMock` in a C# 14 extension block. The generator tests
+		pin the same version so a newer API creeping in fails the build instead of the users' IDE. -->
+		<MinimumRoslynVersion>5.0.0</MinimumRoslynVersion>
+	</PropertyGroup>
+
 </Project>

--- a/Source/Mockolate.Analyzers.CodeFixers/Mockolate.Analyzers.CodeFixers.csproj
+++ b/Source/Mockolate.Analyzers.CodeFixers/Mockolate.Analyzers.CodeFixers.csproj
@@ -18,9 +18,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.Common"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="$(MinimumRoslynVersion)"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MinimumRoslynVersion)"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(MinimumRoslynVersion)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj
+++ b/Source/Mockolate.Analyzers/Mockolate.Analyzers.csproj
@@ -22,8 +22,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.Common"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="$(MinimumRoslynVersion)"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MinimumRoslynVersion)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj
+++ b/Source/Mockolate.SourceGenerators/Mockolate.SourceGenerators.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="$(MinimumRoslynVersion)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Mockolate.SourceGenerators.Tests/Mockolate.SourceGenerators.Tests.csproj
+++ b/Tests/Mockolate.SourceGenerators.Tests/Mockolate.SourceGenerators.Tests.csproj
@@ -8,7 +8,7 @@
 		<ProjectReference Include="..\..\Source\Mockolate.SourceGenerators\Mockolate.SourceGenerators.csproj"/>
 		<ProjectReference Include="..\..\Source\Mockolate\Mockolate.csproj"/>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="$(MinimumRoslynVersion)"/>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
The generator and analyzers referenced Microsoft.CodeAnalysis 5.6.0, which ships with the .NET 10.0.30x SDK. Roslyn refuses to load a component that references a newer compiler than the host (CS9057), so every older host silently skipped them: no generated members, and 'Cannot resolve symbol CreateMock' throughout the IDE while the command-line build stayed green.

Pin the three shipped components to the oldest Roslyn they actually need. 5.0 is the floor, not lower: the emitted Mock.g.cs declares CreateMock in a C# 14 extension block, so a C# 13 host parses it as garbage and generates no mocks at all. That also rules out any pre-C# 14 host, since a static extension member has no older equivalent.

Mockolate.SourceGenerators.Tests pins the same version, so reaching for a newer Roslyn API fails the build and the generator tests here rather than silently breaking consumers' IDEs.

MinimumRoslynVersion sits in the root Directory.Build.props because the test tree imports that one but not Source/Directory.Build.props.