### PR TITLE
fix: forward wrapped access of hidden interface members to the declaring interface

### DIFF
--- a/Docs/pages/01-create-mocks.md
+++ b/Docs/pages/01-create-mocks.md
@@ -141,6 +141,9 @@ wrappedDispenser.Mock.Verify.Dispense(It.Is("Dark"), It.Is(5)).Once();
 
 - Both interface and class types can be wrapped.
 - All public calls are forwarded to the wrapped instance.
+- Members that hide a base member with `new` are forwarded to the interface that declares them, so each
+  interface view of the mock reaches the matching member on the wrapped instance.
 - You can still set up custom behavior that overrides the wrapped instance's behavior.
 - Protected members are not forwarded to the wrapped instance; the base class implementation is used instead.
+- Init-only properties are not forwarded to the wrapped instance, since it is already constructed.
 - Verification works the same as with regular mocks.

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1592,8 +1592,12 @@ internal static partial class Sources
 		}
 
 		sb.AppendLine("\t\t{");
-		bool supportsWrapping = @event is { IsStatic: false, IsProtected: false, ExplicitImplementation: null, } &&
+		bool supportsWrapping = @event is { IsStatic: false, IsProtected: false, } &&
 		                        !explicitInterfaceImplementation;
+		// An event that hides a base member (`new`) is emitted as an explicit interface implementation.
+		// The wrapped instance must be cast to the declaring interface, otherwise the subscription
+		// binds to the hiding member, whose delegate type differs from the one being implemented.
+		string wrapsType = @event.ExplicitImplementation ?? className;
 		bool supportsBaseForwarding = supportsWrapping && !isClassInterface && @event.UseOverride && !@event.IsAbstract;
 		if (supportsWrapping)
 		{
@@ -1604,7 +1608,7 @@ internal static partial class Sources
 			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(addCall).Append(@event.GetUniqueNameString()).Append(", value.Target, value.Method);").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
 			sb.Append("\t\t\t\t").Append(backingFieldAccess).Append(" += value;").AppendLine();
-			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className).Append(" wraps)").AppendLine();
+			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType).Append(" wraps)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\t\twraps.").Append(@event.Name).Append(" += value;").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
@@ -1624,7 +1628,7 @@ internal static partial class Sources
 			sb.Append("\t\t\t\t\t").Append(mockRegistry).Append(removeCall).Append(@event.GetUniqueNameString()).Append(", value.Target, value.Method);").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
 			sb.Append("\t\t\t\t").Append(backingFieldAccess).Append(" -= value;").AppendLine();
-			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className).Append(" wraps)").AppendLine();
+			sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType).Append(" wraps)").AppendLine();
 			sb.Append("\t\t\t\t{").AppendLine();
 			sb.Append("\t\t\t\t\twraps.").Append(@event.Name).Append(" -= value;").AppendLine();
 			sb.Append("\t\t\t\t}").AppendLine();
