### PR TITLE
fix: forward wrapped access of interface members via the declaring interface

### DIFF
--- a/Docs/pages/01-create-mocks.md
+++ b/Docs/pages/01-create-mocks.md
@@ -141,8 +141,9 @@ wrappedDispenser.Mock.Verify.Dispense(It.Is("Dark"), It.Is(5)).Once();
 
 - Both interface and class types can be wrapped.
 - All public calls are forwarded to the wrapped instance.
-- Members that hide a base member with `new` are forwarded to the interface that declares them, so each
-  interface view of the mock reaches the matching member on the wrapped instance.
+- Interface members are forwarded through the interface that declares them, so each interface view of the mock
+  reaches the matching member on the wrapped instance. This also covers members that hide a base member with
+  `new` and same-named members declared by several base interfaces.
 - You can still set up custom behavior that overrides the wrapped instance's behavior.
 - Protected members are not forwarded to the wrapped instance; the base class implementation is used instead.
 - Init-only properties are not forwarded to the wrapped instance, since it is already constructed.

--- a/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
+++ b/Source/Mockolate.SourceGenerators/Sources/Sources.MockClass.cs
@@ -1594,10 +1594,11 @@ internal static partial class Sources
 		sb.AppendLine("\t\t{");
 		bool supportsWrapping = @event is { IsStatic: false, IsProtected: false, } &&
 		                        !explicitInterfaceImplementation;
-		// An event that hides a base member (`new`) is emitted as an explicit interface implementation.
-		// The wrapped instance must be cast to the declaring interface, otherwise the subscription
-		// binds to the hiding member, whose delegate type differs from the one being implemented.
-		string wrapsType = @event.ExplicitImplementation ?? className;
+		// Interface members are forwarded via their declaring interface: an explicit implementation (hidden
+		// via `new`, or a name collision between sibling interfaces) has a different delegate type than the
+		// one reachable through the mocked interface, and an implicit member declared by several sibling
+		// interfaces is ambiguous on the mocked interface (CS0229).
+		string wrapsType = isClassInterface ? @event.ContainingType : className;
 		bool supportsBaseForwarding = supportsWrapping && !isClassInterface && @event.UseOverride && !@event.IsAbstract;
 		if (supportsWrapping)
 		{
@@ -1673,10 +1674,11 @@ internal static partial class Sources
 #pragma warning restore S107
 	{
 		string mockRegistry = property.IsStatic ? "MockRegistryProvider.Value" : $"this.{mockRegistryName}";
-		// A property that hides a base member (`new`) is emitted as an explicit interface implementation.
-		// The wrapped instance must be cast to the declaring interface, otherwise the delegated access
-		// binds to the hiding member instead: wrong property type (CS0266).
-		string wrapsType = property.ExplicitImplementation ?? className;
+		// Interface members are forwarded via their declaring interface: an explicit implementation (hidden
+		// via `new`, or a name collision between sibling interfaces) has a different property type than the
+		// one reachable through the mocked interface (CS0266), and an implicit member declared by several
+		// sibling interfaces is ambiguous on the mocked interface (CS0229/CS0121).
+		string wrapsType = isClassInterface ? property.ContainingType : className;
 		bool useFastForProperty = useFastBuffers && !property.IsIndexer && IsFastBufferEligibleProperty(property);
 		bool useFastForIndexer = useFastBuffers && property.IsIndexer && IsFastBufferEligibleIndexer(property);
 		string indexerGetIdRef = property.IsIndexer
@@ -2340,10 +2342,11 @@ internal static partial class Sources
 		string wpc = Helpers.GetUniqueLocalVariableName("wpc", method.Parameters);
 		string wraps = Helpers.GetUniqueLocalVariableName("wraps", method.Parameters);
 		bool supportsWrapping = !explicitInterfaceImplementation && method is { IsStatic: false, IsProtected: false, };
-		// A method that hides a base member (`new`) is emitted as an explicit interface implementation.
-		// The wrapped instance must be cast to the declaring interface, otherwise the delegated call
-		// binds to the hiding member instead: wrong return type (CS0266) or missing constraints (CS0452/CS0453).
-		string wrapsType = method.ExplicitImplementation ?? className;
+		// Interface members are forwarded via their declaring interface: an explicit implementation (hidden
+		// via `new`, or a name collision between sibling interfaces) has a different signature than the one
+		// reachable through the mocked interface, and an implicit member declared by several sibling
+		// interfaces is ambiguous on the mocked interface (CS0121).
+		string wrapsType = isClassInterface ? method.ContainingType : className;
 		bool isAbstractOrInterface = isClassInterface || method.IsAbstract;
 
 		StringBuilder sb2 = new();

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.EventsTests.cs
@@ -292,7 +292,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.AddEvent(global::Mockolate.Mock.IMyService.MemberId_MyBaseEvent1_Subscribe, "global::MyCode.IMyServiceBase1.MyBaseEvent1", value.Target, value.Method);
 					          				}
 					          				this._mockolateEvent_global__MyCode_IMyServiceBase1_MyBaseEvent1 += value;
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase1 wraps)
 					          				{
 					          					wraps.MyBaseEvent1 += value;
 					          				}
