### PR TITLE
feat!: narrow indexer surfaces with more than four keys

### DIFF
--- a/Docs/pages/setup/03-indexers.md
+++ b/Docs/pages/setup/03-indexers.md
@@ -119,8 +119,7 @@ interactions. See [Mockolate0002](../analyzers#mockolate0002) for when such a ty
 
 Both facades are fully restricted: the fluent builders returned by `Returns`, `Throws`, `Do` and
 `TransitionTo` stay on the narrowed surface, so no amount of chaining reaches the accessor the mock
-does not intercept. This applies to any number of keys: up to four keys the narrowed types ship with
-the library, for more keys they are generated per-compilation.
+does not intercept.
 
 **Notes:**
 

--- a/Docs/pages/setup/03-indexers.md
+++ b/Docs/pages/setup/03-indexers.md
@@ -119,7 +119,8 @@ interactions. See [Mockolate0002](../analyzers#mockolate0002) for when such a ty
 
 Both facades are fully restricted: the fluent builders returned by `Returns`, `Throws`, `Do` and
 `TransitionTo` stay on the narrowed surface, so no amount of chaining reaches the accessor the mock
-does not intercept. Indexers with more than four keys keep the full surface.
+does not intercept. This applies to any number of keys: up to four keys the narrowed types ship with
+the library, for more keys they are generated per-compilation.
 
 **Notes:**
 

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -89,14 +89,8 @@ public class MockGenerator : IIncrementalGenerator
 					return;
 				}
 
-				Dictionary<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> indexerSetups = new();
-				foreach (IndexerSetupKey key in source.Left)
-				{
-					indexerSetups[key.Arity] = (key.NeedsGetterOnly, key.NeedsSetterOnly);
-				}
-
 				spc.AddSource("IndexerSetups.g.cs",
-					ToSource(Sources.Sources.IndexerSetups(indexerSetups, source.Right)));
+					ToSource(Sources.Sources.IndexerSetups(source.Left, source.Right)));
 			});
 
 		IncrementalValueProvider<EquatableArray<MethodSetupKey>> methodSetupKeys = collectedMocks
@@ -247,15 +241,9 @@ public class MockGenerator : IIncrementalGenerator
 					int arity = property.IndexerParameters.Value.Count;
 					bool needsGetterOnly = property is { Getter: not null, Setter: null, };
 					bool needsSetterOnly = property is { Getter: null, Setter: not null, };
-					if (map.TryGetValue(arity, out (bool NeedsGetterOnly, bool NeedsSetterOnly) existing))
-					{
-						map[arity] = (existing.NeedsGetterOnly || needsGetterOnly,
-							existing.NeedsSetterOnly || needsSetterOnly);
-					}
-					else
-					{
-						map[arity] = (needsGetterOnly, needsSetterOnly);
-					}
+					map.TryGetValue(arity, out (bool NeedsGetterOnly, bool NeedsSetterOnly) existing);
+					map[arity] = (existing.NeedsGetterOnly || needsGetterOnly,
+						existing.NeedsSetterOnly || needsSetterOnly);
 				}
 			}
 		}

--- a/Source/Mockolate.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockolate.SourceGenerators/MockGenerator.cs
@@ -77,17 +77,27 @@ public class MockGenerator : IIncrementalGenerator
 		});
 
 		// Aggregate inputs derived from per-mock projections — each aggregate caches independently.
-		IncrementalValueProvider<EquatableArray<int>> indexerSetupArities = collectedMocks
-			.Select(static (arr, _) => CollectIndexerSetupArities(arr));
+		IncrementalValueProvider<EquatableArray<IndexerSetupKey>> indexerSetupKeys = collectedMocks
+			.Select(static (arr, _) => CollectIndexerSetupKeys(arr));
 
-		context.RegisterSourceOutput(indexerSetupArities, static (spc, arities) =>
-		{
-			if (arities.Count > 0)
+		context.RegisterSourceOutput(
+			indexerSetupKeys.Combine(hasOverloadResolutionPriority),
+			static (spc, source) =>
 			{
+				if (source.Left.Count == 0)
+				{
+					return;
+				}
+
+				Dictionary<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> indexerSetups = new();
+				foreach (IndexerSetupKey key in source.Left)
+				{
+					indexerSetups[key.Arity] = (key.NeedsGetterOnly, key.NeedsSetterOnly);
+				}
+
 				spc.AddSource("IndexerSetups.g.cs",
-					ToSource(Sources.Sources.IndexerSetups(ToHashSet(arities))));
-			}
-		});
+					ToSource(Sources.Sources.IndexerSetups(indexerSetups, source.Right)));
+			});
 
 		IncrementalValueProvider<EquatableArray<MethodSetupKey>> methodSetupKeys = collectedMocks
 			.Select(static (arr, _) => CollectMethodSetupKeys(arr));
@@ -212,18 +222,6 @@ public class MockGenerator : IIncrementalGenerator
 		return new EquatableArray<MockClass>(distinct.ToArray());
 	}
 
-	private static HashSet<int> ToHashSet(EquatableArray<int> arities)
-	{
-		int[] arr = arities.AsArray();
-		HashSet<int> set = new();
-		foreach (int item in arr)
-		{
-			set.Add(item);
-		}
-
-		return set;
-	}
-
 	private static HashSet<(int, bool)> ToMethodSetupHashSet(EquatableArray<MethodSetupKey> keys)
 	{
 		MethodSetupKey[] arr = keys.AsArray();
@@ -236,24 +234,37 @@ public class MockGenerator : IIncrementalGenerator
 		return set;
 	}
 
-	private static EquatableArray<int> CollectIndexerSetupArities(EquatableArray<MockClass> mocks)
+	private static EquatableArray<IndexerSetupKey> CollectIndexerSetupKeys(EquatableArray<MockClass> mocks)
 	{
 		MockClass[] arr = mocks.AsArray();
-		HashSet<int> set = new();
+		Dictionary<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> map = new();
 		foreach (MockClass mc in arr)
 		{
 			foreach (Property property in mc.AllProperties())
 			{
 				if (property.IndexerParameters?.Count > 4)
 				{
-					set.Add(property.IndexerParameters.Value.Count);
+					int arity = property.IndexerParameters.Value.Count;
+					bool needsGetterOnly = property is { Getter: not null, Setter: null, };
+					bool needsSetterOnly = property is { Getter: null, Setter: not null, };
+					if (map.TryGetValue(arity, out (bool NeedsGetterOnly, bool NeedsSetterOnly) existing))
+					{
+						map[arity] = (existing.NeedsGetterOnly || needsGetterOnly,
+							existing.NeedsSetterOnly || needsSetterOnly);
+					}
+					else
+					{
+						map[arity] = (needsGetterOnly, needsSetterOnly);
+					}
 				}
 			}
 		}
 
-		int[] sorted = set.ToArray();
-		Array.Sort(sorted);
-		return new EquatableArray<int>(sorted);
+		IndexerSetupKey[] sorted = map
+			.OrderBy(kvp => kvp.Key)
+			.Select(kvp => new IndexerSetupKey(kvp.Key, kvp.Value.NeedsGetterOnly, kvp.Value.NeedsSetterOnly))
+			.ToArray();
+		return new EquatableArray<IndexerSetupKey>(sorted);
 	}
 
 	private static EquatableArray<MethodSetupKey> CollectMethodSetupKeys(EquatableArray<MockClass> mocks)
@@ -543,6 +554,8 @@ public class MockGenerator : IIncrementalGenerator
 internal readonly record struct MethodSetupKey(int Arity, bool IsVoid);
 
 internal readonly record struct RefStructIndexerSetup(int Arity, bool HasGetter, bool HasSetter);
+
+internal readonly record struct IndexerSetupKey(int Arity, bool NeedsGetterOnly, bool NeedsSetterOnly);
 
 internal readonly record struct MockAsExtensionPair(
 	string SourceName,

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -4,7 +4,9 @@ namespace Mockolate.SourceGenerators.Sources;
 
 internal static partial class Sources
 {
-	public static string IndexerSetups(HashSet<int> indexerSetups)
+	public static string IndexerSetups(
+		Dictionary<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> indexerSetups,
+		bool hasOverloadResolutionPriority)
 	{
 		StringBuilder sb = InitializeBuilder();
 
@@ -14,10 +16,19 @@ internal static partial class Sources
 		          namespace Mockolate.Setup
 		          {
 		          """);
-		foreach (int item in indexerSetups)
+		foreach (KeyValuePair<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> item in indexerSetups)
 		{
 			sb.AppendLine();
-			AppendIndexerSetup(sb, item);
+			AppendIndexerSetup(sb, item.Key, item.Value.NeedsGetterOnly, item.Value.NeedsSetterOnly);
+			if (item.Value.NeedsGetterOnly)
+			{
+				AppendGetterOnlyIndexerInterfaces(sb, item.Key);
+			}
+
+			if (item.Value.NeedsSetterOnly)
+			{
+				AppendSetterOnlyIndexerInterfaces(sb, item.Key);
+			}
 		}
 
 		sb.AppendLine();
@@ -35,8 +46,9 @@ internal static partial class Sources
 		              	internal static class IndexerSetupExtensions
 		              	{
 		              """).AppendLine();
-		foreach (int item in indexerSetups)
+		foreach (KeyValuePair<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> setup in indexerSetups)
 		{
+			int item = setup.Key;
 			string types = GetGenericTypeParameters(item);
 			sb.Append($$"""
 			            		/// <summary>
@@ -83,6 +95,62 @@ internal static partial class Sources
 			            				=> setup.Only(1);
 			            		}
 			            """).AppendLine();
+
+			if (setup.Value.NeedsGetterOnly)
+			{
+				sb.AppendLine();
+				sb.Append($$"""
+				            		/// <summary>
+				            		///     Extensions for setups of get-only indexers with {{item}} parameters.
+				            		/// </summary>
+				            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{types}}> setup)
+				            		{
+				            			/// <summary>
+				            			///     Returns/throws forever.
+				            			/// </summary>
+				            			public void Forever()
+				            			{
+				            				setup.For(int.MaxValue);
+				            			}
+
+				            			/// <summary>
+				            			///     Uses the return value only once.
+				            			/// </summary>
+				            			public global::Mockolate.Setup.IIndexerGetterOnlySetup<TValue, {{types}}> OnlyOnce()
+				            				=> setup.Only(1);
+				            		}
+
+				            		/// <summary>
+				            		///     Extensions for getter callback setups of get-only indexers with {{item}} parameters.
+				            		/// </summary>
+				            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{types}}> setup)
+				            		{
+				            			/// <summary>
+				            			///     Executes the callback only once.
+				            			/// </summary>
+				            			public global::Mockolate.Setup.IIndexerGetterOnlySetup<TValue, {{types}}> OnlyOnce()
+				            				=> setup.Only(1);
+				            		}
+				            """).AppendLine();
+			}
+
+			if (setup.Value.NeedsSetterOnly)
+			{
+				sb.AppendLine();
+				sb.Append($$"""
+				            		/// <summary>
+				            		///     Extensions for setter callback setups of set-only indexers with {{item}} parameters.
+				            		/// </summary>
+				            		extension<TValue, {{types}}>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{types}}> setup)
+				            		{
+				            			/// <summary>
+				            			///     Executes the callback only once.
+				            			/// </summary>
+				            			public global::Mockolate.Setup.IIndexerSetterOnlySetup<TValue, {{types}}> OnlyOnce()
+				            				=> setup.Only(1);
+				            		}
+				            """).AppendLine();
+			}
 		}
 
 		sb.Append("""
@@ -91,7 +159,7 @@ internal static partial class Sources
 		          """).AppendLine();
 		sb.Append("namespace Mockolate.Interactions").AppendLine();
 		sb.Append("{").AppendLine();
-		foreach (int count in indexerSetups)
+		foreach (int count in indexerSetups.Keys)
 		{
 			AppendIndexerGetterAccess(sb, count);
 			AppendIndexerSetterAccess(sb, count);
@@ -99,6 +167,27 @@ internal static partial class Sources
 
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
+
+		if (indexerSetups.Values.Any(v => v.NeedsGetterOnly || v.NeedsSetterOnly))
+		{
+			sb.Append("namespace Mockolate.Verify").AppendLine();
+			sb.Append("{").AppendLine();
+			foreach (KeyValuePair<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> item in indexerSetups)
+			{
+				if (item.Value.NeedsGetterOnly)
+				{
+					AppendIndexerVerifyGetterResult(sb, item.Key);
+				}
+
+				if (item.Value.NeedsSetterOnly)
+				{
+					AppendIndexerVerifySetterResult(sb, item.Key, hasOverloadResolutionPriority);
+				}
+			}
+
+			sb.Append("}").AppendLine();
+			sb.AppendLine();
+		}
 
 		sb.AppendLine("#nullable disable");
 		return sb.ToString();
@@ -209,7 +298,8 @@ internal static partial class Sources
 		sb.Append("\t\t}").AppendLine();
 	}
 
-	private static void AppendIndexerSetup(StringBuilder sb, int numberOfParameters)
+	private static void AppendIndexerSetup(StringBuilder sb, int numberOfParameters,
+		bool needsGetterOnly, bool needsSetterOnly)
 	{
 		string typeParams = GetGenericTypeParameters(numberOfParameters);
 		string outTypeParams = GetOutGenericTypeParameters(numberOfParameters);
@@ -472,7 +562,25 @@ internal static partial class Sources
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
 		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, ").Append(typeParams).Append(">,").AppendLine();
-		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, ").Append(typeParams).Append(">").AppendLine();
+		sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, ").Append(typeParams).Append(">");
+		if (needsGetterOnly)
+		{
+			sb.Append(",").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterOnlySetup<TValue, ").Append(typeParams).Append(">,").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, ").Append(typeParams).Append(">,").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, ").Append(typeParams).Append(">,").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, ").Append(typeParams).Append(">");
+		}
+
+		if (needsSetterOnly)
+		{
+			sb.Append(",").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterOnlySetup<TValue, ").Append(typeParams).Append(">,").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, ").Append(typeParams).Append(">,").AppendLine();
+			sb.Append("\t\tglobal::Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, ").Append(typeParams).Append(">");
+		}
+
+		sb.AppendLine();
 		sb.Append("\t{").AppendLine();
 		sb.Append("\t\tprivate Callbacks<global::System.Action<int, ").Append(typeParams)
 			.Append(", TValue>>? _getterCallbacks;")
@@ -1183,6 +1291,595 @@ internal static partial class Sources
 			Enumerable.Range(1, numberOfParameters).Select(i => $"{{parameter{i}}}"))).Append("]\";").AppendLine();
 		sb.AppendLine();
 