@@ -1669,6 +1673,10 @@ internal static partial class Sources
 #pragma warning restore S107
 	{
 		string mockRegistry = property.IsStatic ? "MockRegistryProvider.Value" : $"this.{mockRegistryName}";
+		// A property that hides a base member (`new`) is emitted as an explicit interface implementation.
+		// The wrapped instance must be cast to the declaring interface, otherwise the delegated access
+		// binds to the hiding member instead: wrong property type (CS0266).
+		string wrapsType = property.ExplicitImplementation ?? className;
 		bool useFastForProperty = useFastBuffers && !property.IsIndexer && IsFastBufferEligibleProperty(property);
 		bool useFastForIndexer = useFastBuffers && property.IsIndexer && IsFastBufferEligibleIndexer(property);
 		string indexerGetIdRef = property.IsIndexer
@@ -1764,7 +1772,7 @@ internal static partial class Sources
 			{
 				AppendRefStructIndexerGetterBody(sb, property, mockRegistry);
 			}
-			else if (isClassInterface && !explicitInterfaceImplementation && property.ExplicitImplementation is null)
+			else if (isClassInterface && !explicitInterfaceImplementation)
 			{
 				if (property is { IsIndexer: true, IndexerParameters: not null, })
 				{
@@ -1781,7 +1789,7 @@ internal static partial class Sources
 						property.Type, property.IndexerParameters.Value, useFastForIndexer,
 						useFastForIndexer ? indexerGetIdRef : null,
 						cachedBufferRef: indexerGetCachedBufferRef);
-					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is not ").Append(className)
+					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is not ").Append(wrapsType)
 						.Append(' ').Append(wrapsVarName).Append(')').AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t\treturn ").Append(setupVarName).Append(" is null")
@@ -1814,7 +1822,7 @@ internal static partial class Sources
 							.AppendDefaultValueGeneratorFor(property.Type, "b.DefaultValue");
 						if (!property.IsStatic)
 						{
-							sb.Append(", ").Append(mockRegistry).Append(".Wraps is not ").Append(className)
+							sb.Append(", ").Append(mockRegistry).Append(".Wraps is not ").Append(wrapsType)
 								.Append(" wraps ? null : () => wraps.").Append(property.Name);
 						}
 
@@ -1828,7 +1836,7 @@ internal static partial class Sources
 							.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue");
 						if (!property.IsStatic)
 						{
-							sb.Append(", ").Append(mockRegistry).Append(".Wraps is not ").Append(className)
+							sb.Append(", ").Append(mockRegistry).Append(".Wraps is not ").Append(wrapsType)
 								.Append(" wraps ? null : () => wraps.").Append(property.Name);
 						}
 						else
@@ -1865,7 +1873,7 @@ internal static partial class Sources
 						sb.Append("\t\t\t\t\t").AppendTypeOrWrapper(property.Type).Append(' ')
 							.Append(baseResultVarName).Append(" = this.")
 							.Append(mockRegistryName)
-							.Append(".Wraps is ").Append(className).Append(' ').Append(wrapsVarName).Append(" ? ")
+							.Append(".Wraps is ").Append(wrapsType).Append(' ').Append(wrapsVarName).Append(" ? ")
 							.Append(wrapsVarName).Append('[')
 							.Append(FormatIndexerParametersAsNames(property.IndexerParameters.Value))
 							.Append("] : base[")
@@ -1905,7 +1913,7 @@ internal static partial class Sources
 							.AppendDefaultValueGeneratorFor(property.Type, "b.DefaultValue");
 						if (property is { IsStatic: false, } && property.Getter?.IsProtected != true)
 						{
-							sb.Append(", ").Append(mockRegistry).Append(".Wraps is ").Append(className)
+							sb.Append(", ").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType)
 								.Append(" wraps ? () => wraps.").Append(property.Name).Append(" : () => base.")
 								.Append(property.Name);
 						}
@@ -1924,7 +1932,7 @@ internal static partial class Sources
 							.AppendDefaultValueGeneratorFor(property.Type, $"{mockRegistry}.Behavior.DefaultValue");
 						if (property is { IsStatic: false, } && property.Getter?.IsProtected != true)
 						{
-							sb.Append(", ").Append(mockRegistry).Append(".Wraps is ").Append(className)
+							sb.Append(", ").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType)
 								.Append(" wraps ? () => wraps.").Append(property.Name).Append(" : () => base.")
 								.Append(property.Name);
 						}
@@ -2001,7 +2009,7 @@ internal static partial class Sources
 			{
 				AppendRefStructIndexerSetterBody(sb, property, mockRegistry);
 			}
-			else if (isClassInterface && !explicitInterfaceImplementation && property.ExplicitImplementation is null)
+			else if (isClassInterface && !explicitInterfaceImplementation)
 			{
 				if (property is { IsIndexer: true, IndexerParameters: not null, })
 				{
@@ -2022,7 +2030,7 @@ internal static partial class Sources
 						.Append(signatureIndex).Append(");")
 						.AppendLine();
 
-					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className)
+					sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType)
 						.Append(' ').Append(wrapsVarName).Append(')').AppendLine();
 					sb.Append("\t\t\t\t{").AppendLine();
 					sb.Append("\t\t\t\t\t").Append(wrapsVarName).Append('[')
