### PR TITLE
fix: delegate wrapped calls of hidden interface members to the declaring interface

### DIFF
--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2332,6 +2332,10 @@ internal static partial class Sources
 		string wpc = Helpers.GetUniqueLocalVariableName("wpc", method.Parameters);
 		string wraps = Helpers.GetUniqueLocalVariableName("wraps", method.Parameters);
 		bool supportsWrapping = !explicitInterfaceImplementation && method is { IsStatic: false, IsProtected: false, };
+		// A method that hides a base member (`new`) is emitted as an explicit interface implementation.
+		// The wrapped instance must be cast to the declaring interface, otherwise the delegated call
+		// binds to the hiding member instead: wrong return type (CS0266) or missing constraints (CS0452/CS0453).
+		string wrapsType = method.ExplicitImplementation ?? className;
 		bool isAbstractOrInterface = isClassInterface || method.IsAbstract;
 
 		StringBuilder sb2 = new();
@@ -2452,7 +2456,7 @@ internal static partial class Sources
 
 		if (supportsWrapping)
 		{
-			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className)
+			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType)
 				.Append(' ').Append(wraps).Append(')').AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
 			if (method.ReturnType != Type.Void)

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -471,6 +471,174 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task HiddenGenericMethod_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	IEnumerable<T> Get<T>() where T : notnull;
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<T> Get<T>() where T : notnull;
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wrappedResult = wraps.Get<T>();
+			          """).IgnoringNewlineStyle()
+			.Because(
+				"the explicit implementation of the hidden member must delegate to the declaring interface, not to the hiding member");
+	}
+
+	[Fact]
+	public async Task HiddenGenericMethod_WithAdditionalConstraints_ShouldNotDelegateToHidingMember()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	IEnumerable<T> Get<T>();
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<T> Get<T>() where T : class, new();
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0452: the hiding member requires a reference type, the hidden member does not");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wrappedResult = wraps.Get<T>();
+			          """).IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task HiddenGenericMethod_WithNarrowedConstraints_ShouldNotDelegateToHidingMember()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	IEnumerable<T> Get<T>() where T : notnull;
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IEnumerable<T> Get<T>() where T : struct;
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0453: the hiding member requires a non-nullable value type, the hidden member does not");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wrappedResult = wraps.Get<T>();
+			          """).IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task HiddenGenericMethod_InDeepHierarchy_ShouldNotDelegateToHidingMember()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface IGrandParent
+			     {
+			     	T Get<T>(int id) where T : notnull;
+			     }
+
+			     public interface ITestParent : IGrandParent
+			     {
+			     	new IEnumerable<T> Get<T>(int id) where T : notnull;
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<T> Get<T>(int id) where T : notnull;
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0266: each hidden member has its own return type");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wrappedResult = wraps.Get<T>(id);
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.IGrandParent wraps)
+			          				{
+			          					wrappedResult = wraps.Get<T>(id);
+			          """).IgnoringNewlineStyle()
+			.Because("every level of the hierarchy must delegate to its own declaring interface");
+	}
+
+	[Fact]
 	public async Task MembersWithReservedNames_ShouldPrefixAtSymbol()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
@@ -80,6 +80,18 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task Wrap_HiddenGenericMethod_ShouldDelegateToDeclaringInterface()
+		{
+			MyChocolateCatalog myCatalog = new();
+			IChocolateCatalog wrappedCatalog = IChocolateCatalog.CreateMock().Wrapping(myCatalog);
+
+			_ = wrappedCatalog.Get<string>();
+			_ = ((IChocolateSource)wrappedCatalog).Get<string>();
+
+			await That(myCatalog.ReceivedCalls).IsEqualTo(["catalog", "source",]);
+		}
+
+		[Fact]
 		public async Task Wrap_Indexer_ShouldDelegateToWrappedInstance()
 		{
 			MyChocolateDispenser myDispenser = new();
@@ -169,6 +181,23 @@ public sealed partial class MockTests
 			}
 
 			public event ChocolateDispensedDelegate? ChocolateDispensed;
+		}
+
+		private class MyChocolateCatalog : IChocolateCatalog
+		{
+			public List<string> ReceivedCalls { get; } = [];
+
+			public IList<T> Get<T>() where T : notnull
+			{
+				ReceivedCalls.Add("catalog");
+				return [];
+			}
+
+			IEnumerable<T> IChocolateSource.Get<T>()
+			{
+				ReceivedCalls.Add("source");
+				return [];
+			}
 		}
 
 		public delegate void MyDelegate();

--- a/Tests/Mockolate.Tests/TestHelpers/IChocolateCatalog.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/IChocolateCatalog.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Mockolate.Tests.TestHelpers;
+
+public interface IChocolateSource
+{
+	IEnumerable<T> Get<T>() where T : notnull;
+}
+
+public interface IChocolateCatalog : IChocolateSource
+{
+	new IList<T> Get<T>() where T : notnull;
+}


### PR DESCRIPTION
A method that hides a base interface member via `new` is emitted as an explicit interface implementation, but its wrapping delegation cast `MockRegistry.Wraps` to the mocked type instead of the declaring interface. The delegated call therefore bound to the hiding member:

- same constraints, different return type: wrong member invoked silently
- hiding member adds a constraint: CS0452
- hiding member narrows a constraint: CS0453
- three-level hierarchy: CS0266

Cast to `method.ExplicitImplementation` when set, mirroring how events already treat explicitly implemented members.