+		if (needsGetterOnly)
+		{
+			AppendGetterOnlyIndexerImplementation(sb, numberOfParameters);
+		}
+
+		if (needsSetterOnly)
+		{
+			AppendSetterOnlyIndexerImplementation(sb, numberOfParameters);
+		}
+
 		sb.Append("\t}").AppendLine();
+	}
+
+	private static void AppendGetterOnlyIndexerInterfaces(StringBuilder sb, int numberOfParameters)
+	{
+		string tp = GetGenericTypeParameters(numberOfParameters);
+		string outTp = GetOutGenericTypeParameters(numberOfParameters);
+		string description = GetTypeParametersDescription(numberOfParameters);
+
+		sb.AppendLine();
+		sb.Append($$"""
+		            	/// <summary>
+		            	///     Setup for a mocked <typeparamref name="TValue"/> indexer for {{description}} that the mock only reads.
+		            	/// </summary>
+		            	/// <remarks>
+		            	///     Used instead of <see cref="IIndexerSetup{TValue, {{tp}}}" /> when the mock has no setter to intercept, either
+		            	///     because the indexer is declared without one or because its setter is not accessible from the mock's assembly.
+		            	///     Writes then never reach the mock, so <see cref="IIndexerSetup{TValue, {{tp}}}.OnSet" /> is not offered.
+		            	/// </remarks>
+		            	internal interface IIndexerGetterOnlySetup<TValue, {{outTp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.OnGet" />
+		            		IIndexerGetterOnlyGetterSetup<TValue, {{tp}}> OnGet { get; }
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.SkippingBaseClass(bool)" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> SkippingBaseClass(bool skipBaseClass = true);
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.InitializeWith(TValue)" />
+		            		/// <remarks>
+		            		///     Seeds the value that reads return. Unlike a read-write indexer there is no setter to update the
+		            		///     slot afterwards, so it stays at <paramref name="value" /> unless a <c>Returns</c> entry applies.
+		            		/// </remarks>
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> InitializeWith(TValue value);
+
+		            		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, {{tp}}}.InitializeWith(global::System.Func{{{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> InitializeWith(global::System.Func<{{tp}}, TValue> valueGenerator);
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.Returns(TValue)" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Returns(TValue returnValue);
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.Returns(global::System.Func{TValue})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Returns(global::System.Func<TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, {{tp}}}.Returns(global::System.Func{{{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Returns(global::System.Func<{{tp}}, TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, {{tp}}}.Returns(global::System.Func{{{tp}}, TValue, TValue})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Returns(global::System.Func<{{tp}}, TValue, TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.Throws{TException}()" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Throws<TException>()
+		            			where TException : global::System.Exception, new();
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.Throws(global::System.Exception)" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Throws(global::System.Exception exception);
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.Throws(global::System.Func{global::System.Exception})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Throws(global::System.Func<global::System.Exception> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, {{tp}}}.Throws(global::System.Func{{{tp}}, global::System.Exception})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Throws(global::System.Func<{{tp}}, global::System.Exception> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, {{tp}}}.Throws(global::System.Func{{{tp}}, TValue, global::System.Exception})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> Throws(global::System.Func<{{tp}}, TValue, global::System.Exception> callback);
+		            	}
+
+		            	/// <summary>
+		            	///     Setup for attaching side-effects to the getter of a get-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	/// <remarks>
+		            	///     The counterpart of <see cref="IIndexerGetterSetupWithCallback{TValue, {{tp}}}" /> for
+		            	///     <see cref="IIndexerGetterOnlySetup{TValue, {{tp}}}" />: the returned builders stay on the getter-only surface,
+		            	///     so chaining can never reach <see cref="IIndexerSetup{TValue, {{tp}}}.OnSet" />.
+		            	/// </remarks>
+		            	internal interface IIndexerGetterOnlyGetterSetup<TValue, {{outTp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerGetterSetup{TValue, {{tp}}}.Do(global::System.Action)" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action callback);
+
+		            		/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, {{tp}}}.Do(global::System.Action{{{tp}}})" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action<{{tp}}> callback);
+
+		            		/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, {{tp}}}.Do(global::System.Action{{{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action<{{tp}}, TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, {{tp}}}.Do(global::System.Action{int, {{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action<int, {{tp}}, TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerGetterSetup{TValue, {{tp}}}.TransitionTo(string)" />
+		            		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> TransitionTo(string scenario);
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a callback for a get-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerGetterOnlySetupCallbackBuilder<TValue, {{outTp}}>
+		            		: IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, {{tp}}}.InParallel()" />
+		            		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> InParallel();
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a parallel callback for a get-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, {{outTp}}>
+		            		: IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, {{tp}}}.When(global::System.Func{int, bool})" />
+		            		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> When(global::System.Func<int, bool> predicate);
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a when callback for a get-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{outTp}}>
+		            		: IIndexerGetterOnlySetup<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, {{tp}}}.For(int)" />
+		            		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> For(int times);
+
+		            		/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, {{tp}}}.Only(int)" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> Only(int times);
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a return/throw builder for a get-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerGetterOnlySetupReturnBuilder<TValue, {{outTp}}>
+		            		: IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetupReturnBuilder{TValue, {{tp}}}.When(global::System.Func{int, bool})" />
+		            		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{tp}}> When(global::System.Func<int, bool> predicate);
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a when builder for returns/throws for a get-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{outTp}}>
+		            		: IIndexerGetterOnlySetup<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, {{tp}}}.For(int)" />
+		            		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{tp}}> For(int times);
+
+		            		/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, {{tp}}}.Only(int)" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> Only(int times);
+		            	}
+		            """).AppendLine();
+	}
+
+	private static void AppendSetterOnlyIndexerInterfaces(StringBuilder sb, int numberOfParameters)
+	{
+		string tp = GetGenericTypeParameters(numberOfParameters);
+		string outTp = GetOutGenericTypeParameters(numberOfParameters);
+		string description = GetTypeParametersDescription(numberOfParameters);
+
+		sb.AppendLine();
+		sb.Append($$"""
+		            	/// <summary>
+		            	///     Setup for a mocked <typeparamref name="TValue"/> indexer for {{description}} that the mock only writes.
+		            	/// </summary>
+		            	/// <remarks>
+		            	///     The write-only counterpart of <see cref="IIndexerGetterOnlySetup{TValue, {{tp}}}" />: the mock has no getter to
+		            	///     intercept, so <see cref="IIndexerSetup{TValue, {{tp}}}.OnGet" />, <c>InitializeWith</c> and the
+		            	///     <c>Returns</c>/<c>Throws</c> read-sequence are not offered.
+		            	/// </remarks>
+		            	internal interface IIndexerSetterOnlySetup<TValue, {{outTp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.OnSet" />
+		            		IIndexerSetterOnlySetterSetup<TValue, {{tp}}> OnSet { get; }
+
+		            		/// <inheritdoc cref="IIndexerSetup{TValue, {{tp}}}.SkippingBaseClass(bool)" />
+		            		IIndexerSetterOnlySetup<TValue, {{tp}}> SkippingBaseClass(bool skipBaseClass = true);
+		            	}
+
+		            	/// <summary>
+		            	///     Setup for attaching side-effects to the setter of a set-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	/// <remarks>
+		            	///     The counterpart of <see cref="IIndexerSetterSetupWithCallback{TValue, {{tp}}}" /> for
+		            	///     <see cref="IIndexerSetterOnlySetup{TValue, {{tp}}}" />: the returned builders stay on the setter-only surface,
+		            	///     so chaining can never reach <see cref="IIndexerSetup{TValue, {{tp}}}.OnGet" /> or the
+		            	///     <c>Returns</c>/<c>Throws</c> read-sequence.
+		            	/// </remarks>
+		            	internal interface IIndexerSetterOnlySetterSetup<TValue, {{outTp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetterSetup{TValue, {{tp}}}.Do(global::System.Action)" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action callback);
+
+		            		/// <inheritdoc cref="IIndexerSetterSetup{TValue, {{tp}}}.Do(global::System.Action{TValue})" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action<TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, {{tp}}}.Do(global::System.Action{{{tp}}, TValue})" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action<{{tp}}, TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, {{tp}}}.Do(global::System.Action{int, {{tp}}, TValue})" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> Do(global::System.Action<int, {{tp}}, TValue> callback);
+
+		            		/// <inheritdoc cref="IIndexerSetterSetup{TValue, {{tp}}}.TransitionTo(string)" />
+		            		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> TransitionTo(string scenario);
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a setter callback for a set-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerSetterOnlySetupCallbackBuilder<TValue, {{outTp}}>
+		            		: IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, {{tp}}}.InParallel()" />
+		            		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> InParallel();
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a parallel setter callback for a set-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, {{outTp}}>
+		            		: IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, {{tp}}}.When(global::System.Func{int, bool})" />
+		            		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> When(global::System.Func<int, bool> predicate);
+		            	}
+
+		            	/// <summary>
+		            	///     Sets up a when setter callback for a set-only <typeparamref name="TValue"/> indexer for {{description}}.
+		            	/// </summary>
+		            	internal interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{outTp}}>
+		            		: IIndexerSetterOnlySetup<TValue, {{tp}}>
+		            	{
+		            		/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, {{tp}}}.For(int)" />
+		            		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> For(int times);
+
+		            		/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, {{tp}}}.Only(int)" />
+		            		IIndexerSetterOnlySetup<TValue, {{tp}}> Only(int times);
+		            	}
+		            """).AppendLine();
+	}
+
+	private static void AppendGetterOnlyIndexerImplementation(StringBuilder sb, int numberOfParameters)
+	{
+		string tp = GetGenericTypeParameters(numberOfParameters);
+
+		sb.Append($$"""
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.SkippingBaseClass(bool)" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.SkippingBaseClass(bool skipBaseClass)
+		            		{
+		            			SkippingBaseClass(skipBaseClass);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.InitializeWith(TValue)" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.InitializeWith(TValue value)
+		            		{
+		            			InitializeWith(value);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.InitializeWith(global::System.Func{{{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.InitializeWith(global::System.Func<{{tp}}, TValue> valueGenerator)
+		            		{
+		            			InitializeWith(valueGenerator);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.OnGet" />
+		            		IIndexerGetterOnlyGetterSetup<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.OnGet
+		            			=> this;
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, {{tp}}}.Do(global::System.Action)" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerGetterOnlyGetterSetup<TValue, {{tp}}>.Do(global::System.Action callback)
+		            		{
+		            			((IIndexerGetterSetup<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, {{tp}}}.Do(global::System.Action{{{tp}}})" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerGetterOnlyGetterSetup<TValue, {{tp}}>.Do(global::System.Action<{{tp}}> callback)
+		            		{
+		            			((IIndexerGetterSetupWithCallback<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, {{tp}}}.Do(global::System.Action{{{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerGetterOnlyGetterSetup<TValue, {{tp}}>.Do(global::System.Action<{{tp}}, TValue> callback)
+		            		{
+		            			((IIndexerGetterSetupWithCallback<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, {{tp}}}.Do(global::System.Action{int, {{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerGetterOnlyGetterSetup<TValue, {{tp}}>.Do(global::System.Action<int, {{tp}}, TValue> callback)
+		            		{
+		            			((IIndexerGetterSetupWithCallback<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, {{tp}}}.TransitionTo(string)" />
+		            		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> IIndexerGetterOnlyGetterSetup<TValue, {{tp}}>.TransitionTo(string scenario)
+		            		{
+		            			((IIndexerGetterSetup<TValue, {{tp}}>)this).TransitionTo(scenario);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackBuilder{TValue, {{tp}}}.InParallel()" />
+		            		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> IIndexerGetterOnlySetupCallbackBuilder<TValue, {{tp}}>.InParallel()
+		            		{
+		            			((IIndexerGetterSetupCallbackBuilder<TValue, {{tp}}>)this).InParallel();
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetupParallelCallbackBuilder{TValue, {{tp}}}.When(global::System.Func{int, bool})" />
+		            		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}>.When(global::System.Func<int, bool> predicate)
+		            		{
+		            			((IIndexerGetterSetupParallelCallbackBuilder<TValue, {{tp}}>)this).When(predicate);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, {{tp}}}.For(int)" />
+		            		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}>.For(int times)
+		            		{
+		            			((IIndexerGetterSetupCallbackWhenBuilder<TValue, {{tp}}>)this).For(times);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, {{tp}}}.Only(int)" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}>.Only(int times)
+		            		{
+		            			((IIndexerGetterSetupCallbackWhenBuilder<TValue, {{tp}}>)this).Only(times);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Returns(TValue)" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Returns(TValue returnValue)
+		            		{
+		            			Returns(returnValue);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Returns(global::System.Func{TValue})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Returns(global::System.Func<TValue> callback)
+		            		{
+		            			Returns(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Returns(global::System.Func{{{tp}}, TValue})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Returns(global::System.Func<{{tp}}, TValue> callback)
+		            		{
+		            			Returns(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Returns(global::System.Func{{{tp}}, TValue, TValue})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Returns(global::System.Func<{{tp}}, TValue, TValue> callback)
+		            		{
+		            			Returns(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Throws{TException}()" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Throws<TException>()
+		            		{
+		            			Throws<TException>();
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Throws(global::System.Exception)" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Throws(global::System.Exception exception)
+		            		{
+		            			Throws(exception);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Throws(global::System.Func{global::System.Exception})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Throws(global::System.Func<global::System.Exception> callback)
+		            		{
+		            			Throws(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Throws(global::System.Func{{{tp}}, global::System.Exception})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Throws(global::System.Func<{{tp}}, global::System.Exception> callback)
+		            		{
+		            			Throws(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, {{tp}}}.Throws(global::System.Func{{{tp}}, TValue, global::System.Exception})" />
+		            		IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}> IIndexerGetterOnlySetup<TValue, {{tp}}>.Throws(global::System.Func<{{tp}}, TValue, global::System.Exception> callback)
+		            		{
+		            			Throws(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetupReturnBuilder{TValue, {{tp}}}.When(global::System.Func{int, bool})" />
+		            		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{tp}}> IIndexerGetterOnlySetupReturnBuilder<TValue, {{tp}}>.When(global::System.Func<int, bool> predicate)
+		            		{
+		            			((IIndexerSetupReturnBuilder<TValue, {{tp}}>)this).When(predicate);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, {{tp}}}.For(int)" />
+		            		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{tp}}> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{tp}}>.For(int times)
+		            		{
+		            			((IIndexerSetupReturnWhenBuilder<TValue, {{tp}}>)this).For(times);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, {{tp}}}.Only(int)" />
+		            		IIndexerGetterOnlySetup<TValue, {{tp}}> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, {{tp}}>.Only(int times)
+		            		{
+		            			((IIndexerSetupReturnWhenBuilder<TValue, {{tp}}>)this).Only(times);
+		            			return this;
+		            		}
+
+		            """).AppendLine();
+	}
+
+	private static void AppendSetterOnlyIndexerImplementation(StringBuilder sb, int numberOfParameters)
+	{
+		string tp = GetGenericTypeParameters(numberOfParameters);
+
+		sb.Append($$"""
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, {{tp}}}.SkippingBaseClass(bool)" />
+		            		IIndexerSetterOnlySetup<TValue, {{tp}}> IIndexerSetterOnlySetup<TValue, {{tp}}>.SkippingBaseClass(bool skipBaseClass)
+		            		{
+		            			SkippingBaseClass(skipBaseClass);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, {{tp}}}.OnSet" />
+		            		IIndexerSetterOnlySetterSetup<TValue, {{tp}}> IIndexerSetterOnlySetup<TValue, {{tp}}>.OnSet
+		            			=> this;
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, {{tp}}}.Do(global::System.Action)" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerSetterOnlySetterSetup<TValue, {{tp}}>.Do(global::System.Action callback)
+		            		{
+		            			((IIndexerSetterSetup<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, {{tp}}}.Do(global::System.Action{TValue})" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerSetterOnlySetterSetup<TValue, {{tp}}>.Do(global::System.Action<TValue> callback)
+		            		{
+		            			((IIndexerSetterSetup<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, {{tp}}}.Do(global::System.Action{{{tp}}, TValue})" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerSetterOnlySetterSetup<TValue, {{tp}}>.Do(global::System.Action<{{tp}}, TValue> callback)
+		            		{
+		            			((IIndexerSetterSetupWithCallback<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, {{tp}}}.Do(global::System.Action{int, {{tp}}, TValue})" />
+		            		IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}> IIndexerSetterOnlySetterSetup<TValue, {{tp}}>.Do(global::System.Action<int, {{tp}}, TValue> callback)
+		            		{
+		            			((IIndexerSetterSetupWithCallback<TValue, {{tp}}>)this).Do(callback);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, {{tp}}}.TransitionTo(string)" />
+		            		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> IIndexerSetterOnlySetterSetup<TValue, {{tp}}>.TransitionTo(string scenario)
+		            		{
+		            			((IIndexerSetterSetup<TValue, {{tp}}>)this).TransitionTo(scenario);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackBuilder{TValue, {{tp}}}.InParallel()" />
+		            		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}> IIndexerSetterOnlySetupCallbackBuilder<TValue, {{tp}}>.InParallel()
+		            		{
+		            			((IIndexerSetterSetupCallbackBuilder<TValue, {{tp}}>)this).InParallel();
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetupParallelCallbackBuilder{TValue, {{tp}}}.When(global::System.Func{int, bool})" />
+		            		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, {{tp}}>.When(global::System.Func<int, bool> predicate)
+		            		{
+		            			((IIndexerSetterSetupParallelCallbackBuilder<TValue, {{tp}}>)this).When(predicate);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, {{tp}}}.For(int)" />
+		            		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}>.For(int times)
+		            		{
+		            			((IIndexerSetterSetupCallbackWhenBuilder<TValue, {{tp}}>)this).For(times);
+		            			return this;
+		            		}
+
+		            		/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, {{tp}}}.Only(int)" />
+		            		IIndexerSetterOnlySetup<TValue, {{tp}}> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, {{tp}}>.Only(int times)
+		            		{
+		            			((IIndexerSetterSetupCallbackWhenBuilder<TValue, {{tp}}>)this).Only(times);
+		            			return this;
+		            		}
+
+		            """).AppendLine();
+	}
+
+	private static void AppendIndexerVerifyGetterResult(StringBuilder sb, int numberOfParameters)
+	{
+		string tp = GetGenericTypeParameters(numberOfParameters);
+		string description = GetTypeParametersDescription(numberOfParameters);
+
+		sb.Append($$"""
+		            	/// <summary>
+		            	///     Verifications on a {{numberOfParameters}}-key indexer for {{description}} that the mock only reads.
+		            	/// </summary>
+		            	/// <remarks>
+		            	///     Used instead of <see cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}" /> when the
+		            	///     mock has no setter to intercept. Writes then never reach the mock, so offering <c>Set(...)</c> here would
+		            	///     always report zero interactions.
+		            	/// </remarks>
+		            """).AppendLine();
+#if !DEBUG
+		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
+		sb.Append($$"""
+		            	internal class VerificationIndexerGetterResult<TSubject, {{tp}}>(
+		            		TSubject subject,
+		            		global::Mockolate.MockRegistry mockRegistry,
+		            		int getMemberId,
+		            		global::System.Func<global::Mockolate.Interactions.IInteraction, bool> gotPredicate,
+		            		global::System.Func<string> parametersDescription)
+		            	{
+		            		/// <inheritdoc cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}.Got()" />
+		            		public global::Mockolate.Verify.VerificationResult<TSubject> Got()
+		            			=> mockRegistry.IndexerGot(subject, getMemberId, gotPredicate, parametersDescription);
+		            	}
+		            """).AppendLine();
+	}
+
+	private static void AppendIndexerVerifySetterResult(StringBuilder sb, int numberOfParameters,
+		bool hasOverloadResolutionPriority)
+	{
+		string tp = GetGenericTypeParameters(numberOfParameters);
+		string description = GetTypeParametersDescription(numberOfParameters);
+
+		sb.Append($$"""
+		            	/// <summary>
+		            	///     Verifications on a {{numberOfParameters}}-key indexer of type <typeparamref name="TParameter" /> for {{description}} that the mock only writes.
+		            	/// </summary>
+		            	/// <remarks>
+		            	///     Used instead of <see cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}" /> when the
+		            	///     mock has no getter to intercept, so <c>Got()</c> is not offered.
+		            	/// </remarks>
+		            """).AppendLine();
+#if !DEBUG
+		sb.Append("\t[global::System.Diagnostics.DebuggerNonUserCode]").AppendLine();
+#endif
+		sb.Append("\t[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]").AppendLine();
+		sb.Append($$"""
+		            	internal class VerificationIndexerSetterResult<TSubject, {{tp}}, TParameter>(
+		            		TSubject subject,
+		            		global::Mockolate.MockRegistry mockRegistry,
+		            		int setMemberId,
+		            		global::System.Func<global::Mockolate.Interactions.IInteraction, global::Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate,
+		            		global::System.Func<string> parametersDescription)
+		            	{
+		            		/// <inheritdoc cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}.Set(global::Mockolate.Parameters.IParameter{TParameter})" />
+		            		public global::Mockolate.Verify.VerificationResult<TSubject> Set(global::Mockolate.Parameters.IParameter<TParameter> value)
+		            			=> mockRegistry.IndexerSet(subject, setMemberId, setPredicate,
+		            				(global::Mockolate.Parameters.IParameterMatch<TParameter>)value, parametersDescription);
+
+		            """).AppendLine();
+		if (hasOverloadResolutionPriority)
+		{
+			sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]").AppendLine();
+		}
+
+		sb.Append($$"""
+		            		/// <summary>
+		            		///     Verifies the indexer write access on the mock with the given <paramref name="value" />.
+		            		/// </summary>
+		            		public global::Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value)
+		            			=> mockRegistry.IndexerSet(subject, setMemberId, setPredicate,
+		            				(global::Mockolate.Parameters.IParameterMatch<TParameter>)global::Mockolate.It.Is(value, value?.ToString() ?? "null"), parametersDescription);
+		            	}
+		            """).AppendLine();
 	}
 }

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.IndexerSetups.cs
@@ -5,7 +5,7 @@ namespace Mockolate.SourceGenerators.Sources;
 internal static partial class Sources
 {
 	public static string IndexerSetups(
-		Dictionary<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> indexerSetups,
+		IEnumerable<IndexerSetupKey> indexerSetups,
 		bool hasOverloadResolutionPriority)
 	{
 		StringBuilder sb = InitializeBuilder();
@@ -16,18 +16,18 @@ internal static partial class Sources
 		          namespace Mockolate.Setup
 		          {
 		          """);
-		foreach (KeyValuePair<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> item in indexerSetups)
+		foreach (IndexerSetupKey item in indexerSetups)
 		{
 			sb.AppendLine();
-			AppendIndexerSetup(sb, item.Key, item.Value.NeedsGetterOnly, item.Value.NeedsSetterOnly);
-			if (item.Value.NeedsGetterOnly)
+			AppendIndexerSetup(sb, item.Arity, item.NeedsGetterOnly, item.NeedsSetterOnly);
+			if (item.NeedsGetterOnly)
 			{
-				AppendGetterOnlyIndexerInterfaces(sb, item.Key);
+				AppendGetterOnlyIndexerInterfaces(sb, item.Arity);
 			}
 
-			if (item.Value.NeedsSetterOnly)
+			if (item.NeedsSetterOnly)
 			{
-				AppendSetterOnlyIndexerInterfaces(sb, item.Key);
+				AppendSetterOnlyIndexerInterfaces(sb, item.Arity);
 			}
 		}
 
@@ -46,9 +46,9 @@ internal static partial class Sources
 		              	internal static class IndexerSetupExtensions
 		              	{
 		              """).AppendLine();
-		foreach (KeyValuePair<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> setup in indexerSetups)
+		foreach (IndexerSetupKey setup in indexerSetups)
 		{
-			int item = setup.Key;
+			int item = setup.Arity;
 			string types = GetGenericTypeParameters(item);
 			sb.Append($$"""
 			            		/// <summary>
@@ -96,7 +96,7 @@ internal static partial class Sources
 			            		}
 			            """).AppendLine();
 
-			if (setup.Value.NeedsGetterOnly)
+			if (setup.NeedsGetterOnly)
 			{
 				sb.AppendLine();
 				sb.Append($$"""
@@ -134,7 +134,7 @@ internal static partial class Sources
 				            """).AppendLine();
 			}
 
-			if (setup.Value.NeedsSetterOnly)
+			if (setup.NeedsSetterOnly)
 			{
 				sb.AppendLine();
 				sb.Append($$"""
@@ -159,29 +159,29 @@ internal static partial class Sources
 		          """).AppendLine();
 		sb.Append("namespace Mockolate.Interactions").AppendLine();
 		sb.Append("{").AppendLine();
-		foreach (int count in indexerSetups.Keys)
+		foreach (IndexerSetupKey key in indexerSetups)
 		{
-			AppendIndexerGetterAccess(sb, count);
-			AppendIndexerSetterAccess(sb, count);
+			AppendIndexerGetterAccess(sb, key.Arity);
+			AppendIndexerSetterAccess(sb, key.Arity);
 		}
 
 		sb.Append("}").AppendLine();
 		sb.AppendLine();
 
-		if (indexerSetups.Values.Any(v => v.NeedsGetterOnly || v.NeedsSetterOnly))
+		if (indexerSetups.Any(v => v.NeedsGetterOnly || v.NeedsSetterOnly))
 		{
 			sb.Append("namespace Mockolate.Verify").AppendLine();
 			sb.Append("{").AppendLine();
-			foreach (KeyValuePair<int, (bool NeedsGetterOnly, bool NeedsSetterOnly)> item in indexerSetups)
+			foreach (IndexerSetupKey item in indexerSetups)
 			{
-				if (item.Value.NeedsGetterOnly)
+				if (item.NeedsGetterOnly)
 				{
-					AppendIndexerVerifyGetterResult(sb, item.Key);
+					AppendIndexerVerifyGetterResult(sb, item.Arity);
 				}
 
-				if (item.Value.NeedsSetterOnly)
+				if (item.NeedsSetterOnly)
 				{
-					AppendIndexerVerifySetterResult(sb, item.Key, hasOverloadResolutionPriority);
+					AppendIndexerVerifySetterResult(sb, item.Arity, hasOverloadResolutionPriority);
 				}
 			}
 
@@ -1872,13 +1872,17 @@ internal static partial class Sources
 			sb.Append("\t\t[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]").AppendLine();
 		}
 
+		// It.IsValue instead of It.Is: this file is emitted into the consumer's compilation, which
+		// cannot see the internal CallerArgumentExpression polyfill the shipped result relies on.
+		// IsValue formats the value lazily and invariantly, so a literal renders exactly as it does
+		// on the shipped surface, and no description is built on the passing path.
 		sb.Append($$"""
 		            		/// <summary>
 		            		///     Verifies the indexer write access on the mock with the given <paramref name="value" />.
 		            		/// </summary>
 		            		public global::Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value)
 		            			=> mockRegistry.IndexerSet(subject, setMemberId, setPredicate,
-		            				(global::Mockolate.Parameters.IParameterMatch<TParameter>)global::Mockolate.It.Is(value, value?.ToString() ?? "null"), parametersDescription);
+		            				(global::Mockolate.Parameters.IParameterMatch<TParameter>)global::Mockolate.It.IsValue<TParameter>(value), parametersDescription);
 		            	}
 		            """).AppendLine();
 	}

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -3191,22 +3191,13 @@ internal static partial class Sources
 		};
 
 	/// <summary>
-	///     Which accessors of the <paramref name="indexer" /> the narrowed setup/verify facades follow. The
-	///     narrowed indexer types only exist for up to <see cref="MaxExplicitParameters" /> keys, so indexers
-	///     with more keys keep the full surface regardless of <see cref="GetInterceptedAccessors" />.
-	/// </summary>
-	private static PropertyAccessors GetIndexerInterceptedAccessors(Property indexer)
-		=> indexer.IndexerParameters!.Value.Count <= MaxExplicitParameters
-			? GetInterceptedAccessors(indexer)
-			: PropertyAccessors.Both;
-
-	/// <summary>
 	///     The open-generic setup facade emitted for the <paramref name="indexer" />, narrowed to the accessors
-	///     classified by <see cref="GetIndexerInterceptedAccessors" />. The caller appends the value and key type
-	///     arguments and the closing angle bracket.
+	///     classified by <see cref="GetInterceptedAccessors" />. The narrowed types are shipped for up to
+	///     <see cref="MaxExplicitParameters" /> keys and generated per-compilation for more. The caller appends
+	///     the value and key type arguments and the closing angle bracket.
 	/// </summary>
 	private static string GetIndexerSetupType(Property indexer)
-		=> GetIndexerInterceptedAccessors(indexer) switch
+		=> GetInterceptedAccessors(indexer) switch
 		{
 			PropertyAccessors.GetOnly => "global::Mockolate.Setup.IIndexerGetterOnlySetup<",
 			PropertyAccessors.SetOnly => "global::Mockolate.Setup.IIndexerSetterOnlySetup<",
@@ -3215,13 +3206,13 @@ internal static partial class Sources
 
 	/// <summary>
 	///     Appends the verify facade emitted for the <paramref name="indexer" />, narrowed to the accessors
-	///     classified by <see cref="GetIndexerInterceptedAccessors" />. The narrowed results are keyed by the
+	///     classified by <see cref="GetInterceptedAccessors" />. The narrowed results are keyed by the
 	///     indexer parameters (the setter result additionally by the value type), the full
 	///     <c>VerificationIndexerResult</c> only by the value type.
 	/// </summary>
 	private static void AppendIndexerVerifyType(StringBuilder sb, Property indexer, string verifyName)
 	{
-		switch (GetIndexerInterceptedAccessors(indexer))
+		switch (GetInterceptedAccessors(indexer))
 		{
 			case PropertyAccessors.GetOnly:
 				sb.Append("global::Mockolate.Verify.VerificationIndexerGetterResult<").Append(verifyName);
@@ -4827,7 +4818,7 @@ internal static partial class Sources
 		bool useTypedVerify = indexer.IndexerParameters.Value.Count is >= 1 and <= 4;
 		if (useTypedVerify)
 		{
-			PropertyAccessors interceptedAccessors = GetIndexerInterceptedAccessors(indexer);
+			PropertyAccessors interceptedAccessors = GetInterceptedAccessors(indexer);
 			string typedVerifyType = interceptedAccessors switch
 			{
 				PropertyAccessors.GetOnly => "VerificationIndexerGetterResult",
@@ -4861,39 +4852,72 @@ internal static partial class Sources
 		}
 		else
 		{
-			sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName)
-				.Append(", ").AppendTypeOrWrapper(indexer.Type).Append(">(this, this.").Append(mockRegistryName)
-				.Append(", ").Append(indexerGetMemberId).Append(", ").Append(indexerSetMemberId).Append(",").AppendLine();
-
-			sb.Append("\t\t\t\t\tinteraction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<");
-			int ti = 0;
-			foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+			PropertyAccessors interceptedAccessors = GetInterceptedAccessors(indexer);
+			// The narrow views take only the member id and predicate of the accessor they expose.
+			switch (interceptedAccessors)
 			{
-				if (ti > 0)
+				case PropertyAccessors.GetOnly:
+					sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerGetterResult<")
+						.Append(verifyName);
+					foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+					{
+						sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
+					}
+
+					sb.Append(">(this, this.").Append(mockRegistryName)
+						.Append(", ").Append(indexerGetMemberId).Append(",").AppendLine();
+					break;
+				case PropertyAccessors.SetOnly:
+					sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerSetterResult<")
+						.Append(verifyName);
+					foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+					{
+						sb.Append(", ").AppendTypeOrWrapper(parameter.Type);
+					}
+
+					sb.Append(", ").AppendTypeOrWrapper(indexer.Type).Append(">(this, this.").Append(mockRegistryName)
+						.Append(", ").Append(indexerSetMemberId).Append(",").AppendLine();
+					break;
+				default:
+					sb.Append("\t\t\t\treturn new global::Mockolate.Verify.VerificationIndexerResult<").Append(verifyName)
+						.Append(", ").AppendTypeOrWrapper(indexer.Type).Append(">(this, this.").Append(mockRegistryName)
+						.Append(", ").Append(indexerGetMemberId).Append(", ").Append(indexerSetMemberId).Append(",").AppendLine();
+					break;
+			}
+
+			if (interceptedAccessors != PropertyAccessors.SetOnly)
+			{
+				sb.Append("\t\t\t\t\tinteraction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<");
+				int ti = 0;
+				foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
 				{
-					sb.Append(", ");
+					if (ti > 0)
+					{
+						sb.Append(", ");
+					}
+
+					sb.AppendTypeOrWrapper(parameter.Type);
+					ti++;
 				}
 
-				sb.AppendTypeOrWrapper(parameter.Type);
-				ti++;
+				sb.Append("> g");
+				AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "g");
+				sb.Append(",").AppendLine();
 			}
 
-			sb.Append("> g");
-			AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "g");
-			sb.Append(",").AppendLine();
-
-			sb.Append(
-				"\t\t\t\t\t(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<");
-			ti = 0;
-			foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+			if (interceptedAccessors != PropertyAccessors.GetOnly)
 			{
-				sb.AppendTypeOrWrapper(parameter.Type).Append(", ");
-				ti++;
-			}
+				sb.Append(
+					"\t\t\t\t\t(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<");
+				foreach (MethodParameter parameter in indexer.IndexerParameters.Value)
+				{
+					sb.AppendTypeOrWrapper(parameter.Type).Append(", ");
+				}
 
-			sb.AppendTypeOrWrapper(indexer.Type).Append("> s");
-			AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "s");
-			sb.Append(" && value.Matches(s.TypedValue),").AppendLine();
+				sb.AppendTypeOrWrapper(indexer.Type).Append("> s");
+				AppendIndexerVerifyParameterMatches(sb, indexer.IndexerParameters.Value, valueFlags, "s");
+				sb.Append(" && value.Matches(s.TypedValue),").AppendLine();
+			}
 		}
 
 		sb.Append("\t\t\t\t\t() => global::System.String.Format(\"[");

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -32,6 +32,21 @@ public sealed partial class MockTests
 				"Verify.VerificationIndexerSetterResult<IMockVerifyForIMyService, int, bool, string>",
 				"Setup.IndexerSetup<string, int, bool>",
 				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string this[int a, int b, int c, int d, int e] { get; }",
+				"Setup.IIndexerGetterOnlySetup<string, int, int, int, int, int>",
+				"Verify.VerificationIndexerGetterResult<IMockVerifyForIMyService, int, int, int, int, int>",
+				"Setup.IndexerSetup<string, int, int, int, int, int>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string this[int a, int b, int c, int d, int e] { set; }",
+				"Setup.IIndexerSetterOnlySetup<string, int, int, int, int, int>",
+				"Verify.VerificationIndexerSetterResult<IMockVerifyForIMyService, int, int, int, int, int, string>",
+				"Setup.IndexerSetup<string, int, int, int, int, int>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>")]
+			[InlineData("string this[int a, int b, int c, int d, int e] { get; set; }",
+				"Setup.IndexerSetup<string, int, int, int, int, int>",
+				"Verify.VerificationIndexerResult<IMockVerifyForIMyService, string>",
+				"Setup.IIndexerGetterOnlySetup<string, int, int, int, int, int>",
+				"Verify.VerificationIndexerGetterResult<IMockVerifyForIMyService, int, int, int, int, int>")]
 			public async Task IndexerSurface_ShouldOnlyExposeTheAccessorsTheMockIntercepts(
 				string indexer, string expectedSetupType, string expectedVerifyType,
 				string unexpectedSetupType, string unexpectedVerifyType)