@@ -304,7 +304,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RemoveEvent(global::Mockolate.Mock.IMyService.MemberId_MyBaseEvent1_Unsubscribe, "global::MyCode.IMyServiceBase1.MyBaseEvent1", value.Target, value.Method);
 					          				}
 					          				this._mockolateEvent_global__MyCode_IMyServiceBase1_MyBaseEvent1 -= value;
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase1 wraps)
 					          				{
 					          					wraps.MyBaseEvent1 -= value;
 					          				}
@@ -323,7 +323,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.AddEvent(global::Mockolate.Mock.IMyService.MemberId_MyBaseEvent2_Subscribe, "global::MyCode.IMyServiceBase2.MyBaseEvent2", value.Target, value.Method);
 					          				}
 					          				this._mockolateEvent_global__MyCode_IMyServiceBase2_MyBaseEvent2 += value;
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase2 wraps)
 					          				{
 					          					wraps.MyBaseEvent2 += value;
 					          				}
@@ -335,7 +335,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RemoveEvent(global::Mockolate.Mock.IMyService.MemberId_MyBaseEvent2_Unsubscribe, "global::MyCode.IMyServiceBase2.MyBaseEvent2", value.Target, value.Method);
 					          				}
 					          				this._mockolateEvent_global__MyCode_IMyServiceBase2_MyBaseEvent2 -= value;
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase2 wraps)
 					          				{
 					          					wraps.MyBaseEvent2 -= value;
 					          				}
@@ -354,7 +354,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.AddEvent(global::Mockolate.Mock.IMyService.MemberId_MyBaseEvent3_Subscribe, "global::MyCode.IMyServiceBase3.MyBaseEvent3", value.Target, value.Method);
 					          				}
 					          				this._mockolateEvent_global__MyCode_IMyServiceBase3_MyBaseEvent3 += value;
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase3 wraps)
 					          				{
 					          					wraps.MyBaseEvent3 += value;
 					          				}
@@ -366,7 +366,7 @@ public sealed partial class MockTests
 					          					this.MockRegistry.RemoveEvent(global::Mockolate.Mock.IMyService.MemberId_MyBaseEvent3_Unsubscribe, "global::MyCode.IMyServiceBase3.MyBaseEvent3", value.Target, value.Method);
 					          				}
 					          				this._mockolateEvent_global__MyCode_IMyServiceBase3_MyBaseEvent3 -= value;
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase3 wraps)
 					          				{
 					          					wraps.MyBaseEvent3 -= value;
 					          				}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.MethodTests.cs
@@ -735,7 +735,7 @@ public sealed partial class MockTests
 					          			}
 					          			try
 					          			{
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase1 wraps)
 					          				{
 					          					wrappedResult = wraps.MyBaseMethod1(value);
 					          					hasWrappedResult = true;
@@ -774,7 +774,7 @@ public sealed partial class MockTests
 					          			}
 					          			try
 					          			{
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase2 wraps)
 					          				{
 					          					wrappedResult = wraps.MyBaseMethod2(value);
 					          					hasWrappedResult = true;
@@ -813,7 +813,7 @@ public sealed partial class MockTests
 					          			}
 					          			try
 					          			{
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase3 wraps)
 					          				{
 					          					wrappedResult = wraps.MyBaseMethod3(value);
 					          					hasWrappedResult = true;

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.ClassTests.PropertiesTests.cs
@@ -380,12 +380,12 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty1_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty1_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty1);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty1_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty1_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyServiceBase1 wraps ? null : () => wraps.MyBaseProperty1);
 					          			}
 					          			set
 					          			{
 					          				this.MockRegistry.SetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty1_Get, global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty1_Set, "global::MyCode.IMyServiceBase1.MyBaseProperty1", value);
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase1 wraps)
 					          				{
 					          					wraps.MyBaseProperty1 = value;
 					          				}
