### PR TITLE
test: pin pending-task returns and abstract-indexer generation

### DIFF
--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.IndexerTests.cs
@@ -471,6 +471,38 @@ public sealed partial class MockTests
 			}
 
 			[Fact]
+			public async Task ShouldNotCallBaseForAbstractIndexersOfAbstractClasses()
+			{
+				GeneratorResult result = Generator
+					.Run("""
+					     using Mockolate;
+
+					     namespace MyCode;
+					     public class Program
+					     {
+					         public static void Main(string[] args)
+					         {
+					     		_ = MyAbstractService.CreateMock();
+					         }
+					     }
+
+					     public abstract class MyAbstractService
+					     {
+					         public abstract object this[int index] { get; }
+					         public abstract int this[string key] { get; set; }
+					     }
+					     """);
+
+				await That(result.Diagnostics).IsEmpty();
+				await That(result.Sources).ContainsKey("Mock.MyAbstractService.g.cs");
+				await That(result.Sources["Mock.MyAbstractService.g.cs"])
+					.Contains("public override object this[int index]").And
+					.Contains("public override int this[string key]").And
+					.DoesNotContain("base[")
+					.Because("abstract indexers have no base implementation to call (CS0205)");
+			}
+
+			[Fact]
 			public async Task ShouldSupportSpanAndReadOnlySpanIndexerParameters()
 			{
 				GeneratorResult result = Generator

--- a/Tests/Mockolate.Tests/ReturnsThrowsAsyncExtensionsTests.cs
+++ b/Tests/Mockolate.Tests/ReturnsThrowsAsyncExtensionsTests.cs
@@ -317,6 +317,21 @@ public sealed class ReturnsThrowsAsyncExtensionsTests
 
 			await That(result).IsEqualTo(42);
 		}
+
+		[Fact]
+		public async Task Returns_TaskFactory_ShouldReturnPendingTaskAsIs()
+		{
+			TaskCompletionSource<int> completionSource = new();
+			IReturnsAsyncExtensionsSetupTest sut = IReturnsAsyncExtensionsSetupTest.CreateMock();
+			sut.Mock.Setup.Method0().Returns(() => completionSource.Task);
+
+			Task<int> result = sut.Method0();
+
+			await That(result.IsCompleted).IsFalse()
+				.Because("the factory's task must be handed to the caller as-is, so it can be raced against timeouts or cancellation");
+			completionSource.SetResult(42);
+			await That(await result).IsEqualTo(42);
+		}
 	}
 
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
Add two regression tests prompted by TUnit issues [#6515](https://github.com/thomhurst/TUnit/issues/6515) and [#6516](https://github.com/thomhurst/TUnit/issues/6516):
- Returns(() => tcs.Task) must hand the pending task to the caller as-is, so it can be raced against timeouts or cancellation.
- Mocking an abstract class with abstract indexers must not emit base[...] calls (would be CS0205).