@@ -2050,7 +2058,7 @@ internal static partial class Sources
 
 					if (!property.IsStatic && !property.Setter.IsInitOnly)
 					{
-						sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className)
+						sb.Append("\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType)
 							.Append(" wraps)").AppendLine();
 						sb.Append("\t\t\t\t{").AppendLine();
 						sb.Append("\t\t\t\t\twraps.").Append(property.Name).Append(" = value;").AppendLine();
@@ -2080,7 +2088,7 @@ internal static partial class Sources
 					sb.Append("\t\t\t\t{").AppendLine();
 					if (property.Setter?.IsProtected != true)
 					{
-						sb.Append("\t\t\t\t\tif (this.").Append(mockRegistryName).Append(".Wraps is ").Append(className)
+						sb.Append("\t\t\t\t\tif (this.").Append(mockRegistryName).Append(".Wraps is ").Append(wrapsType)
 							.Append(' ').Append(wrapsVarName).Append(')').AppendLine();
 						sb.Append("\t\t\t\t\t{").AppendLine();
 						sb.Append("\t\t\t\t\t\t").Append(wrapsVarName).Append('[')
@@ -2138,7 +2146,7 @@ internal static partial class Sources
 					sb.Append("\t\t\t\t{").AppendLine();
 					if (property is { IsStatic: false, } && property.Setter?.IsProtected != true)
 					{
-						sb.Append("\t\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(className)
+						sb.Append("\t\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType)
 							.Append(" wraps)").AppendLine();
 						sb.Append("\t\t\t\t\t{").AppendLine();
 						sb.Append("\t\t\t\t\t\twraps.").Append(property.Name).Append(" = value;").AppendLine();

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -2144,7 +2144,7 @@ internal static partial class Sources
 					}
 
 					sb.Append("\t\t\t\t{").AppendLine();
-					if (property is { IsStatic: false, } && property.Setter?.IsProtected != true)
+					if (property is { IsStatic: false, Setter: { IsProtected: false, IsInitOnly: false, }, })
 					{
 						sb.Append("\t\t\t\t\tif (").Append(mockRegistry).Append(".Wraps is ").Append(wrapsType)
 							.Append(" wraps)").AppendLine();

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -267,4 +267,41 @@ public class ExampleTests
 		await That(result).IsEqualTo(returnValue);
 		sut.Mock.Verify.TryDelete(It.Is(id), It.IsOut<User?>()).Once();
 	}
+
+	[Fact]
+	public async Task Wrapping_HiddenMember_ShouldForwardToDeclaringInterface()
+	{
+		User alice = new(Guid.NewGuid(), "Alice");
+		User bob = new(Guid.NewGuid(), "Bob");
+		MyUserCache realCache = new();
+		IUserCache sut = IUserCache.CreateMock().Wrapping(realCache);
+
+		sut.Users = [alice,];
+		((IReadOnlyUserCache)sut).Users = [bob,];
+
+		// Each interface sees its own member on the wrapped instance.
+		await That(sut.Users).IsEqualTo([alice,]);
+		await That(((IReadOnlyUserCache)sut).Users).IsEqualTo([bob,]);
+		await That(realCache.CacheUsers).IsEqualTo([alice,]);
+		await That(realCache.ReadOnlyUsers).IsEqualTo([bob,]);
+	}
+
+	private sealed class MyUserCache : IUserCache
+	{
+		public IList<User> CacheUsers { get; private set; } = [];
+
+		public IEnumerable<User> ReadOnlyUsers { get; private set; } = [];
+
+		public IList<User> Users
+		{
+			get => CacheUsers;
+			set => CacheUsers = value;
+		}
+
+		IEnumerable<User> IReadOnlyUserCache.Users
+		{
+			get => ReadOnlyUsers;
+			set => ReadOnlyUsers = value;
+		}
+	}
 }

--- a/Tests/Mockolate.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockolate.ExampleTests/ExampleTests.cs
@@ -277,20 +277,20 @@ public class ExampleTests
 		IUserCache sut = IUserCache.CreateMock().Wrapping(realCache);
 
 		sut.Users = [alice,];
-		((IReadOnlyUserCache)sut).Users = [bob,];
+		((IUserCacheBase)sut).Users = [bob,];
 
 		// Each interface sees its own member on the wrapped instance.
 		await That(sut.Users).IsEqualTo([alice,]);
-		await That(((IReadOnlyUserCache)sut).Users).IsEqualTo([bob,]);
+		await That(((IUserCacheBase)sut).Users).IsEqualTo([bob,]);
 		await That(realCache.CacheUsers).IsEqualTo([alice,]);
-		await That(realCache.ReadOnlyUsers).IsEqualTo([bob,]);
+		await That(realCache.BaseUsers).IsEqualTo([bob,]);
 	}
 
 	private sealed class MyUserCache : IUserCache
 	{
 		public IList<User> CacheUsers { get; private set; } = [];
 
-		public IEnumerable<User> ReadOnlyUsers { get; private set; } = [];
+		public IEnumerable<User> BaseUsers { get; private set; } = [];
 
 		public IList<User> Users
 		{
@@ -298,10 +298,10 @@ public class ExampleTests
 			set => CacheUsers = value;
 		}
 
-		IEnumerable<User> IReadOnlyUserCache.Users
+		IEnumerable<User> IUserCacheBase.Users
 		{
-			get => ReadOnlyUsers;
-			set => ReadOnlyUsers = value;
+			get => BaseUsers;
+			set => BaseUsers = value;
 		}
 	}
 }

--- a/Tests/Mockolate.ExampleTests/TestData/IUserCache.cs
+++ b/Tests/Mockolate.ExampleTests/TestData/IUserCache.cs
@@ -2,12 +2,12 @@ using System.Collections.Generic;
 
 namespace Mockolate.ExampleTests.TestData;
 
-public interface IReadOnlyUserCache
+public interface IUserCacheBase
 {
 	IEnumerable<User> Users { get; set; }
 }
 
-public interface IUserCache : IReadOnlyUserCache
+public interface IUserCache : IUserCacheBase
 {
 	new IList<User> Users { get; set; }
 }

--- a/Tests/Mockolate.ExampleTests/TestData/IUserCache.cs
+++ b/Tests/Mockolate.ExampleTests/TestData/IUserCache.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Mockolate.ExampleTests.TestData;
+
+public interface IReadOnlyUserCache
+{
+	IEnumerable<User> Users { get; set; }
+}
+
+public interface IUserCache : IReadOnlyUserCache
+{
+	new IList<User> Users { get; set; }
+}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -794,6 +794,36 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task InitOnlyProperty_InClass_ShouldNotDelegateSetterToWrappedInstance()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = MyClass.CreateMock();
+			         }
+			     }
+
+			     public class MyClass
+			     {
+			     	public virtual int Items { get; init; }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources["Mock.MyClass.g.cs"])
+			.Contains("base.Items = value;").And
+			.DoesNotContain("wraps.Items = value")
+			.Because("an init accessor cannot be forwarded to an already constructed instance");
+	}
+
+	[Fact]
 	public async Task HiddenIndexer_ShouldDelegateWrappingToDeclaringInterface()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -639,6 +639,294 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task HiddenProperty_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	IEnumerable<int> Items { get; set; }
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<int> Items { get; set; }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0266: the hiding member has a narrower property type than the hidden member");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.ITestParent wraps ? null : () => wraps.Items")
+			.Because("the getter of the explicit implementation must read the declaring interface").And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wraps.Items = value;
+			          """).IgnoringNewlineStyle()
+			.Because("the setter of the explicit implementation must write to the declaring interface");
+	}
+
+	[Fact]
+	public async Task HiddenProperty_WithUnrelatedType_ShouldNotDelegateToHidingMember()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	string Label { get; set; }
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new DateTime Label { get; set; }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0029: the hiding member has a type unrelated to the hidden member");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.ITestParent wraps ? null : () => wraps.Label")
+			.And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wraps.Label = value;
+			          """).IgnoringNewlineStyle();
+	}
+
+	[Fact]
+	public async Task HiddenGetOnlyProperty_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	IEnumerable<int> Items { get; }
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<int> Items { get; }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.ITestParent wraps ? null : () => wraps.Items")
+			.Because("a get-only hidden property must still read from the declaring interface");
+	}
+
+	[Fact]
+	public async Task HiddenInitOnlyProperty_ShouldOnlyDelegateGetterToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	IEnumerable<int> Items { get; init; }
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<int> Items { get; init; }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty();
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.ITestParent wraps ? null : () => wraps.Items")
+			.Because("the getter of the explicit implementation must read the declaring interface").And
+			.DoesNotContain("wraps.Items = value")
+			.Because("an init accessor cannot be forwarded to an already constructed instance");
+	}
+
+	[Fact]
+	public async Task HiddenIndexer_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	IEnumerable<int> this[int index] { get; set; }
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<int> this[int index] { get; set; }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0266: the hiding indexer has a narrower value type than the hidden indexer");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is not global::MyCode.ITestParent wraps)
+			          """).IgnoringNewlineStyle()
+			.Because("the getter of the explicit implementation must read the declaring interface").And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wraps[index] = value;
+			          """).IgnoringNewlineStyle()
+			.Because("the setter of the explicit implementation must write to the declaring interface");
+	}
+
+	[Fact]
+	public async Task HiddenEvent_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestParent
+			     {
+			     	event EventHandler Changed;
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new event Action Changed;
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("the hiding event has a delegate type unrelated to the hidden event");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wraps.Changed += value;
+			          """).IgnoringNewlineStyle()
+			.Because("subscribing on the explicit implementation must subscribe on the declaring interface").And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestParent wraps)
+			          				{
+			          					wraps.Changed -= value;
+			          """).IgnoringNewlineStyle()
+			.Because("unsubscribing on the explicit implementation must unsubscribe on the declaring interface");
+	}
+
+	[Fact]
+	public async Task HiddenProperty_InDeepHierarchy_ShouldNotDelegateToHidingMember()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System.Collections.Generic;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface IGrandParent
+			     {
+			     	object Items { get; set; }
+			     }
+
+			     public interface ITestParent : IGrandParent
+			     {
+			     	new IEnumerable<int> Items { get; set; }
+			     }
+
+			     public interface ITest : ITestParent
+			     {
+			     	new IList<int> Items { get; set; }
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0266: each hidden member has its own property type");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.ITestParent wraps ? null : () => wraps.Items")
+			.And
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.IGrandParent wraps ? null : () => wraps.Items")
+			.Because("every level of the hierarchy must delegate to its own declaring interface");
+	}
+
+	[Fact]
 	public async Task MembersWithReservedNames_ShouldPrefixAtSymbol()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