@@ -398,12 +398,12 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty2_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty2_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty2);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty2_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty2_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyServiceBase2 wraps ? null : () => wraps.MyBaseProperty2);
 					          			}
 					          			set
 					          			{
 					          				this.MockRegistry.SetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty2_Get, global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty2_Set, "global::MyCode.IMyServiceBase2.MyBaseProperty2", value);
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase2 wraps)
 					          				{
 					          					wraps.MyBaseProperty2 = value;
 					          				}
@@ -416,12 +416,12 @@ public sealed partial class MockTests
 					          		{
 					          			get
 					          			{
-					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty3_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty3_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyService wraps ? null : () => wraps.MyBaseProperty3);
+					          				return this.MockRegistry.GetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty3_Get, global::Mockolate.Mock.IMyService.PropertyAccess_MyBaseProperty3_Get, static b => b.DefaultValue.Generate(default(int)!), this.MockRegistry.Wraps is not global::MyCode.IMyServiceBase3 wraps ? null : () => wraps.MyBaseProperty3);
 					          			}
 					          			set
 					          			{
 					          				this.MockRegistry.SetPropertyFast<int>(global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty3_Get, global::Mockolate.Mock.IMyService.MemberId_MyBaseProperty3_Set, "global::MyCode.IMyServiceBase3.MyBaseProperty3", value);
-					          				if (this.MockRegistry.Wraps is global::MyCode.IMyService wraps)
+					          				if (this.MockRegistry.Wraps is global::MyCode.IMyServiceBase3 wraps)
 					          				{
 					          					wraps.MyBaseProperty3 = value;
 					          				}

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -957,6 +957,199 @@ public sealed partial class MockTests
 	}
 
 	[Fact]
+	public async Task SiblingInterfaceProperty_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestLeft
+			     {
+			     	string Name { get; set; }
+			     }
+
+			     public interface ITestRight
+			     {
+			     	string Name { get; set; }
+			     }
+
+			     public interface ITest : ITestLeft, ITestRight
+			     {
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0229: accessing the member on the mocked interface is ambiguous between the siblings");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.ITestLeft wraps ? null : () => wraps.Name").And
+			.Contains("this.MockRegistry.Wraps is not global::MyCode.ITestRight wraps ? null : () => wraps.Name").And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestLeft wraps)
+			          				{
+			          					wraps.Name = value;
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestRight wraps)
+			          				{
+			          					wraps.Name = value;
+			          """).IgnoringNewlineStyle()
+			.Because("each sibling member must delegate to its own declaring interface");
+	}
+
+	[Fact]
+	public async Task SiblingInterfaceIndexer_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestLeft
+			     {
+			     	string this[int index] { get; set; }
+			     }
+
+			     public interface ITestRight
+			     {
+			     	string this[int index] { get; set; }
+			     }
+
+			     public interface ITest : ITestLeft, ITestRight
+			     {
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0229: accessing the indexer on the mocked interface is ambiguous between the siblings");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is not global::MyCode.ITestLeft wraps)
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is not global::MyCode.ITestRight wraps)
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestLeft wraps)
+			          				{
+			          					wraps[index] = value;
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestRight wraps)
+			          				{
+			          					wraps[index] = value;
+			          """).IgnoringNewlineStyle()
+			.Because("each sibling indexer must delegate to its own declaring interface");
+	}
+
+	[Fact]
+	public async Task SiblingInterfaceEvent_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using System;
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestLeft
+			     {
+			     	event EventHandler Changed;
+			     }
+
+			     public interface ITestRight
+			     {
+			     	event EventHandler Changed;
+			     }
+
+			     public interface ITest : ITestLeft, ITestRight
+			     {
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0229: subscribing on the mocked interface is ambiguous between the siblings");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestLeft wraps)
+			          				{
+			          					wraps.Changed += value;
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestRight wraps)
+			          				{
+			          					wraps.Changed -= value;
+			          """).IgnoringNewlineStyle()
+			.Because("each sibling event must subscribe on its own declaring interface");
+	}
+
+	[Fact]
+	public async Task SiblingInterfaceMethod_ShouldDelegateWrappingToDeclaringInterface()
+	{
+		GeneratorResult result = Generator
+			.Run("""
+			     using Mockolate;
+
+			     namespace MyCode;
+
+			     public class Program
+			     {
+			         public static void Main(string[] args)
+			         {
+			     		_ = ITest.CreateMock();
+			         }
+			     }
+
+			     public interface ITestLeft
+			     {
+			     	int Count(string value);
+			     }
+
+			     public interface ITestRight
+			     {
+			     	int Count(string value);
+			     }
+
+			     public interface ITest : ITestLeft, ITestRight
+			     {
+			     }
+			     """);
+
+		await That(result.Diagnostics).IsEmpty()
+			.Because("CS0121: calling the method on the mocked interface is ambiguous between the siblings");
+		await That(result.Sources["Mock.ITest.g.cs"])
+			.Contains("if (this.MockRegistry.Wraps is global::MyCode.ITestLeft wraps)").And
+			.Contains("if (this.MockRegistry.Wraps is global::MyCode.ITestRight wraps)")
+			.Because("each sibling method must delegate to its own declaring interface");
+	}
+
+	[Fact]
 	public async Task MembersWithReservedNames_ShouldPrefixAtSymbol()
 	{
 		GeneratorResult result = Generator

--- a/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
+++ b/Tests/Mockolate.SourceGenerators.Tests/MockTests.cs
@@ -1102,11 +1102,21 @@ public sealed partial class MockTests
 			          					wraps.Changed += value;
 			          """).IgnoringNewlineStyle().And
 			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestLeft wraps)