@@ -62,41 +77,6 @@ public sealed partial class MockTests
 					.DoesNotContain($"global::Mockolate.{unexpectedSetupType} this[").And
 					.DoesNotContain($"global::Mockolate.{unexpectedVerifyType} this[")
 					.Because("a widened facade would silently re-expose an accessor the mock never intercepts");
-			}
-
-			[Theory]
-			[InlineData("string this[int a, int b, int c, int d, int e] { get; }")]
-			[InlineData("string this[int a, int b, int c, int d, int e] { set; }")]
-			public async Task IndexerWithMoreThanFourKeys_ShouldKeepTheFullSurface(string indexer)
-			{
-				GeneratorResult result = Generator
-					.Run($$"""
-					       using Mockolate;
-
-					       namespace MyCode;
-					       public class Program
-					       {
-					           public static void Main(string[] args)
-					           {
-					       		_ = IMyService.CreateMock();
-					           }
-					       }
-
-					       public interface IMyService
-					       {
-					           {{indexer}}
-					       }
-					       """);
-
-				await That(result.Diagnostics).IsEmpty();
-				await That(result.Sources["Mock.IMyService.g.cs"])
-					.Contains("global::Mockolate.Setup.IndexerSetup<string, int, int, int, int, int> this[").And
-					.Contains("global::Mockolate.Verify.VerificationIndexerResult<IMockVerifyForIMyService, string> this[").And
-					.DoesNotContain("IIndexerGetterOnlySetup").And
-					.DoesNotContain("IIndexerSetterOnlySetup").And
-					.DoesNotContain("VerificationIndexerGetterResult").And
-					.DoesNotContain("VerificationIndexerSetterResult")
-					.Because("the narrowed indexer types only exist for up to four keys, so a wider indexer keeps the full surface");
 			}
 
 			[Fact]

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/IndexerSetups.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/IndexerSetups.g.cs
@@ -1611,7 +1611,7 @@ namespace Mockolate.Verify
 		/// </summary>
 		public global::Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value)
 			=> mockRegistry.IndexerSet(subject, setMemberId, setPredicate,
-				(global::Mockolate.Parameters.IParameterMatch<TParameter>)global::Mockolate.It.Is(value, value?.ToString() ?? "null"), parametersDescription);
+				(global::Mockolate.Parameters.IParameterMatch<TParameter>)global::Mockolate.It.IsValue<TParameter>(value), parametersDescription);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/IndexerSetups.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/IndexerSetups.g.cs
@@ -341,7 +341,14 @@ namespace Mockolate.Setup
 		global::Mockolate.Setup.IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4, T5>,
 		global::Mockolate.Setup.IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4, T5>,
 		global::Mockolate.Setup.IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>,