@@ -80,6 +80,24 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task Wrap_HiddenEvent_ShouldSubscribeOnDeclaringInterface()
+		{
+			MyChocolateShelf myShelf = new();
+			IChocolateShelf wrappedShelf = IChocolateShelf.CreateMock().Wrapping(myShelf);
+
+			int baseInvocations = 0;
+			int shelfInvocations = 0;
+			((IChocolateShelfBase)wrappedShelf).Restocked += (_, _) => baseInvocations++;
+			wrappedShelf.Restocked += () => shelfInvocations++;
+
+			myShelf.RaiseBaseRestocked();
+			myShelf.RaiseShelfRestocked();
+
+			await That(baseInvocations).IsEqualTo(1);
+			await That(shelfInvocations).IsEqualTo(1);
+		}
+
+		[Fact]
 		public async Task Wrap_HiddenGenericMethod_ShouldDelegateToDeclaringInterface()
 		{
 			MyChocolateCatalog myCatalog = new();
@@ -89,6 +107,82 @@ public sealed partial class MockTests
 			_ = ((IChocolateSource)wrappedCatalog).Get<string>();
 
 			await That(myCatalog.ReceivedCalls).IsEqualTo(["catalog", "source",]);
+		}
+
+		[Fact]
+		public async Task Wrap_HiddenGetOnlyProperty_ShouldDelegateToDeclaringInterface()
+		{
+			MyChocolateShelf myShelf = new();
+			IChocolateShelf wrappedShelf = IChocolateShelf.CreateMock().Wrapping(myShelf);
+
+			await That(wrappedShelf.Featured).IsEqualTo(["Dark",]);
+			await That(((IChocolateShelfBase)wrappedShelf).Featured).IsEqualTo(["Praline",]);
+			await That(myShelf.ReceivedCalls).IsEqualTo(["get:shelf-featured", "get:base-featured",]);
+		}
+
+		[Fact]
+		public async Task Wrap_HiddenIndexer_ShouldDelegateGetterToDeclaringInterface()
+		{
+			MyChocolateShelf myShelf = new();
+			IChocolateShelf wrappedShelf = IChocolateShelf.CreateMock().Wrapping(myShelf);
+
+			await That(wrappedShelf[1]).IsEqualTo(["Truffle",]);
+			await That(((IChocolateShelfBase)wrappedShelf)[1]).IsEqualTo(["Ganache",]);
+			await That(myShelf.ReceivedCalls).IsEqualTo(["get:shelf-item", "get:base-item",]);
+		}
+
+		[Fact]
+		public async Task Wrap_HiddenIndexer_ShouldDelegateSetterToDeclaringInterface()
+		{
+			MyChocolateShelf myShelf = new();
+			IChocolateShelf wrappedShelf = IChocolateShelf.CreateMock().Wrapping(myShelf);
+
+			wrappedShelf[2] = ["Nougat",];
+			((IChocolateShelfBase)wrappedShelf)[2] = ["Marzipan",];
+
+			await That(myShelf.ReceivedCalls).IsEqualTo(["set:shelf-item", "set:base-item",]);
+			await That(myShelf.ShelfItems[2]).IsEqualTo(["Nougat",]);
+			await That(myShelf.BaseItems[2]).IsEqualTo(["Marzipan",]);
+		}
+
+		[Fact]
+		public async Task Wrap_HiddenProperty_ShouldDelegateGetterToDeclaringInterface()
+		{
+			MyChocolateShelf myShelf = new();
+			IChocolateShelf wrappedShelf = IChocolateShelf.CreateMock().Wrapping(myShelf);
+
+			await That(wrappedShelf.Assortment).IsEqualTo(["Milk", "Dark",]);
+			await That(((IChocolateShelfBase)wrappedShelf).Assortment).IsEqualTo(["Praline",]);
+			await That(myShelf.ReceivedCalls).IsEqualTo(["get:shelf", "get:base",]);
+		}
+
+		[Fact]
+		public async Task Wrap_HiddenProperty_ShouldDelegateSetterToDeclaringInterface()
+		{
+			MyChocolateShelf myShelf = new();
+			IChocolateShelf wrappedShelf = IChocolateShelf.CreateMock().Wrapping(myShelf);
+
+			wrappedShelf.Assortment = ["Truffle",];
+			((IChocolateShelfBase)wrappedShelf).Assortment = ["Ganache",];
+
+			await That(myShelf.ReceivedCalls).IsEqualTo(["set:shelf", "set:base",]);
+			await That(myShelf.ShelfAssortment).IsEqualTo(["Truffle",]);
+			await That(myShelf.BaseAssortment).IsEqualTo(["Ganache",]);
+		}
+
+		[Fact]
+		public async Task Wrap_HiddenPropertyWithUnrelatedType_ShouldDelegateToDeclaringInterface()
+		{
+			MyChocolateShelf myShelf = new();
+			IChocolateShelf wrappedShelf = IChocolateShelf.CreateMock().Wrapping(myShelf);
+
+			wrappedShelf.Label = 7;
+			((IChocolateShelfBase)wrappedShelf).Label = "Seasonal";
+
+			await That(wrappedShelf.Label).IsEqualTo(7);
+			await That(((IChocolateShelfBase)wrappedShelf).Label).IsEqualTo("Seasonal");
+			await That(myShelf.ShelfLabel).IsEqualTo(7);
+			await That(myShelf.BaseLabel).IsEqualTo("Seasonal");
 		}
 
 		[Fact]