+			          				{
+			          					wraps.Changed -= value;
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
+			          				if (this.MockRegistry.Wraps is global::MyCode.ITestRight wraps)
+			          				{
+			          					wraps.Changed += value;
+			          """).IgnoringNewlineStyle().And
+			.Contains("""
 			          				if (this.MockRegistry.Wraps is global::MyCode.ITestRight wraps)
 			          				{
 			          					wraps.Changed -= value;
 			          """).IgnoringNewlineStyle()
-			.Because("each sibling event must subscribe on its own declaring interface");
+			.Because("each sibling event must subscribe and unsubscribe on its own declaring interface");
 	}
 
 	[Fact]

--- a/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
@@ -243,6 +243,27 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task Wrap_SiblingInterfaceEvent_ShouldUnsubscribeOnDeclaringInterface()
+		{
+			MyChocolateGiftSet myGiftSet = new();
+			IChocolateGiftSet wrappedGiftSet = IChocolateGiftSet.CreateMock().Wrapping(myGiftSet);
+
+			int trayInvocations = 0;
+			int boxInvocations = 0;
+			EventHandler trayHandler = (_, _) => trayInvocations++;
+			EventHandler boxHandler = (_, _) => boxInvocations++;
+			((IChocolateTray)wrappedGiftSet).Refilled += trayHandler;
+			((IChocolateBox)wrappedGiftSet).Refilled += boxHandler;
+
+			((IChocolateTray)wrappedGiftSet).Refilled -= trayHandler;
+			myGiftSet.RaiseTrayRefilled();
+			myGiftSet.RaiseBoxRefilled();
+
+			await That(trayInvocations).IsEqualTo(0);
+			await That(boxInvocations).IsEqualTo(1);
+		}
+
+		[Fact]
 		public async Task Wrap_SiblingInterfaceIndexer_ShouldDelegateGetterToDeclaringInterface()
 		{
 			MyChocolateGiftSet myGiftSet = new();

--- a/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
+++ b/Tests/Mockolate.Tests/MockTests.WrappingInterfaceTests.cs
@@ -225,6 +225,88 @@ public sealed partial class MockTests
 		}
 
 		[Fact]
+		public async Task Wrap_SiblingInterfaceEvent_ShouldSubscribeOnDeclaringInterface()
+		{
+			MyChocolateGiftSet myGiftSet = new();
+			IChocolateGiftSet wrappedGiftSet = IChocolateGiftSet.CreateMock().Wrapping(myGiftSet);
+
+			int trayInvocations = 0;
+			int boxInvocations = 0;
+			((IChocolateTray)wrappedGiftSet).Refilled += (_, _) => trayInvocations++;
+			((IChocolateBox)wrappedGiftSet).Refilled += (_, _) => boxInvocations++;
+
+			myGiftSet.RaiseTrayRefilled();
+			myGiftSet.RaiseBoxRefilled();
+
+			await That(trayInvocations).IsEqualTo(1);
+			await That(boxInvocations).IsEqualTo(1);
+		}
+
+		[Fact]
+		public async Task Wrap_SiblingInterfaceIndexer_ShouldDelegateGetterToDeclaringInterface()
+		{
+			MyChocolateGiftSet myGiftSet = new();
+			IChocolateGiftSet wrappedGiftSet = IChocolateGiftSet.CreateMock().Wrapping(myGiftSet);
+
+			await That(((IChocolateTray)wrappedGiftSet)[1]).IsEqualTo(5);
+			await That(((IChocolateBox)wrappedGiftSet)[1]).IsEqualTo(7);
+			await That(myGiftSet.ReceivedCalls).IsEqualTo(["get:tray-slot", "get:box-slot",]);
+		}
+
+		[Fact]
+		public async Task Wrap_SiblingInterfaceIndexer_ShouldDelegateSetterToDeclaringInterface()
+		{
+			MyChocolateGiftSet myGiftSet = new();
+			IChocolateGiftSet wrappedGiftSet = IChocolateGiftSet.CreateMock().Wrapping(myGiftSet);
+
+			((IChocolateTray)wrappedGiftSet)[2] = 50;
+			((IChocolateBox)wrappedGiftSet)[2] = 70;
+
+			await That(myGiftSet.ReceivedCalls).IsEqualTo(["set:tray-slot", "set:box-slot",]);
+			await That(myGiftSet.TraySlots[2]).IsEqualTo(50);
+			await That(myGiftSet.BoxSlots[2]).IsEqualTo(70);
+		}
+
+		[Fact]
+		public async Task Wrap_SiblingInterfaceMethod_ShouldDelegateToDeclaringInterface()
+		{
+			MyChocolateGiftSet myGiftSet = new();
+			IChocolateGiftSet wrappedGiftSet = IChocolateGiftSet.CreateMock().Wrapping(myGiftSet);
+
+			int trayCount = ((IChocolateTray)wrappedGiftSet).Count("Dark");
+			int boxCount = ((IChocolateBox)wrappedGiftSet).Count("Dark");
+
+			await That(trayCount).IsEqualTo(2);
+			await That(boxCount).IsEqualTo(1);
+			await That(myGiftSet.ReceivedCalls).IsEqualTo(["count:tray", "count:box",]);
+		}
+
+		[Fact]
+		public async Task Wrap_SiblingInterfaceProperty_ShouldDelegateGetterToDeclaringInterface()
+		{
+			MyChocolateGiftSet myGiftSet = new();
+			IChocolateGiftSet wrappedGiftSet = IChocolateGiftSet.CreateMock().Wrapping(myGiftSet);
+
+			await That(((IChocolateTray)wrappedGiftSet).Flavor).IsEqualTo("Dark");
+			await That(((IChocolateBox)wrappedGiftSet).Flavor).IsEqualTo("Milk");
+			await That(myGiftSet.ReceivedCalls).IsEqualTo(["get:tray", "get:box",]);
+		}
+
+		[Fact]
+		public async Task Wrap_SiblingInterfaceProperty_ShouldDelegateSetterToDeclaringInterface()
+		{
+			MyChocolateGiftSet myGiftSet = new();
+			IChocolateGiftSet wrappedGiftSet = IChocolateGiftSet.CreateMock().Wrapping(myGiftSet);
+
+			((IChocolateTray)wrappedGiftSet).Flavor = "Ruby";
+			((IChocolateBox)wrappedGiftSet).Flavor = "White";
+
+			await That(myGiftSet.ReceivedCalls).IsEqualTo(["set:tray", "set:box",]);
+			await That(myGiftSet.TrayFlavor).IsEqualTo("Ruby");
+			await That(myGiftSet.BoxFlavor).IsEqualTo("White");
+		}
+
+		[Fact]
 		public async Task Wrap_WithSetup_ShouldOverrideMethod()
 		{
 			MyChocolateDispenser myDispenser = new();
@@ -421,6 +503,116 @@ public sealed partial class MockTests
 			public void RaiseBaseRestocked() => _baseRestocked?.Invoke(this, EventArgs.Empty);
 
 			public void RaiseShelfRestocked() => Restocked?.Invoke();
+		}
+
+		private class MyChocolateGiftSet : IChocolateGiftSet
+		{
+			private event EventHandler? _boxRefilled;
+			private event EventHandler? _trayRefilled;
+
+			public List<string> ReceivedCalls { get; } = [];
+
+			public Dictionary<int, int> BoxSlots { get; } = new()
+			{
+				{
+					1, 7
+				},
+			};
+
+			public Dictionary<int, int> TraySlots { get; } = new()
+			{
+				{
+					1, 5
+				},
+			};
+
+			public string BoxFlavor { get; private set; } = "Milk";
+
+			public string TrayFlavor { get; private set; } = "Dark";
+
+			int IChocolateBox.this[int slot]
+			{
+				get
+				{
+					ReceivedCalls.Add("get:box-slot");
+					return BoxSlots[slot];
+				}
+				set
+				{
+					ReceivedCalls.Add("set:box-slot");
+					BoxSlots[slot] = value;
+				}
+			}
+
+			int IChocolateTray.this[int slot]
+			{
+				get
+				{
+					ReceivedCalls.Add("get:tray-slot");
+					return TraySlots[slot];
+				}
+				set
+				{
+					ReceivedCalls.Add("set:tray-slot");
+					TraySlots[slot] = value;
+				}
+			}
+
+			string IChocolateBox.Flavor
+			{
+				get
+				{
+					ReceivedCalls.Add("get:box");
+					return BoxFlavor;
+				}
+				set
+				{
+					ReceivedCalls.Add("set:box");
+					BoxFlavor = value;
+				}
+			}
+
+			string IChocolateTray.Flavor
+			{
+				get
+				{
+					ReceivedCalls.Add("get:tray");
+					return TrayFlavor;
+				}
+				set
+				{
+					ReceivedCalls.Add("set:tray");
+					TrayFlavor = value;
+				}
+			}
+
+			event EventHandler IChocolateBox.Refilled
+			{
+				add => _boxRefilled += value;
+				remove => _boxRefilled -= value;
+			}
+
+			event EventHandler IChocolateTray.Refilled
+			{
+				add => _trayRefilled += value;
+				remove => _trayRefilled -= value;
+			}
+
+			int IChocolateBox.Count(string flavor)
+			{
+				ReceivedCalls.Add("count:box");
+				return 1;
+			}
+
+			int IChocolateTray.Count(string flavor)
+			{
+				ReceivedCalls.Add("count:tray");
+				return 2;
+			}
+
+			public void RaiseBoxRefilled() => _boxRefilled?.Invoke(this, EventArgs.Empty);
+
+			public void RaiseTrayRefilled() => _trayRefilled?.Invoke(this, EventArgs.Empty);
 		}
 
 		public delegate void MyDelegate();

--- a/Tests/Mockolate.Tests/TestHelpers/IChocolateGiftSet.cs
+++ b/Tests/Mockolate.Tests/TestHelpers/IChocolateGiftSet.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Mockolate.Tests.TestHelpers;
+
+public interface IChocolateTray
+{
+	string Flavor { get; set; }
+	int this[int slot] { get; set; }
+	event EventHandler Refilled;
+	int Count(string flavor);
+}
+
+public interface IChocolateBox
+{
+	string Flavor { get; set; }
+	int this[int slot] { get; set; }
+	event EventHandler Refilled;
+	int Count(string flavor);
+}
+
+public interface IChocolateGiftSet : IChocolateTray, IChocolateBox
+{
+}


### PR DESCRIPTION
Mocking an interface that inherits two sibling interfaces declaring a member with the same name did not compile: the implicit member forwarded to the wrapped instance through the mocked interface, where the access is ambiguous between the siblings (CS0229 for properties and events, CS0121 for methods and indexers).

Always cast `MockRegistry.Wraps` to the declaring interface (`ContainingType`) for interface mocks. This subsumes the special case for explicit implementations (hidden members), whose `ExplicitImplementation` is the containing type anyway. Class mocks keep forwarding through the mocked class.