-		global::Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>
+		global::Mockolate.Setup.IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>,
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>,
+		global::Mockolate.Setup.IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5>,
+		global::Mockolate.Setup.IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5>,
+		global::Mockolate.Setup.IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5>,
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5>,
+		global::Mockolate.Setup.IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5>,
+		global::Mockolate.Setup.IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5>
 	{
 		private Callbacks<global::System.Action<int, T1, T2, T3, T4, T5, TValue>>? _getterCallbacks;
 		private Callbacks<global::System.Action<int, T1, T2, T3, T4, T5, TValue>>? _setterCallbacks;
@@ -842,6 +849,466 @@ namespace Mockolate.Setup
 		public override string ToString()
 			=> $"{FormatType(typeof(TValue))} this[{parameter1}, {parameter2}, {parameter3}, {parameter4}, {parameter5}]";
 
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.SkippingBaseClass(bool)" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.SkippingBaseClass(bool skipBaseClass)
+		{
+			SkippingBaseClass(skipBaseClass);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.InitializeWith(TValue)" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.InitializeWith(TValue value)
+		{
+			InitializeWith(value);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.InitializeWith(global::System.Func{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.InitializeWith(global::System.Func<T1, T2, T3, T4, T5, TValue> valueGenerator)
+		{
+			InitializeWith(valueGenerator);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.OnGet" />
+		IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.OnGet
+			=> this;
+
+		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action)" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action callback)
+		{
+			((IIndexerGetterSetup<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{T1, T2, T3, T4, T5})" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action<T1, T2, T3, T4, T5> callback)
+		{
+			((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action<T1, T2, T3, T4, T5, TValue> callback)
+		{
+			((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{int, T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action<int, T1, T2, T3, T4, T5, TValue> callback)
+		{
+			((IIndexerGetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlyGetterSetup{TValue, T1, T2, T3, T4, T5}.TransitionTo(string)" />
+		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5>.TransitionTo(string scenario)
+		{
+			((IIndexerGetterSetup<TValue, T1, T2, T3, T4, T5>)this).TransitionTo(scenario);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackBuilder{TValue, T1, T2, T3, T4, T5}.InParallel()" />
+		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5>.InParallel()
+		{
+			((IIndexerGetterSetupCallbackBuilder<TValue, T1, T2, T3, T4, T5>)this).InParallel();
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetupParallelCallbackBuilder{TValue, T1, T2, T3, T4, T5}.When(global::System.Func{int, bool})" />
+		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5>.When(global::System.Func<int, bool> predicate)
+		{
+			((IIndexerGetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5>)this).When(predicate);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.For(int)" />
+		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>.For(int times)
+		{
+			((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>)this).For(times);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.Only(int)" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>.Only(int times)
+		{
+			((IIndexerGetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>)this).Only(times);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Returns(TValue)" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Returns(TValue returnValue)
+		{
+			Returns(returnValue);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Returns(global::System.Func{TValue})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Returns(global::System.Func<TValue> callback)
+		{
+			Returns(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Returns(global::System.Func{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Returns(global::System.Func<T1, T2, T3, T4, T5, TValue> callback)
+		{
+			Returns(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Returns(global::System.Func{T1, T2, T3, T4, T5, TValue, TValue})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Returns(global::System.Func<T1, T2, T3, T4, T5, TValue, TValue> callback)
+		{
+			Returns(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Throws{TException}()" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Throws<TException>()
+		{
+			Throws<TException>();
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Exception)" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Throws(global::System.Exception exception)
+		{
+			Throws(exception);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Func{global::System.Exception})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Throws(global::System.Func<global::System.Exception> callback)
+		{
+			Throws(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Func{T1, T2, T3, T4, T5, global::System.Exception})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Throws(global::System.Func<T1, T2, T3, T4, T5, global::System.Exception> callback)
+		{
+			Throws(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Func{T1, T2, T3, T4, T5, TValue, global::System.Exception})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>.Throws(global::System.Func<T1, T2, T3, T4, T5, TValue, global::System.Exception> callback)
+		{
+			Throws(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetupReturnBuilder{TValue, T1, T2, T3, T4, T5}.When(global::System.Func{int, bool})" />
+		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5>.When(global::System.Func<int, bool> predicate)
+		{
+			((IIndexerSetupReturnBuilder<TValue, T1, T2, T3, T4, T5>)this).When(predicate);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2, T3, T4, T5}.For(int)" />
+		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5>.For(int times)
+		{
+			((IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5>)this).For(times);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerGetterOnlySetupReturnWhenBuilder{TValue, T1, T2, T3, T4, T5}.Only(int)" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5>.Only(int times)
+		{
+			((IIndexerSetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5>)this).Only(times);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3, T4, T5}.SkippingBaseClass(bool)" />
+		IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5>.SkippingBaseClass(bool skipBaseClass)
+		{
+			SkippingBaseClass(skipBaseClass);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3, T4, T5}.OnSet" />
+		IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5>.OnSet
+			=> this;
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action)" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action callback)
+		{
+			((IIndexerSetterSetup<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{TValue})" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action<TValue> callback)
+		{
+			((IIndexerSetterSetup<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action<T1, T2, T3, T4, T5, TValue> callback)
+		{
+			((IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{int, T1, T2, T3, T4, T5, TValue})" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5>.Do(global::System.Action<int, T1, T2, T3, T4, T5, TValue> callback)
+		{
+			((IIndexerSetterSetupWithCallback<TValue, T1, T2, T3, T4, T5>)this).Do(callback);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetterSetup{TValue, T1, T2, T3, T4, T5}.TransitionTo(string)" />
+		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5>.TransitionTo(string scenario)
+		{
+			((IIndexerSetterSetup<TValue, T1, T2, T3, T4, T5>)this).TransitionTo(scenario);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackBuilder{TValue, T1, T2, T3, T4, T5}.InParallel()" />
+		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5>.InParallel()
+		{
+			((IIndexerSetterSetupCallbackBuilder<TValue, T1, T2, T3, T4, T5>)this).InParallel();
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetupParallelCallbackBuilder{TValue, T1, T2, T3, T4, T5}.When(global::System.Func{int, bool})" />
+		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5>.When(global::System.Func<int, bool> predicate)
+		{
+			((IIndexerSetterSetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5>)this).When(predicate);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.For(int)" />
+		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>.For(int times)
+		{
+			((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>)this).For(times);
+			return this;
+		}
+
+		/// <inheritdoc cref="IIndexerSetterOnlySetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.Only(int)" />
+		IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5> IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>.Only(int times)
+		{
+			((IIndexerSetterSetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>)this).Only(times);
+			return this;
+		}
+
+	}
+
+	/// <summary>
+	///     Setup for a mocked <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" /> that the mock only reads.
+	/// </summary>
+	/// <remarks>
+	///     Used instead of <see cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}">IIndexerSetup&lt;TValue, T1, T2, T3, T4, T5&gt;</see> when the mock has no setter to intercept, either
+	///     because the indexer is declared without one or because its setter is not accessible from the mock's assembly.
+	///     Writes then never reach the mock, so <see cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.OnSet">IIndexerSetup&lt;TValue, T1, T2, T3, T4, T5&gt;.OnSet</see> is not offered.
+	/// </remarks>
+	internal interface IIndexerGetterOnlySetup<TValue, out T1, out T2, out T3, out T4, out T5>
+	{
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.OnGet" />
+		IIndexerGetterOnlyGetterSetup<TValue, T1, T2, T3, T4, T5> OnGet { get; }
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.SkippingBaseClass(bool)" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> SkippingBaseClass(bool skipBaseClass = true);
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.InitializeWith(TValue)" />
+		/// <remarks>
+		///     Seeds the value that reads return. Unlike a read-write indexer there is no setter to update the
+		///     slot afterwards, so it stays at <paramref name="value" /> unless a <c>Returns</c> entry applies.
+		/// </remarks>
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> InitializeWith(TValue value);
+
+		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4, T5}.InitializeWith(global::System.Func{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> InitializeWith(global::System.Func<T1, T2, T3, T4, T5, TValue> valueGenerator);
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.Returns(TValue)" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Returns(TValue returnValue);
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.Returns(global::System.Func{TValue})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Returns(global::System.Func<TValue> callback);
+
+		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Returns(global::System.Func{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Returns(global::System.Func<T1, T2, T3, T4, T5, TValue> callback);
+
+		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Returns(global::System.Func{T1, T2, T3, T4, T5, TValue, TValue})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Returns(global::System.Func<T1, T2, T3, T4, T5, TValue, TValue> callback);
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.Throws{TException}()" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Throws<TException>()
+			where TException : global::System.Exception, new();
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Exception)" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Throws(global::System.Exception exception);
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Func{global::System.Exception})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Throws(global::System.Func<global::System.Exception> callback);
+
+		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Func{T1, T2, T3, T4, T5, global::System.Exception})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Throws(global::System.Func<T1, T2, T3, T4, T5, global::System.Exception> callback);
+
+		/// <inheritdoc cref="IIndexerSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Throws(global::System.Func{T1, T2, T3, T4, T5, TValue, global::System.Exception})" />
+		IIndexerGetterOnlySetupReturnBuilder<TValue, T1, T2, T3, T4, T5> Throws(global::System.Func<T1, T2, T3, T4, T5, TValue, global::System.Exception> callback);
+	}
+
+	/// <summary>
+	///     Setup for attaching side-effects to the getter of a get-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	/// <remarks>
+	///     The counterpart of <see cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4, T5}">IIndexerGetterSetupWithCallback&lt;TValue, T1, T2, T3, T4, T5&gt;</see> for
+	///     <see cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}">IIndexerGetterOnlySetup&lt;TValue, T1, T2, T3, T4, T5&gt;</see>: the returned builders stay on the getter-only surface,
+	///     so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.OnSet">IIndexerSetup&lt;TValue, T1, T2, T3, T4, T5&gt;.OnSet</see>.
+	/// </remarks>
+	internal interface IIndexerGetterOnlyGetterSetup<TValue, out T1, out T2, out T3, out T4, out T5>
+	{
+		/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action)" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action callback);
+
+		/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{T1, T2, T3, T4, T5})" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action<T1, T2, T3, T4, T5> callback);
+
+		/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action<T1, T2, T3, T4, T5, TValue> callback);
+
+		/// <inheritdoc cref="IIndexerGetterSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{int, T1, T2, T3, T4, T5, TValue})" />
+		IIndexerGetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action<int, T1, T2, T3, T4, T5, TValue> callback);
+
+		/// <inheritdoc cref="IIndexerGetterSetup{TValue, T1, T2, T3, T4, T5}.TransitionTo(string)" />
+		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> TransitionTo(string scenario);
+	}
+
+	/// <summary>
+	///     Sets up a callback for a get-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerGetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerGetterSetupCallbackBuilder{TValue, T1, T2, T3, T4, T5}.InParallel()" />
+		IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> InParallel();
+	}
+
+	/// <summary>
+	///     Sets up a parallel callback for a get-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerGetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerGetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4, T5}.When(global::System.Func{int, bool})" />
+		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> When(global::System.Func<int, bool> predicate);
+	}
+
+	/// <summary>
+	///     Sets up a when callback for a get-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.For(int)" />
+		IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> For(int times);
+
+		/// <inheritdoc cref="IIndexerGetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.Only(int)" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> Only(int times);
+	}
+
+	/// <summary>
+	///     Sets up a return/throw builder for a get-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerGetterOnlySetupReturnBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerSetupReturnBuilder{TValue, T1, T2, T3, T4, T5}.When(global::System.Func{int, bool})" />
+		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5> When(global::System.Func<int, bool> predicate);
+	}
+
+	/// <summary>
+	///     Sets up a when builder for returns/throws for a get-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerGetterOnlySetupReturnWhenBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2, T3, T4, T5}.For(int)" />
+		IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5> For(int times);
+
+		/// <inheritdoc cref="IIndexerSetupReturnWhenBuilder{TValue, T1, T2, T3, T4, T5}.Only(int)" />
+		IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> Only(int times);
+	}
+
+	/// <summary>
+	///     Setup for a mocked <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" /> that the mock only writes.
+	/// </summary>
+	/// <remarks>
+	///     The write-only counterpart of <see cref="IIndexerGetterOnlySetup{TValue, T1, T2, T3, T4, T5}">IIndexerGetterOnlySetup&lt;TValue, T1, T2, T3, T4, T5&gt;</see>: the mock has no getter to
+	///     intercept, so <see cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.OnGet">IIndexerSetup&lt;TValue, T1, T2, T3, T4, T5&gt;.OnGet</see>, <c>InitializeWith</c> and the
+	///     <c>Returns</c>/<c>Throws</c> read-sequence are not offered.
+	/// </remarks>
+	internal interface IIndexerSetterOnlySetup<TValue, out T1, out T2, out T3, out T4, out T5>
+	{
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.OnSet" />
+		IIndexerSetterOnlySetterSetup<TValue, T1, T2, T3, T4, T5> OnSet { get; }
+
+		/// <inheritdoc cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.SkippingBaseClass(bool)" />
+		IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5> SkippingBaseClass(bool skipBaseClass = true);
+	}
+
+	/// <summary>
+	///     Setup for attaching side-effects to the setter of a set-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	/// <remarks>
+	///     The counterpart of <see cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3, T4, T5}">IIndexerSetterSetupWithCallback&lt;TValue, T1, T2, T3, T4, T5&gt;</see> for
+	///     <see cref="IIndexerSetterOnlySetup{TValue, T1, T2, T3, T4, T5}">IIndexerSetterOnlySetup&lt;TValue, T1, T2, T3, T4, T5&gt;</see>: the returned builders stay on the setter-only surface,
+	///     so chaining can never reach <see cref="IIndexerSetup{TValue, T1, T2, T3, T4, T5}.OnGet">IIndexerSetup&lt;TValue, T1, T2, T3, T4, T5&gt;.OnGet</see> or the
+	///     <c>Returns</c>/<c>Throws</c> read-sequence.
+	/// </remarks>
+	internal interface IIndexerSetterOnlySetterSetup<TValue, out T1, out T2, out T3, out T4, out T5>
+	{
+		/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action)" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action callback);
+
+		/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{TValue})" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action<TValue> callback);
+
+		/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{T1, T2, T3, T4, T5, TValue})" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action<T1, T2, T3, T4, T5, TValue> callback);
+
+		/// <inheritdoc cref="IIndexerSetterSetupWithCallback{TValue, T1, T2, T3, T4, T5}.Do(global::System.Action{int, T1, T2, T3, T4, T5, TValue})" />
+		IIndexerSetterOnlySetupCallbackBuilder<TValue, T1, T2, T3, T4, T5> Do(global::System.Action<int, T1, T2, T3, T4, T5, TValue> callback);
+
+		/// <inheritdoc cref="IIndexerSetterSetup{TValue, T1, T2, T3, T4, T5}.TransitionTo(string)" />
+		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> TransitionTo(string scenario);
+	}
+
+	/// <summary>
+	///     Sets up a setter callback for a set-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerSetterOnlySetupCallbackBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerSetterSetupCallbackBuilder{TValue, T1, T2, T3, T4, T5}.InParallel()" />
+		IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, T1, T2, T3, T4, T5> InParallel();
+	}
+
+	/// <summary>
+	///     Sets up a parallel setter callback for a set-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerSetterOnlySetupParallelCallbackBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerSetterSetupParallelCallbackBuilder{TValue, T1, T2, T3, T4, T5}.When(global::System.Func{int, bool})" />
+		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> When(global::System.Func<int, bool> predicate);
+	}
+
+	/// <summary>
+	///     Sets up a when setter callback for a set-only <typeparamref name="TValue"/> indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" />.
+	/// </summary>
+	internal interface IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, out T1, out T2, out T3, out T4, out T5>
+		: IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5>
+	{
+		/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.For(int)" />
+		IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> For(int times);
+
+		/// <inheritdoc cref="IIndexerSetterSetupCallbackWhenBuilder{TValue, T1, T2, T3, T4, T5}.Only(int)" />
+		IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5> Only(int times);
 	}
 
 }
@@ -892,6 +1359,50 @@ namespace Mockolate
 			///     Uses the return value only once.
 			/// </summary>
 			public global::Mockolate.Setup.IIndexerSetup<TValue, T1, T2, T3, T4, T5> OnlyOnce()
+				=> setup.Only(1);
+		}
+
+		/// <summary>
+		///     Extensions for setups of get-only indexers with 5 parameters.
+		/// </summary>
+		extension<TValue, T1, T2, T3, T4, T5>(Mockolate.Setup.IIndexerGetterOnlySetupReturnWhenBuilder<TValue, T1, T2, T3, T4, T5> setup)
+		{
+			/// <summary>
+			///     Returns/throws forever.
+			/// </summary>
+			public void Forever()
+			{
+				setup.For(int.MaxValue);
+			}
+
+			/// <summary>
+			///     Uses the return value only once.
+			/// </summary>
+			public global::Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> OnlyOnce()
+				=> setup.Only(1);
+		}
+
+		/// <summary>
+		///     Extensions for getter callback setups of get-only indexers with 5 parameters.
+		/// </summary>
+		extension<TValue, T1, T2, T3, T4, T5>(Mockolate.Setup.IIndexerGetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> setup)
+		{
+			/// <summary>
+			///     Executes the callback only once.
+			/// </summary>
+			public global::Mockolate.Setup.IIndexerGetterOnlySetup<TValue, T1, T2, T3, T4, T5> OnlyOnce()
+				=> setup.Only(1);
+		}
+
+		/// <summary>
+		///     Extensions for setter callback setups of set-only indexers with 5 parameters.
+		/// </summary>
+		extension<TValue, T1, T2, T3, T4, T5>(Mockolate.Setup.IIndexerSetterOnlySetupCallbackWhenBuilder<TValue, T1, T2, T3, T4, T5> setup)
+		{
+			/// <summary>
+			///     Executes the callback only once.
+			/// </summary>
+			public global::Mockolate.Setup.IIndexerSetterOnlySetup<TValue, T1, T2, T3, T4, T5> OnlyOnce()
 				=> setup.Only(1);
 		}
 	}
@@ -1049,6 +1560,58 @@ namespace Mockolate.Interactions
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> $"set indexer [{Parameter1?.ToString() ?? "null"}, {Parameter2?.ToString() ?? "null"}, {Parameter3?.ToString() ?? "null"}, {Parameter4?.ToString() ?? "null"}, {Parameter5?.ToString() ?? "null"}] to {TypedValue?.ToString() ?? "null"}";
+	}
+}
+
+namespace Mockolate.Verify
+{
+	/// <summary>
+	///     Verifications on a 5-key indexer for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" /> that the mock only reads.
+	/// </summary>
+	/// <remarks>
+	///     Used instead of <see cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}">VerificationIndexerResult&lt;TSubject, TParameter&gt;</see> when the
+	///     mock has no setter to intercept. Writes then never reach the mock, so offering <c>Set(...)</c> here would
+	///     always report zero interactions.
+	/// </remarks>
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	internal class VerificationIndexerGetterResult<TSubject, T1, T2, T3, T4, T5>(
+		TSubject subject,
+		global::Mockolate.MockRegistry mockRegistry,
+		int getMemberId,
+		global::System.Func<global::Mockolate.Interactions.IInteraction, bool> gotPredicate,
+		global::System.Func<string> parametersDescription)
+	{
+		/// <inheritdoc cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}.Got()" />
+		public global::Mockolate.Verify.VerificationResult<TSubject> Got()
+			=> mockRegistry.IndexerGot(subject, getMemberId, gotPredicate, parametersDescription);
+	}
+	/// <summary>
+	///     Verifications on a 5-key indexer of type <typeparamref name="TParameter" /> for <typeparamref name="T1" />, <typeparamref name="T2" />, <typeparamref name="T3" />, <typeparamref name="T4" /> and <typeparamref name="T5" /> that the mock only writes.
+	/// </summary>
+	/// <remarks>
+	///     Used instead of <see cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}">VerificationIndexerResult&lt;TSubject, TParameter&gt;</see> when the
+	///     mock has no getter to intercept, so <c>Got()</c> is not offered.
+	/// </remarks>
+	[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	internal class VerificationIndexerSetterResult<TSubject, T1, T2, T3, T4, T5, TParameter>(
+		TSubject subject,
+		global::Mockolate.MockRegistry mockRegistry,
+		int setMemberId,
+		global::System.Func<global::Mockolate.Interactions.IInteraction, global::Mockolate.Parameters.IParameterMatch<TParameter>, bool> setPredicate,
+		global::System.Func<string> parametersDescription)
+	{
+		/// <inheritdoc cref="global::Mockolate.Verify.VerificationIndexerResult{TSubject, TParameter}.Set(global::Mockolate.Parameters.IParameter{TParameter})" />
+		public global::Mockolate.Verify.VerificationResult<TSubject> Set(global::Mockolate.Parameters.IParameter<TParameter> value)
+			=> mockRegistry.IndexerSet(subject, setMemberId, setPredicate,
+				(global::Mockolate.Parameters.IParameterMatch<TParameter>)value, parametersDescription);
+
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+		/// <summary>
+		///     Verifies the indexer write access on the mock with the given <paramref name="value" />.
+		/// </summary>
+		public global::Mockolate.Verify.VerificationResult<TSubject> Set(TParameter value)
+			=> mockRegistry.IndexerSet(subject, setMemberId, setPredicate,
+				(global::Mockolate.Parameters.IParameterMatch<TParameter>)global::Mockolate.It.Is(value, value?.ToString() ?? "null"), parametersDescription);
 	}
 }
 

--- a/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/Snapshot/Expected/ComprehensiveInterface_CanBeCreated/Mock.IComprehensiveInterface.g.cs
@@ -43,40 +43,44 @@ internal static partial class Mock
 		internal const int MemberId_Indexer_int_Set = 19;
 		internal const int MemberId_Indexer_int_int_int_int_int_Get = 20;
 		internal const int MemberId_Indexer_int_int_int_int_int_Set = 21;
-		internal const int MemberId_Indexer_double_Get = 22;
-		internal const int MemberId_Indexer_double_Set = 23;
-		internal const int MemberId_Indexer_char_Get = 24;
-		internal const int MemberId_Indexer_char_Set = 25;
-		internal const int MemberId_StaticAbstractMethod = 26;
-		internal const int MemberId_WithModifiers = 27;
-		internal const int MemberId_WithDefaults = 28;
-		internal const int MemberId_WithCollidingNames = 29;
-		internal const int MemberId_GetMaybeNull = 30;
-		internal const int MemberId_TakeObject = 31;
-		internal const int MemberId_TakeTwoObjects = 32;
-		internal const int MemberId_TakeIntAndObject = 33;
-		internal const int MemberId_DoTask = 34;
-		internal const int MemberId_DoTaskOf = 35;
-		internal const int MemberId_DoVT = 36;
-		internal const int MemberId_DoVTOf = 37;
-		internal const int MemberId_GetTuple = 38;
-		internal const int MemberId_GetNullable = 39;
-		internal const int MemberId_GetSpan = 40;
-		internal const int MemberId_GetROSpan = 41;
-		internal const int MemberId_GetByRef = 42;
-		internal const int MemberId_GetByRefReadonly = 43;
-		internal const int MemberId_G1_T_ = 44;
-		internal const int MemberId_G2_T_ = 45;
-		internal const int MemberId_G3_T_ = 46;
-		internal const int MemberId_G4_T_ = 47;
-		internal const int MemberId_G5_T_ = 48;
-		internal const int MemberId_G6_T_ = 49;
-		internal const int MemberId_G7_T_ = 50;
-		internal const int MemberId_G8_T_ = 51;
-		internal const int MemberId_Five = 52;
-		internal const int MemberId_Seventeen = 53;
-		internal const int MemberId_SeventeenVoid = 54;
-		internal const int MemberCount = 55;
+		internal const int MemberId_Indexer_byte_byte_byte_byte_byte_Get = 22;
+		internal const int MemberId_Indexer_byte_byte_byte_byte_byte_Set = 23;
+		internal const int MemberId_Indexer_short_short_short_short_short_Get = 24;
+		internal const int MemberId_Indexer_short_short_short_short_short_Set = 25;
+		internal const int MemberId_Indexer_double_Get = 26;
+		internal const int MemberId_Indexer_double_Set = 27;
+		internal const int MemberId_Indexer_char_Get = 28;
+		internal const int MemberId_Indexer_char_Set = 29;
+		internal const int MemberId_StaticAbstractMethod = 30;
+		internal const int MemberId_WithModifiers = 31;
+		internal const int MemberId_WithDefaults = 32;
+		internal const int MemberId_WithCollidingNames = 33;
+		internal const int MemberId_GetMaybeNull = 34;
+		internal const int MemberId_TakeObject = 35;
+		internal const int MemberId_TakeTwoObjects = 36;
+		internal const int MemberId_TakeIntAndObject = 37;
+		internal const int MemberId_DoTask = 38;
+		internal const int MemberId_DoTaskOf = 39;
+		internal const int MemberId_DoVT = 40;
+		internal const int MemberId_DoVTOf = 41;
+		internal const int MemberId_GetTuple = 42;
+		internal const int MemberId_GetNullable = 43;
+		internal const int MemberId_GetSpan = 44;
+		internal const int MemberId_GetROSpan = 45;
+		internal const int MemberId_GetByRef = 46;
+		internal const int MemberId_GetByRefReadonly = 47;
+		internal const int MemberId_G1_T_ = 48;
+		internal const int MemberId_G2_T_ = 49;
+		internal const int MemberId_G3_T_ = 50;
+		internal const int MemberId_G4_T_ = 51;
+		internal const int MemberId_G5_T_ = 52;
+		internal const int MemberId_G6_T_ = 53;
+		internal const int MemberId_G7_T_ = 54;
+		internal const int MemberId_G8_T_ = 55;
+		internal const int MemberId_Five = 56;
+		internal const int MemberId_Seventeen = 57;
+		internal const int MemberId_SeventeenVoid = 58;
+		internal const int MemberCount = 59;
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_GetSet_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetSet");
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_GetOnly_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.GetOnly");
 		internal static readonly global::Mockolate.Interactions.PropertyGetterAccess PropertyAccess_SetOnly_Get = new global::Mockolate.Interactions.PropertyGetterAccess("global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.SetOnly");
@@ -522,6 +526,47 @@ internal static partial class Mock
 			}
 		}
 
+		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[byte, byte, byte, byte, byte]" />
+		public long this[byte a, byte b, byte c, byte d, byte e]
+		{
+			get
+			{
+				global::Mockolate.Interactions.IndexerGetterAccess<byte, byte, byte, byte, byte> access = new(a, b, c, d, e);
+				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+				{
+					this.MockRegistry.RegisterInteraction(access);
+				}
+				global::Mockolate.Setup.IndexerSetup<long, byte, byte, byte, byte, byte>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<long, byte, byte, byte, byte, byte>>(access);
+				if (this.MockRegistry.Wraps is not global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
+				{
+					return setup is null
+						? this.MockRegistry.GetIndexerFallback<long>(access, 2)
+						: this.MockRegistry.ApplyIndexerSetup<long>(access, setup, 2);
+				}
+				long baseResult = wraps[a, b, c, d, e];
+				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 2);
+			}
+		}
+
+		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[short, short, short, short, short]" />
+		public long this[short a, short b, short c, short d, short e]
+		{
+			set
+			{
+				global::Mockolate.Interactions.IndexerSetterAccess<short, short, short, short, short, long> access = new(a, b, c, d, e, value);
+				if (this.MockRegistry.Behavior.SkipInteractionRecording == false)
+				{
+					this.MockRegistry.RegisterInteraction(access);
+				}
+				global::Mockolate.Setup.IndexerSetup<long, short, short, short, short, short>? setup = this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<long, short, short, short, short, short>>(access);
+				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 3);
+				if (this.MockRegistry.Wraps is global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
+				{
+					wraps[a, b, c, d, e] = value;
+				}
+			}
+		}
+
 		/// <inheritdoc cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]" />
 		public string this[double key]
 		{
@@ -552,11 +597,11 @@ internal static partial class Mock
 				if (this.MockRegistry.Wraps is not global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
 				{
 					return setup is null
-						? this.MockRegistry.GetIndexerFallback<string>(access, 2)
-						: this.MockRegistry.ApplyIndexerSetup<string>(access, setup, 2);
+						? this.MockRegistry.GetIndexerFallback<string>(access, 4)
+						: this.MockRegistry.ApplyIndexerSetup<string>(access, setup, 4);
 				}
 				string baseResult = wraps[key];
-				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 2);
+				return this.MockRegistry.ApplyIndexerGetter(access, setup, baseResult, 4);
 			}
 		}
 
@@ -587,7 +632,7 @@ internal static partial class Mock
 				}
 				global::Mockolate.Interactions.IndexerSetterAccess<char, string> access = new(key, value);
 				setup ??= this.MockRegistry.GetIndexerSetup<global::Mockolate.Setup.IndexerSetup<string, char>>(access);
-				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 3);
+				this.MockRegistry.ApplyIndexerSetter(access, setup, value, 5);
 				if (this.MockRegistry.Wraps is global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface wraps)
 				{
 					wraps[key] = value;
@@ -2425,6 +2470,54 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<long, byte, byte, byte, byte, byte> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<byte>? parameter1, global::Mockolate.Parameters.IParameter<byte>? parameter2, global::Mockolate.Parameters.IParameter<byte>? parameter3, global::Mockolate.Parameters.IParameter<byte>? parameter4, global::Mockolate.Parameters.IParameter<byte>? parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, byte, byte, byte, byte, byte>(MockRegistry, CovariantParameterAdapter<byte>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter2 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter3 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter4 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter5 ?? global::Mockolate.It.IsNull<byte>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_byte_byte_byte_byte_byte_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<long, byte, byte, byte, byte, byte> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[byte parameter1, byte parameter2, byte parameter3, byte parameter4, byte parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, byte, byte, byte, byte, byte>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter1), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter2), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter3), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter4), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter5));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_byte_byte_byte_byte_byte_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<long, short, short, short, short, short> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<short>? parameter1, global::Mockolate.Parameters.IParameter<short>? parameter2, global::Mockolate.Parameters.IParameter<short>? parameter3, global::Mockolate.Parameters.IParameter<short>? parameter4, global::Mockolate.Parameters.IParameter<short>? parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, short, short, short, short, short>(MockRegistry, CovariantParameterAdapter<short>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter2 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter3 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter4 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter5 ?? global::Mockolate.It.IsNull<short>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_short_short_short_short_short_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<long, short, short, short, short, short> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[short parameter1, short parameter2, short parameter3, short parameter4, short parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, short, short, short, short, short>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter1), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter2), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter3), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter4), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter5));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_short_short_short_short_short_Get, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		global::Mockolate.Setup.IIndexerGetterOnlySetup<string, double> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<double>? parameter1]
 		{
 			get
@@ -3113,6 +3206,54 @@ internal static partial class Mock
 
 		/// <inheritdoc />
 		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<byte>? a, global::Mockolate.Parameters.IParameter<byte>? b, global::Mockolate.Parameters.IParameter<byte>? c, global::Mockolate.Parameters.IParameter<byte>? d, global::Mockolate.Parameters.IParameter<byte>? e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte>(this, this.MockRegistry, -1,
+					interaction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<byte, byte, byte, byte, byte> g && CovariantParameterAdapter<byte>.Wrap(a ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter1) && CovariantParameterAdapter<byte>.Wrap(b ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter2) && CovariantParameterAdapter<byte>.Wrap(c ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter3) && CovariantParameterAdapter<byte>.Wrap(d ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter4) && CovariantParameterAdapter<byte>.Wrap(e ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter5),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a ?? "null", (object?)b ?? "null", (object?)c ?? "null", (object?)d ?? "null", (object?)e ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte> IMockVerifyForIComprehensiveInterface.this[byte a, byte b, byte c, byte d, byte e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte>(this, this.MockRegistry, -1,
+					interaction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<byte, byte, byte, byte, byte> g && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(a, g.Parameter1) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(b, g.Parameter2) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(c, g.Parameter3) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(d, g.Parameter4) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(e, g.Parameter5),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a, (object?)b, (object?)c, (object?)d, (object?)e));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<short>? a, global::Mockolate.Parameters.IParameter<short>? b, global::Mockolate.Parameters.IParameter<short>? c, global::Mockolate.Parameters.IParameter<short>? d, global::Mockolate.Parameters.IParameter<short>? e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long>(this, this.MockRegistry, -1,
+					(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<short, short, short, short, short, long> s && CovariantParameterAdapter<short>.Wrap(a ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter1) && CovariantParameterAdapter<short>.Wrap(b ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter2) && CovariantParameterAdapter<short>.Wrap(c ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter3) && CovariantParameterAdapter<short>.Wrap(d ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter4) && CovariantParameterAdapter<short>.Wrap(e ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter5) && value.Matches(s.TypedValue),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a ?? "null", (object?)b ?? "null", (object?)c ?? "null", (object?)d ?? "null", (object?)e ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long> IMockVerifyForIComprehensiveInterface.this[short a, short b, short c, short d, short e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long>(this, this.MockRegistry, -1,
+					(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<short, short, short, short, short, long> s && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(a, s.Parameter1) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(b, s.Parameter2) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(c, s.Parameter3) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(d, s.Parameter4) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(e, s.Parameter5) && value.Matches(s.TypedValue),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a, (object?)b, (object?)c, (object?)d, (object?)e));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, double> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<double>? key]
 		{
 			get
@@ -3685,6 +3826,54 @@ internal static partial class Mock
 				return new global::Mockolate.Verify.VerificationIndexerResult<IMockVerifyForIComprehensiveInterface, string>(this, this.MockRegistry, -1, -1,
 					interaction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<int, int, int, int, int> g && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(a, g.Parameter1) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(b, g.Parameter2) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(c, g.Parameter3) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(d, g.Parameter4) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(e, g.Parameter5),
 					(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<int, int, int, int, int, string> s && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(a, s.Parameter1) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(b, s.Parameter2) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(c, s.Parameter3) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(d, s.Parameter4) && global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(e, s.Parameter5) && value.Matches(s.TypedValue),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a, (object?)b, (object?)c, (object?)d, (object?)e));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<byte>? a, global::Mockolate.Parameters.IParameter<byte>? b, global::Mockolate.Parameters.IParameter<byte>? c, global::Mockolate.Parameters.IParameter<byte>? d, global::Mockolate.Parameters.IParameter<byte>? e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte>(this, this.MockRegistry, -1,
+					interaction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<byte, byte, byte, byte, byte> g && CovariantParameterAdapter<byte>.Wrap(a ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter1) && CovariantParameterAdapter<byte>.Wrap(b ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter2) && CovariantParameterAdapter<byte>.Wrap(c ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter3) && CovariantParameterAdapter<byte>.Wrap(d ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter4) && CovariantParameterAdapter<byte>.Wrap(e ?? global::Mockolate.It.IsNull<byte>("null")).Matches(g.Parameter5),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a ?? "null", (object?)b ?? "null", (object?)c ?? "null", (object?)d ?? "null", (object?)e ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte> IMockVerifyForIComprehensiveInterface.this[byte a, byte b, byte c, byte d, byte e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte>(this, this.MockRegistry, -1,
+					interaction => interaction is global::Mockolate.Interactions.IndexerGetterAccess<byte, byte, byte, byte, byte> g && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(a, g.Parameter1) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(b, g.Parameter2) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(c, g.Parameter3) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(d, g.Parameter4) && global::System.Collections.Generic.EqualityComparer<byte>.Default.Equals(e, g.Parameter5),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a, (object?)b, (object?)c, (object?)d, (object?)e));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long> IMockVerifyForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<short>? a, global::Mockolate.Parameters.IParameter<short>? b, global::Mockolate.Parameters.IParameter<short>? c, global::Mockolate.Parameters.IParameter<short>? d, global::Mockolate.Parameters.IParameter<short>? e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long>(this, this.MockRegistry, -1,
+					(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<short, short, short, short, short, long> s && CovariantParameterAdapter<short>.Wrap(a ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter1) && CovariantParameterAdapter<short>.Wrap(b ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter2) && CovariantParameterAdapter<short>.Wrap(c ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter3) && CovariantParameterAdapter<short>.Wrap(d ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter4) && CovariantParameterAdapter<short>.Wrap(e ?? global::Mockolate.It.IsNull<short>("null")).Matches(s.Parameter5) && value.Matches(s.TypedValue),
+					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a ?? "null", (object?)b ?? "null", (object?)c ?? "null", (object?)d ?? "null", (object?)e ?? "null"));
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long> IMockVerifyForIComprehensiveInterface.this[short a, short b, short c, short d, short e]
+		{
+			get
+			{
+				return new global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long>(this, this.MockRegistry, -1,
+					(interaction, value) => interaction is global::Mockolate.Interactions.IndexerSetterAccess<short, short, short, short, short, long> s && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(a, s.Parameter1) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(b, s.Parameter2) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(c, s.Parameter3) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(d, s.Parameter4) && global::System.Collections.Generic.EqualityComparer<short>.Default.Equals(e, s.Parameter5) && value.Matches(s.TypedValue),
 					() => global::System.String.Format("[{0}, {1}, {2}, {3}, {4}]", (object?)a, (object?)b, (object?)c, (object?)d, (object?)e));
 			}
 		}
@@ -4301,6 +4490,54 @@ internal static partial class Mock
 			{
 				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<string, int, int, int, int, int>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter1), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter2), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter3), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter4), (global::Mockolate.Parameters.IParameterMatch<int>)global::Mockolate.It.IsValue<int>(parameter5));
 				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_int_int_int_int_int_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<long, byte, byte, byte, byte, byte> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<byte>? parameter1, global::Mockolate.Parameters.IParameter<byte>? parameter2, global::Mockolate.Parameters.IParameter<byte>? parameter3, global::Mockolate.Parameters.IParameter<byte>? parameter4, global::Mockolate.Parameters.IParameter<byte>? parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, byte, byte, byte, byte, byte>(MockRegistry, CovariantParameterAdapter<byte>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter2 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter3 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter4 ?? global::Mockolate.It.IsNull<byte>("null")), CovariantParameterAdapter<byte>.Wrap(parameter5 ?? global::Mockolate.It.IsNull<byte>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_byte_byte_byte_byte_byte_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<long, byte, byte, byte, byte, byte> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[byte parameter1, byte parameter2, byte parameter3, byte parameter4, byte parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, byte, byte, byte, byte, byte>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter1), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter2), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter3), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter4), (global::Mockolate.Parameters.IParameterMatch<byte>)global::Mockolate.It.IsValue<byte>(parameter5));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_byte_byte_byte_byte_byte_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<long, short, short, short, short, short> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[global::Mockolate.Parameters.IParameter<short>? parameter1, global::Mockolate.Parameters.IParameter<short>? parameter2, global::Mockolate.Parameters.IParameter<short>? parameter3, global::Mockolate.Parameters.IParameter<short>? parameter4, global::Mockolate.Parameters.IParameter<short>? parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, short, short, short, short, short>(MockRegistry, CovariantParameterAdapter<short>.Wrap(parameter1 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter2 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter3 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter4 ?? global::Mockolate.It.IsNull<short>("null")), CovariantParameterAdapter<short>.Wrap(parameter5 ?? global::Mockolate.It.IsNull<short>("null")));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_short_short_short_short_short_Get, _scenarioName, indexerSetup);
+				return indexerSetup;
+			}
+		}
+
+		/// <inheritdoc />
+		[global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<long, short, short, short, short, short> global::Mockolate.Mock.IMockSetupForIComprehensiveInterface.this[short parameter1, short parameter2, short parameter3, short parameter4, short parameter5]
+		{
+			get
+			{
+				var indexerSetup = new global::Mockolate.Setup.IndexerSetup<long, short, short, short, short, short>(MockRegistry, (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter1), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter2), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter3), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter4), (global::Mockolate.Parameters.IParameterMatch<short>)global::Mockolate.It.IsValue<short>(parameter5));
+				this.MockRegistry.SetupIndexer(global::Mockolate.Mock.IComprehensiveInterface.MemberId_Indexer_short_short_short_short_short_Get, _scenarioName, indexerSetup);
 				return indexerSetup;
 			}
 		}
@@ -5041,6 +5278,42 @@ internal static partial class Mock
 		global::Mockolate.Setup.IndexerSetup<string, int, int, int, int, int> this[int parameter1, int parameter2, int parameter3, int parameter4, int parameter5] { get; }
 
 		/// <summary>
+		///     Setup for the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[byte, byte, byte, byte, byte]">this[byte, byte, byte, byte, byte]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<long, byte, byte, byte, byte, byte> this[global::Mockolate.Parameters.IParameter<byte>? parameter1, global::Mockolate.Parameters.IParameter<byte>? parameter2, global::Mockolate.Parameters.IParameter<byte>? parameter3, global::Mockolate.Parameters.IParameter<byte>? parameter4, global::Mockolate.Parameters.IParameter<byte>? parameter5] { get; }
+
+		/// <summary>
+		///     Setup for the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[byte, byte, byte, byte, byte]">this[byte, byte, byte, byte, byte]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Setup.IIndexerGetterOnlySetup<long, byte, byte, byte, byte, byte> this[byte parameter1, byte parameter2, byte parameter3, byte parameter4, byte parameter5] { get; }
+
+		/// <summary>
+		///     Setup for the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[short, short, short, short, short]">this[short, short, short, short, short]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<long, short, short, short, short, short> this[global::Mockolate.Parameters.IParameter<short>? parameter1, global::Mockolate.Parameters.IParameter<short>? parameter2, global::Mockolate.Parameters.IParameter<short>? parameter3, global::Mockolate.Parameters.IParameter<short>? parameter4, global::Mockolate.Parameters.IParameter<short>? parameter5] { get; }
+
+		/// <summary>
+		///     Setup for the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[short, short, short, short, short]">this[short, short, short, short, short]</see>
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter; each is treated as <c>It.Is&lt;T&gt;(value)</c>.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Setup.IIndexerSetterOnlySetup<long, short, short, short, short, short> this[short parameter1, short parameter2, short parameter3, short parameter4, short parameter5] { get; }
+
+		/// <summary>
 		///     Setup for the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]">this[double]</see>
 		/// </summary>
 		/// <remarks>
@@ -5679,6 +5952,42 @@ internal static partial class Mock
 		/// </remarks>
 		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
 		global::Mockolate.Verify.VerificationIndexerResult<IMockVerifyForIComprehensiveInterface, string> this[int a, int b, int c, int d, int e] { get; }
+
+		/// <summary>
+		///     Verify interactions with the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[byte, byte, byte, byte, byte]">this[byte, byte, byte, byte, byte]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte> this[global::Mockolate.Parameters.IParameter<byte>? a, global::Mockolate.Parameters.IParameter<byte>? b, global::Mockolate.Parameters.IParameter<byte>? c, global::Mockolate.Parameters.IParameter<byte>? d, global::Mockolate.Parameters.IParameter<byte>? e] { get; }
+
+		/// <summary>
+		///     Verify interactions with the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[byte, byte, byte, byte, byte]">this[byte, byte, byte, byte, byte]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Verify.VerificationIndexerGetterResult<IMockVerifyForIComprehensiveInterface, byte, byte, byte, byte, byte> this[byte a, byte b, byte c, byte d, byte e] { get; }
+
+		/// <summary>
+		///     Verify interactions with the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[short, short, short, short, short]">this[short, short, short, short, short]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload takes <see cref="global::Mockolate.It">It</see> argument matchers (e.g. <c>It.IsAny&lt;T&gt;()</c>, <c>It.Is&lt;T&gt;(value)</c>) for every parameter.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(int.MaxValue)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long> this[global::Mockolate.Parameters.IParameter<short>? a, global::Mockolate.Parameters.IParameter<short>? b, global::Mockolate.Parameters.IParameter<short>? c, global::Mockolate.Parameters.IParameter<short>? d, global::Mockolate.Parameters.IParameter<short>? e] { get; }
+
+		/// <summary>
+		///     Verify interactions with the long indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[short, short, short, short, short]">this[short, short, short, short, short]</see>.
+		/// </summary>
+		/// <remarks>
+		///     This overload accepts direct values for every parameter and returns a <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters">VerificationResult&lt;TVerify&gt;.IgnoreParameters</see> whose <see cref="global::Mockolate.Verify.VerificationResult{TVerify}.IgnoreParameters.AnyParameters()">VerificationResult&lt;TVerify&gt;.AnyParameters()</see> drops per-parameter matching entirely.
+		/// </remarks>
+		[global::System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
+		global::Mockolate.Verify.VerificationIndexerSetterResult<IMockVerifyForIComprehensiveInterface, short, short, short, short, short, long> this[short a, short b, short c, short d, short e] { get; }
 
 		/// <summary>
 		///     Verify interactions with the string indexer <see cref="global::Mockolate.Tests.GeneratorCoverage.IComprehensiveInterface.this[double]">this[double]</see>.

--- a/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
+++ b/Tests/Mockolate.Tests/GeneratorCoverage/IComprehensiveInterface.cs
@@ -6,7 +6,7 @@ namespace Mockolate.Tests.GeneratorCoverage;
 
 /// <summary>
 ///     Squeezes every interface-shaped generator branch we can fit into a single type:
-///     property accessor combinations, indexers (single + arity-5, get-only + set-only), all three event flavors,
+///     property accessor combinations, indexers (single + arity-5, get-only + set-only at both arities), all three event flavors,
 ///     static abstract members, every parameter modifier, every default-value kind,
 ///     every "reserved" parameter name, nullable annotations, async returns, special return
 ///     shapes (Span/ReadOnlySpan/ref/ref-readonly/tuple/Nullable&lt;T&gt;),
@@ -23,6 +23,8 @@ public interface IComprehensiveInterface
 
 	string this[int i] { get; set; }
 	string this[int a, int b, int c, int d, int e] { get; set; }
+	long this[byte a, byte b, byte c, byte d, byte e] { get; }
+	long this[short a, short b, short c, short d, short e] { set; }
 	string this[double key] { get; }
 	string this[char key] { set; }
 

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.AccessorRestrictedTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.AccessorRestrictedTests.cs
@@ -378,6 +378,55 @@ public sealed partial class SetupIndexerTests
 			await That(sut.Mock.Verify[It.Is(1), It.Is(2), It.Is(3), It.Is(5)].Set(It.IsAny<string>())).Never();
 		}
 
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_ChainedReturns_ShouldStayOnGetterOnlySurface()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			IIndexerGetterOnlySetup<int, int, int, int, int, int> chained = sut.Mock
+				.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.Returns(1).OnlyOnce();
+			chained.Returns((k1, k2, k3, k4, k5) => k1 + k2 + k3 + k4 + k5);
+
+			await That(sut[1, 2, 3, 4, 5]).IsEqualTo(1);
+			await That(sut[1, 2, 3, 4, 5]).IsEqualTo(15);
+			await That(sut.Mock.Verify[It.Is(1), It.Is(2), It.Is(3), It.Is(4), It.Is(5)].Got()).Exactly(2)
+				.Because("the narrowed surface is generated per-compilation for indexers with more than four keys");
+			await That(sut.Mock.Verify[It.Is(1), It.Is(2), It.Is(3), It.Is(4), It.Is(6)].Got()).Never();
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_ReturnsForever_ShouldUseTheLastValueForever()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.Returns(2)
+				.Returns(4).Forever();
+
+			int[] result = new int[4];
+			for (int i = 0; i < 4; i++)
+			{
+				result[i] = sut[i, i, i, i, i];
+			}
+
+			await That(result).IsEqualTo([2, 4, 4, 4,]);
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_OnSetAndVerify_ShouldUseTheNarrowedSurface()
+		{
+			List<string> written = new();
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock
+				.Setup[It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()]
+				.OnSet.Do((k1, k2, k3, k4, k5, v) => written.Add($"{k1}{k2}{k3}{k4}{k5}-{v}"));
+
+			sut["a", "b", "c", "d", "e"] = "x";
+
+			await That(written).IsEqualTo(["abcde-x",]);
+			await That(sut.Mock.Verify[It.Is("a"), It.Is("b"), It.Is("c"), It.Is("d"), It.Is("e")].Set("x")).Once();
+			await That(sut.Mock.Verify[It.Is("a"), It.Is("b"), It.Is("c"), It.Is("d"), It.Is("e")].Set("y")).Never();
+		}
+
 		public interface IAccessorService
 		{
 			int this[int key] { get; }
@@ -385,6 +434,8 @@ public sealed partial class SetupIndexerTests
 			int this[int key1, int key2] { get; }
 			string this[string key1, string key2] { set; }
 			string this[int key1, int key2, int key3, int key4] { set; }
+			int this[int key1, int key2, int key3, int key4, int key5] { get; }
+			string this[string key1, string key2, string key3, string key4, string key5] { set; }
 		}
 
 		public class AccessorService

--- a/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.AccessorRestrictedTests.cs
+++ b/Tests/Mockolate.Tests/MockIndexers/SetupIndexerTests.AccessorRestrictedTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Mockolate.Setup;
+using Mockolate.Verify;
 
 namespace Mockolate.Tests.MockIndexers;
 
@@ -425,6 +426,317 @@ public sealed partial class SetupIndexerTests
 			await That(written).IsEqualTo(["abcde-x",]);
 			await That(sut.Mock.Verify[It.Is("a"), It.Is("b"), It.Is("c"), It.Is("d"), It.Is("e")].Set("x")).Once();
 			await That(sut.Mock.Verify[It.Is("a"), It.Is("b"), It.Is("c"), It.Is("d"), It.Is("e")].Set("y")).Never();
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_Throws_ShouldIterateThroughAllRegisteredExceptions()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.Throws<InvalidOperationException>()
+				.Throws(new Exception("foo"))
+				.Throws(() => new Exception("bar"))
+				.Throws((k1, k2, k3, k4, k5) => new Exception($"baz-{k1 + k2 + k3 + k4 + k5}"))
+				.Throws((k1, k2, k3, k4, k5, v) => new Exception($"qux-{k1 + k2 + k3 + k4 + k5}-{v}"));
+
+			void Act() => _ = sut[1, 2, 3, 4, 5];
+
+			await That(Act).Throws<InvalidOperationException>();
+			Exception? result2 = Record.Exception(Act);
+			Exception? result3 = Record.Exception(Act);
+			Exception? result4 = Record.Exception(Act);
+			Exception? result5 = Record.Exception(Act);
+			await That(result2).HasMessage("foo");
+			await That(result3).HasMessage("bar");
+			await That(result4).HasMessage("baz-15");
+			await That(result5).HasMessage("qux-15-0");
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_InitializeWith_ShouldSeedTheReadValue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.InitializeWith(3)
+				.Returns((_, _, _, _, _, v) => 4 * v);
+
+			await That(sut[1, 2, 3, 4, 5]).IsEqualTo(12);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_InitializeWithGenerator_ShouldSeedTheReadValue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.InitializeWith((k1, k2, k3, k4, k5) => 10 * (k1 + k2 + k3 + k4 + k5));
+
+			await That(sut[1, 2, 3, 4, 5]).IsEqualTo(150);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_ReturnsWhen_ShouldOnlyUseValueWhenPredicateIsTrue()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.Returns(() => 4).When(i => i > 0);
+
+			int result1 = sut[1, 2, 3, 4, 5];
+			int result2 = sut[1, 2, 3, 4, 5];
+
+			await That(result1).IsEqualTo(0);
+			await That(result2).IsEqualTo(4);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_SkippingBaseClass_ShouldStayOnGetterOnlySurface()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			IIndexerGetterOnlySetup<int, int, int, int, int, int> chained = sut.Mock
+				.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.SkippingBaseClass();
+			chained.Returns(7);
+
+			await That(sut[1, 2, 3, 4, 5]).IsEqualTo(7);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_OnGetChain_ShouldStayOnGetterOnlySurface()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			IIndexerGetterOnlySetup<int, int, int, int, int, int> chained = sut.Mock
+				.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do((k1, k2, k3, k4, k5) => { callCount2++; }).OnlyOnce();
+			chained.Returns(9);
+
+			int result = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+
+			await That(result).IsEqualTo(9);
+			await That(callCount1).IsEqualTo(3);
+			await That(callCount2).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_OnGetWhen_ShouldOnlyInvokeCallbackWhenPredicateIsTrue()
+		{
+			int callCount = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnGet.Do(() => { callCount++; }).When(i => i > 0);
+
+			_ = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+
+			await That(callCount).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_OnGetInParallel_ShouldInvokeParallelCallbacksAlways()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			int callCount3 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnGet.Do(() => { callCount1++; })
+				.OnGet.Do((k1, k2, k3, k4, k5) => { callCount2++; }).InParallel()
+				.OnGet.Do((k1, k2, k3, k4, k5, v) => { callCount3++; });
+
+			_ = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+			_ = sut[1, 2, 3, 4, 5];
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(4);
+			await That(callCount3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_OnGetFor_ShouldRepeatCallbackTheGivenNumberOfTimes()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnGet.Do(() => { callCount1++; }).For(2)
+				.OnGet.Do(() => { callCount2++; });
+
+			for (int i = 0; i < 6; i++)
+			{
+				_ = sut[1, 2, 3, 4, 5];
+			}
+
+			await That(callCount1).IsEqualTo(4);
+			await That(callCount2).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_OnGetDoWithCounter_ShouldReceiveTheAccessCounter()
+		{
+			List<int> invocations = [];
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnGet.Do((i, _, _, _, _, _, _) => { invocations.Add(i); });
+
+			for (int i = 0; i < 3; i++)
+			{
+				_ = sut[1, 2, 3, 4, 5];
+			}
+
+			await That(invocations).IsEqualTo([0, 1, 2,]);
+		}
+
+		[Fact]
+		public async Task GetOnlyFiveKeyIndexer_OnGetTransitionTo_ShouldSwitchScenario()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.InScenario("a")
+				.Setup[It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()]
+				.OnGet.Do(() => { })
+				.OnGet.TransitionTo("b");
+			sut.Mock.TransitionTo("a");
+
+			_ = sut[1, 2, 3, 4, 5];
+
+			await That(((IMock)sut).MockRegistry.Scenario).IsEqualTo("b");
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_OnSetChain_ShouldStayOnSetterOnlySurface()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			IIndexerSetterOnlySetup<string, string, string, string, string, string> chained = sut.Mock
+				.Setup[It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+					It.IsAny<string>()]
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do(v => { callCount2++; }).OnlyOnce();
+			chained.SkippingBaseClass();
+
+			sut["a", "b", "c", "d", "e"] = "1";
+			sut["a", "b", "c", "d", "e"] = "2";
+			sut["a", "b", "c", "d", "e"] = "3";
+			sut["a", "b", "c", "d", "e"] = "4";
+
+			await That(callCount1).IsEqualTo(3);
+			await That(callCount2).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_OnSetWhen_ShouldOnlyInvokeCallbackWhenPredicateIsTrue()
+		{
+			int callCount = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock
+				.Setup[It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+					It.IsAny<string>()]
+				.OnSet.Do(() => { callCount++; }).When(i => i > 0);
+
+			sut["a", "b", "c", "d", "e"] = "1";
+			sut["a", "b", "c", "d", "e"] = "2";
+			sut["a", "b", "c", "d", "e"] = "3";
+
+			await That(callCount).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_OnSetInParallel_ShouldInvokeParallelCallbacksAlways()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			int callCount3 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock
+				.Setup[It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+					It.IsAny<string>()]
+				.OnSet.Do(() => { callCount1++; })
+				.OnSet.Do((k1, k2, k3, k4, k5, v) => { callCount2++; }).InParallel()
+				.OnSet.Do(() => { callCount3++; });
+
+			sut["a", "b", "c", "d", "e"] = "1";
+			sut["a", "b", "c", "d", "e"] = "2";
+			sut["a", "b", "c", "d", "e"] = "3";
+			sut["a", "b", "c", "d", "e"] = "4";
+
+			await That(callCount1).IsEqualTo(2);
+			await That(callCount2).IsEqualTo(4);
+			await That(callCount3).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_OnSetFor_ShouldRepeatCallbackTheGivenNumberOfTimes()
+		{
+			int callCount1 = 0;
+			int callCount2 = 0;
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock
+				.Setup[It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+					It.IsAny<string>()]
+				.OnSet.Do(() => { callCount1++; }).For(2)
+				.OnSet.Do(() => { callCount2++; });
+
+			for (int i = 0; i < 6; i++)
+			{
+				sut["a", "b", "c", "d", "e"] = "1";
+			}
+
+			await That(callCount1).IsEqualTo(4);
+			await That(callCount2).IsEqualTo(2);
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_OnSetDoWithCounter_ShouldReceiveTheAccessCounter()
+		{
+			List<int> invocations = [];
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock
+				.Setup[It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+					It.IsAny<string>()]
+				.OnSet.Do((i, _, _, _, _, _, _) => { invocations.Add(i); });
+
+			for (int i = 0; i < 3; i++)
+			{
+				sut["a", "b", "c", "d", "e"] = "1";
+			}
+
+			await That(invocations).IsEqualTo([0, 1, 2,]);
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_OnSetTransitionTo_ShouldSwitchScenario()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+			sut.Mock.InScenario("a")
+				.Setup[It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+					It.IsAny<string>()]
+				.OnSet.Do(() => { })
+				.OnSet.TransitionTo("b");
+			sut.Mock.TransitionTo("a");
+
+			sut["a", "b", "c", "d", "e"] = "x";
+
+			await That(((IMock)sut).MockRegistry.Scenario).IsEqualTo("b");
+		}
+
+		[Fact]
+		public async Task SetOnlyFiveKeyIndexer_SetExpectation_ShouldFormatTheValueLikeTheShippedSurface()
+		{
+			IAccessorService sut = IAccessorService.CreateMock();
+
+			IVerificationResult result = (IVerificationResult)sut.Mock
+				.Verify[It.Is("a"), It.Is("b"), It.Is("c"), It.Is("d"), It.Is("e")].Set("x");
+
+			await That(result.Expectation)
+				.IsEqualTo("set indexer [\"a\", \"b\", \"c\", \"d\", \"e\"] to \"x\"")
+				.Because("the generated narrowed result must render the value like the shipped one");
 		}
 
 		public interface IAccessorService


### PR DESCRIPTION
The accessor narrowing introduced for indexers (#830) stopped at four keys: the narrowed setup/verify types only ship with the library for arities 1-4, so a five-key get-only indexer still offered OnSet and Verify[...].Set(...), which compiled and silently did nothing.

Since the setup types for indexers with more than four keys are generated per-compilation anyway, generate the narrowed surface there too:

- IndexerSetups.g.cs now emits IIndexerGetterOnlySetup / IIndexerSetterOnlySetup interface hierarchies (builders included) for each affected arity, implements them on the generated IndexerSetup class, and adds the Forever/OnlyOnce extensions for the narrowed when-builders.
- Narrowed VerificationIndexerGetterResult / -SetterResult classes are generated in Mockolate.Verify, dispatching through the predicate-based MockRegistry.IndexerGot/IndexerSet overloads that the full VerificationIndexerResult already uses above four keys. Each takes only the member id and predicate of the accessor it exposes.
- The facade selection in the mock emission now uses the plain accessor classification for every arity; the narrowed hierarchies are only generated for arities that need them, keyed on the same Getter/Setter nullity that guards body emission.

BREAKING CHANGE: on an indexer with more than four keys that the mock reads or writes but not both, Setup[...].OnSet/OnGet, Setup[...].Returns/Throws/InitializeWith and Verify[...].Set(...)/Got() no longer compile for the absent accessor. Each previously compiled and silently had no effect. This closes the gap the four-key narrowing left; the shipped library API is unchanged.