@@ -198,6 +292,135 @@ public sealed partial class MockTests
 				ReceivedCalls.Add("source");
 				return [];
 			}
+		}
+
+		private class MyChocolateShelf : IChocolateShelf
+		{
+			private IEnumerable<string> _baseAssortment = ["Praline",];
+			private string _baseLabel = "Classic";
+			private event EventHandler? _baseRestocked;
+
+			public List<string> ReceivedCalls { get; } = [];
+
+			public Dictionary<int, IList<string>> ShelfItems { get; } = new()
+			{
+				{
+					1, ["Truffle",]
+				},
+			};
+
+			public Dictionary<int, IEnumerable<string>> BaseItems { get; } = new()
+			{
+				{
+					1, ["Ganache",]
+				},
+			};
+
+			public IList<string> ShelfAssortment { get; private set; } = ["Milk", "Dark",];
+
+			public IEnumerable<string> BaseAssortment => _baseAssortment;
+
+			public int ShelfLabel { get; private set; }
+
+			public string BaseLabel => _baseLabel;
+
+			public IList<string> this[int index]
+			{
+				get
+				{
+					ReceivedCalls.Add("get:shelf-item");
+					return ShelfItems[index];
+				}
+				set
+				{
+					ReceivedCalls.Add("set:shelf-item");
+					ShelfItems[index] = value;
+				}
+			}
+
+			public IList<string> Assortment
+			{
+				get
+				{
+					ReceivedCalls.Add("get:shelf");
+					return ShelfAssortment;
+				}
+				set
+				{
+					ReceivedCalls.Add("set:shelf");
+					ShelfAssortment = value;
+				}
+			}
+
+			public IList<string> Featured
+			{
+				get
+				{
+					ReceivedCalls.Add("get:shelf-featured");
+					return ["Dark",];
+				}
+			}
+
+			public int Label
+			{
+				get => ShelfLabel;
+				set => ShelfLabel = value;
+			}
+
+			public event Action? Restocked;
+
+			IEnumerable<string> IChocolateShelfBase.this[int index]
+			{
+				get
+				{
+					ReceivedCalls.Add("get:base-item");
+					return BaseItems[index];
+				}
+				set
+				{
+					ReceivedCalls.Add("set:base-item");
+					BaseItems[index] = value;
+				}
+			}
+
+			IEnumerable<string> IChocolateShelfBase.Assortment
+			{
+				get
+				{
+					ReceivedCalls.Add("get:base");
+					return _baseAssortment;
+				}
+				set
+				{
+					ReceivedCalls.Add("set:base");
+					_baseAssortment = value;
+				}
+			}
+
+			IEnumerable<string> IChocolateShelfBase.Featured
+			{
+				get
+				{
+					ReceivedCalls.Add("get:base-featured");
+					return ["Praline",];
+				}
+			}
+
+			string IChocolateShelfBase.Label
+			{
+				get => _baseLabel;
+				set => _baseLabel = value;
+			}
+
+			event EventHandler IChocolateShelfBase.Restocked
+			{
+				add => _baseRestocked += value;
+				remove => _baseRestocked -= value;
+			}
+
+			public void RaiseBaseRestocked() => _baseRestocked?.Invoke(this, EventArgs.Empty);
+
+			public void RaiseShelfRestocked() => Restocked?.Invoke();
 		}
 
 		public delegate void MyDelegate();

--- a/Tests/Mockolate.Tests/TestHelpers/IChocolateShelf.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/IChocolateShelf.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mockolate.Tests.TestHelpers;
+
+public interface IChocolateShelfBase
+{
+	IEnumerable<string> Assortment { get; set; }
+	IEnumerable<string> Featured { get; }
+	string Label { get; set; }
+	IEnumerable<string> this[int index] { get; set; }
+	event EventHandler Restocked;
+}
+
+public interface IChocolateShelf : IChocolateShelfBase
+{
+	new IList<string> Assortment { get; set; }
+	new IList<string> Featured { get; }
+	new int Label { get; set; }
+	new IList<string> this[int index] { get; set; }
+	new event Action Restocked;
+}


### PR DESCRIPTION
A property, indexer or event that hides a base interface member via `new` is emitted as an explicit interface implementation, but those implementations emitted no wrapping branch at all. On a mock created with `.Wrapping(instance)` the wrapped instance was never consulted for the hidden member: getters returned the mock default, setters only reached the registry, and event subscriptions never arrived at the instance.

Let the explicit implementations take the wrapping branch and cast `MockRegistry.Wraps` to `ExplicitImplementation` when set, mirroring the method fix in #847. Casting to the mocked type instead would not compile, because the hiding member has a different type (CS0266, or CS0029 when the types are unrelated).

Init-only setters stay unforwarded, since the wrapped instance is already constructed.